### PR TITLE
Type-guard narrowing for rlang standalone checkers and stopifnot/assert_that

### DIFF
--- a/crates/ry-checker/src/infer/call.rs
+++ b/crates/ry-checker/src/infer/call.rs
@@ -652,6 +652,48 @@ impl Checker {
             }
             return RType::new(Mode::Null, Length::Zero);
         }
+        if !name.contains("::")
+            && let Some(mut target) = standalone_check_target(&lookup_name)
+            && user_function.as_ref().is_none_or(|function| {
+                ["arg", "call"].into_iter().all(|required| {
+                    function
+                        .params
+                        .iter()
+                        .any(|parameter| parameter.name == required)
+                })
+            })
+            && let Some(Expr::Ident { name: var, .. }) = args.first().map(|a| &a.value)
+        {
+            // A non-literal opt-in is treated like TRUE: weakening the fact
+            // avoids excluding a value the checker may accept at runtime.
+            if args.iter().any(|argument| {
+                argument.name.as_deref() == Some("allow_null")
+                    && !matches!(argument.value, Expr::Logical(false, _))
+            }) {
+                target = target.join(RType::new(Mode::Null, Length::Zero));
+            }
+            if args.iter().any(|argument| {
+                argument.name.as_deref() == Some("allow_na")
+                    && !matches!(argument.value, Expr::Logical(false, _))
+            }) {
+                target = target.join(RType::scalar(Mode::Logical));
+            }
+            scope.insert(var.clone(), target);
+            return RType::new(Mode::Null, Length::Zero);
+        }
+
+        let assertion_predicates =
+            name == "stopifnot" || name == "assert_that" || name == "assertthat::assert_that";
+        if assertion_predicates {
+            for argument in args {
+                if name.ends_with("assert_that") && argument.name.as_deref() == Some("msg") {
+                    continue;
+                }
+                let narrowing = extract_type_narrowing(&argument.value);
+                let (positive_scope, _, _) = apply_narrowing(scope, &narrowing, false);
+                *scope = positive_scope;
+            }
+        }
 
         // Indirect call through a closure value: if the name is bound
         // in scope to a `Function`-typed value with an inferred

--- a/crates/ry-checker/src/infer/misc.rs
+++ b/crates/ry-checker/src/infer/misc.rs
@@ -344,6 +344,31 @@ pub(crate) fn assertion_call_target(name: &str) -> Option<RType> {
     }
 }
 
+/// Map rlang's inlined standalone checkers to the fact they establish about
+/// their first argument. These helpers are package-local rather than exported
+/// from rlang, so call-site recognition also verifies their defining shape
+/// when a definition is available.
+pub(crate) fn standalone_check_target(name: &str) -> Option<RType> {
+    match name {
+        "check_bool" => Some(RType::scalar(Mode::Logical)),
+        "check_string" | "check_name" => Some(RType::scalar(Mode::Character)),
+        "check_number_whole" | "check_number_decimal" => {
+            Some(RType::scalar(Mode::Integer).join(RType::scalar(Mode::Double)))
+        }
+        "check_function" | "check_closure" => Some(RType::scalar(Mode::Function)),
+        "check_environment" => predicate_target("is.environment"),
+        "check_symbol" | "check_arg" => {
+            Some(RType::unknown().with_class(ClassVector::single("name")))
+        }
+        "check_call" => Some(RType::unknown().with_class(ClassVector::single("call"))),
+        "check_formula" => Some(RType::unknown().with_class(ClassVector::single("formula"))),
+        "check_character" => Some(RType::new(Mode::Character, Length::Unknown)),
+        "check_logical" => Some(RType::new(Mode::Logical, Length::Unknown)),
+        "check_data_frame" => predicate_target("is.data.frame"),
+        _ => None,
+    }
+}
+
 /// Narrow a type away from NULL: the value is known to be non-null in
 /// this branch. Returns `None` when nothing changes (the type carries no
 /// NULL member to remove).

--- a/crates/ry-checker/src/tests.rs
+++ b/crates/ry-checker/src/tests.rs
@@ -4087,6 +4087,181 @@ fn type_narrowing_is_character_then_branch() {
 }
 
 #[test]
