### PR TITLE
Release 0.5.0 (changelog, version bump, crossbeam-epoch security update)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,12 @@
 
 All notable changes to ry are documented in this file.
 
-## [Unreleased]
+## [0.5.0] - 2026-07-16
 
 Driven by the ranks-301-500 audit (ry 0.4.0 on the top-500 CRAN packages).
+Minor bump: RY050's dispatch semantics, RY097's collapse criteria, and the
+new binding/quoting/narrowing rules intentionally change reported
+diagnostics between versions.
 
 ### Performance
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -353,9 +353,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1166,7 +1166,7 @@ checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "ry-checker"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "criterion",
  "insta",
@@ -1182,7 +1182,7 @@ dependencies = [
 
 [[package]]
 name = "ry-cli"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "bzip2",
  "clap",
@@ -1209,7 +1209,7 @@ dependencies = [
 
 [[package]]
 name = "ry-core"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "thiserror",
  "tracing",
@@ -1219,7 +1219,7 @@ dependencies = [
 
 [[package]]
 name = "ry-lsp"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "ry-checker",
  "ry-core",
@@ -1234,7 +1234,7 @@ dependencies = [
 
 [[package]]
 name = "ry-typeshed"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.4.1"
+version = "0.5.0"
 edition = "2024"
 rust-version = "1.88"
 license = "MIT"


### PR DESCRIPTION
Brings the v0.5.0 release commit to main: changelog section retitled with the minor-bump rationale, workspace version 0.5.0, and crossbeam-epoch 0.9.18 -> 0.9.20 (RUSTSEC-2026-0204, found by the pre-release cargo audit). The v0.5.0 tag and release are already published from this commit.