### PR TITLE
fix(checker): resolve native-pipe `_` extraction placeholder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,18 @@ All notable changes to ry are documented in this file.
 - The native-pipe extraction placeholder (R >= 4.3), as in `mtcars |> _$mpg` or
   `df |> _[["col"]]`, no longer produces a false `RY010` "variable `_` is not
   bound in this scope" warning. The placeholder now resolves to the piped
-  left-hand side, so the extracted type is inferred (#27).
+  left-hand side, so the extracted type is inferred (#27). This also covers
+  longer extraction chains rooted at the placeholder, such as
+  `mtcars |> _$mpg[1]` and `df %>% .$col[i]`.
+- Every `.` argument of a magrittr call now receives the piped value, matching
+  magrittr's substitution rule. `x %>% paste(., ., sep = "-")` no longer reports
+  a false `RY010` on the second `.`. `.` is also bound throughout the piped
+  call, so nested pronouns such as `x %>% sum(rev(.))` and the filtering idiom
+  `mtcars %>% .[.$mpg > 20, ]` resolve as well.
+- Pipe placeholders are now specific to their operator: `.` only resolves to the
+  piped value in magrittr pipes and `_` only in the native `|>`. `mtcars |> .$mpg`
+  and `mtcars %>% _$mpg` are invalid R, and both now report `RY010` instead of
+  being silently accepted.
 
 ## [0.7.1] - 2026-07-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to ry are documented in this file.
 
+## [Unreleased]
+
+### Fixed
+
+- The native-pipe extraction placeholder (R >= 4.3), as in `mtcars |> _$mpg` or
+  `df |> _[["col"]]`, no longer produces a false `RY010` "variable `_` is not
+  bound in this scope" warning. The placeholder now resolves to the piped
+  left-hand side, so the extracted type is inferred (#27).
+
 ## [0.7.1] - 2026-07-24
 
 ### Typeshed semantics

--- a/crates/ry-checker/src/infer/binop.rs
+++ b/crates/ry-checker/src/infer/binop.rs
@@ -197,7 +197,7 @@ impl Checker {
         if symbol == "?"
             || matches!(
                 op,
-                BinOpKind::In | BinOpKind::Colon | BinOpKind::PipeForward
+                BinOpKind::In | BinOpKind::Colon | BinOpKind::PipeForward | BinOpKind::PipeNative
             )
         {
             return None;

--- a/crates/ry-checker/src/infer/index.rs
+++ b/crates/ry-checker/src/infer/index.rs
@@ -507,13 +507,6 @@ pub(crate) fn extract_literal_int(e: &Expr) -> Option<i64> {
     }
 }
 
-/// True if `e` is a magrittr (`.`) or base-R (`_`) pipe placeholder.
-/// These are bare identifier references used inside a piped call to
-/// mark where the LHS value should be substituted.
-pub(crate) fn is_pipe_placeholder(e: &Expr) -> bool {
-    matches!(e, Expr::Ident { name, .. } if name == "." || name == "_")
-}
-
 /// Functions whose arguments are bare symbols (NSE), not expressions.
 /// When these are called, the checker does NOT evaluate the arguments
 /// as variable references, preventing spurious RY010 warnings.

--- a/crates/ry-checker/src/infer/misc.rs
+++ b/crates/ry-checker/src/infer/misc.rs
@@ -93,16 +93,6 @@ pub(crate) fn op_symbol(op: BinOpKind) -> &'static str {
     }
 }
 
-/// True if `e` is the magrittr `.` data pronoun. Unlike
-/// [`is_pipe_placeholder`], this excludes base-R's `_` placeholder,
-/// which has no data-pronoun role: `x %>% _$col` is not valid R.
-/// Used by `infer_pipe` to detect nested access forms like
-/// `x %>% .$col`, `x %>% .[i]`, and `x %>% .[[i]]`, where the `.` at
-/// the base of the index refers to the piped LHS value.
-pub(crate) fn is_dot_pronoun(e: &Expr) -> bool {
-    matches!(e, Expr::Ident { name, .. } if name == ".")
-}
-
 /// A type refinement extracted from an `if` condition. Represents the
 /// information we can glean from a type predicate call like
 /// `is.numeric(x)` or `is.null(x)`.

--- a/crates/ry-checker/src/infer/misc.rs
+++ b/crates/ry-checker/src/infer/misc.rs
@@ -88,6 +88,7 @@ pub(crate) fn op_symbol(op: BinOpKind) -> &'static str {
         BinOpKind::Assign => "<-",
         BinOpKind::SuperAssign => "<<-",
         BinOpKind::PipeForward => "%>%",
+        BinOpKind::PipeNative => "|>",
         BinOpKind::PipeTee => "%T>%",
         BinOpKind::PipeAssign => "%<>%",
     }

--- a/crates/ry-checker/src/infer/mod.rs
+++ b/crates/ry-checker/src/infer/mod.rs
@@ -1,6 +1,7 @@
 use super::*;
 pub(crate) use index::*;
 pub(crate) use misc::*;
+pub(crate) use pipe::PipeForm;
 pub(crate) mod binop;
 pub(crate) mod call;
 pub(crate) mod construct;
@@ -1515,14 +1516,15 @@ impl Checker {
                 // Pipes need structural access to `rhs` (to build a
                 // desugared call), so they bypass `infer_binop`'s
                 // type-only signature.
-                if matches!(*op, BinOpKind::PipeForward) {
-                    return self.infer_pipe(lhs, rhs, *span, scope);
+                if matches!(*op, BinOpKind::PipeForward | BinOpKind::PipeNative) {
+                    let form = PipeForm::of(*op);
+                    return self.infer_pipe(lhs, rhs, *span, form, scope);
                 }
                 if matches!(*op, BinOpKind::PipeAssign) {
                     // `%<>%` (assignment pipe): like `%>%` but also
                     // rebinds the LHS identifier to the result, so
                     // `x %<>% f()` is `x <- x %>% f()`.
-                    let result = self.infer_pipe(lhs, rhs, *span, scope);
+                    let result = self.infer_pipe(lhs, rhs, *span, PipeForm::Magrittr, scope);
                     if let Expr::Ident { name, .. } = lhs.as_ref() {
                         scope.insert(name.clone(), result.clone());
                     }

--- a/crates/ry-checker/src/infer/pipe.rs
+++ b/crates/ry-checker/src/infer/pipe.rs
@@ -27,13 +27,17 @@ impl Checker {
         scope: &mut Scope,
     ) -> RType {
         match rhs {
-            // Magrittr data pronoun with nested access:
-            // `df %>% .$col`, `df %>% .[i]`, `df %>% .[[i]]`. The `.` at
-            // the base of the index resolves to the piped LHS value, so
-            // we infer the index against `lhs_t` directly.
+            // Pipe placeholder with nested access: magrittr's
+            // `df %>% .$col`, `df %>% .[i]`, `df %>% .[[i]]` and base R's
+            // extraction placeholder (R >= 4.3) `df |> _$col`,
+            // `df |> _[["col"]]`. The placeholder at the base of the index
+            // resolves to the piped LHS value, so we infer the index
+            // against `lhs_t` directly.
             Expr::Index {
                 base, kind, args, ..
-            } if is_dot_pronoun(base) => self.infer_index(lhs_t, *kind, args, span, false, scope),
+            } if is_pipe_placeholder(base) => {
+                self.infer_index(lhs_t, *kind, args, span, false, scope)
+            }
             // A braced magrittr RHS is a unary lambda whose `.` pronoun is
             // bound to the LHS (`x %>% { .$field == value }`).
             Expr::Block { body, .. } => {

--- a/crates/ry-checker/src/infer/pipe.rs
+++ b/crates/ry-checker/src/infer/pipe.rs
@@ -1,16 +1,105 @@
 use super::*;
 
+/// Which pipe operator introduced the RHS. The two forms use different
+/// placeholders: magrittr binds `.`, base R's native pipe binds `_`
+/// (R 4.2+). A placeholder only resolves to the LHS in its own form;
+/// in the other form it is an ordinary identifier reference.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PipeForm {
+    /// `%>%`, `%T>%`, `%<>%`.
+    Magrittr,
+    /// `|>`.
+    Native,
+}
+
+impl PipeForm {
+    pub(crate) fn of(op: BinOpKind) -> Self {
+        match op {
+            BinOpKind::PipeNative => PipeForm::Native,
+            _ => PipeForm::Magrittr,
+        }
+    }
+
+    /// True if `e` is the placeholder belonging to this pipe form.
+    fn is_placeholder(self, e: &Expr) -> bool {
+        match self {
+            PipeForm::Magrittr => matches!(e, Expr::Ident { name, .. } if name == "."),
+            PipeForm::Native => matches!(e, Expr::Ident { name, .. } if name == "_"),
+        }
+    }
+}
+
+/// True if `e` is an extraction chain rooted at `form`'s placeholder,
+/// e.g. `_$mpg`, `_[["mpg"]][2]` or `.$mpg[1]`.
+fn is_placeholder_chain(e: &Expr, form: PipeForm) -> bool {
+    match e {
+        Expr::Index { base, .. } => form.is_placeholder(base) || is_placeholder_chain(base, form),
+        _ => false,
+    }
+}
+
 impl Checker {
+    /// Run `f` with magrittr's `.` bound to the piped value, restoring the
+    /// previous binding (if any) afterwards. magrittr binds `.` across the
+    /// whole RHS, so pronouns nested inside call arguments or subscripts
+    /// (`df %>% .[.$mpg > 20, ]`) resolve to the piped value too. The
+    /// native `_` is deliberately not bound: R accepts it only in specific
+    /// positions, which are matched structurally instead.
+    fn with_dot_bound<R>(
+        &mut self,
+        form: PipeForm,
+        lhs_t: &RType,
+        scope: &mut Scope,
+        f: impl FnOnce(&mut Self, &mut Scope) -> R,
+    ) -> R {
+        let restore = matches!(form, PipeForm::Magrittr)
+            .then(|| scope.bindings.insert(".".to_string(), lhs_t.clone()));
+        let result = f(self, scope);
+        if let Some(previous) = restore {
+            match previous {
+                Some(t) => scope.bindings.insert(".".to_string(), t),
+                None => scope.bindings.remove("."),
+            };
+        }
+        result
+    }
+
+    /// Infer an extraction chain rooted at a pipe placeholder by applying
+    /// each index operation to `lhs_t` from the root outwards. Returns
+    /// `None` if `e` is not such a chain.
+    fn infer_placeholder_chain(
+        &mut self,
+        e: &Expr,
+        lhs_t: RType,
+        form: PipeForm,
+        span: Span,
+        scope: &mut Scope,
+    ) -> Option<RType> {
+        let Expr::Index {
+            base, kind, args, ..
+        } = e
+        else {
+            return None;
+        };
+        let base_t = if form.is_placeholder(base) {
+            lhs_t
+        } else {
+            self.infer_placeholder_chain(base, lhs_t, form, span_of(base), scope)?
+        };
+        Some(self.infer_index(base_t, *kind, args, span, false, scope))
+    }
+
     pub(crate) fn infer_pipe(
         &mut self,
         lhs: &Expr,
         rhs: &Expr,
         span: Span,
+        form: PipeForm,
         scope: &mut Scope,
     ) -> RType {
         // Infer the LHS so diagnostics fire on it (e.g. unbound name).
         let lhs_t = self.infer(lhs, scope);
-        self.infer_pipe_with_lhs_type(lhs, rhs, span, lhs_t, scope)
+        self.infer_pipe_with_lhs_type(lhs, rhs, span, lhs_t, form, scope)
     }
 
     /// Infer a pipe RHS after its LHS has already been inferred in `scope`.
@@ -24,19 +113,26 @@ impl Checker {
         rhs: &Expr,
         span: Span,
         lhs_t: RType,
+        form: PipeForm,
         scope: &mut Scope,
     ) -> RType {
         match rhs {
             // Pipe placeholder with nested access: magrittr's
             // `df %>% .$col`, `df %>% .[i]`, `df %>% .[[i]]` and base R's
             // extraction placeholder (R >= 4.3) `df |> _$col`,
-            // `df |> _[["col"]]`. The placeholder at the base of the index
-            // resolves to the piped LHS value, so we infer the index
-            // against `lhs_t` directly.
-            Expr::Index {
-                base, kind, args, ..
-            } if is_pipe_placeholder(base) => {
-                self.infer_index(lhs_t, *kind, args, span, false, scope)
+            // `df |> _[["col"]]`. The placeholder at the root of the
+            // extraction resolves to the piped LHS value, so we infer the
+            // chain against `lhs_t` directly. Only the placeholder
+            // belonging to this pipe form counts: `df |> .$col` reads an
+            // ordinary (and here unbound) `.`, so it falls through to the
+            // generic arm below and keeps its normal index inference.
+            Expr::Index { .. } if is_placeholder_chain(rhs, form) => {
+                let chain_t = lhs_t.clone();
+                self.with_dot_bound(form, &lhs_t, scope, |checker, scope| {
+                    checker
+                        .infer_placeholder_chain(rhs, chain_t, form, span, scope)
+                        .unwrap_or_else(RType::unknown)
+                })
             }
             // A braced magrittr RHS is a unary lambda whose `.` pronoun is
             // bound to the LHS (`x %>% { .$field == value }`).
@@ -55,7 +151,7 @@ impl Checker {
             // itself (the `.` refers to the LHS). This is distinct from
             // the general `Ident` arm below, which would treat `.` as a
             // function name and call `.(lhs)`.
-            Expr::Ident { name, .. } if name == "." => lhs_t,
+            Expr::Ident { .. } if form.is_placeholder(rhs) => lhs_t,
             Expr::Call {
                 func,
                 args,
@@ -64,7 +160,13 @@ impl Checker {
                 let mut new_args: Vec<Arg> = Vec::with_capacity(args.len() + 1);
                 let mut placeholder_seen = false;
                 for a in args {
-                    if !placeholder_seen && is_pipe_placeholder(&a.value) {
+                    // magrittr substitutes *every* `.` argument, so
+                    // `x %>% paste(., ., sep = "-")` pipes `x` into both.
+                    // The native pipe permits a single `_`, so only its
+                    // first occurrence is substituted.
+                    let substitute = form.is_placeholder(&a.value)
+                        && (!placeholder_seen || matches!(form, PipeForm::Magrittr));
+                    if substitute {
                         new_args.push(Arg {
                             name: a.name.clone(),
                             value: lhs.clone(),
@@ -85,7 +187,14 @@ impl Checker {
                         },
                     );
                 }
-                self.infer_pipe_call(func, &new_args, lhs, lhs_t.clone(), scope, *call_span)
+                // Nested pronouns resolve through the binding rather than
+                // the substitution above: `x %>% sum(rev(.))` is
+                // `sum(x, rev(x))`. Only a *top-level* `.` suppresses the
+                // prepended LHS, which is why both mechanisms are needed.
+                let call_t = lhs_t.clone();
+                self.with_dot_bound(form, &lhs_t, scope, |checker, scope| {
+                    checker.infer_pipe_call(func, &new_args, lhs, call_t, scope, *call_span)
+                })
             }
             Expr::Ident { .. } => {
                 let new_args = vec![Arg {
@@ -129,7 +238,14 @@ impl Checker {
     pub(crate) fn infer_pipe_tee(&mut self, lhs: &Expr, rhs: &Expr, scope: &mut Scope) -> RType {
         let lhs_t = self.infer(lhs, scope);
         // Still walk the RHS so any diagnostics on its body fire.
-        let _ = self.infer_pipe_with_lhs_type(lhs, rhs, span_of(rhs), lhs_t.clone(), scope);
+        let _ = self.infer_pipe_with_lhs_type(
+            lhs,
+            rhs,
+            span_of(rhs),
+            lhs_t.clone(),
+            PipeForm::Magrittr,
+            scope,
+        );
         lhs_t
     }
 

--- a/crates/ry-checker/src/tests.rs
+++ b/crates/ry-checker/src/tests.rs
@@ -2559,8 +2559,110 @@ fn pipe_underscore_placeholder_extraction() {
     let col = scope.get("col").expect("col should be bound");
     assert_eq!(col.mode, Mode::Double, "mtcars |> _$mpg must infer double");
     assert_eq!(col.length, Length::Known(32), "mpg has 32 rows");
+    let m = scope.get("m").expect("m should be bound");
+    assert_eq!(m.mode, Mode::Double, "mean() of a double column is double");
+    assert_eq!(m.length, Length::One, "mean() returns a scalar");
     let also = scope.get("also").expect("also should be bound");
     assert_eq!(also.mode, Mode::Double, "mtcars |> _[[\"mpg\"]] is double");
+    assert_eq!(
+        also.length,
+        Length::Known(32),
+        "mtcars |> _[[\"mpg\"]] has 32 rows"
+    );
+}
+
+#[test]
+fn pipe_placeholder_extraction_chain() {
+    // The placeholder may sit at the root of a longer extraction chain
+    // (`mtcars |> _$mpg[1]` evaluates to 21 in R 4.6). Every link is
+    // applied to the piped LHS, so no link may report an unbound `_`/`.`.
+    let (diags, scope) = check_with_scope(
+        "a <- mtcars |> _$mpg[1]\nb <- mtcars |> _[[\"mpg\"]][2]\nd <- mtcars %>% .$mpg[1]\n",
+    );
+    assert!(
+        diags.iter().all(|d| d.code != "RY010"),
+        "placeholder-rooted extraction chains should not emit RY010, got {:?}",
+        diags
+    );
+    for name in ["a", "b", "d"] {
+        let t = scope.get(name).expect("binding should exist");
+        assert_eq!(
+            t.mode,
+            Mode::Double,
+            "{} indexes the double column mpg",
+            name
+        );
+        assert_eq!(t.length, Length::One, "{} extracts a single element", name);
+    }
+}
+
+#[test]
+fn pipe_dot_substituted_at_every_placeholder_argument() {
+    // magrittr replaces every `.` argument with the LHS, so the second
+    // `.` in `paste(., ., sep = "-")` must not read as an unbound name.
+    let (diags, scope) =
+        check_with_scope("x <- c(\"a\", \"b\")\ny <- x %>% paste(., ., sep = \"-\")\n");
+    assert!(
+        diags.iter().all(|d| d.code != "RY010"),
+        "repeated `.` arguments should not emit RY010, got {:?}",
+        diags
+    );
+    let y = scope.get("y").expect("y should be bound");
+    assert_eq!(y.mode, Mode::Character, "paste() returns character");
+    assert_eq!(
+        y.length,
+        Length::Known(2),
+        "both `.` arguments have length 2"
+    );
+}
+
+#[test]
+fn pipe_dot_substituted_inside_nested_calls() {
+    // magrittr binds `.` throughout the RHS, so a pronoun nested in an
+    // inner call resolves too: `c(1, 2) %>% sum(rev(.))` is 6 in R.
+    let (diags, scope) = check_with_scope("x <- c(1, 2)\ny <- x %>% sum(rev(.))\n");
+    assert!(
+        diags.iter().all(|d| d.code != "RY010"),
+        "a nested `.` should not emit RY010, got {:?}",
+        diags
+    );
+    let y = scope.get("y").expect("y should be bound");
+    assert_eq!(y.mode, Mode::Double, "sum() of doubles is double");
+}
+
+#[test]
+fn pipe_dot_resolves_inside_subscripts() {
+    // The magrittr filtering idiom subscripts the pronoun with a
+    // predicate over the pronoun itself: `mtcars %>% .[.$mpg > 20, ]`
+    // selects 14 rows in R. The inner `.` must resolve to the LHS.
+    let diags = check("a <- mtcars %>% .[.$mpg > 20, ]\nb <- mtcars %>% .$mpg[.$cyl > 4]\n");
+    assert!(
+        diags.iter().all(|d| d.code != "RY010"),
+        "a `.` inside a subscript should not emit RY010, got {:?}",
+        diags
+    );
+}
+
+#[test]
+fn pipe_placeholders_are_specific_to_their_pipe_form() {
+    // Each pipe binds only its own placeholder: `.` is magrittr's, `_`
+    // is the native pipe's. Used in the other form they are ordinary
+    // identifier references, so they must still report RY010.
+    for (src, placeholder) in [
+        ("a <- mtcars |> .$mpg\n", "."),
+        ("b <- mtcars %>% _$mpg\n", "_"),
+    ] {
+        let diags = check(src);
+        assert!(
+            diags
+                .iter()
+                .any(|d| d.code == "RY010" && d.message.contains(placeholder)),
+            "`{}` is unbound in `{}`, got {:?}",
+            placeholder,
+            src.trim(),
+            diags
+        );
+    }
 }
 
 #[test]

--- a/crates/ry-checker/src/tests.rs
+++ b/crates/ry-checker/src/tests.rs
@@ -2544,6 +2544,26 @@ fn pipe_dot_pronoun_dollar_column() {
 }
 
 #[test]
+fn pipe_underscore_placeholder_extraction() {
+    // R >= 4.3 allows the native-pipe placeholder as the base of an
+    // extraction: `mtcars |> _$mpg`. The `_` is the piped LHS, so it
+    // must not be reported as an unbound variable (issue #27).
+    let (diags, scope) = check_with_scope(
+        "col <- mtcars |> _$mpg\nm <- mtcars |> _$mpg |> mean()\nalso <- mtcars |> _[[\"mpg\"]]\n",
+    );
+    assert!(
+        diags.iter().all(|d| d.code != "RY010"),
+        "`_` extraction placeholder should not emit RY010, got {:?}",
+        diags
+    );
+    let col = scope.get("col").expect("col should be bound");
+    assert_eq!(col.mode, Mode::Double, "mtcars |> _$mpg must infer double");
+    assert_eq!(col.length, Length::Known(32), "mpg has 32 rows");
+    let also = scope.get("also").expect("also should be bound");
+    assert_eq!(also.mode, Mode::Double, "mtcars |> _[[\"mpg\"]] is double");
+}
+
+#[test]
 fn pipe_dot_pronoun_double_bracket() {
     // `df %>% .[["mpg"]]` resolves `.` to the LHS and indexes by
     // string-literal column name via `[[`, mirroring `$` semantics.

--- a/crates/ry-core/src/ast.rs
+++ b/crates/ry-core/src/ast.rs
@@ -188,10 +188,19 @@ pub enum BinOpKind {
     In,
     Assign,
     SuperAssign,
-    /// `|>` (base R 4.1+) and `%>%` (magrittr). Both desugar the same
-    /// way at v1: `lhs |> rhs` calls `rhs` with `lhs` prepended to its
-    /// positional arguments (or substituted into the placeholder).
+    /// `%>%` (magrittr). `lhs %>% rhs` calls `rhs` with `lhs` prepended
+    /// to its positional arguments, or substituted into the `.`
+    /// placeholder. Unlike [`BinOpKind::PipeNative`]'s single `_`
+    /// insertion point, `.` may appear any number of times anywhere in
+    /// the RHS (`x %>% paste(., ., sep = "-")`, `x %>% sum(rev(.))`);
+    /// only a top-level `.` argument suppresses the prepended LHS.
     PipeForward,
+    /// `|>` (base R 4.1+). Inserts the LHS as the first argument of the
+    /// RHS call. R 4.2+ additionally allows `_` once, and only as a named
+    /// argument (`x |> f(y = _)`) — never positionally or nested inside an
+    /// inner call — and R 4.3+ allows it at the root of an extraction
+    /// chain (`x |> _$col`). Its placeholder is `_`, never magrittr's `.`.
+    PipeNative,
     /// `%T>%` (magrittr tee pipe). Returns the LHS, ignoring RHS.
     PipeTee,
     /// `%<>%` (magrittr assignment pipe). `x %<>% f()` is `x <- x %>% f()`.

--- a/crates/ry-core/src/parser.rs
+++ b/crates/ry-core/src/parser.rs
@@ -540,7 +540,7 @@ impl RParser {
             "|" => BinOpKind::Or,
             "||" => BinOpKind::OrOr,
             "%in%" => BinOpKind::In,
-            "|>" => BinOpKind::PipeForward,
+            "|>" => BinOpKind::PipeNative,
             "%>%" => BinOpKind::PipeForward,
             "%T>%" => BinOpKind::PipeTee,
             "%<>%" => BinOpKind::PipeAssign,
@@ -1127,11 +1127,12 @@ mod tests {
 
     #[test]
     fn parses_base_r_pipe() {
-        // Base-R `|>` lowers to PipeForward.
+        // Base-R `|>` lowers to PipeNative (distinct from magrittr's
+        // `%>%` so the checker can tell `_` and `.` placeholders apart).
         let f = parse("c(1, 2, 3) |> mean()\n");
         match f.stmts.first() {
             Some(Stmt::Expr(Expr::BinOp {
-                op: BinOpKind::PipeForward,
+                op: BinOpKind::PipeNative,
                 lhs,
                 rhs,
                 ..


### PR DESCRIPTION
`mtcars |> _$mpg` and `df |> _[["col"]]` use R 4.3's extraction placeholder, but the pipe RHS index arm only matched magrittr's `.` pronoun, so `_` fell through and was reported as an unbound variable (RY010). Match any pipe placeholder there so it resolves to the piped LHS and the extracted type is inferred.

Closes #27


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed false `RY010` warnings when using native `|>` placeholder (`_`) with extraction/indexing (including chained cases).
  * Corrected Magrittr `%>%` `.` substitution across repeated and nested call arguments.
  * Now reports `RY010` when placeholders are used with the wrong pipe style.
* **Documentation**
  * Clarified placeholder and pipe (`%>%`, `|>`) behavior in developer documentation.
* **Tests**
  * Added regression tests for native/base-R pipe extraction/indexing and placeholder mismatch scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->