+fn standalone_check_string_narrows_name_trusted_calls() {
+    let diagnostics = check(
+        "h2 <- function() {\n\
+           choice <- c(\"foo\", \"bar\")\n\
+           check_string(choice)\n\
+           if (choice == \"foo\") 1 else 2\n\
+         }\n",
+    );
+    assert!(
+        diagnostics
+            .iter()
+            .all(|diagnostic| diagnostic.code != "RY002"),
+        "the standalone guard must prove a scalar string: {diagnostics:?}"
+    );
+}
+
+#[test]
+fn standalone_check_string_narrows_fingerprinted_user_function() {
+    let diagnostics = check(
+        "check_string <- function(x, ..., arg = caller_arg(x), call = caller_env()) invisible(NULL)\n\
+         choice <- c(\"foo\", \"bar\")\n\
+         check_string(choice)\n\
+         if (choice == \"foo\") 1 else 2\n",
+    );
+    assert!(
+        diagnostics
+            .iter()
+            .all(|diagnostic| diagnostic.code != "RY002"),
+        "an inlined standalone checker must retain guard semantics: {diagnostics:?}"
+    );
+}
+
+#[test]
+fn standalone_check_string_does_not_narrow_name_collision() {
+    let (diagnostics, scope) = check_with_scope(
+        "check_string <- function(x) nchar(x) > 0\n\
+         choice <- c(\"foo\", \"bar\")\n\
+         guard_result <- check_string(choice)\n\
+         if (choice == \"foo\") 1 else 2\n",
+    );
+    assert!(
+        diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code == "RY002"),
+        "a same-named ordinary user function must not narrow: {diagnostics:?}"
+    );
+    assert_ne!(
+        scope.get("guard_result").map(|ty| ty.mode),
+        Some(Mode::Null),
+        "a rejected name collision must use the user function's return type"
+    );
+}
+
+#[test]
+fn standalone_check_string_allow_null_weakens_target() {
+    let (_, scope) = check_with_scope(
+        "choice <- c(\"foo\", \"bar\")\n\
+         check_string(choice, allow_null = TRUE)\n\
+         field <- choice$field\n",
+    );
+    let choice = scope.get("choice").expect("choice should stay bound");
+    assert_eq!(choice.mode, Mode::Union, "{choice:?}");
+    let members = choice
+        .members
+        .as_ref()
+        .expect("allow_null should produce a populated union");
+    assert!(
+        members
+            .iter()
+            .any(|member| member.mode == Mode::Character && member.length == Length::One),
+        "the scalar character member must be preserved: {choice:?}"
+    );
+    assert!(
+        members.iter().any(|member| member.mode == Mode::Null),
+        "the weakened guard must retain NULL: {choice:?}"
+    );
+}
+
+#[test]
+fn standalone_check_number_whole_narrows_to_scalar_numeric_union() {
+    let (diagnostics, scope) = check_with_scope(
+        "n <- c(1L, 2L)\n\
+         check_number_whole(n)\n\
+         if (n > 1) 1 else 2\n",
+    );
+    assert!(
+        diagnostics
+            .iter()
+            .all(|diagnostic| !matches!(diagnostic.code, "RY002" | "RY033")),
+        "the numeric guard must make the condition scalar numeric: {diagnostics:?}"
+    );
+    let n = scope.get("n").expect("n should stay bound");
+    assert_eq!(n.mode, Mode::Union, "{n:?}");
+    let members = n
+        .members
+        .as_ref()
+        .expect("numeric target should be a union");
+    assert!(
+        [Mode::Integer, Mode::Double].into_iter().all(|mode| members
+            .iter()
+            .any(|member| member.mode == mode && member.length == Length::One)),
+        "the target must be scalar integer-or-double: {n:?}"
+    );
+}
+
+#[test]
+fn stopifnot_installs_positive_predicate_narrowing() {
+    let (diagnostics, scope) = check_with_scope(
+        "x <- if (runif(1) > 0.5) 1L else c(\"a\", \"b\")\n\
+         stopifnot(is.character(x))\n\
+         width <- nchar(x)\n",
+    );
+    assert!(
+        diagnostics
+            .iter()
+            .all(|diagnostic| diagnostic.code != "RY092"),
+        "character-only use after stopifnot must be accepted: {diagnostics:?}"
+    );
+    assert_eq!(scope.get("x").map(|ty| ty.mode), Some(Mode::Character));
+}
+
+#[test]
+fn assert_that_installs_positive_predicate_narrowing() {
+    let (diagnostics, scope) = check_with_scope(
+        "x <- if (runif(1) > 0.5) \"a\" else 1L\n\
+         assert_that(is.numeric(x))\n\
+         value <- x + 1\n",
+    );
+    assert!(
+        diagnostics
+            .iter()
+            .all(|diagnostic| diagnostic.code != "RY040"),
+        "numeric use after assert_that must be accepted: {diagnostics:?}"
+    );
+    let x = scope.get("x").expect("x should stay bound");
+    assert_eq!(x.mode, Mode::Union, "{x:?}");
+    let members = x
+        .members
+        .as_ref()
+        .expect("numeric target should be a union");
+    assert!(
+        [Mode::Integer, Mode::Double]
+            .into_iter()
+            .all(|mode| members.iter().any(|member| member.mode == mode)),
+        "assert_that must retain the full numeric target: {x:?}"
+    );
+}
+
+#[test]
+fn namespaced_assert_that_narrows_predicates_but_not_msg() {
+    let (_, scope) = check_with_scope(
+        "x <- if (runif(1) > 0.5) \"a\" else 1L\n\
+         y <- if (runif(1) > 0.5) \"b\" else 2L\n\
+         assertthat::assert_that(is.numeric(x), msg = is.character(y))\n",
+    );
+    let x = scope.get("x").expect("x should stay bound");
+    let x_members = x
+        .members
+        .as_ref()
+        .expect("numeric target should be a union");
+    assert!(
+        x_members
+            .iter()
+            .all(|member| matches!(member.mode, Mode::Integer | Mode::Double)),
+        "the predicate argument must narrow x: {x:?}"
+    );
+    let y = scope.get("y").expect("y should stay bound");
+    let y_members = y.members.as_ref().expect("y should remain a union");
+    assert!(
+        y_members.iter().any(|member| member.mode == Mode::Integer),
+        "the msg expression must not narrow y: {y:?}"
+    );
+}
+
+#[test]
 fn if_expr_integer_branches_join_to_integer() {
     // `if (TRUE) 1L else 2L` joins to integer. Using the result
     // with a character must fire RY040, proving the type was


### PR DESCRIPTION
Closes #21.

Bare calls to the inlined `standalone-types-check.R` family (`check_string()`, `check_bool()`, `check_number_whole()`, ...) are now understood as type guards: execution past the call proves the asserted type of the first argument, so downstream diagnostics (e.g. RY002 on `if (choice == "foo")` after `check_string(choice)`) no longer fire.

## Design

- Extends the existing assertion-narrowing mechanism (`assertion_call_target`, previously covering admiral's `assert_*_scalar` family) with a `standalone_check_target` table: scalar targets for `check_bool`/`check_string`/`check_name`/`check_number_*`/`check_function`/`check_closure`, class targets for `check_symbol`/`check_arg`/`check_call`/`check_formula`/`check_environment`/`check_data_frame`, unknown-length vector targets for `check_character`/`check_logical`. `check_required` proves nothing about type and is excluded.
- **Fingerprint gating**: these names are conventional, not reserved. When a same-named user definition exists, narrowing applies only if its formals include `arg` and `call` — the signature every standalone checker has (`function(x, ..., arg = caller_arg(x), call = caller_env())`). A non-fingerprinted collision is inferred as an ordinary call. When no definition is in view (single-file checks), the name is trusted, which is the FP-suppressing direction.
- **`allow_null` / `allow_na`**: absent or literal `FALSE` keeps the full claim; literal `TRUE` or a non-literal value weakens the target by joining NULL (resp. scalar logical for a bare `NA`). The length-1 claim survives the weakening, which is what matters for the condition-length FPs.
- **`stopifnot()` / `assert_that()`**: each argument runs through the existing if-condition narrowing extraction and applies its positive (then-branch) refinement to the continuation scope — correct for all narrowing kinds since execution continues exactly when every argument is TRUE. `assert_that`'s `msg =` argument is skipped. Arguments are still inferred normally first, so diagnostics inside them are preserved.

The inverse diagnostic (`check_string(x)` on a known-incompatible `x` always throws — flag the guard, treat the continuation as unreachable) is deliberately left for a follow-up.

## Validation

- 8 new unit tests: name-trust, fingerprint-accept, collision-reject, `allow_null` weakening, `check_number_whole` scalar union, `stopifnot`/`assert_that` positive narrowing, namespaced `assert_that` with `msg` exclusion.
- Full `ry-checker` suite green (385 unit tests + corpus/oracle/project/real-world/vendor suites); vendor snapshots unchanged.
- `cargo clippy --workspace --all-targets -- -D warnings` and `cargo fmt --check` clean.
- End-to-end repro: known length-2 vector + `check_string()` + `if (==)` is silent; the same code without the guard still fires RY002.
