### PR TITLE
release: ry 0.2.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,7 @@ jobs:
       prerelease: ${{ steps.meta.outputs.prerelease }}
       make_latest: ${{ steps.meta.outputs.make_latest }}
     steps:
+      - uses: actions/checkout@v7
       - id: meta
         name: Resolve release metadata
         shell: bash
@@ -50,6 +51,21 @@ jobs:
 
           if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]]; then
             echo "Invalid release tag: $tag" >&2
+            exit 1
+          fi
+
+          cargo_version="$(awk '
+            $0 == "[workspace.package]" { in_workspace_package = 1; next }
+            in_workspace_package && /^\[/ { exit }
+            in_workspace_package && /^version = "/ {
+              gsub(/^version = "|"$/, "")
+              print
+              exit
+            }
+          ' Cargo.toml)"
+
+          if [[ -z "$cargo_version" || "$cargo_version" != "$version" ]]; then
+            echo "Release tag $tag does not match Cargo version ${cargo_version:-<missing>}" >&2
             exit 1
           fi
 
@@ -113,6 +129,23 @@ jobs:
         env:
           CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
         run: cargo build --release --locked -p ry-cli --bin ry --target "${{ matrix.target }}"
+      - name: Verify binary version
+        if: matrix.target != 'aarch64-unknown-linux-gnu' && matrix.target != 'aarch64-pc-windows-msvc'
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          binary="target/${{ matrix.target }}/release/ry"
+          if [[ "${{ runner.os }}" == "Windows" ]]; then
+            binary="$binary.exe"
+          fi
+
+          expected="ry ${{ needs.metadata.outputs.version }}"
+          actual="$("$binary" version)"
+          if [[ "$actual" != "$expected" ]]; then
+            echo "Release binary reports '$actual', expected '$expected'" >&2
+            exit 1
+          fi
       - name: Package
         shell: bash
         run: |
@@ -149,6 +182,23 @@ jobs:
     needs: [metadata, build]
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v7
+      - name: Extract changelog section
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          version="${{ needs.metadata.outputs.version }}"
+          awk -v heading="## [$version]" '
+            index($0, heading) == 1 { capture = 1 }
+            capture && /^## \[/ && index($0, heading) != 1 { exit }
+            capture { print }
+          ' CHANGELOG.md > "$RUNNER_TEMP/release-notes.md"
+
+          if [[ ! -s "$RUNNER_TEMP/release-notes.md" ]]; then
+            echo "No CHANGELOG.md section found for $version" >&2
+            exit 1
+          fi
       - uses: actions/download-artifact@v8
         with:
           pattern: release-*
@@ -159,6 +209,7 @@ jobs:
         with:
           tag_name: ${{ needs.metadata.outputs.tag }}
           name: ${{ needs.metadata.outputs.name }}
+          body_path: ${{ runner.temp }}/release-notes.md
           generate_release_notes: true
           prerelease: ${{ needs.metadata.outputs.prerelease }}
           make_latest: ${{ needs.metadata.outputs.make_latest }}

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,0 +1,7 @@
+extends: default
+
+rules:
+  document-start: disable
+  line-length: disable
+  truthy:
+    check-keys: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,46 @@
+# Changelog
+
+All notable changes to ry are documented in this file.
+
+## [Unreleased]
+
+## [0.2.0] - 2026-07-10
+
+### Added
+
+- Static resolution of `NAMESPACE` imports, including
+  `importFrom(package, name)` and whole-package imports.
+- Resolution of exports introduced by `library()` and `require()` without
+  executing R or loading package code.
+- Support for installed package libraries on Linux, macOS, Windows, and
+  renv-managed projects.
+- ANSI-colored human-readable diagnostics with
+  `--color auto|always|never` and `NO_COLOR` support.
+- `RY034` for comparisons with `NA` using `==` or `!=`.
+- `RY041` for non-divisible vector recycling.
+- `RY042` for arithmetic on factors.
+
+### Fixed
+
+- False-positive `RY010` diagnostics for imported package values such as
+  bare `tags` imported from shiny.
+- `requireNamespace()` no longer incorrectly introduces unqualified names.
+- Package bindings no longer leak between unrelated packages checked together.
+- Package-library and R-version precedence now respect the active project,
+  including renv libraries.
+- Several arithmetic, raw-vector, factor-comparison, assignment, and scope
+  inference edge cases.
+
+### Changed
+
+- The minimum supported Rust version is now 1.88 and is verified in CI.
+- Human and machine-readable diagnostic output are tested independently;
+  JSON and CI formats never contain ANSI escapes.
+
+## [0.1.0] - 2026-07-07
+
+- Initial release.
+
+[Unreleased]: https://github.com/sims1253/ry/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/sims1253/ry/compare/v0.1.0...v0.2.0
+[0.1.0]: https://github.com/sims1253/ry/releases/tag/v0.1.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -886,7 +886,7 @@ dependencies = [
 
 [[package]]
 name = "ry-checker"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "insta",
  "rayon",
@@ -900,7 +900,7 @@ dependencies = [
 
 [[package]]
 name = "ry-cli"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "clap",
  "clap_complete",
@@ -923,7 +923,7 @@ dependencies = [
 
 [[package]]
 name = "ry-core"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "thiserror",
  "tracing",
@@ -933,7 +933,7 @@ dependencies = [
 
 [[package]]
 name = "ry-lsp"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "ry-checker",
  "ry-core",
@@ -947,7 +947,7 @@ dependencies = [
 
 [[package]]
 name = "ry-typeshed"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 rust-version = "1.88"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ cargo build --release
 ```
 
 Prebuilt binaries are attached to GitHub releases.
+See [CHANGELOG.md](CHANGELOG.md) for release highlights and upgrade notes.
 
 ## Quickstart
 


### PR DESCRIPTION
Bump the workspace to ry 0.2.0, add a curated changelog, and harden release automation with manifest/tag and binary version checks. The release workflow now prepends the matching changelog section to GitHub-generated PR and contributor notes.