### PR TITLE
checker: higher-order formals, inference, and x_times cleanup

### DIFF
--- a/crates/ry-checker/src/collect.rs
+++ b/crates/ry-checker/src/collect.rs
@@ -19,9 +19,13 @@ impl Checker {
                 // to be resolvable from other files (and from later in
                 // this same file) without triggering RY010.
                 if let Some(name) = binding_name(target) {
-                    Arc::make_mut(&mut self.fn_table)
-                        .known_vars
-                        .insert(name.to_string());
+                    let table = Arc::make_mut(&mut self.fn_table);
+                    table.known_vars.insert(name.to_string());
+                    if is_callable_object_constructor(value) {
+                        table.callable_vars.insert(name.to_string());
+                    } else {
+                        table.callable_vars.remove(name);
+                    }
                 }
                 if let (Some(name), Expr::Function { params, body, .. }) =
                     (binding_name(target), value)
@@ -496,6 +500,20 @@ impl Checker {
 /// `match.call()`, `sys.call()`, and `sys.function()` capture the complete
 /// call, so they make every formal quoting. `missing(p)` is deliberately not
 /// included: it tests a promise without changing how an argument is evaluated.
+fn is_callable_object_constructor(expression: &Expr) -> bool {
+    let Expr::Call { func, .. } = expression else {
+        return false;
+    };
+    matches!(
+        func.as_ref(),
+        Expr::Ident { name, .. }
+            if matches!(
+                name.as_str(),
+                "S7::new_class" | "S7::new_generic" | "S7::new_S3_class"
+            )
+    )
+}
+
 fn parameter_is_quoted(body: &[Stmt], params: &[Param], parameter: &str) -> bool {
     body.iter().any(stmt_captures_all_arguments)
         || (params.iter().any(|formal| formal.name == parameter)
@@ -554,10 +572,8 @@ fn stmt_captures_all_arguments(statement: &Stmt) -> bool {
 fn expr_captures_all_arguments(expression: &Expr) -> bool {
     match expression {
         Expr::Call { func, args, .. } => {
-            matches!(
-                bare_call_name(func),
-                Some("match.call" | "sys.call" | "sys.function")
-            ) || expr_captures_all_arguments(func)
+            matches!(bare_call_name(func), Some("match.call" | "sys.call"))
+                || expr_captures_all_arguments(func)
                 || args
                     .iter()
                     .any(|argument| expr_captures_all_arguments(&argument.value))
@@ -774,6 +790,10 @@ fn expr_captures_promise_parameter(expression: &Expr, parameter: &str) -> bool {
 /// Whether a package stub declares this callee as a promise-capture helper.
 /// Collection happens before ordinary call-site resolution, so bare names are
 /// recognized from the loaded stub inventory rather than lexical scope.
+///
+/// Unqualified names resolve against a one-time global index built from the
+/// embedded base and package stubs, so each call-site check is a single map
+/// lookup instead of a scan of the whole package inventory.
 fn is_promise_capture(function: &Expr, dots: bool) -> bool {
     let Some(name) = ident_name(function) else {
         return false;
@@ -782,27 +802,73 @@ fn is_promise_capture(function: &Expr, dots: bool) -> bool {
         .rsplit_once("::")
         .map(|(package, function)| (Some(package.trim_end_matches(':')), function))
         .unwrap_or((None, name));
-    let has_capture = |signature: &FunctionSig| {
-        signature.eval.iter().any(|(parameter, mode)| {
-            *mode == EvalMode::CapturesPromise && (parameter == "...") == dots
-        })
-    };
     match package {
         Some(package) => ry_typeshed::load_package(package)
             .and_then(|typeshed| typeshed.functions.get(function))
-            .is_some_and(has_capture),
-        None => {
-            ry_typeshed::load_base_cached()
-                .ok()
-                .and_then(|typeshed| typeshed.functions.get(function))
-                .is_some_and(has_capture)
-                || ry_typeshed::known_packages().any(|package| {
-                    ry_typeshed::load_package(package)
-                        .and_then(|typeshed| typeshed.functions.get(function))
-                        .is_some_and(has_capture)
-                })
-        }
+            .is_some_and(|signature| signature_captures_promises(signature, dots)),
+        // Unqualified names consult the one-time global index below.
+        //
+        // Known limitation: the index is built exclusively from the
+        // embedded base and the bundled package stubs, NOT from
+        // user-provided stubs installed via `Checker::set_user_stubs`.
+        // A custom stub that DECLARES a promise-capturing helper is
+        // therefore recognized only when called QUALIFIED
+        // (`mypkg::captures(...)`, which reaches the stub through
+        // `load_package`); an unqualified `captures(...)` call to such a
+        // user-stub helper is treated as an ordinary function. This is a
+        // deliberate trade-off: scoring unqualified names against the
+        // per-checker user stubs would thread an `&Arc<BTreeMap>` through
+        // the entire quoting-analysis call tree for an edge case, so we
+        // document rather than refactor. The qualified path is unaffected.
+        None => promise_capture_index()
+            .get(function)
+            .is_some_and(|&(single, dots_capture)| if dots { dots_capture } else { single }),
     }
+}
+
+/// Whether `signature` declares a promise-capturing parameter: a `...`
+/// capture when `dots` is set, otherwise a named-parameter capture.
+fn signature_captures_promises(signature: &FunctionSig, dots: bool) -> bool {
+    signature
+        .eval
+        .iter()
+        .any(|(parameter, mode)| *mode == EvalMode::CapturesPromise && (parameter == "...") == dots)
+}
+
+/// One-time global index over the embedded base and package stubs:
+/// function name -> (named-parameter capture, `...` capture). Built
+/// lazily on first use; `is_promise_capture` consults it for
+/// unqualified names instead of re-scanning every package's function
+/// table on every call-site check.
+fn promise_capture_index() -> &'static std::collections::HashMap<String, (bool, bool)> {
+    static INDEX: std::sync::OnceLock<std::collections::HashMap<String, (bool, bool)>> =
+        std::sync::OnceLock::new();
+    INDEX.get_or_init(|| {
+        let mut index = std::collections::HashMap::new();
+        let mut add_typeshed = |typeshed: &ry_typeshed::Typeshed| {
+            for (name, signature) in &typeshed.functions {
+                let flags = index.entry(name.clone()).or_insert((false, false));
+                for (parameter, mode) in &signature.eval {
+                    if *mode == EvalMode::CapturesPromise {
+                        if parameter == "..." {
+                            flags.1 = true;
+                        } else {
+                            flags.0 = true;
+                        }
+                    }
+                }
+            }
+        };
+        if let Ok(base) = ry_typeshed::load_base_cached() {
+            add_typeshed(base);
+        }
+        for package in ry_typeshed::known_packages() {
+            if let Some(typeshed) = ry_typeshed::load_package(package) {
+                add_typeshed(typeshed);
+            }
+        }
+        index
+    })
 }
 
 fn is_single_promise_capture(function: &Expr) -> bool {
@@ -1214,10 +1280,14 @@ fn statement_force_flow(statement: &Stmt, name: &str) -> (bool, bool) {
             let forces = expression_must_force(cond, name) || (then_forces && else_forces);
             (forces, then_falls && else_falls)
         }
-        Stmt::For { iter, body, .. } => (
-            expression_must_force(iter, name),
-            block_force_flow(body, name).1,
-        ),
+        // A `for` loop always falls through for force-flow purposes: an
+        // empty iterable never runs the body, so a name forced only
+        // inside the body is not guaranteed on any path (and the code
+        // after the loop is always reachable, even when the body
+        // `return`s on its first iteration). Reporting the body's
+        // fall-through as the loop's own could wrongly mark a parameter
+        // required.
+        Stmt::For { iter, .. } => (expression_must_force(iter, name), true),
         Stmt::While { cond, .. } => (expression_must_force(cond, name), false),
         Stmt::Return { value, .. } => (
             value

--- a/crates/ry-checker/src/higher_order.rs
+++ b/crates/ry-checker/src/higher_order.rs
@@ -524,22 +524,19 @@ impl Checker {
         arg_types: &[RType],
         scope: &mut Scope,
     ) {
-        let spec = match self
-            .resolve_typeshed_sig(name)
-            .and_then(|signature| signature.higher_order)
-        {
+        let signature = match self.resolve_typeshed_sig(name) {
+            Some(signature) => signature,
+            None => return,
+        };
+        let spec = match signature.higher_order.as_ref() {
             Some(spec) => spec,
             None => return,
         };
         if matches!(spec.result.kind, HigherOrderResultKind::CallbackIdentity) {
             return;
         }
-        let signature = match self.resolve_typeshed_sig(name) {
-            Some(signature) => signature,
-            None => return,
-        };
         let argument_match = higher_order_argument_match(&signature.params, args);
-        let elem_types = self.higher_order_callback_types(&spec, arg_types, &argument_match);
+        let elem_types = self.higher_order_callback_types(spec, arg_types, &argument_match);
         let cb = match argument_bound_to_formal(args, &argument_match, spec.callback_position) {
             Some(argument) => &argument.value,
             None => return,

--- a/crates/ry-checker/src/higher_order.rs
+++ b/crates/ry-checker/src/higher_order.rs
@@ -1,6 +1,66 @@
 use super::*;
 use crate::infer::*;
 
+fn higher_order_argument_match(params: &[ParamSpec], args: &[Arg]) -> ArgumentMatch {
+    let names = params
+        .iter()
+        .map(|parameter| parameter.name.as_str())
+        .collect::<Vec<_>>();
+    match_arguments(&names, args)
+}
+
+fn matched_argument_index(argument_match: &ArgumentMatch, formal_index: usize) -> Option<usize> {
+    argument_match
+        .param_for_arg
+        .iter()
+        .position(|matched| *matched == Some(formal_index))
+}
+
+fn matched_argument_type<'a>(
+    arg_types: &'a [RType],
+    argument_match: &ArgumentMatch,
+    formal_index: usize,
+) -> Option<&'a RType> {
+    matched_argument_index(argument_match, formal_index).and_then(|index| arg_types.get(index))
+}
+
+fn argument_bound_to_formal<'a>(
+    args: &'a [Arg],
+    argument_match: &ArgumentMatch,
+    formal_index: usize,
+) -> Option<&'a Arg> {
+    matched_argument_index(argument_match, formal_index).and_then(|index| args.get(index))
+}
+
+/// `HigherOrderSpec` argument indices name formal slots, never raw call
+/// positions. Build one ordinary R argument match and use it for callback,
+/// source, length, and template lookup throughout the higher-order path.
+struct HigherOrderCall<'a> {
+    args: &'a [Arg],
+    arg_types: &'a [RType],
+    argument_match: &'a ArgumentMatch,
+}
+
+fn arguments_bound_to_dots<'a>(
+    arg_types: &'a [RType],
+    argument_match: &'a ArgumentMatch,
+) -> impl Iterator<Item = &'a RType> {
+    arg_types
+        .iter()
+        .enumerate()
+        .filter_map(|(index, argument_type)| {
+            // With a `...` formal, every unmatched actual is part of dots.
+            // Preserve actual call order because Map/mapply pass that order
+            // on to the callback.
+            (argument_match.dots.is_some()
+                && argument_match
+                    .param_for_arg
+                    .get(index)
+                    .is_some_and(Option::is_none))
+            .then_some(argument_type)
+        })
+}
+
 impl Checker {
     pub(crate) fn infer_higher_order_call(
         &mut self,
@@ -10,8 +70,15 @@ impl Checker {
         scope: &Scope,
         span: Span,
     ) -> Option<RType> {
-        let spec = self.resolve_typeshed_sig(name)?.higher_order?;
-        Some(self.infer_ho_result(name, &spec, args, arg_types, scope, span))
+        let signature = self.resolve_typeshed_sig(name)?;
+        let spec = signature.higher_order.as_ref()?;
+        let argument_match = higher_order_argument_match(&signature.params, args);
+        let call = HigherOrderCall {
+            args,
+            arg_types,
+            argument_match: &argument_match,
+        };
+        Some(self.infer_ho_result(name, spec, &call, scope, span))
     }
 
     /// Per-builtin result-type computation. Used by both pass 2 (pure,
@@ -19,21 +86,20 @@ impl Checker {
     /// the pass-3 entry point: it calls `self.infer` on data
     /// arguments (which may emit RY010 etc.) before computing the
     /// element type.
-    pub(crate) fn infer_ho_result(
+    fn infer_ho_result(
         &mut self,
         name: &str,
         spec: &HigherOrderSpec,
-        args: &[Arg],
-        arg_types: &[RType],
+        call: &HigherOrderCall<'_>,
         scope: &Scope,
         span: Span,
     ) -> RType {
-        let callback_types = self.higher_order_callback_types(spec, arg_types);
-        let callback = Self::extract_callback(
-            args,
-            &[spec.callback_param.as_str()],
-            spec.callback_position,
-        );
+        let args = call.args;
+        let arg_types = call.arg_types;
+        let argument_match = call.argument_match;
+        let callback_types = self.higher_order_callback_types(spec, arg_types, argument_match);
+        let callback = argument_bound_to_formal(args, argument_match, spec.callback_position)
+            .map(|argument| &argument.value);
         let callback_return = callback
             .and_then(|callback| self.callback_return_type(callback, &callback_types, scope));
         match spec.result.kind {
@@ -41,7 +107,7 @@ impl Checker {
                 let length = spec
                     .result
                     .length_arg
-                    .and_then(|i| arg_types.get(i))
+                    .and_then(|i| matched_argument_type(arg_types, argument_match, i))
                     .map(|ty| ty.length)
                     .unwrap_or(Length::Unknown);
                 let mut result = RType::new(Mode::List, length);
@@ -87,16 +153,19 @@ impl Checker {
                 let length = spec
                     .result
                     .length_arg
-                    .and_then(|i| arg_types.get(i))
+                    .and_then(|i| matched_argument_type(arg_types, argument_match, i))
                     .map(|ty| ty.length)
                     .unwrap_or(Length::One);
                 RType::new(mode, length)
             }
             HigherOrderResultKind::SameAsArg0 => {
-                let mut result = arg_types
-                    .get(spec.result.source_arg.unwrap_or(0))
-                    .cloned()
-                    .unwrap_or_else(RType::unknown);
+                let mut result = matched_argument_type(
+                    arg_types,
+                    argument_match,
+                    spec.result.source_arg.unwrap_or(0),
+                )
+                .cloned()
+                .unwrap_or_else(RType::unknown);
                 if spec.result.unknown_length {
                     result.length = Length::Unknown;
                 }
@@ -104,21 +173,23 @@ impl Checker {
             }
             HigherOrderResultKind::CallbackReturn => {
                 if let Some(index) = spec.result.source_arg {
-                    arg_types
-                        .get(index)
+                    matched_argument_type(arg_types, argument_match, index)
                         .map(RType::element)
                         .unwrap_or_else(RType::unknown)
                 } else {
                     callback_return.unwrap_or_else(RType::unknown)
                 }
             }
-            HigherOrderResultKind::FirstArg => arg_types
-                .get(spec.result.source_arg.unwrap_or(0))
-                .cloned()
-                .unwrap_or_else(RType::unknown),
+            HigherOrderResultKind::FirstArg => matched_argument_type(
+                arg_types,
+                argument_match,
+                spec.result.source_arg.unwrap_or(0),
+            )
+            .cloned()
+            .unwrap_or_else(RType::unknown),
             HigherOrderResultKind::Simplify => {
                 if spec.callback_args == [CallbackArg::Unknown] {
-                    return self.ho_rapply(args, arg_types, scope);
+                    return self.ho_rapply(args, arg_types, argument_match, scope);
                 }
                 match callback_return {
                     Some(ty)
@@ -128,7 +199,7 @@ impl Checker {
                         let length = spec
                             .result
                             .length_arg
-                            .and_then(|i| arg_types.get(i))
+                            .and_then(|i| matched_argument_type(arg_types, argument_match, i))
                             .map(|ty| ty.length)
                             .unwrap_or(Length::Unknown);
                         RType::new(ty.mode, length)
@@ -140,7 +211,7 @@ impl Checker {
                 let template = spec
                     .result
                     .template_position
-                    .and_then(|i| arg_types.get(i))
+                    .and_then(|i| matched_argument_type(arg_types, argument_match, i))
                     .cloned()
                     .unwrap_or_else(RType::unknown);
                 let mode = if matches!(template.mode, Mode::Union) {
@@ -151,7 +222,7 @@ impl Checker {
                 let length = if matches!(template.length, Length::One) {
                     spec.result
                         .length_arg
-                        .and_then(|i| arg_types.get(i))
+                        .and_then(|i| matched_argument_type(arg_types, argument_match, i))
                         .map(|ty| ty.length)
                         .unwrap_or(Length::Unknown)
                 } else {
@@ -159,7 +230,9 @@ impl Checker {
                 };
                 RType::new(mode, length)
             }
-            HigherOrderResultKind::CallbackIdentity => self.ho_callback_identity(spec, args, scope),
+            HigherOrderResultKind::CallbackIdentity => {
+                self.ho_callback_identity(spec, args, argument_match, scope)
+            }
         }
     }
 
@@ -167,58 +240,34 @@ impl Checker {
         &self,
         spec: &HigherOrderSpec,
         arg_types: &[RType],
+        argument_match: &ArgumentMatch,
     ) -> Vec<RType> {
         let mut types = Vec::new();
         for callback_arg in &spec.callback_args {
             match callback_arg {
                 CallbackArg::ElementOfArg0 => types.push(
-                    arg_types
-                        .first()
+                    matched_argument_type(arg_types, argument_match, 0)
                         .map(RType::element)
                         .unwrap_or_else(RType::unknown),
                 ),
                 CallbackArg::ElementOfArg1 => types.push(
-                    arg_types
-                        .get(1)
+                    matched_argument_type(arg_types, argument_match, 1)
                         .map(RType::element)
                         .unwrap_or_else(RType::unknown),
                 ),
                 CallbackArg::Unknown => types.push(RType::unknown()),
                 CallbackArg::AccumulatorAndElement => {
                     let data_index = if spec.callback_position == 0 { 1 } else { 0 };
-                    let element = arg_types
-                        .get(data_index)
+                    let element = matched_argument_type(arg_types, argument_match, data_index)
                         .map(RType::element)
                         .unwrap_or_else(RType::unknown);
                     types.extend([element.clone(), element]);
                 }
-                CallbackArg::ElementsAfterCallback => types.extend(
-                    arg_types
-                        .iter()
-                        .skip(spec.callback_position + 1)
-                        .map(RType::element),
-                ),
+                CallbackArg::ElementsAfterCallback => types
+                    .extend(arguments_bound_to_dots(arg_types, argument_match).map(RType::element)),
             }
         }
         types
-    }
-
-    /// Extract the callback expression from an argument list by name
-    /// (`FUN`, `f`) or by positional index. Returns `None` when no
-    /// callback argument is present.
-    pub(crate) fn extract_callback<'a>(
-        args: &'a [Arg],
-        names: &[&str],
-        positional_idx: usize,
-    ) -> Option<&'a Expr> {
-        for a in args {
-            if let Some(n) = a.name.as_deref() {
-                if names.contains(&n) {
-                    return Some(&a.value);
-                }
-            }
-        }
-        args.get(positional_idx).map(|a| &a.value)
     }
 
     /// If `expr` is a `purrr::in_parallel(.f)` / `in_parallel(.f)` call
@@ -254,14 +303,11 @@ impl Checker {
         &mut self,
         spec: &HigherOrderSpec,
         args: &[Arg],
+        argument_match: &ArgumentMatch,
         scope: &Scope,
     ) -> RType {
-        let cb = match Self::extract_callback(
-            args,
-            &[spec.callback_param.as_str()],
-            spec.callback_position,
-        ) {
-            Some(c) => c,
+        let cb = match argument_bound_to_formal(args, argument_match, spec.callback_position) {
+            Some(argument) => &argument.value,
             None => return RType::unknown(),
         };
         match cb {
@@ -285,9 +331,18 @@ impl Checker {
     /// `rapply(L, f, ...)`: recursively applies `f` to each leaf of
     /// list `L`. The result is a list of the same shape. We model only
     /// the top-level shape: result is a list with L's length.
-    pub(crate) fn ho_rapply(&mut self, args: &[Arg], arg_types: &[RType], scope: &Scope) -> RType {
-        let l_type = arg_types.first().cloned().unwrap_or(RType::unknown());
-        let callback_return = Self::extract_callback(args, &["f", "FUN"], 1)
+    pub(crate) fn ho_rapply(
+        &mut self,
+        args: &[Arg],
+        arg_types: &[RType],
+        argument_match: &ArgumentMatch,
+        scope: &Scope,
+    ) -> RType {
+        let l_type = matched_argument_type(arg_types, argument_match, 0)
+            .cloned()
+            .unwrap_or_else(RType::unknown);
+        let callback_return = argument_bound_to_formal(args, argument_match, 1)
+            .map(|argument| &argument.value)
             .and_then(|cb| self.callback_return_type(cb, &[RType::unknown()], scope));
         let how = args
             .iter()
@@ -479,13 +534,14 @@ impl Checker {
         if matches!(spec.result.kind, HigherOrderResultKind::CallbackIdentity) {
             return;
         }
-        let elem_types = self.higher_order_callback_types(&spec, arg_types);
-        let cb = match Self::extract_callback(
-            args,
-            &[spec.callback_param.as_str()],
-            spec.callback_position,
-        ) {
-            Some(c) => c,
+        let signature = match self.resolve_typeshed_sig(name) {
+            Some(signature) => signature,
+            None => return,
+        };
+        let argument_match = higher_order_argument_match(&signature.params, args);
+        let elem_types = self.higher_order_callback_types(&spec, arg_types, &argument_match);
+        let cb = match argument_bound_to_formal(args, &argument_match, spec.callback_position) {
+            Some(argument) => &argument.value,
             None => return,
         };
         // Look through a `purrr::in_parallel(.f)` wrapper so the inner
@@ -559,14 +615,13 @@ impl Checker {
                 if let Some(sig) = self.typeshed.s3_methods.get(&key).cloned() {
                     return Some(self.apply_sig(candidate, &sig, arg_types, &[], span));
                 }
-                for pkg in self.available_package_names() {
-                    if let Some(sig) = self
-                        .package_typeshed(pkg)
+                let sig = self.available_package_names().find_map(|pkg| {
+                    self.package_typeshed(pkg)
                         .and_then(|t| t.s3_methods.get(&key))
                         .cloned()
-                    {
-                        return Some(self.apply_sig(candidate, &sig, arg_types, &[], span));
-                    }
+                });
+                if let Some(sig) = sig {
+                    return Some(self.apply_sig(candidate, &sig, arg_types, &[], span));
                 }
             }
         }

--- a/crates/ry-checker/src/infer/call.rs
+++ b/crates/ry-checker/src/infer/call.rs
@@ -54,6 +54,28 @@ impl Checker {
             }
         };
 
+        // An explicitly qualified typed package value is known not to be
+        // callable. Bare names wait until after lexical callable lookup below,
+        // because a local function or function-valued formal may legitimately
+        // shadow an attached package constant.
+        if name.contains("::")
+            && let Some(value_type) = self.resolve_typeshed_value(&name)
+        {
+            self.emit(
+                Severity::Error,
+                span,
+                "RY070",
+                format!(
+                    "`{}` is `{}`, not a function; cannot call it",
+                    name, value_type.mode
+                ),
+            );
+            for argument in args {
+                self.infer(&argument.value, scope);
+            }
+            return RType::unknown();
+        }
+
         // For namespace-qualified calls (`pkg::fn(args)`), strip the
         // package prefix for the typeshed / FnTable / higher-order /
         // S3-generic lookups below, so `stats::rnorm(10)` resolves the
@@ -816,7 +838,12 @@ impl Checker {
                     // through to the resolution below instead of firing RY070.
                     // Only when no function of that name exists anywhere does
                     // calling the non-function value warrant RY070.
-                    let has_function_elsewhere = self.has_function_anywhere(&name);
+                    // A concrete lexical value at this point wins over the
+                    // whole-project callable inventory; a later or cross-file
+                    // S7 constructor must not hide this proven call error.
+                    let has_function_elsewhere = self.has_function_anywhere(&name)
+                        && (scope.is_default_parameter(&name)
+                            || !self.fn_table.callable_vars.contains(&name));
                     if !has_function_elsewhere {
                         // RY070: a non-function value is being called as if it
                         // were a function. R errors at runtime with
@@ -838,6 +865,23 @@ impl Checker {
                 // Opaque: fall through; the name might still resolve via
                 // the FnTable or typeshed below.
             }
+        }
+
+        // No lexical callable won. A bare typed package value is therefore a
+        // non-function call, not a zero-argument function signature.
+        if scope.get(&lookup_name).is_none()
+            && let Some(value_type) = self.resolve_typeshed_value(&name)
+        {
+            self.emit(
+                Severity::Error,
+                span,
+                "RY070",
+                format!(
+                    "`{}` is `{}`, not a function; cannot call it",
+                    name, value_type.mode
+                ),
+            );
+            return RType::unknown();
         }
 
         // Built-in: `c(...)` concatenates and produces the common mode.
@@ -968,7 +1012,7 @@ impl Checker {
         // we can pin the result length exactly. We place this AFTER the
         // FnTable lookup so a user-defined `rep`/`seq` still wins, and
         // BEFORE the typeshed so the precise length is preferred over
-        // the conservative `x_times` / `unknown` spec.
+        // the conservative `unknown` spec.
         if lookup_name == "vector" {
             return self.infer_vector(args);
         }

--- a/crates/ry-checker/src/infer/construct.rs
+++ b/crates/ry-checker/src/infer/construct.rs
@@ -520,8 +520,6 @@ impl Checker {
                     Some(JsonLength::LongestArg) => longest_arg_length(arg_types),
                     // Number of arguments (for list()).
                     Some(JsonLength::NArgs) => Length::Known(args.len()),
-                    // x_times: arg0 length * arg1 value (for rep).
-                    Some(JsonLength::XTimes) => rep_length(arg_types),
                     Some(JsonLength::Test) => first.length,
                     None => Length::Unknown,
                 };

--- a/crates/ry-checker/src/infer/index.rs
+++ b/crates/ry-checker/src/infer/index.rs
@@ -278,9 +278,19 @@ impl Checker {
                         Mode::Integer | Mode::Double if positive_numeric_index(&args[0].value) => {
                             index.length
                         }
+                        Mode::Integer | Mode::Double => {
+                            literal_negative_exclusion_length(bt.length, &args[0].value)
+                                .unwrap_or(Length::Unknown)
+                        }
                         _ => Length::Unknown,
                     };
-                    return RType { length, ..bt };
+                    let mut result = RType { length, ..bt };
+                    // Generic `[` changes which names/elements are present.
+                    // Until we transform ColumnSchema by the index itself,
+                    // retaining the source schema would expose fields that the
+                    // subset may not contain (e.g. list(a=1, b=2)[2]$a).
+                    result.columns = None;
+                    return result;
                 }
                 bt
             }
@@ -340,6 +350,40 @@ fn positive_numeric_index(expr: &Expr) -> bool {
         }
         _ => false,
     }
+}
+
+/// Exact result length for a single literal negative exclusion. R ignores an
+/// out-of-range exclusion; an in-range exclusion removes exactly one element.
+/// Dynamic or compound negative indices remain unknown until the AST/value
+/// model can prove uniqueness and bounds for every excluded position.
+fn literal_negative_exclusion_length(base: Length, expr: &Expr) -> Option<Length> {
+    let Expr::UnaryOp {
+        op: UnaryOpKind::Neg,
+        expr,
+        ..
+    } = expr
+    else {
+        return None;
+    };
+    let excluded = match expr.as_ref() {
+        Expr::Integer(index, _) if *index > 0 => *index as usize,
+        Expr::Double(index, _) if index.is_finite() && *index > 0.0 && index.fract() == 0.0 => {
+            *index as usize
+        }
+        _ => return None,
+    };
+    let base = match base {
+        Length::Zero => 0,
+        Length::One => 1,
+        Length::Known(length) => length,
+        Length::Unknown => return None,
+    };
+    let length = base - usize::from(excluded <= base);
+    Some(match length {
+        0 => Length::Zero,
+        1 => Length::One,
+        length => Length::Known(length),
+    })
 }
 
 /// Apply a `SeverityFilter` to a vec of diagnostics in place. Each

--- a/crates/ry-checker/src/infer/index.rs
+++ b/crates/ry-checker/src/infer/index.rs
@@ -252,31 +252,35 @@ impl Checker {
                         return RType::unknown();
                     }
                 }
-                // Single-bracket subsetting semantics are complex
-                // (column slice vs row slice depends on commas and
-                // drops). For atomic vectors with one scalar index,
-                // however, the result is a scalar of the same mode.
-                let scalar_atomic_index = args.len() == 1
-                    && args
-                        .first()
-                        .is_some_and(|a| is_non_negative_scalar_index(&a.value, scope))
-                    && matches!(
-                        bt.mode,
-                        Mode::Integer
-                            | Mode::Double
-                            | Mode::Character
-                            | Mode::Logical
-                            | Mode::Complex
-                            | Mode::Raw
-                    );
-                for a in args {
-                    self.infer(&a.value, scope);
-                }
-                if scalar_atomic_index {
-                    return RType {
-                        length: Length::One,
-                        ..bt
+                // For one-dimensional vector subsetting, result length is
+                // controlled by the index rather than the source. Logical
+                // masks select by their TRUE count, and numeric indices may
+                // exclude or select nothing, so retain a length only when R's
+                // index mode makes that length provable.
+                let index_types: Vec<_> = args
+                    .iter()
+                    .map(|argument| self.infer(&argument.value, scope))
+                    .collect();
+                let vector_base = matches!(
+                    bt.mode,
+                    Mode::Integer
+                        | Mode::Double
+                        | Mode::Character
+                        | Mode::Logical
+                        | Mode::Complex
+                        | Mode::Raw
+                        | Mode::List
+                );
+                if vector_base && args.len() == 1 {
+                    let index = &index_types[0];
+                    let length = match index.mode {
+                        Mode::Character => index.length,
+                        Mode::Integer | Mode::Double if positive_numeric_index(&args[0].value) => {
+                            index.length
+                        }
+                        _ => Length::Unknown,
                     };
+                    return RType { length, ..bt };
                 }
                 bt
             }
@@ -309,22 +313,31 @@ impl Checker {
 }
 
 /// Whether an index expression is a scalar element selector, rather than a
-/// negative exclusion selector. R has no sign information in `RType`, so a
-/// scalar identifier is accepted while syntactically negative literals are
-/// deliberately rejected.
-pub(crate) fn is_non_negative_scalar_index(expr: &Expr, scope: &Scope) -> bool {
+/// negative exclusion selector. Zero selects no elements under `[`, so only a
+/// syntactically positive numeric literal proves scalar result length. A
+/// scalar identifier has unknown sign and is therefore not sufficient.
+pub(crate) fn is_non_negative_scalar_index(expr: &Expr, _scope: &Scope) -> bool {
     match expr {
-        Expr::Integer(index, _) => *index >= 0,
-        Expr::Double(index, _) => *index >= 0.0,
+        Expr::Integer(index, _) => *index > 0,
+        Expr::Double(index, _) => *index > 0.0,
         Expr::String(_, _) => true,
-        Expr::Ident { name, .. } => scope.get(name).is_some_and(|ty| {
-            matches!(ty.length, Length::One)
-                && matches!(ty.mode, Mode::Integer | Mode::Double | Mode::Character)
-        }),
-        Expr::UnaryOp {
-            op: UnaryOpKind::Neg,
-            ..
-        } => false,
+        _ => false,
+    }
+}
+
+/// Numeric subsetting preserves index length only when every index value is
+/// provably positive and non-zero. The AST currently retains concrete values
+/// for literals and `c(...)`; identifiers carry mode and length but no sign.
+fn positive_numeric_index(expr: &Expr) -> bool {
+    match expr {
+        Expr::Integer(index, _) => *index > 0,
+        Expr::Double(index, _) => index.is_finite() && *index > 0.0 && index.fract() == 0.0,
+        Expr::Call { func, args, .. } if matches!(func.as_ref(), Expr::Ident { name, .. } if name == "c") => {
+            !args.is_empty()
+                && args
+                    .iter()
+                    .all(|argument| positive_numeric_index(&argument.value))
+        }
         _ => false,
     }
 }
@@ -523,8 +536,8 @@ pub(crate) fn is_nse_symbol_fn(name: &str) -> bool {
         // ggplot2 NSE
         "from_theme" | "aes" | "aes_" | "aes_string" | "aes_q"
         // rlang NSE
-        | "sym" | "expr"
-        | "exprs" | "quo" | "quos" | "abort" | "inform"
+        | "sym" | "expr" | "enexpr" | "ensym"
+        | "exprs" | "quo" | "quos" | "enquo" | "enquos" | "ensyms" | "abort" | "inform"
         | "defuse" | "tidyeval_data" | "new_formula" | "new_quosure"
         // dplyr/tidyselect NSE
         | "tidyselect" | "all_vars" | "peek_vars"

--- a/crates/ry-checker/src/infer/misc.rs
+++ b/crates/ry-checker/src/infer/misc.rs
@@ -813,6 +813,23 @@ pub(crate) fn collect_forwarded_calls_in_expr(
     }
 }
 
+const DEFUSING_CALLS: [&str; 14] = [
+    "expression",
+    "quote",
+    "substitute",
+    "bquote",
+    "alist",
+    "expr",
+    "exprs",
+    "quo",
+    "quos",
+    "enexpr",
+    "enquo",
+    "ensym",
+    "enquos",
+    "ensyms",
+];
+
 impl Checker {
     /// Diagnose the narrow, provable lazy-default ordering bug where a
     /// parameter is used by an earlier top-level statement than the direct
@@ -824,11 +841,48 @@ impl Checker {
         assigned: &HashSet<String>,
     ) {
         let formals: HashSet<&str> = params.iter().map(|param| param.name.as_str()).collect();
+        let mut trusted_defusers: HashSet<String> =
+            DEFUSING_CALLS.into_iter().map(str::to_string).collect();
+        for (name, function) in &self.fn_table.fns {
+            if function
+                .params
+                .iter()
+                .all(|param| param.quoting || param.defused)
+            {
+                trusted_defusers.insert(name.clone());
+            } else {
+                trusted_defusers.remove(name);
+            }
+        }
 
         for param in params {
             let Some(default) = &param.default else {
                 continue;
             };
+
+            // A formal promise shadows every enclosing binding of the same
+            // name. Diagnose a recursive default only when the body actually
+            // forces that promise; defusing helpers such as enexpr()/enquo()
+            // may deliberately capture `function(x = x)` without evaluating
+            // the default.
+            let forced_in_body =
+                guaranteed_force_before_replacement(body, &param.name, &trusted_defusers);
+            if forced_in_body
+                && let Some(span) =
+                    first_executed_identifier(default, &param.name, &trusted_defusers)
+            {
+                self.emit(
+                    Severity::Warning,
+                    span,
+                    "RY098",
+                    format!(
+                        "parameter `{}` has a self-referential default that recurses when forced",
+                        param.name
+                    ),
+                );
+                continue;
+            }
+
             let mut references = HashSet::new();
             collect_executed_identifiers(default, &mut references);
 
@@ -845,7 +899,7 @@ impl Checker {
                 };
 
                 let forced = body[..assign_index].iter().find_map(|statement| {
-                    first_executed_identifier_in_stmt(statement, &param.name)
+                    definitely_forced_identifier_in_stmt(statement, &param.name, &trusted_defusers)
                 });
                 if let Some(span) = forced {
                     self.emit(
@@ -864,71 +918,218 @@ impl Checker {
     }
 }
 
-fn first_executed_identifier_in_stmt(statement: &Stmt, wanted: &str) -> Option<Span> {
+fn guaranteed_force_before_replacement(
+    body: &[Stmt],
+    wanted: &str,
+    trusted_defusers: &HashSet<String>,
+) -> bool {
+    for statement in body {
+        match statement {
+            Stmt::Assign {
+                target: Expr::Ident { name, .. },
+                value,
+                ..
+            } if name == wanted => {
+                return definitely_forced_identifier(value, wanted, trusted_defusers).is_some();
+            }
+            _ => {}
+        }
+        if definitely_forced_identifier_in_stmt(statement, wanted, trusted_defusers).is_some() {
+            return true;
+        }
+        if matches!(statement, Stmt::If { .. }) {
+            // A non-literal condition may take a diverging branch, so later
+            // statements are not guaranteed to execute.
+            return false;
+        }
+        let explicit_return = matches!(statement, Stmt::Return { .. })
+            || matches!(
+                statement,
+                Stmt::Expr(Expr::Call { func, .. })
+                    if matches!(func.as_ref(), Expr::Ident { name, .. } if name == "return")
+            );
+        if explicit_return {
+            return false;
+        }
+    }
+    false
+}
+
+/// Find a force that is guaranteed when this statement executes. Conditional
+/// branch bodies and loop bodies are not guaranteed to run; their conditions
+/// (and a for-loop's iterator) are.
+fn definitely_forced_identifier_in_stmt(
+    statement: &Stmt,
+    wanted: &str,
+    trusted_defusers: &HashSet<String>,
+) -> Option<Span> {
     match statement {
-        Stmt::Assign { value, .. } => first_executed_identifier(value, wanted),
-        Stmt::Expr(expr) => first_executed_identifier(expr, wanted),
+        Stmt::Assign { value, .. } | Stmt::Expr(value) => {
+            definitely_forced_identifier(value, wanted, trusted_defusers)
+        }
         Stmt::If {
             cond, then, else_, ..
-        } => first_executed_identifier(cond, wanted)
+        } => match cond {
+            Expr::Logical(true, span) => {
+                guaranteed_force_before_replacement(then, wanted, trusted_defusers).then_some(*span)
+            }
+            Expr::Logical(false, span) => else_.as_ref().and_then(|statements| {
+                guaranteed_force_before_replacement(statements, wanted, trusted_defusers)
+                    .then_some(*span)
+            }),
+            _ => definitely_forced_identifier(cond, wanted, trusted_defusers),
+        },
+        Stmt::While { cond, .. } => definitely_forced_identifier(cond, wanted, trusted_defusers),
+        Stmt::For { iter, .. } => definitely_forced_identifier(iter, wanted, trusted_defusers),
+        Stmt::Return { value, .. } => value
+            .as_ref()
+            .and_then(|value| definitely_forced_identifier(value, wanted, trusted_defusers)),
+        Stmt::FunctionDef { .. } => None,
+    }
+}
+
+fn definitely_forced_identifier(
+    expr: &Expr,
+    wanted: &str,
+    trusted_defusers: &HashSet<String>,
+) -> Option<Span> {
+    match expr {
+        Expr::If {
+            cond, then, else_, ..
+        } => match cond.as_ref() {
+            Expr::Logical(true, _) => definitely_forced_identifier(then, wanted, trusted_defusers),
+            Expr::Logical(false, _) => else_
+                .as_ref()
+                .and_then(|else_| definitely_forced_identifier(else_, wanted, trusted_defusers)),
+            _ => definitely_forced_identifier(cond, wanted, trusted_defusers),
+        },
+        Expr::BinOp {
+            lhs,
+            op: BinOpKind::AndAnd | BinOpKind::OrOr,
+            ..
+        } => definitely_forced_identifier(lhs, wanted, trusted_defusers),
+        Expr::Block { body, span } => {
+            guaranteed_force_before_replacement(body, wanted, trusted_defusers).then_some(*span)
+        }
+        _ => first_executed_identifier(expr, wanted, trusted_defusers),
+    }
+}
+
+fn first_executed_identifier_in_stmt(
+    statement: &Stmt,
+    wanted: &str,
+    trusted_defusers: &HashSet<String>,
+) -> Option<Span> {
+    match statement {
+        Stmt::Assign { value, .. } => first_executed_identifier(value, wanted, trusted_defusers),
+        Stmt::Expr(expr) => first_executed_identifier(expr, wanted, trusted_defusers),
+        Stmt::If {
+            cond, then, else_, ..
+        } => first_executed_identifier(cond, wanted, trusted_defusers)
             .or_else(|| {
-                then.iter()
-                    .find_map(|statement| first_executed_identifier_in_stmt(statement, wanted))
+                then.iter().find_map(|statement| {
+                    first_executed_identifier_in_stmt(statement, wanted, trusted_defusers)
+                })
             })
             .or_else(|| {
                 else_.as_ref().and_then(|statements| {
-                    statements
-                        .iter()
-                        .find_map(|statement| first_executed_identifier_in_stmt(statement, wanted))
+                    statements.iter().find_map(|statement| {
+                        first_executed_identifier_in_stmt(statement, wanted, trusted_defusers)
+                    })
                 })
             }),
-        Stmt::For { iter, body, .. } => first_executed_identifier(iter, wanted).or_else(|| {
-            body.iter()
-                .find_map(|statement| first_executed_identifier_in_stmt(statement, wanted))
-        }),
-        Stmt::While { cond, body, .. } => first_executed_identifier(cond, wanted).or_else(|| {
-            body.iter()
-                .find_map(|statement| first_executed_identifier_in_stmt(statement, wanted))
-        }),
+        Stmt::For { iter, body, .. } => first_executed_identifier(iter, wanted, trusted_defusers)
+            .or_else(|| {
+                body.iter().find_map(|statement| {
+                    first_executed_identifier_in_stmt(statement, wanted, trusted_defusers)
+                })
+            }),
+        Stmt::While { cond, body, .. } => first_executed_identifier(cond, wanted, trusted_defusers)
+            .or_else(|| {
+                body.iter().find_map(|statement| {
+                    first_executed_identifier_in_stmt(statement, wanted, trusted_defusers)
+                })
+            }),
         Stmt::Return { value, .. } => value
             .as_ref()
-            .and_then(|value| first_executed_identifier(value, wanted)),
+            .and_then(|value| first_executed_identifier(value, wanted, trusted_defusers)),
         // Defining a closure does not evaluate its body or force captures.
         Stmt::FunctionDef { .. } => None,
     }
 }
 
-fn first_executed_identifier(expr: &Expr, wanted: &str) -> Option<Span> {
+fn is_defusing_call(name: &str) -> bool {
+    let name = name.rsplit_once("::").map(|(_, bare)| bare).unwrap_or(name);
+    DEFUSING_CALLS.contains(&name)
+}
+
+fn first_executed_identifier(
+    expr: &Expr,
+    wanted: &str,
+    trusted_defusers: &HashSet<String>,
+) -> Option<Span> {
     match expr {
         Expr::Ident { name, span } => (name == wanted).then_some(*span),
-        Expr::Call { func, args, .. } => first_executed_identifier(func, wanted).or_else(|| {
-            args.iter()
-                .find_map(|argument| first_executed_identifier(&argument.value, wanted))
-        }),
-        Expr::BinOp { lhs, rhs, op, .. } => {
-            if matches!(op, BinOpKind::Assign | BinOpKind::SuperAssign) {
-                first_executed_identifier(rhs, wanted)
+        Expr::Call { func, args, .. } => {
+            let callee = ident_name(func);
+            if callee.is_some_and(|name| {
+                let qualified_defuser = name.rsplit_once("::").is_some_and(|(package, _)| {
+                    matches!(package.trim_end_matches(':'), "base" | "rlang")
+                        && is_defusing_call(name)
+                });
+                name == "missing" || qualified_defuser || trusted_defusers.contains(name)
+            }) {
+                first_executed_identifier(func, wanted, trusted_defusers)
+            } else if callee.is_some_and(|name| {
+                // Only explicitly qualified strict builtins establish
+                // guaranteed argument forcing. Bare names may be shadowed by
+                // lazy user functions.
+                name.rsplit_once("::").is_some_and(|(package, bare)| {
+                    matches!(package.trim_end_matches(':'), "base" | "rlang")
+                        && matches!(bare, "abort" | "stop" | "warning" | "message")
+                })
+            }) {
+                first_executed_identifier(func, wanted, trusted_defusers).or_else(|| {
+                    args.iter().find_map(|argument| {
+                        first_executed_identifier(&argument.value, wanted, trusted_defusers)
+                    })
+                })
             } else {
-                first_executed_identifier(lhs, wanted)
-                    .or_else(|| first_executed_identifier(rhs, wanted))
+                first_executed_identifier(func, wanted, trusted_defusers)
             }
         }
-        Expr::UnaryOp { expr, .. } => first_executed_identifier(expr, wanted),
-        Expr::Index { base, args, .. } => first_executed_identifier(base, wanted).or_else(|| {
-            args.iter()
-                .find_map(|argument| first_executed_identifier(&argument.value, wanted))
+        Expr::BinOp { lhs, rhs, op, .. } => {
+            if matches!(op, BinOpKind::Assign | BinOpKind::SuperAssign) {
+                first_executed_identifier(rhs, wanted, trusted_defusers)
+            } else {
+                first_executed_identifier(lhs, wanted, trusted_defusers)
+                    .or_else(|| first_executed_identifier(rhs, wanted, trusted_defusers))
+            }
+        }
+        Expr::UnaryOp { expr, .. } => first_executed_identifier(expr, wanted, trusted_defusers),
+        Expr::Index {
+            base, kind, args, ..
+        } => first_executed_identifier(base, wanted, trusted_defusers).or_else(|| {
+            // `$field` stores `field` as a synthesized identifier in the AST,
+            // but R does not evaluate it as an expression. Counting that name
+            // would turn `vars = parent$vars` into a self-reference.
+            (!matches!(kind, IndexKind::Dollar)).then(|| {
+                args.iter().find_map(|argument| {
+                    first_executed_identifier(&argument.value, wanted, trusted_defusers)
+                })
+            })?
         }),
-        Expr::Block { body, .. } => body
-            .iter()
-            .find_map(|statement| first_executed_identifier_in_stmt(statement, wanted)),
+        Expr::Block { body, .. } => body.iter().find_map(|statement| {
+            first_executed_identifier_in_stmt(statement, wanted, trusted_defusers)
+        }),
         Expr::If {
             cond, then, else_, ..
-        } => first_executed_identifier(cond, wanted)
-            .or_else(|| first_executed_identifier(then, wanted))
+        } => first_executed_identifier(cond, wanted, trusted_defusers)
+            .or_else(|| first_executed_identifier(then, wanted, trusted_defusers))
             .or_else(|| {
                 else_
                     .as_ref()
-                    .and_then(|else_| first_executed_identifier(else_, wanted))
+                    .and_then(|else_| first_executed_identifier(else_, wanted, trusted_defusers))
             }),
         Expr::Function { .. }
         | Expr::Logical(_, _)
@@ -959,10 +1160,14 @@ fn collect_executed_identifiers(expr: &Expr, names: &mut HashSet<String>) {
             collect_executed_identifiers(rhs, names);
         }
         Expr::UnaryOp { expr, .. } => collect_executed_identifiers(expr, names),
-        Expr::Index { base, args, .. } => {
+        Expr::Index {
+            base, kind, args, ..
+        } => {
             collect_executed_identifiers(base, names);
-            for argument in args {
-                collect_executed_identifiers(&argument.value, names);
+            if !matches!(kind, IndexKind::Dollar) {
+                for argument in args {
+                    collect_executed_identifiers(&argument.value, names);
+                }
             }
         }
         Expr::Block { body, .. } => {
@@ -1501,29 +1706,6 @@ pub(crate) fn longest_arg_length(arg_types: &[RType]) -> Length {
         };
     }
     max
-}
-
-/// Compute the result length of `rep(x, times)`. `x` is arg0, `times`
-/// is arg1. R's `rep(x, times)` returns `x` repeated `times` times; the
-/// total length is `length(x) * times`. We can only compute this when
-/// both lengths are known and `times` is a single integer.
-pub(crate) fn rep_length(arg_types: &[RType]) -> Length {
-    let x_len = arg_types
-        .first()
-        .map(|t| t.length)
-        .unwrap_or(Length::Unknown);
-    let times_type = arg_types.get(1).cloned().unwrap_or(RType::unknown());
-    match (x_len, times_type.length) {
-        (Length::Known(x), Length::One) => {
-            // We know the structure but not the runtime `times` value;
-            // approximate as Unknown unless `times` is a length-1 value
-            // (which it is). R's `rep(x, 3)` gives `length(x) * 3`, but
-            // we can't know the value `3` statically. Return Unknown.
-            let _ = x;
-            Length::Unknown
-        }
-        _ => Length::Unknown,
-    }
 }
 
 /// Build a `ColumnSchema` from a `list(...)` / `data.frame(...)` argument

--- a/crates/ry-checker/src/infer/mod.rs
+++ b/crates/ry-checker/src/infer/mod.rs
@@ -678,7 +678,25 @@ impl Checker {
         for (name, (then_t, else_t)) in branch_types {
             let merged = match (then_t, else_t) {
                 (Some(a), Some(b)) => a.join(b),
-                (Some(a), None) | (None, Some(a)) => a.join(RType::unknown()),
+                (Some(a), None) | (None, Some(a)) => {
+                    // The name is assigned in only one branch (no
+                    // `else`). When the name is already bound in the
+                    // parent it is definitely defined on every path --
+                    // only its type changes -- so carry the branch's
+                    // type and let the parent fold below union in the
+                    // prior type (so `s <- 1L; if (c) { s <- "x" }`
+                    // stays `union[integer, character]` rather than
+                    // collapsing to opaque). When the parent has NO
+                    // binding the name is possibly missing, which has no
+                    // sound type, so it degrades to opaque. Joining with
+                    // `RType::unknown()` here would be absorbing and make
+                    // the parent fold below dead code.
+                    if scope.get(&name).is_some() {
+                        a
+                    } else {
+                        a.join(RType::unknown())
+                    }
+                }
                 (None, None) => continue,
             };
             // If the name already existed in the parent with a *different*
@@ -1394,6 +1412,11 @@ impl Checker {
                     }
                 }
                 None => {
+                    // Typed package values take precedence over existence-only
+                    // import bindings so constants retain their declared type.
+                    if let Some(value_type) = self.resolve_typeshed_value(name) {
+                        return value_type;
+                    }
                     if self.external_bindings.contains(name) {
                         return RType::unknown();
                     }
@@ -1404,11 +1427,6 @@ impl Checker {
                         })
                     }) {
                         return RType::unknown();
-                    }
-                    // Built-in dataset? (mtcars, iris, ...) Resolve before
-                    // flagging the identifier as unbound.
-                    if let Some(jt) = self.typeshed.datasets.get(name) {
-                        return json_rtype_to_rtype(jt);
                     }
                     // Known typeshed function used as a value (e.g.
                     // `sapply(x, sqrt)` passes `sqrt` as a bare

--- a/crates/ry-checker/src/lib.rs
+++ b/crates/ry-checker/src/lib.rs
@@ -409,6 +409,11 @@ pub(crate) struct FnTable {
     // set, we know it's defined in another file (or later in this
     // same file) and return opaque instead of flagging it as unbound.
     pub(crate) known_vars: std::collections::HashSet<String>,
+    // Names bound to callable objects that are not ordinary R functions.
+    // S7 class and generic objects implement `()` themselves, so call-position
+    // lookup must treat them as candidates even though their inferred value is
+    // otherwise opaque.
+    pub(crate) callable_vars: std::collections::HashSet<String>,
     // Syntactic call sites used only for conservative internal-helper
     // default selection. Each argument records its optional exact name.
     pub(crate) call_sites: HashMap<String, Vec<Vec<Option<String>>>>,
@@ -442,6 +447,7 @@ impl FnTable {
         self.s4_methods.extend(collected.s4_methods);
         self.s4_classes.extend(collected.s4_classes);
         self.known_vars.extend(collected.known_vars);
+        self.callable_vars.extend(collected.callable_vars);
         for (name, sites) in collected.call_sites {
             self.call_sites.entry(name).or_default().extend(sites);
         }
@@ -561,33 +567,20 @@ pub struct Checker {
 
 impl Checker {
     pub fn new(path: &str) -> Self {
-        let typeshed = embedded_base();
-        Self {
-            typeshed,
-            user_stubs: Arc::new(BTreeMap::new()),
-            diagnostics: Vec::new(),
-            path: path.to_string(),
-            discarding: false,
-            validate_user_call_arguments: true,
-            fn_table: Arc::new(FnTable::default()),
-            known_vars: Arc::new(HashSet::new()),
-            return_slots: Arc::new(ReturnSlots::default()),
-            inferring: Vec::new(),
-            loaded: Arc::new(HashSet::new()),
-            bare_loaded: Arc::new(HashSet::new()),
-            external_bindings: HashSet::new(),
-            imported_from: HashMap::new(),
-            external_s3_methods: HashSet::new(),
-            load_bindings: HashMap::new(),
-            deferred_captures: Vec::new(),
-            enclosing_formals: Vec::new(),
-            vector_intent_parameters: Vec::new(),
-            pipe_argument_types: HashMap::new(),
-        }
+        Self::with_tables_impl(
+            path,
+            Arc::new(FnTable::default()),
+            Arc::new(ReturnSlots::default()),
+        )
     }
 
     pub fn check(&mut self, file: &SourceFile) -> &[Diagnostic] {
         self.path = file.path.clone();
+
+        // Clear diagnostics FIRST so a second `check` on the same
+        // instance starts fresh rather than accumulating the previous
+        // run's diagnostics on top of the re-collected tables.
+        self.diagnostics.clear();
 
         // Parse errors first: a syntax error means the recovered tree is
         // unreliable, so RY000 is the primary signal for broken input. We
@@ -642,29 +635,7 @@ impl Checker {
     //
     // [`into_tables`]: Checker::into_tables
     pub(crate) fn with_tables(path: &str, fn_table: FnTable, return_slots: ReturnSlots) -> Self {
-        let typeshed = embedded_base();
-        Self {
-            typeshed,
-            user_stubs: Arc::new(BTreeMap::new()),
-            diagnostics: Vec::new(),
-            path: path.to_string(),
-            discarding: false,
-            validate_user_call_arguments: true,
-            fn_table: Arc::new(fn_table),
-            known_vars: Arc::new(HashSet::new()),
-            return_slots: Arc::new(return_slots),
-            inferring: Vec::new(),
-            loaded: Arc::new(HashSet::new()),
-            bare_loaded: Arc::new(HashSet::new()),
-            external_bindings: HashSet::new(),
-            imported_from: HashMap::new(),
-            external_s3_methods: HashSet::new(),
-            load_bindings: HashMap::new(),
-            deferred_captures: Vec::new(),
-            enclosing_formals: Vec::new(),
-            vector_intent_parameters: Vec::new(),
-            pipe_argument_types: HashMap::new(),
-        }
+        Self::with_tables_impl(path, Arc::new(fn_table), Arc::new(return_slots))
     }
 
     // Construct a checker that SHARES the given tables by `Arc` handle
@@ -677,9 +648,21 @@ impl Checker {
         fn_table: Arc<FnTable>,
         return_slots: Arc<ReturnSlots>,
     ) -> Self {
-        let typeshed = embedded_base();
+        Self::with_tables_impl(path, fn_table, return_slots)
+    }
+
+    /// Shared private constructor: builds a checker with the given
+    /// (already-shared) tables and the standard default field list.
+    /// The three public/crate constructors differ only in table
+    /// ownership, so they delegate here rather than re-listing every
+    /// field (keeps the field list in one place).
+    fn with_tables_impl(
+        path: &str,
+        fn_table: Arc<FnTable>,
+        return_slots: Arc<ReturnSlots>,
+    ) -> Self {
         Self {
-            typeshed,
+            typeshed: embedded_base(),
             user_stubs: Arc::new(BTreeMap::new()),
             diagnostics: Vec::new(),
             path: path.to_string(),
@@ -1097,15 +1080,19 @@ impl Checker {
         self.user_stubs.contains_key(package) || is_known_package(package)
     }
 
-    pub(crate) fn available_package_names(&self) -> Vec<&str> {
-        let mut packages: Vec<&str> = known_packages().collect();
-        packages.extend(
+    /// All package names with typeshed signatures, in resolution
+    /// order: the embedded known packages, then user-stub packages
+    /// that do not shadow a known one. Each name appears once. The
+    /// iterator chains over static data and the stub map directly, so
+    /// no per-call `Vec` is allocated (callers iterate inside nested
+    /// loops over loaded packages).
+    pub(crate) fn available_package_names<'a>(&'a self) -> impl Iterator<Item = &'a str> + 'a {
+        known_packages().map(|package| package as &'a str).chain(
             self.user_stubs
                 .keys()
                 .map(String::as_str)
                 .filter(|package| *package != "base" && !is_known_package(package)),
-        );
-        packages
+        )
     }
 
     // Seed opaque bindings established by metadata for this source file.

--- a/crates/ry-checker/src/suppress.rs
+++ b/crates/ry-checker/src/suppress.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::infer::json_rtype_to_rtype;
 
 impl Checker {
     /// Resolve only signatures that declare checker schema semantics. Unlike
@@ -103,6 +104,47 @@ impl Checker {
             }
         }
         (candidates.len() == 1).then(|| candidates.remove(0))
+    }
+
+    /// Resolve a typed package value under the same provenance rules as
+    /// function signatures. The legacy `datasets` map stores typed exported
+    /// values as well as package datasets; unlike `functions`, these names are
+    /// never callable.
+    pub(crate) fn resolve_typeshed_value(&self, name: &str) -> Option<RType> {
+        if let Some((pkg_raw, value)) = name.rsplit_once("::") {
+            let package = pkg_raw.trim_end_matches(':');
+            if matches!(
+                package,
+                "base" | "stats" | "utils" | "graphics" | "grDevices" | "methods" | "datasets"
+            ) && let Some(value_type) = self.typeshed.datasets.get(value)
+            {
+                return Some(json_rtype_to_rtype(value_type));
+            }
+            return self
+                .package_typeshed(package)
+                .and_then(|typeshed| typeshed.datasets.get(value))
+                .map(json_rtype_to_rtype);
+        }
+        if let Some(package) = self.imported_from.get(name)
+            && let Some(value_type) = self
+                .package_typeshed(package)
+                .and_then(|typeshed| typeshed.datasets.get(name))
+        {
+            return Some(json_rtype_to_rtype(value_type));
+        }
+        if let Some(value_type) = self.typeshed.datasets.get(name) {
+            return Some(json_rtype_to_rtype(value_type));
+        }
+        for package in self.available_package_names() {
+            if self.bare_loaded.contains(package)
+                && let Some(value_type) = self
+                    .package_typeshed(package)
+                    .and_then(|typeshed| typeshed.datasets.get(name))
+            {
+                return Some(json_rtype_to_rtype(value_type));
+            }
+        }
+        None
     }
 
     pub(crate) fn resolve_typeshed_sig(&self, name: &str) -> Option<FunctionSig> {
@@ -244,7 +286,7 @@ impl Checker {
                 }
             }
         }
-        self.fn_table.fns.contains_key(name)
+        self.fn_table.fns.contains_key(name) || self.fn_table.callable_vars.contains(name)
     }
 
     pub(crate) fn resolves_user_s3_dispatch(&self, generic: &str, first: &RType) -> bool {

--- a/crates/ry-checker/src/tests.rs
+++ b/crates/ry-checker/src/tests.rs
@@ -1227,6 +1227,55 @@ fn import_from_applies_metadata_only_to_the_imported_binding() {
 }
 
 #[test]
+fn typed_package_constants_are_values_not_functions() {
+    let mut parser = RParser::new().unwrap();
+    let file = parser
+        .parse("test.R", "value <- na_chr\nbad <- na_chr()\n")
+        .unwrap();
+    let mut checker = Checker::new("test.R");
+    checker.set_loaded(HashSet::from(["rlang".to_string()]));
+    let (diagnostics, scope) = checker.check_with_scope(&file);
+
+    assert_eq!(
+        scope.get("value").map(|ty| &ty.mode),
+        Some(&Mode::Character)
+    );
+    assert_eq!(scope.get("value").map(|ty| ty.length), Some(Length::One));
+    assert!(
+        diagnostics.iter().any(|diagnostic| {
+            diagnostic.code == "RY070" && diagnostic.message.contains("na_chr")
+        })
+    );
+}
+
+#[test]
+fn local_callable_shadows_typed_package_constant() {
+    let diagnostics = check(
+        "library(rlang)\nna_chr <- function() \"ok\"\nvalue <- na_chr()\nf <- function(na_chr) na_chr()\nf(function() \"formal\")\n",
+    );
+    assert!(
+        diagnostics
+            .iter()
+            .all(|diagnostic| diagnostic.code != "RY070"),
+        "lexical callables must win over attached package constants: {diagnostics:?}"
+    );
+}
+
+#[test]
+fn import_from_preserves_typed_package_constant() {
+    let mut parser = RParser::new().unwrap();
+    let file = parser.parse("test.R", "value <- na_int\n").unwrap();
+    let mut checker = Checker::new("test.R");
+    checker.set_external_bindings(HashSet::from(["na_int".to_string()]));
+    checker.set_imported_from(HashMap::from([("na_int".to_string(), "rlang".to_string())]));
+    let (diagnostics, scope) = checker.check_with_scope(&file);
+
+    assert!(diagnostics.is_empty(), "{diagnostics:?}");
+    assert_eq!(scope.get("value").map(|ty| &ty.mode), Some(&Mode::Integer));
+    assert_eq!(scope.get("value").map(|ty| ty.length), Some(Length::One));
+}
+
+#[test]
 fn unknown_user_infix_quotes_both_operands_and_returns_unknown() {
     let (diagnostics, scope) =
         check_with_scope("result <- missing_left %custom% missing_right\nafter <- result + 1L\n");
@@ -1455,12 +1504,17 @@ fn data_frame_scalar_column_subset_drops_to_column_type() {
 
 #[test]
 fn negative_scalar_subscript_is_not_narrowed_to_length_one() {
-    let diagnostics = check("x <- c(10, 20, 30)\nif (x[-1] > 1) print(1)\n");
+    let (diagnostics, scope) =
+        check_with_scope("x <- c(10, 20, 30)\ny <- x[-1]\nif (y > 1) print(1)\n");
     assert!(
         diagnostics
             .iter()
-            .any(|diagnostic| diagnostic.code == "RY002"),
-        "negative subscript excludes an element rather than extracting one: {diagnostics:?}"
+            .all(|diagnostic| diagnostic.code != "RY002"),
+        "an exclusion index has unknown result length and must stay silent: {diagnostics:?}"
+    );
+    assert_eq!(
+        scope.get("y").map(|value| value.length),
+        Some(Length::Unknown)
     );
 }
 
@@ -1738,20 +1792,14 @@ fn lazy_defaults_can_reference_body_local_bindings() {
 }
 
 #[test]
-fn lazy_default_forced_before_body_local_assignment_is_diagnosed() {
+fn conditional_lazy_default_force_stays_silent() {
     let diags = check(include_str!(
         "../testdata/ry098_default_forced_before_assignment.R"
     ));
-    let matches: Vec<_> = diags
-        .iter()
-        .filter(|diagnostic| diagnostic.code == "RY098")
-        .collect();
-    assert_eq!(
-        matches.len(),
-        1,
-        "only the early return should fire: {diags:?}"
+    assert!(
+        diags.iter().all(|diagnostic| diagnostic.code != "RY098"),
+        "a conditional force is not guaranteed: {diags:?}"
     );
-    assert_eq!(matches[0].span.line, 2);
 }
 
 #[test]
@@ -6194,10 +6242,10 @@ fn if_branch_join_type_is_union_when_branches_disagree() {
 #[test]
 fn if_branch_reassignment_over_existing_type_stays_visible() {
     // `s <- 1L` then reassigned to `"x"` inside a single branch (no
-    // else). The plan specifies single-branch bindings degrade to
-    // unknown (opaque), since there is no sound type for "possibly
-    // missing". What matters is that the use after the `if` stays
-    // RY010-free; the merged type is opaque by design.
+    // else). `s` is definitely bound on every path (it exists in the
+    // parent), so the merged type is the union of the branch's
+    // character and the parent's integer -- NOT opaque. That keeps the
+    // use after the `if` RY010-free while preserving the precise type.
     let (diags, top) = check_with_scope("s <- 1L\nif (TRUE) { s <- \"x\" }\ns\n");
     assert!(
         diags.iter().all(|d| d.code != "RY010"),
@@ -6206,8 +6254,8 @@ fn if_branch_reassignment_over_existing_type_stays_visible() {
     );
     let t = top.get("s").expect("s should be bound at top level");
     assert!(
-        matches!(t.mode, Mode::Opaque),
-        "single-branch reassignment degrades to unknown (opaque) per plan, got {:?}",
+        matches!(t.mode, Mode::Union),
+        "parent-defined single-branch reassignment should be a union of parent and branch types, got {:?}",
         t
     );
 }

--- a/crates/ry-checker/src/tests.rs
+++ b/crates/ry-checker/src/tests.rs
@@ -1230,7 +1230,10 @@ fn import_from_applies_metadata_only_to_the_imported_binding() {
 fn typed_package_constants_are_values_not_functions() {
     let mut parser = RParser::new().unwrap();
     let file = parser
-        .parse("test.R", "value <- na_chr\nbad <- na_chr()\n")
+        .parse(
+            "test.R",
+            "value <- na_chr\nbad <- na_chr()\nqualified_bad <- rlang::na_chr()\n",
+        )
         .unwrap();
     let mut checker = Checker::new("test.R");
     checker.set_loaded(HashSet::from(["rlang".to_string()]));
@@ -1241,11 +1244,12 @@ fn typed_package_constants_are_values_not_functions() {
         Some(&Mode::Character)
     );
     assert_eq!(scope.get("value").map(|ty| ty.length), Some(Length::One));
-    assert!(
-        diagnostics.iter().any(|diagnostic| {
-            diagnostic.code == "RY070" && diagnostic.message.contains("na_chr")
-        })
-    );
+    assert!(diagnostics.iter().any(|diagnostic| {
+        diagnostic.code == "RY070" && diagnostic.message.contains("`na_chr`")
+    }));
+    assert!(diagnostics.iter().any(|diagnostic| {
+        diagnostic.code == "RY070" && diagnostic.message.contains("`rlang::na_chr`")
+    }));
 }
 
 #[test]
@@ -1503,18 +1507,36 @@ fn data_frame_scalar_column_subset_drops_to_column_type() {
 }
 
 #[test]
-fn negative_scalar_subscript_is_not_narrowed_to_length_one() {
+fn literal_negative_scalar_subscript_preserves_exact_exclusion_length() {
     let (diagnostics, scope) =
         check_with_scope("x <- c(10, 20, 30)\ny <- x[-1]\nif (y > 1) print(1)\n");
     assert!(
         diagnostics
             .iter()
-            .all(|diagnostic| diagnostic.code != "RY002"),
-        "an exclusion index has unknown result length and must stay silent: {diagnostics:?}"
+            .any(|diagnostic| diagnostic.code == "RY002"),
+        "excluding one element from a known length-three vector leaves length two: {diagnostics:?}"
     );
     assert_eq!(
         scope.get("y").map(|value| value.length),
-        Some(Length::Unknown)
+        Some(Length::Known(2))
+    );
+}
+
+#[test]
+fn list_subset_drops_stale_column_schema() {
+    let (diagnostics, scope) =
+        check_with_scope("x <- list(a = 1L, b = \"x\")\ny <- x[2]\nmissing <- y$a\n");
+    assert!(diagnostics.is_empty(), "{diagnostics:?}");
+    let y = scope.get("y").expect("subset should be bound");
+    assert_eq!(y.length, Length::One);
+    assert!(
+        y.columns.is_none(),
+        "subset must not retain the source schema"
+    );
+    assert_eq!(
+        scope.get("missing").map(|value| &value.mode),
+        Some(&Mode::Opaque),
+        "without a transformed schema, missing name access stays conservative"
     );
 }
 

--- a/crates/ry-checker/testdata/err_recursive_default_forced_call.R
+++ b/crates/ry-checker/testdata/err_recursive_default_forced_call.R
@@ -1,0 +1,3 @@
+# expect: RY098
+# abort() evaluates its message argument; it is not a promise-defusing helper.
+f <- function(x = x) rlang::abort(x)

--- a/crates/ry-checker/testdata/err_recursive_default_literal_branch.R
+++ b/crates/ry-checker/testdata/err_recursive_default_literal_branch.R
@@ -1,0 +1,4 @@
+# expect: RY098
+# A literal TRUE branch guarantees that the recursive default is forced.
+f <- function(x = x) if (TRUE) x else 1L
+f()

--- a/crates/ry-checker/testdata/err_recursive_default_literal_false_block.R
+++ b/crates/ry-checker/testdata/err_recursive_default_literal_false_block.R
@@ -1,0 +1,5 @@
+# expect: RY098
+# A literal FALSE branch guarantees that the recursive default is forced
+# through the else block.
+f <- function(x = x) if (FALSE) 1L else { x }
+f()

--- a/crates/ry-checker/testdata/err_recursive_parameter_default.R
+++ b/crates/ry-checker/testdata/err_recursive_parameter_default.R
@@ -1,0 +1,3 @@
+# expect: RY098 RY098
+copy_step <- function(copy = copy) copy
+across_step <- function(j = j) j

--- a/crates/ry-checker/testdata/err_s7_callable_future_assignment.R
+++ b/crates/ry-checker/testdata/err_s7_callable_future_assignment.R
@@ -1,0 +1,6 @@
+# expect: RY070
+# A later callable assignment cannot change the concrete value at an earlier
+# call site.
+x <- 1L
+x()
+x <- S7::new_class("x")

--- a/crates/ry-checker/testdata/err_s7_callable_reassigned.R
+++ b/crates/ry-checker/testdata/err_s7_callable_reassigned.R
@@ -1,0 +1,5 @@
+# expect: RY070
+# A later ordinary assignment replaces an earlier callable S7 object.
+x <- S7::new_class("x")
+x <- 1L
+x()

--- a/crates/ry-checker/testdata/ok_fractional_numeric_index_length.R
+++ b/crates/ry-checker/testdata/ok_fractional_numeric_index_length.R
@@ -1,0 +1,6 @@
+# no-diag
+# R truncates double subscripts before indexing, so c(0.5, 1.5) selects one
+# element rather than proving a result of the index vector's length.
+x <- c(TRUE, FALSE)
+y <- x[c(0.5, 1.5)]
+if (y) 1L else 0L

--- a/crates/ry-checker/testdata/ok_ho_named_arg_binding.R
+++ b/crates/ry-checker/testdata/ok_ho_named_arg_binding.R
@@ -2,15 +2,16 @@
 # Higher-order metadata uses formal indices, so R argument matching must happen
 # before callback argument, source, length, and result-template inference.
 f <- function(x) {
-  # Exact names can scramble the formals. FUN.VALUE after `...` requires an
-  # exact match, while FUN.VAL is a legal partial match before `...`.
+  # Exact names can be supplied out of order. FUN.VALUE precedes `...`, so
+  # FUN.VAL is a legal partial match to that formal.
   a <- vapply(FUN.VALUE = logical(1), X = x, FUN = is.numeric)
   b <- vapply(x, is.numeric, FUN.VAL = logical(1))
 
   # Map and mapply invoke the callback with the actuals absorbed by `...`, not
   # with every raw argument appearing after the callback's formal position.
-  d <- Map(x, x, f = function(p, q) q - 1)
-  e <- mapply(right = x, FUN = function(p, q) q - 1, left = x)
+  # Distinct inputs and use of both callback parameters catch swapped bindings.
+  d <- Map(x, x + 1, f = function(p, q) p + q)
+  e <- mapply(right = x, FUN = function(p, q) p + q, left = x + 1)
 
   # Source and callback formals likewise resolve by name for the other base
   # higher-order signatures.

--- a/crates/ry-checker/testdata/ok_ho_named_arg_binding.R
+++ b/crates/ry-checker/testdata/ok_ho_named_arg_binding.R
@@ -1,0 +1,38 @@
+# no-diag
+# Higher-order metadata uses formal indices, so R argument matching must happen
+# before callback argument, source, length, and result-template inference.
+f <- function(x) {
+  # Exact names can scramble the formals. FUN.VALUE after `...` requires an
+  # exact match, while FUN.VAL is a legal partial match before `...`.
+  a <- vapply(FUN.VALUE = logical(1), X = x, FUN = is.numeric)
+  b <- vapply(x, is.numeric, FUN.VAL = logical(1))
+
+  # Map and mapply invoke the callback with the actuals absorbed by `...`, not
+  # with every raw argument appearing after the callback's formal position.
+  d <- Map(x, x, f = function(p, q) q - 1)
+  e <- mapply(right = x, FUN = function(p, q) q - 1, left = x)
+
+  # Source and callback formals likewise resolve by name for the other base
+  # higher-order signatures.
+  filtered <- Filter(x = x, f = is.numeric)
+  found <- Find(x = x, f = is.numeric)
+  reduced <- Reduce(x = x, f = function(p, q) p + q)
+  applied <- lapply(FUN = function(p) p + 1, X = x)
+  simplified <- sapply(FUN = function(p) p + 1, X = x)
+
+  # Positional calls remain supported.
+  positional <- vapply(x, is.numeric, logical(1))
+  called <- do.call(sum, list(x))
+
+  # Package higher-order specs use the same formal-index matcher.
+  mapped <- purrr::map_dbl(.f = function(p) p + 1, .x = x)
+  mapped2 <- purrr::map2(.f = function(p, q) p + q, .y = x, .x = x)
+  walked <- purrr::walk(.f = function(p) p + 1, .x = x)
+  compacted <- purrr::compact(.p = is.numeric, .x = x)
+  accumulated <- purrr::accumulate(.f = function(p, q) p + q, .x = x)
+
+  list(!a, !b, d, e, filtered + 1, found + 1, reduced + 1,
+       applied, simplified + 1, !positional, called, mapped + 1,
+       mapped2, walked + 1, compacted + 1, accumulated)
+}
+f(c(1, 2))

--- a/crates/ry-checker/testdata/ok_index_length_from_index.R
+++ b/crates/ry-checker/testdata/ok_index_length_from_index.R
@@ -1,0 +1,21 @@
+# no-diag
+k <- function(x) {
+  formats <- c(xlsx = "a", xls = "b", csv = "c", tsv = "d", txt = "e")
+  fmt <- unname(formats[x])
+  if (is.na(fmt)) stop("bad")
+}
+
+chars <- c("a", "b", "c")[c("a", "missing")]
+if (length(chars) != 2L) stop("character index length changed")
+
+positive <- c(10L, 20L, 30L)[c(1L, 3L)]
+if (length(positive) != 2L) stop("positive numeric index length changed")
+
+scalar <- c(10L, 20L)[1L]
+if (length(scalar) != 1L) stop("scalar index length changed")
+
+excluded <- c(10L, 20L)[-1L]
+if (length(excluded) > 1L) stop("negative index length is dynamic")
+
+empty <- c(10L, 20L)[0L]
+if (length(empty) > 1L) stop("zero index length is dynamic")

--- a/crates/ry-checker/testdata/ok_logical_mask_length.R
+++ b/crates/ry-checker/testdata/ok_logical_mask_length.R
@@ -1,0 +1,11 @@
+# no-diag
+a <- function(units) {
+  day.units <- c("day", "wday", "mday", "yday")
+  wunit <- day.units %in% names(units)
+  n <- sum(wunit)
+  if (n > 0) {
+    if (n > 1) stop("conflicting days input")
+    uname <- day.units[wunit]
+    if (uname != "mday") 1 else 2
+  }
+}

--- a/crates/ry-checker/testdata/ok_parameter_default_other_formal.R
+++ b/crates/ry-checker/testdata/ok_parameter_default_other_formal.R
@@ -1,0 +1,3 @@
+# no-diag
+valid_default <- function(a, b = a) b
+valid_default(1L)

--- a/crates/ry-checker/testdata/ok_parameter_default_quoted_self.R
+++ b/crates/ry-checker/testdata/ok_parameter_default_quoted_self.R
@@ -1,0 +1,5 @@
+# no-diag
+quoted_default <- function(x = quote(x)) x
+substituted_default <- function(x = substitute(x)) x
+expression_default <- function(x = expression(x)) x
+alist_default <- function(x = alist(x)) x

--- a/crates/ry-checker/testdata/ok_recursive_default_captured.R
+++ b/crates/ry-checker/testdata/ok_recursive_default_captured.R
@@ -1,0 +1,7 @@
+# no-diag
+# A self-referential default is legal when the promise is captured without
+# forcing it. rlang uses this shape to test enexpr()/enquo() defusing.
+expr_default <- function(x = x) rlang::enexpr(x)
+quo_default <- function(x = x) list(rlang::enquo(x), rlang::quo(x))
+expr_default()
+quo_default()

--- a/crates/ry-checker/testdata/ok_recursive_default_conditional_return.R
+++ b/crates/ry-checker/testdata/ok_recursive_default_conditional_return.R
@@ -1,0 +1,7 @@
+# no-diag
+# A conditional early return means the later force is not guaranteed.
+f <- function(x = x, flag) {
+  if (flag) return(1L)
+  x
+}
+f(flag = TRUE)

--- a/crates/ry-checker/testdata/ok_recursive_default_lazy_call.R
+++ b/crates/ry-checker/testdata/ok_recursive_default_lazy_call.R
@@ -1,0 +1,6 @@
+# no-diag
+# Ordinary R calls are lazy; a callee can ignore the argument without forcing
+# its recursive default.
+ignore <- function(z) 1L
+f <- function(x = x) ignore(x)
+f()

--- a/crates/ry-checker/testdata/ok_recursive_default_missing.R
+++ b/crates/ry-checker/testdata/ok_recursive_default_missing.R
@@ -1,0 +1,5 @@
+# no-diag
+# missing() inspects whether a promise was supplied without forcing its
+# self-referential default.
+f <- function(x = x) missing(x)
+f()

--- a/crates/ry-checker/testdata/ok_recursive_default_qualified_defuser.R
+++ b/crates/ry-checker/testdata/ok_recursive_default_qualified_defuser.R
@@ -1,0 +1,6 @@
+# no-diag
+# Qualified base/rlang defusers retain known provenance even when a local
+# function shadows the same bare helper name.
+expression <- function(x) x
+f <- function(x = x) base::expression(x)
+f()

--- a/crates/ry-checker/testdata/ok_recursive_default_replaced.R
+++ b/crates/ry-checker/testdata/ok_recursive_default_replaced.R
@@ -1,0 +1,14 @@
+# no-diag
+# Returning before a force and replacing the formal both avoid forcing the
+# self-referential default.
+f <- function(x = x) {
+  return(1L)
+  x
+}
+f()
+
+g <- function(x = x) {
+  x <- 1L
+  x
+}
+g()

--- a/crates/ry-checker/testdata/ok_recursive_default_shadowed_defuser.R
+++ b/crates/ry-checker/testdata/ok_recursive_default_shadowed_defuser.R
@@ -1,0 +1,6 @@
+# no-diag
+# Ordinary R functions are lazy; without interprocedural force proof, a local
+# helper named like a defuser remains conservatively silent.
+quote <- function(x) x
+f <- function(x = x) quote(x)
+f()

--- a/crates/ry-checker/testdata/ok_recursive_default_shadowed_strict.R
+++ b/crates/ry-checker/testdata/ok_recursive_default_shadowed_strict.R
@@ -1,0 +1,5 @@
+# no-diag
+# A bare helper named like a strict builtin may be a lazy user function.
+abort <- function(x) 1L
+f <- function(x = x) abort(x)
+f()

--- a/crates/ry-checker/testdata/ok_recursive_default_short_circuit.R
+++ b/crates/ry-checker/testdata/ok_recursive_default_short_circuit.R
@@ -1,0 +1,6 @@
+# no-diag
+# The RHS of scalar short-circuit operators is not guaranteed to execute.
+f <- function(x = x) FALSE && x
+g <- function(x = x) TRUE || x
+f()
+g()

--- a/crates/ry-checker/testdata/ok_recursive_default_unforced_branch.R
+++ b/crates/ry-checker/testdata/ok_recursive_default_unforced_branch.R
@@ -1,0 +1,5 @@
+# no-diag
+# A self-referential default is harmless when every possible force is in an
+# unreachable branch. The rule reports only guaranteed forcing.
+f <- function(x = x) if (FALSE) x else 1L
+f()

--- a/crates/ry-checker/testdata/ok_recursive_default_unreachable_block.R
+++ b/crates/ry-checker/testdata/ok_recursive_default_unreachable_block.R
@@ -1,0 +1,10 @@
+# no-diag
+# A return inside a statically selected block makes the later reference
+# unreachable and therefore cannot guarantee forcing the default.
+f <- function(x = x) {
+  if (TRUE) {
+    return(1L)
+    x
+  }
+}
+f()

--- a/crates/ry-checker/testdata/ok_recursive_default_user_defuser.R
+++ b/crates/ry-checker/testdata/ok_recursive_default_user_defuser.R
@@ -1,0 +1,6 @@
+# no-diag
+# A user helper whose formal is captured with substitute() does not force the
+# recursive default passed to it.
+capture <- function(z) substitute(z)
+f <- function(x = x) capture(x)
+f()

--- a/crates/ry-checker/testdata/ok_s7_class_callable.R
+++ b/crates/ry-checker/testdata/ok_s7_class_callable.R
@@ -1,0 +1,12 @@
+# no-diag
+margin <- S7::new_class("margin", parent = S7::class_double)
+titleGrob <- function(margin = NULL) {
+  if (is.null(margin)) margin <- margin(0, 0, 0, 0)
+  margin
+}
+
+verb <- S7::new_generic("verb", "x")
+verb(NULL)
+
+old_class <- S7::new_S3_class("old_class")
+old_class(NULL)

--- a/crates/ry-checker/testdata/oracle/inconsistent_superassignment.R
+++ b/crates/ry-checker/testdata/oracle/inconsistent_superassignment.R
@@ -1,0 +1,11 @@
+# oracle: known-gap local assignment on one branch leaves the outer binding NULL
+state <- NULL
+initialize <- function(enabled) {
+  if (enabled) {
+    state <<- TRUE
+  } else {
+    state <- FALSE
+  }
+}
+initialize(FALSE)
+state && TRUE

--- a/crates/ry-checker/testdata/oracle/parameter_default_other_formal.R
+++ b/crates/ry-checker/testdata/oracle/parameter_default_other_formal.R
@@ -1,0 +1,3 @@
+# oracle: must-pass
+valid_default <- function(a, b = a) b
+stopifnot(identical(valid_default(1L), 1L))

--- a/crates/ry-checker/testdata/oracle/parameter_default_quoted_self.R
+++ b/crates/ry-checker/testdata/oracle/parameter_default_quoted_self.R
@@ -1,0 +1,5 @@
+# oracle: must-pass
+quoted_default <- function(x = quote(x)) x
+substituted_default <- function(x = substitute(x)) x
+stopifnot(identical(quoted_default(), quote(x)))
+stopifnot(identical(substituted_default(), quote(substitute(x))))

--- a/crates/ry-checker/testdata/oracle/recursive_parameter_default.R
+++ b/crates/ry-checker/testdata/oracle/recursive_parameter_default.R
@@ -1,0 +1,8 @@
+# oracle: must-warn RY098
+outer <- 1
+recursive_default <- function(outer = outer) outer
+error <- tryCatch({
+  recursive_default()
+  NULL
+}, error = identity)
+stopifnot(inherits(error, "error"))

--- a/crates/ry-checker/testdata/oracle/switch_vector_expr.R
+++ b/crates/ry-checker/testdata/oracle/switch_vector_expr.R
@@ -1,0 +1,5 @@
+# oracle: known-gap switch EXPR must have length one
+choose_alert <- function(type = c("success", "info", "warning", "danger")) {
+  switch(type, success = 1L, info = 2L, warning = 3L, danger = 4L)
+}
+choose_alert()

--- a/crates/ry-checker/testdata/oracle/unguarded_parameter_length.R
+++ b/crates/ry-checker/testdata/oracle/unguarded_parameter_length.R
@@ -1,0 +1,10 @@
+# oracle: known-gap a sibling scalar guard does not protect the numeric branch
+as_week_start_shape <- function(x) {
+  if (is.numeric(x)) {
+    if (x > 7 || x < 1) stop("out of range")
+  } else {
+    if (length(x) != 1) stop("must be scalar")
+  }
+  x
+}
+as_week_start_shape(c(1, 2))

--- a/crates/ry-checker/testdata/ry098_default_forced_before_assignment.R
+++ b/crates/ry-checker/testdata/ry098_default_forced_before_assignment.R
@@ -1,4 +1,4 @@
-# expect: RY098
+# no-diag
 dmt <- function(x, mean = rep(0, d), S, df = Inf) {
   if (df == Inf) return(dmnorm(x, mean, S))
   d <- ncol(S)

--- a/crates/ry-checker/testdata/warn_t6_negative_subscript.R
+++ b/crates/ry-checker/testdata/warn_t6_negative_subscript.R
@@ -1,4 +1,4 @@
-# no-diag
+# expect: RY002
 x <- c(10, 20, 30)
 if (x[-1] > 1) print("not scalar")
 

--- a/crates/ry-checker/testdata/warn_t6_negative_subscript.R
+++ b/crates/ry-checker/testdata/warn_t6_negative_subscript.R
@@ -1,4 +1,4 @@
-# expect: RY002
+# no-diag
 x <- c(10, 20, 30)
 if (x[-1] > 1) print("not scalar")
 

--- a/crates/ry-checker/tests/vendor_snapshot.rs
+++ b/crates/ry-checker/tests/vendor_snapshot.rs
@@ -146,8 +146,9 @@ fn purrr_vendor_snapshot() {
     // vendor net alongside glue; purrr is the flagship tidyverse
     // functional-programming package.
     //
-    // The ENTIRE snapshot is RY010: cross-package function and constant
-    // names not yet modeled. There are NO true positives.
+    // Snapshot entries are RY010 cross-package function and constant names
+    // not yet modeled. The `caller_env = caller_env()` default is deliberately
+    // not reported because its force is conditional on the progress-bar path.
     //
     //   * rlang functions: quo_get_expr, eval_tidy, is_bare_list,
     //     is_bare_formula, as_quosure, is_quosure, obj_is_list, is_zap.

--- a/crates/ry-checker/tests/vendor_snapshot.rs
+++ b/crates/ry-checker/tests/vendor_snapshot.rs
@@ -146,9 +146,10 @@ fn purrr_vendor_snapshot() {
     // vendor net alongside glue; purrr is the flagship tidyverse
     // functional-programming package.
     //
-    // Snapshot entries are RY010 cross-package function and constant names
-    // not yet modeled. The `caller_env = caller_env()` default is deliberately
-    // not reported because its force is conditional on the progress-bar path.
+    // Snapshot entries are RY010 function and constant names that are not yet
+    // modeled, including cross-package symbols and purrr's internal helpers.
+    // The `caller_env = caller_env()` default is deliberately not reported
+    // because its force is conditional on the progress-bar path.
     //
     //   * rlang functions: quo_get_expr, eval_tidy, is_bare_list,
     //     is_bare_formula, as_quosure, is_quosure, obj_is_list, is_zap.

--- a/crates/ry-typeshed/src/lib.rs
+++ b/crates/ry-typeshed/src/lib.rs
@@ -212,7 +212,6 @@ pub enum JsonLength {
     NArgs,
     Test,
     Unknown,
-    XTimes,
 }
 
 impl JsonLength {
@@ -225,7 +224,6 @@ impl JsonLength {
             "n_args" => Self::NArgs,
             "test" => Self::Test,
             "unknown" => Self::Unknown,
-            "x_times" => Self::XTimes,
             value => {
                 const KNOWN: &[usize] = &[
                     0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 15, 19, 20, 21, 24, 26, 30, 31, 32, 35,


### PR DESCRIPTION
Part 2 of 4 in the wave-0 stack (split from `review/wave0-p1`). Base: PR #33.

The analysis/inference half of the checker work. Deliberately **excludes** `diagnostics.rs` / `format.rs` / `corpus.rs`, whose public-API changes ripple into ry-cli and ry-lsp — those move together in PR #3 so this branch stays workspace-green on its own.

- **Higher-order / call inference:** match map/apply arguments by FORMAL name (not position); infer result lengths from the index argument (logical masks, numeric/fractional subscripts).
- **Recursive-default (RY098) precision:** force-flow through if/for/while + short-circuiting; broader quoting/defuser recognition incl. qualified `base::expression(...)`; `for` always falls through.
- **Type inference:** single-branch reassignment over a parent binding keeps the union (not opaque); a second `Checker::check` no longer accumulates diagnostics.
- **Misc:** shared `DEFUSING_CALLS` const; `available_package_names` returns an iterator; remove dead `JsonLength::XTimes`/`rep_length`.

**Workspace builds + all checker tests pass (427 unit + corpus/oracle/project/real_world/vendor_snapshot).**