### PR TITLE
coupled API: diagnostics +src, for-loop name_span, and LSP hardening

### DIFF
--- a/crates/ry-checker/src/diagnostics.rs
+++ b/crates/ry-checker/src/diagnostics.rs
@@ -211,49 +211,75 @@ pub fn parse_suppressions(src: &str) -> Vec<Suppression> {
 /// Standalone-vs-trailing is decided by the comment's column: a comment
 /// at column 0 (no code before it on the line) defers to the next code
 /// line; a comment at column > 0 applies to its own line.
-pub fn parse_suppressions_from_comments(comments: &[ry_core::ast::Comment]) -> Vec<Suppression> {
+///
+/// Resolving a standalone directive to "the next code line" requires the
+/// source text: blank lines and comment-only lines in between must be
+/// skipped, which cannot be determined from the comment list alone. Pass
+/// the full source so the resolution matches the legacy
+/// `parse_suppressions(&str)` behavior exactly.
+pub fn parse_suppressions_from_comments(
+    comments: &[ry_core::ast::Comment],
+    src: &str,
+) -> Vec<Suppression> {
+    let src_lines: Vec<&str> = src.lines().collect();
     let mut suppressions = Vec::new();
-    let mut pending: Option<Suppression> = None;
     for c in comments {
-        if let Some(codes) = parse_ignore_comment_body(&c.body) {
-            if c.col == 0 {
-                // Standalone: applies to the next code line. We don't
-                // know which line that is from comments alone, so defer
-                // and resolve against the next comment's line minus one
-                // (a trailing comment on the target line) or the next
-                // comment's line if none.
-                pending = Some(Suppression {
-                    line: 0,
-                    rules: codes,
-                });
-            } else {
-                // Trailing: applies to this line.
-                suppressions.push(Suppression {
-                    line: c.line,
-                    rules: codes,
-                });
-            }
+        let Some(codes) = parse_ignore_comment_body(&c.body) else {
             continue;
-        }
-        // A non-directive comment resolves a pending standalone
-        // suppression if it sits on a later line (heuristic: it marks a
-        // line that has code, since trailing comments follow code).
-        if let Some(mut supp) = pending.take() {
-            if c.col > 0 && c.line > supp.line {
-                supp.line = c.line;
-                suppressions.push(supp);
-            } else {
-                pending = Some(supp);
+        };
+        if c.col == 0 || is_whitespace_only_prefix(&src_lines, c) {
+            // Standalone: applies to the next non-comment, non-blank
+            // line after this comment. If there is no such line (e.g.
+            // the directive is the last thing in the file) there is
+            // nothing to suppress, so the directive is dropped.
+            if let Some(line) = next_code_line(&src_lines, c.line) {
+                suppressions.push(Suppression { line, rules: codes });
             }
+        } else {
+            // Trailing: applies to this line.
+            suppressions.push(Suppression {
+                line: c.line,
+                rules: codes,
+            });
         }
-    }
-    if let Some(mut supp) = pending.take() {
-        // File ended with an unresolved standalone directive: attach to
-        // the line after the last comment as a best effort.
-        supp.line = comments.last().map(|c| c.line + 1).unwrap_or(0);
-        suppressions.push(supp);
     }
     suppressions
+}
+
+/// Whether everything on the comment's line before the `#` is
+/// whitespace. A comment whose line is entirely whitespace up to the
+/// `#` is standalone even when indented (`    # ry: ignore`), as opposed
+/// to a trailing comment that follows code (`x <- 1  # ry: ignore`).
+fn is_whitespace_only_prefix(src_lines: &[&str], c: &ry_core::ast::Comment) -> bool {
+    src_lines
+        .get(c.line)
+        .and_then(|line| {
+            // `c.col` is a BYTE column; only slice when it is within the
+            // line's byte length.
+            if c.col <= line.len() {
+                Some(&line[..c.col])
+            } else {
+                None
+            }
+        })
+        .map(|prefix| prefix.trim().is_empty())
+        .unwrap_or(false)
+}
+
+/// Find the first line after `start` that is neither blank nor a
+/// comment-only line (a line whose first non-whitespace character is
+/// `#`). Used to resolve standalone `# ry: ignore` directives to their
+/// target code line.
+fn next_code_line(lines: &[&str], start: usize) -> Option<usize> {
+    let mut line = start + 1;
+    while line < lines.len() {
+        let trimmed = lines[line].trim();
+        if !trimmed.is_empty() && !trimmed.starts_with('#') {
+            return Some(line);
+        }
+        line += 1;
+    }
+    None
 }
 
 /// Parse a single comment line for an ignore directive. Returns
@@ -316,9 +342,16 @@ fn parse_rule_codes(text: &str) -> Vec<String> {
     if text.is_empty() {
         return Vec::new();
     }
+    // Stop at the closing `]`: anything after it is prose, not a code
+    // (so `# ry: ignore[RY040] note` yields `RY040`, not a bogus
+    // `RY040]` token that never matches).
+    let text = match text.find(']') {
+        Some(pos) => &text[..pos],
+        None => text,
+    };
     // Strip a single layer of surrounding brackets / leading colon.
     let text = text.trim_start_matches(['[', ':', ' ']);
-    let text = text.trim_end_matches(']');
+    let text = text.trim_end();
     text.split([',', ' '])
         .filter(|s| !s.is_empty())
         .map(|s| s.trim().to_uppercase())
@@ -400,15 +433,17 @@ pub fn filter_suppressed(diags: Vec<Diagnostic>, src: &str) -> Vec<Diagnostic> {
 
 /// Lexical variant of `filter_suppressed`: uses the parser's collected
 /// comments so a `#` inside a string literal is not mistaken for a
-/// suppression directive.
+/// suppression directive. The source text is required to resolve
+/// standalone `# ry: ignore` directives to their target code line.
 pub fn filter_suppressed_with_comments(
     diags: Vec<Diagnostic>,
     comments: &[ry_core::ast::Comment],
+    src: &str,
 ) -> Vec<Diagnostic> {
     if has_file_suppression_from_comments(comments) {
         return Vec::new();
     }
-    let supps = parse_suppressions_from_comments(comments);
+    let supps = parse_suppressions_from_comments(comments, src);
     diags
         .into_iter()
         .filter(|d| !is_suppressed(d, &supps))
@@ -417,11 +452,19 @@ pub fn filter_suppressed_with_comments(
 
 /// Severity overrides that a caller (typically the CLI) wants to apply.
 /// Matches ty's `--error` / `--warn` / `--ignore` semantics.
+///
+/// The `expanded_*` fields are private precomputed caches: each `add_*`
+/// expands its token (rule name, code, or "all") into the concrete code
+/// list once, so `effective` is O(codes) per diagnostic instead of
+/// re-examining every token against the rule table on every call.
 #[derive(Debug, Clone, Default)]
 pub struct SeverityFilter {
     pub errors: Vec<String>,
     pub warns: Vec<String>,
     pub ignores: Vec<String>,
+    expanded_errors: Vec<&'static str>,
+    expanded_warns: Vec<&'static str>,
+    expanded_ignores: Vec<&'static str>,
 }
 
 impl SeverityFilter {
@@ -437,34 +480,32 @@ impl SeverityFilter {
         }
     }
 
-    /// Add a token (code / name / "all") to one of the buckets.
+    /// Add a token (code / name / "all") to one of the buckets,
+    /// pre-expanding it into the cached code list.
     pub fn add_error(&mut self, token: &str) {
         self.errors.push(token.to_string());
+        self.expanded_errors.extend(Self::expand(token));
     }
     pub fn add_warn(&mut self, token: &str) {
         self.warns.push(token.to_string());
+        self.expanded_warns.extend(Self::expand(token));
     }
     pub fn add_ignore(&mut self, token: &str) {
         self.ignores.push(token.to_string());
+        self.expanded_ignores.extend(Self::expand(token));
     }
 
     /// Returns the effective severity for a code, or None to suppress it.
     /// Precedence (highest to lowest): ignore > error > warn > default.
     pub fn effective(&self, code: &str, default: Severity) -> Option<Severity> {
-        for tok in &self.ignores {
-            if Self::expand(tok).contains(&code) {
-                return None;
-            }
+        if self.expanded_ignores.contains(&code) {
+            return None;
         }
-        for tok in &self.errors {
-            if Self::expand(tok).contains(&code) {
-                return Some(Severity::Error);
-            }
+        if self.expanded_errors.contains(&code) {
+            return Some(Severity::Error);
         }
-        for tok in &self.warns {
-            if Self::expand(tok).contains(&code) {
-                return Some(Severity::Warning);
-            }
+        if self.expanded_warns.contains(&code) {
+            return Some(Severity::Warning);
         }
         Some(default)
     }
@@ -482,6 +523,9 @@ pub fn apply_filter_to_diagnostics(diagnostics: &mut Vec<Diagnostic>, filter: &S
             .unwrap_or(Severity::Warning);
         if let Some(sev) = filter.effective(d.code, default) {
             let mut d = d;
+            // Severity overrides do not change the evidence supporting a
+            // diagnostic. Preserve instance-specific confidence so
+            // --min-confidence behaves the same with or without an override.
             d.severity = sev;
             out.push(d);
         }

--- a/crates/ry-checker/src/format.rs
+++ b/crates/ry-checker/src/format.rs
@@ -397,6 +397,7 @@ mod tests {
         let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
         assert_eq!(parsed[0]["code"], "RY001");
         assert_eq!(parsed[0]["severity"], "warning");
+        assert_eq!(parsed[0]["confidence"], "medium");
     }
 
     #[test]

--- a/crates/ry-checker/src/format.rs
+++ b/crates/ry-checker/src/format.rs
@@ -42,6 +42,7 @@ struct JsonDiagnostic<'a> {
     path: &'a str,
     line: usize,
     column: usize,
+    confidence: &'a str,
 }
 
 /// Render the diagnostics to a string. `srcs` maps `path` -> source text
@@ -135,6 +136,7 @@ pub fn render_with_color(
                         path: &d.path,
                         line,
                         column: col,
+                        confidence: d.confidence.as_str(),
                     }
                 })
                 .collect();

--- a/crates/ry-checker/tests/corpus.rs
+++ b/crates/ry-checker/tests/corpus.rs
@@ -113,7 +113,8 @@ fn run(name: &str, src: &str) -> Vec<(String, Severity)> {
     // feature behave the same way the CLI / LSP do. Use the lexical
     // (comment-based) filter so a `#` inside a string literal is not
     // mistaken for a suppression directive.
-    let diags = ry_checker::filter_suppressed_with_comments(c.take_diagnostics(), &file.comments);
+    let diags =
+        ry_checker::filter_suppressed_with_comments(c.take_diagnostics(), &file.comments, src);
     diags
         .into_iter()
         .map(|d| (d.code.to_string(), d.severity))

--- a/crates/ry-cli/src/main.rs
+++ b/crates/ry-cli/src/main.rs
@@ -527,16 +527,6 @@ fn render_diagnostics(
     srcs: &HashMap<String, String>,
     color: bool,
 ) -> String {
-    if matches!(format, ry_checker::format::OutputFormat::Json) {
-        let rendered = ry_checker::format::render_with_color(diagnostics, format, srcs, color);
-        let Ok(mut values) = serde_json::from_str::<Vec<serde_json::Value>>(&rendered) else {
-            return rendered;
-        };
-        for (value, diagnostic) in values.iter_mut().zip(diagnostics) {
-            value["confidence"] = serde_json::json!(diagnostic.confidence.as_str());
-        }
-        return serde_json::to_string_pretty(&values).unwrap_or(rendered);
-    }
     if matches!(
         format,
         ry_checker::format::OutputFormat::Full | ry_checker::format::OutputFormat::Concise
@@ -1073,7 +1063,8 @@ fn run_check_once(
     // mistaken for a suppression directive.
     for (path, diags) in &mut per_file_diagnostics {
         if let Some(cs) = comments.get(path) {
-            *diags = ry_checker::filter_suppressed_with_comments(std::mem::take(diags), cs);
+            let src = srcs.get(path).map(String::as_str).unwrap_or("");
+            *diags = ry_checker::filter_suppressed_with_comments(std::mem::take(diags), cs, src);
         }
     }
 
@@ -1343,6 +1334,10 @@ fn collect_r_files_recursive(
         return;
     };
     for entry in entries.flatten() {
+        // Skip symlinks to prevent infinite recursion through symlink loops.
+        if entry.file_type().map(|ft| ft.is_symlink()).unwrap_or(false) {
+            continue;
+        }
         let p = entry.path();
         if package_root
             .as_deref()
@@ -1404,11 +1399,14 @@ fn rbuildignore_pattern(regex: &str) -> Option<glob::Pattern> {
     }
     let anchored_start = regex.starts_with('^');
     let anchored_end = regex.ends_with('$') && !regex.ends_with("\\$");
-    let body = regex
-        .strip_prefix('^')
-        .unwrap_or(regex)
-        .strip_suffix('$')
-        .unwrap_or_else(|| regex.strip_prefix('^').unwrap_or(regex));
+    let body = regex.strip_prefix('^').unwrap_or(regex);
+    // Only strip the trailing `$` when it is a genuine anchor, not an
+    // escaped `\$` (which must survive as a literal in the glob body).
+    let body = if anchored_end {
+        body.strip_suffix('$').unwrap_or(body)
+    } else {
+        body
+    };
     let mut glob = String::new();
     if !anchored_start {
         glob.push('*');

--- a/crates/ry-cli/src/main.rs
+++ b/crates/ry-cli/src/main.rs
@@ -1334,8 +1334,12 @@ fn collect_r_files_recursive(
         return;
     };
     for entry in entries.flatten() {
-        // Skip symlinks to prevent infinite recursion through symlink loops.
-        if entry.file_type().map(|ft| ft.is_symlink()).unwrap_or(false) {
+        // Skip symlinks and entries whose type cannot be classified; following
+        // either could make recursive discovery escape the requested tree.
+        let Ok(file_type) = entry.file_type() else {
+            continue;
+        };
+        if file_type.is_symlink() {
             continue;
         }
         let p = entry.path();
@@ -1398,7 +1402,11 @@ fn rbuildignore_pattern(regex: &str) -> Option<glob::Pattern> {
         return None;
     }
     let anchored_start = regex.starts_with('^');
-    let anchored_end = regex.ends_with('$') && !regex.ends_with("\\$");
+    let trailing_backslashes = regex
+        .strip_suffix('$')
+        .map(|prefix| prefix.chars().rev().take_while(|&ch| ch == '\\').count())
+        .unwrap_or(0);
+    let anchored_end = regex.ends_with('$') && trailing_backslashes.is_multiple_of(2);
     let body = regex.strip_prefix('^').unwrap_or(regex);
     // Only strip the trailing `$` when it is a genuine anchor, not an
     // escaped `\$` (which must survive as a literal in the glob body).
@@ -1466,8 +1474,8 @@ fn sort_and_deduplicate_paths(paths: &mut Vec<PathBuf>) {
 mod tests {
     use super::{
         Baseline, BaselineEntry, ColorChoice, collect_r_files, demote_non_source_paths,
-        load_baseline, run_check_once, sort_and_deduplicate_diagnostics, subtract_baseline,
-        write_baseline_file,
+        load_baseline, rbuildignore_pattern, run_check_once, sort_and_deduplicate_diagnostics,
+        subtract_baseline, write_baseline_file,
     };
     use ry_checker::format::OutputFormat;
     use ry_checker::{Diagnostic, Severity};
@@ -1481,6 +1489,19 @@ mod tests {
             code,
             "same message",
         )
+    }
+
+    #[test]
+    fn rbuildignore_trailing_dollar_respects_escape_parity() {
+        assert!(rbuildignore_pattern("^file$").unwrap().matches("file"));
+        assert!(!rbuildignore_pattern("^file$").unwrap().matches("filex"));
+        assert!(rbuildignore_pattern(r"^file\$").unwrap().matches("file$"));
+        assert!(rbuildignore_pattern(r"^file\\$").unwrap().matches(r"file\"));
+        assert!(
+            !rbuildignore_pattern(r"^file\\$")
+                .unwrap()
+                .matches(r"file\x")
+        );
     }
 
     #[test]

--- a/crates/ry-cli/src/package_metadata.rs
+++ b/crates/ry-cli/src/package_metadata.rs
@@ -248,6 +248,7 @@ pub(crate) fn resolve<'a>(
                 .or_else(|| ry_typeshed::load_package(package))
             {
                 file_bindings.extend(typeshed.functions.keys().cloned());
+                file_bindings.extend(typeshed.datasets.keys().cloned());
                 file_bindings.extend(typeshed.globals.ambient_functions.iter().cloned());
             }
         }
@@ -324,6 +325,10 @@ fn collect_r_source_files(directory: &Path, paths: &mut Vec<PathBuf>) {
         return;
     };
     for entry in entries.flatten() {
+        // Skip symlinks to prevent infinite recursion through symlink loops.
+        if entry.file_type().map(|ft| ft.is_symlink()).unwrap_or(false) {
+            continue;
+        }
         let path = entry.path();
         if path.is_dir() {
             collect_r_source_files(&path, paths);

--- a/crates/ry-core/src/ast.rs
+++ b/crates/ry-core/src/ast.rs
@@ -62,6 +62,11 @@ pub enum Stmt {
     /// `for (nm in iter) body`
     For {
         name: String,
+        /// Span of just the loop-variable identifier (`nm`), as opposed
+        /// to `span`, the whole statement. Consumers that highlight or
+        /// rename the binding (LSP navigation) use this so they do not
+        /// accidentally cover `iter` / `body`.
+        name_span: Span,
         iter: Expr,
         body: Vec<Stmt>,
         span: Span,

--- a/crates/ry-core/src/parser.rs
+++ b/crates/ry-core/src/parser.rs
@@ -224,11 +224,13 @@ impl RParser {
     }
 
     fn lower_for(&self, n: Node, src: &str) -> Option<Stmt> {
-        let name = text(n.child_by_field_name("variable")?, src)?;
+        let variable = n.child_by_field_name("variable")?;
+        let name = text(variable, src)?;
         let iter = self.lower_expr(n.child_by_field_name("sequence")?, src)?;
         let body = self.lower_block(n.child_by_field_name("body")?, src);
         Some(Stmt::For {
             name,
+            name_span: self.span(variable, src),
             iter,
             body,
             span: self.span(n, src),
@@ -803,7 +805,7 @@ fn try_unwrap_raw_string(body: &str) -> Option<String> {
 
 /// Process R string escape sequences. Handles the common cases:
 /// `\"`, `\\`, `\n`, `\r`, `\t`, `\b`, `\f`, `\v`, `\0`, `\'`, and
-/// `\uXXXX` / `\UXXXXXXXX` (4 or 8 hex digits). Unknown escapes are
+/// `\uXXXX` / `\UXXXXXXXX` (1-4 or 1-8 hex digits). Unknown escapes are
 /// passed through verbatim (R warns but keeps the backslash), matching
 /// R's documented behavior.
 fn process_r_escapes(s: &str) -> String {
@@ -840,31 +842,25 @@ fn process_r_escapes(s: &str) -> String {
             b'\'' => (Some('\''), 2),
             b'\\' => (Some('\\'), 2),
             b'\n' => (None, 2), // physical line continuation: drop
-            b'u' => {
-                // \uXXXX (exactly 4 hex).
-                let hex = std::str::from_utf8(bytes.get(i + 2..i + 6).unwrap_or(&[])).unwrap_or("");
-                if let Ok(n) = u32::from_str_radix(hex, 16) {
-                    if let Some(c) = char::from_u32(n) {
-                        (Some(c), 6)
-                    } else {
-                        (None, 6)
-                    }
-                } else {
-                    (None, 2)
+            b'u' | b'U' => {
+                // R accepts 1-4 hex digits after \u and 1-8 after \U.
+                let max_hex = if next == b'u' { 4 } else { 8 };
+                let mut end = i + 2;
+                while end < bytes.len() && end < i + 2 + max_hex && bytes[end].is_ascii_hexdigit() {
+                    end += 1;
                 }
-            }
-            b'U' => {
-                // \UXXXXXXXX (exactly 8 hex).
-                let hex =
-                    std::str::from_utf8(bytes.get(i + 2..i + 10).unwrap_or(&[])).unwrap_or("");
-                if let Ok(n) = u32::from_str_radix(hex, 16) {
-                    if let Some(c) = char::from_u32(n) {
-                        (Some(c), 10)
-                    } else {
-                        (None, 10)
-                    }
-                } else {
+                let hex_bytes = &bytes[i + 2..end];
+                if hex_bytes.is_empty() {
                     (None, 2)
+                } else {
+                    let hex = std::str::from_utf8(hex_bytes).unwrap_or("");
+                    match u32::from_str_radix(hex, 16).ok().and_then(char::from_u32) {
+                        Some(c) => (Some(c), end - i),
+                        // Consume only the prefix for an invalid scalar; the
+                        // main loop then copies the hex digits, preserving the
+                        // complete raw escape.
+                        None => (None, 2),
+                    }
                 }
             }
             b'x' => {
@@ -1474,7 +1470,10 @@ mod tests {
     fn string_unicode_escapes() {
         use super::unquote_r_string;
         assert_eq!(unquote_r_string(r#""\u00e9""#), "é");
-        // Malformed \u (too few hex): keep verbatim, don't panic.
+        assert_eq!(unquote_r_string(r#""\uE9""#), "é");
+        assert_eq!(unquote_r_string(r#""\U1F600""#), "😀");
+        assert_eq!(unquote_r_string(r#""\U00110000""#), r#"\U00110000"#);
+        // A malformed escape without any hex digits remains verbatim.
         assert_eq!(unquote_r_string(r#""\uXY""#), r#"\uXY"#);
     }
 

--- a/crates/ry-lsp/src/backend.rs
+++ b/crates/ry-lsp/src/backend.rs
@@ -62,10 +62,6 @@ pub(super) struct State {
     /// is still the latest. A newer edit during the
     /// sleep window wins and the stale task aborts.
     diag_generation: u64,
-    /// Workspace root, set at `initialize`. Used only for diagnostics
-    /// today; future revisions may use it to discover `ry.toml`.
-    #[allow(dead_code)]
-    root: Option<PathBuf>,
     /// Runtime stubs loaded from the workspace's `ry.toml`. Kept in state so
     /// every rebuilt Project and single-file hover checker sees the same data.
     user_stubs: Arc<std::collections::BTreeMap<String, ry_typeshed::Typeshed>>,
@@ -186,9 +182,15 @@ impl State {
 #[tower_lsp::async_trait]
 impl LanguageServer for Backend {
     async fn initialize(&self, params: InitializeParams) -> LspResult<InitializeResult> {
+        let root = params.root_uri.and_then(|uri| uri.to_file_path().ok());
+        // `load_workspace_stubs` does blocking filesystem I/O (reads
+        // `ry.toml` and walks typeshed directories); run it off the async
+        // executor so a slow disk does not stall every LSP request.
+        let user_stubs = tokio::task::spawn_blocking(move || load_workspace_stubs(root.as_deref()))
+            .await
+            .unwrap_or_else(|_| Arc::new(std::collections::BTreeMap::new()));
         let mut state = self.state.lock().await;
-        state.root = params.root_uri.and_then(|uri| uri.to_file_path().ok());
-        state.user_stubs = load_workspace_stubs(state.root.as_deref());
+        state.user_stubs = user_stubs;
         Ok(InitializeResult {
             capabilities: ServerCapabilities {
                 text_document_sync: Some(TextDocumentSyncCapability::Kind(
@@ -344,14 +346,17 @@ impl LanguageServer for Backend {
     async fn did_close(&self, params: DidCloseTextDocumentParams) {
         let uri = params.text_document.uri.clone();
         let path = uri_to_path(&uri);
-        {
+        let remaining_open_paths = {
             let mut state = self.state.lock().await;
             state.docs.remove(&path);
             state.versions.remove(&path);
             state.parsed.remove(&path);
             state.scopes.remove(&path);
+            // Bump the generation so any in-flight diagnostics publish
+            // queued while the file was open is invalidated.
             state.diag_generation = state.diag_generation.wrapping_add(1);
-        }
+            state.docs.keys().cloned().collect::<Vec<_>>()
+        };
         {
             let project = {
                 let state = self.state.lock().await;
@@ -364,6 +369,14 @@ impl LanguageServer for Backend {
         // Clear diagnostics for the closed document so stale squiggles
         // don't linger after the user closes the file.
         self.client.publish_diagnostics(uri, Vec::new(), None).await;
+        // Closing a document can change diagnostics in the REMAINING open
+        // documents (a name that was defined in the closed file may now
+        // be unresolved, or a locally suppressed diagnostic may surface),
+        // so schedule a re-publish to refresh them rather than leaving
+        // stale cross-file diagnostics.
+        if let Some(first) = remaining_open_paths.first() {
+            self.schedule_diagnostics(path_to_uri(first)).await;
+        }
     }
 
     async fn shutdown(&self) -> LspResult<()> {
@@ -379,17 +392,8 @@ impl LanguageServer for Backend {
         let path = uri_to_path(&uri);
         let position = params.text_document_position_params.position;
 
-        let text = {
-            let state = self.state.lock().await;
-            state.docs.get(&path).cloned()
-        };
-
-        let Some(text) = text else {
-            return Ok(None);
-        };
-
         // Parse (cached) and reuse the cached scope for the type lookup.
-        let Some(file) = self.parsed_file(&path).await else {
+        let Some((file, text)) = self.parsed_file(&path).await else {
             return Ok(None);
         };
         let Some(scope) = self.scope_for(&path).await else {
@@ -399,7 +403,9 @@ impl LanguageServer for Backend {
         // Find the identifier at the hover position via an AST walk
         // (smallest enclosing Expr::Ident), so non-ASCII identifiers and
         // identifiers in any syntactic position resolve correctly.
-        let byte_offset = position_to_byte_offset_pos(&text, position);
+        let Some(byte_offset) = position_to_byte_offset_pos(&text, position) else {
+            return Ok(None);
+        };
         let Some((identifier, _)) = find_ident_at_offset(&file, byte_offset) else {
             return Ok(None);
         };
@@ -431,30 +437,23 @@ impl LanguageServer for Backend {
         let path = uri_to_path(&uri);
         let position = params.text_document_position_params.position;
 
-        let text = {
-            let state = self.state.lock().await;
-            state.docs.get(&path).cloned()
-        };
-
-        let Some(text) = text else {
-            return Ok(None);
-        };
-
         // Parse the current document (cached). We do not
         // need the checker's scope here: definitions live in the AST,
         // not the type environment.
-        let Some(file) = self.parsed_file(&path).await else {
+        let Some((file, text)) = self.parsed_file(&path).await else {
             return Ok(None);
         };
 
         // Find the identifier under the cursor via an AST walk. Returns
         // `None` (no definition) for operators, numbers, and keywords.
-        let byte_offset = position_to_byte_offset_pos(&text, position);
+        let Some(byte_offset) = position_to_byte_offset_pos(&text, position) else {
+            return Ok(None);
+        };
         let Some((identifier, _)) = find_ident_at_offset(&file, byte_offset) else {
             return Ok(None);
         };
 
-        let locations = find_definition_locations(&file, &identifier, &uri);
+        let locations = find_definition_locations(&file, &identifier, &uri, &text);
         if locations.is_empty() {
             Ok(None)
         } else {
@@ -477,40 +476,34 @@ impl LanguageServer for Backend {
             state.docs.clone()
         };
 
-        let text = docs.get(&path).cloned();
-        let Some(text) = text else {
-            return Ok(None);
-        };
-
         // Find the identifier under the cursor via an AST walk of the
         // current document (cached). Returns `None` for
         // operators, numbers, and keywords.
-        let Some(current_file) = self.parsed_file(&path).await else {
+        let Some((current_file, text)) = self.parsed_file(&path).await else {
             return Ok(None);
         };
-        let byte_offset = position_to_byte_offset_pos(&text, position);
+        let Some(byte_offset) = position_to_byte_offset_pos(&text, position) else {
+            return Ok(None);
+        };
         let Some((identifier, _)) = find_ident_at_offset(&current_file, byte_offset) else {
             return Ok(None);
         };
 
         let mut all_locations = Vec::new();
-        for (doc_path, doc_text) in &docs {
-            let file = if doc_path == &path {
-                current_file.clone()
-            } else {
-                // Use the cached parse; skip documents that fail to parse
-                // rather than aborting the whole search.
-                match self.parsed_file(doc_path).await {
-                    Some(f) => f,
-                    None => continue,
-                }
+        for doc_path in docs.keys() {
+            // Use the cache-consistent pairing: `parsed_file` returns the
+            // AST and the text it was parsed FROM, so byte-offset ranges
+            // generated against `doc_text` always match the AST. Skip
+            // documents that fail to parse rather than aborting the search.
+            let Some((file, doc_text)) = self.parsed_file(doc_path).await else {
+                continue;
             };
             let doc_uri = path_to_uri(doc_path);
             let locs = find_references_in_file(
                 &file,
                 &identifier,
                 &doc_uri,
-                doc_text,
+                &doc_text,
                 include_declaration,
             );
             all_locations.extend(locs);
@@ -530,21 +523,12 @@ impl LanguageServer for Backend {
         let uri = params.text_document.uri.clone();
         let path = uri_to_path(&uri);
 
-        let text = {
-            let state = self.state.lock().await;
-            state.docs.get(&path).cloned()
-        };
-
-        let Some(text) = text else {
-            return Ok(None);
-        };
-
         // Reuse the cached parse and cached single-file
         // scope so the symbol panel doesn't re-check on
         // every request. Symbols nested inside function bodies fall back
         // to "function" / "variable" since the top-level scope does not
         // track locals.
-        let Some(file) = self.parsed_file(&path).await else {
+        let Some((file, text)) = self.parsed_file(&path).await else {
             return Ok(None);
         };
         let Some(scope) = self.scope_for(&path).await else {
@@ -564,20 +548,11 @@ impl LanguageServer for Backend {
         let path = uri_to_path(&uri);
         let range = params.range;
 
-        let text = {
-            let state = self.state.lock().await;
-            state.docs.get(&path).cloned()
-        };
-
-        let Some(text) = text else {
-            return Ok(None);
-        };
-
         // Parse the document (cached). On any parse
         // failure we return `None` (no hints) rather than erroring, so
         // the editor simply shows nothing instead of a broken state.
         // Mirrors `document_symbol`.
-        let Some(file) = self.parsed_file(&path).await else {
+        let Some((file, text)) = self.parsed_file(&path).await else {
             return Ok(None);
         };
 
@@ -667,10 +642,10 @@ impl LanguageServer for Backend {
                 None => return Ok(None),
             };
 
-        // Look up the function's parameter names. We only support
-        // base-R functions from the curated table; user-defined
-        // functions would require reaching into the checker's FnTable
-        // from the LSP crate, which is out of scope for v1.
+        // Look up the function's parameter names from the base
+        // typeshed. User-defined functions would require reaching
+        // into the checker's FnTable from the LSP crate, which is
+        // out of scope for v1.
         let Some(params_list) = get_signature(&func_name) else {
             return Ok(None);
         };
@@ -724,18 +699,18 @@ impl LanguageServer for Backend {
         };
 
         let mut all_symbols: Vec<SymbolInformation> = Vec::new();
-        for (doc_path, doc_text) in &docs {
+        for doc_path in docs.keys() {
             // Cached parse and cached single-file scope
             //; skip documents that fail to parse rather
             // than aborting the whole search.
-            let Some(file) = self.parsed_file(doc_path).await else {
+            let Some((file, doc_text)) = self.parsed_file(doc_path).await else {
                 continue;
             };
             let Some(scope) = self.scope_for(doc_path).await else {
                 continue;
             };
 
-            let doc_symbols = collect_symbols(&file.stmts, doc_text, Some(&scope));
+            let doc_symbols = collect_symbols(&file.stmts, &doc_text, Some(&scope));
             let doc_uri = path_to_uri(doc_path);
             // Flatten the hierarchical `DocumentSymbol` tree (which
             // nests function-body bindings as children) into a flat
@@ -767,18 +742,29 @@ impl LanguageServer for Backend {
         let position = params.text_document_position.position;
         let new_name = params.new_name;
 
-        // Snapshot ALL open documents under the lock, then drop the
+        // A rename to an empty / whitespace-only name, or one that is
+        // not a valid R identifier, would corrupt the document. Reject
+        // it up front rather than silently "renaming" to garbage.
+        let is_valid_ident = !new_name.is_empty()
+            && new_name
+                .chars()
+                .all(|c| c.is_alphanumeric() || c == '_' || c == '.')
+            && !new_name
+                .chars()
+                .any(|c| c.is_whitespace() || c.is_control());
+        if !is_valid_ident {
+            return Ok(None);
+        }
+
+        // Snapshot ALL open document paths under the lock, then drop the
         // lock before parsing/walking so a slow rename doesn't block
         // other LSP requests. Rename is workspace-wide, so we walk
-        // every open document (not just the current one).
+        // every open document (not just the current one). The per-file
+        // source text comes from `parsed_file` so it always matches the
+        // AST it was parsed from.
         let docs = {
             let state = self.state.lock().await;
-            state.docs.clone()
-        };
-
-        let text = docs.get(&path).cloned();
-        let Some(text) = text else {
-            return Ok(None);
+            state.docs.keys().cloned().collect::<Vec<_>>()
         };
 
         // Find the identifier at the cursor position via an AST walk to
@@ -786,10 +772,12 @@ impl LanguageServer for Backend {
         // ALL occurrences of that name across all open documents,
         // mirroring how `references` works. Returns `None` (no rename)
         // for operators, numbers, keywords.
-        let Some(current_file) = self.parsed_file(&path).await else {
+        let Some((current_file, text)) = self.parsed_file(&path).await else {
             return Ok(None);
         };
-        let byte_offset = position_to_byte_offset_pos(&text, position);
+        let Some(byte_offset) = position_to_byte_offset_pos(&text, position) else {
+            return Ok(None);
+        };
         let Some((old_name, _)) = find_ident_at_offset(&current_file, byte_offset) else {
             return Ok(None);
         };
@@ -800,32 +788,27 @@ impl LanguageServer for Backend {
         // `TextEdit` replacing the old name with the new one. Edits
         // are grouped by file URI into the `WorkspaceEdit.changes`
         // map; the editor applies each group atomically per file.
-        //
-        // The same loop logic is factored into `build_rename_edits`
-        // (used by the unit tests). We inline it here rather than
-        // share the helper because the helper borrows pre-parsed
-        // `SourceFile`s, while here we parse lazily inside the loop
-        // and skip parse failures per-document.
         let mut edits: HashMap<Url, Vec<TextEdit>> = HashMap::new();
-        for (doc_path, doc_text) in &docs {
-            let file = if doc_path == &path {
-                current_file.clone()
-            } else {
-                match self.parsed_file(doc_path).await {
-                    Some(f) => f,
-                    None => continue,
-                }
+        for doc_path in &docs {
+            let Some((file, doc_text)) = self.parsed_file(doc_path).await else {
+                continue;
             };
             let doc_uri = path_to_uri(doc_path);
             // include_declaration = true: a rename must rewrite the
             // definition site as well as every read / call site.
-            let locations = find_references_in_file(&file, &old_name, &doc_uri, doc_text, true);
+            let locations = find_references_in_file(&file, &old_name, &doc_uri, &doc_text, true);
             for loc in locations {
                 edits.entry(doc_uri.clone()).or_default().push(TextEdit {
                     range: loc.range,
                     new_text: new_name.clone(),
                 });
             }
+        }
+
+        // No occurrences across any open document: report no rename
+        // rather than an empty (no-op) workspace edit.
+        if edits.is_empty() {
+            return Ok(None);
         }
 
         Ok(Some(WorkspaceEdit {
@@ -839,38 +822,24 @@ impl LanguageServer for Backend {
         params: TextDocumentPositionParams,
     ) -> LspResult<Option<PrepareRenameResponse>> {
         let uri = params.text_document.uri.clone();
-        let _ = uri; // retained for symmetry with other handlers
         let path = uri_to_path(&uri);
         let position = params.position;
-
-        let text = {
-            let state = self.state.lock().await;
-            state.docs.get(&path).cloned()
-        };
-
-        let Some(text) = text else {
-            return Ok(None);
-        };
 
         // Validate that the cursor is on a renameable identifier before
         // the editor shows the rename UI. Use the AST-based finder so we
         // get the exact span of the innermost identifier, then convert
         // it to an LSP range. Returns `None` for operators, numbers,
         // keywords, and whitespace.
-        let Some(file) = self.parsed_file(&path).await else {
+        let Some((file, text)) = self.parsed_file(&path).await else {
             return Ok(None);
         };
-        let byte_offset = position_to_byte_offset_pos(&text, position);
+        let Some(byte_offset) = position_to_byte_offset_pos(&text, position) else {
+            return Ok(None);
+        };
         let Some((_, span)) = find_ident_at_offset(&file, byte_offset) else {
             return Ok(None);
         };
-        let range = span_to_range(&text, span).unwrap_or(Range {
-            start: position,
-            end: Position {
-                line: position.line,
-                character: position.character + 1,
-            },
-        });
+        let range = span_to_range(&text, span).unwrap();
 
         Ok(Some(PrepareRenameResponse::Range(range)))
     }
@@ -887,25 +856,19 @@ impl LanguageServer for Backend {
         let path = uri_to_path(&uri);
         let position = params.text_document_position_params.position;
 
-        let text = {
-            let state = self.state.lock().await;
-            state.docs.get(&path).cloned()
-        };
-
-        let Some(text) = text else {
-            return Ok(None);
-        };
-
         // Parse the current document (cached). Document
         // highlight is scoped to the current file (per the LSP spec), so
-        // we only parse once.
-        let Some(file) = self.parsed_file(&path).await else {
+        // we only parse once. `text` comes from the same version the
+        // AST was parsed from, so offsets always match.
+        let Some((file, text)) = self.parsed_file(&path).await else {
             return Ok(None);
         };
 
         // Find the identifier under the cursor via an AST walk. Returns
         // `None` (no highlights) for operators, numbers, and keywords.
-        let byte_offset = position_to_byte_offset_pos(&text, position);
+        let Some(byte_offset) = position_to_byte_offset_pos(&text, position) else {
+            return Ok(None);
+        };
         let Some((identifier, _)) = find_ident_at_offset(&file, byte_offset) else {
             return Ok(None);
         };
@@ -925,19 +888,11 @@ impl LanguageServer for Backend {
         let uri = params.text_document.uri.clone();
         let path = uri_to_path(&uri);
 
-        let text = {
-            let state = self.state.lock().await;
-            state.docs.get(&path).cloned()
-        };
-
-        let Some(text) = text else {
-            return Ok(None);
-        };
-
-        // Parse the document (cached). On any parse
-        // failure we return `None` (no folding ranges) rather than
-        // erroring. Mirrors `document_symbol` / `inlay_hint`.
-        let Some(file) = self.parsed_file(&path).await else {
+        // Parse the document (cached), pairing the AST with the exact
+        // text it was parsed from. On any parse failure we return
+        // `None` (no folding ranges) rather than erroring. Mirrors
+        // `document_symbol` / `inlay_hint`.
+        let Some((file, text)) = self.parsed_file(&path).await else {
             return Ok(None);
         };
 
@@ -995,22 +950,13 @@ impl LanguageServer for Backend {
         params: SelectionRangeParams,
     ) -> LspResult<Option<Vec<SelectionRange>>> {
         let uri = params.text_document.uri.clone();
-        let _ = uri; // retained for symmetry with the other handlers
         let path = uri_to_path(&uri);
 
-        let text = {
-            let state = self.state.lock().await;
-            state.docs.get(&path).cloned()
-        };
-
-        let Some(text) = text else {
-            return Ok(None);
-        };
-
-        // Parse the document (cached). On any parse
-        // failure we return `None` (no selection ranges) rather than
-        // erroring. Mirrors `document_symbol` / `folding_range`.
-        let Some(file) = self.parsed_file(&path).await else {
+        // Parse the document (cached), pairing the AST with the exact
+        // text it was parsed from. On any parse failure we return
+        // `None` (no selection ranges) rather than erroring. Mirrors
+        // `document_symbol` / `folding_range`.
+        let Some((file, text)) = self.parsed_file(&path).await else {
             return Ok(None);
         };
 
@@ -1047,17 +993,26 @@ impl Backend {
     /// parse when its version matches the latest known version. The
     /// cache is read + repopulated under the state lock; parsing itself
     /// (which needs a non-`Send` `RParser`) happens after releasing the
-    /// lock, then the result is stored back.
+    /// Return the current AST for `path` together with the exact source
+    /// text it was parsed from. Pairing the two is atomic: handlers use
+    /// the text for byte-offset / UTF-16 conversions that must match the
+    /// AST's span offsets, so a concurrent `didChange` racing the parse
+    /// can never yield a stale text applied to a fresher AST (or vice
+    /// versa).
     ///
     /// Returns `None` when the path is not an open document or parsing
     /// fails.
-    async fn parsed_file(&self, path: &str) -> Option<Arc<SourceFile>> {
+    async fn parsed_file(&self, path: &str) -> Option<(Arc<SourceFile>, String)> {
         loop {
-            // Fast path: cache hit with matching version.
+            // Fast path: cache hit with matching version. The cache only
+            // returns a parse whose recorded version equals the current
+            // document version, so `docs[path]` is exactly the text that
+            // parse was produced from.
             {
                 let state = self.state.lock().await;
                 if let Some(file) = state.cached_parse(path) {
-                    return Some(file);
+                    let text = state.docs.get(path).cloned()?;
+                    return Some((file, text));
                 }
             }
             // Cache miss / stale: parse the current text and store it.
@@ -1078,7 +1033,7 @@ impl Backend {
             // If an edit landed while parsing, retry against the new version
             // instead of returning an AST already known to be stale.
             if state.record_parse(path, version, Arc::clone(&file)) {
-                return Some(file);
+                return Some((file, text));
             }
         }
     }
@@ -1101,7 +1056,7 @@ impl Backend {
             }
         }
         // Cache miss: parse (via the parse cache) + check, then store.
-        let file = self.parsed_file(path).await?;
+        let (file, _) = self.parsed_file(path).await?;
         let parsed_version = {
             let state = self.state.lock().await;
             state
@@ -1161,7 +1116,7 @@ impl Backend {
         // per-document `SourceFile` cached in `State` and only re-parses
         // documents whose version changed since the last request.
         for doc_path in docs.keys() {
-            let Some(file) = self.parsed_file(doc_path).await else {
+            let Some((file, _)) = self.parsed_file(doc_path).await else {
                 continue;
             };
             per_file_comments.insert(doc_path.clone(), file.comments.clone());
@@ -1190,7 +1145,10 @@ impl Backend {
             let (file_level, suppressions) = match file_comments {
                 Some(comments) => (
                     ry_checker::has_file_suppression_from_comments(comments),
-                    ry_checker::parse_suppressions_from_comments(comments),
+                    ry_checker::parse_suppressions_from_comments(
+                        comments,
+                        source_text.unwrap_or(""),
+                    ),
                 ),
                 None => (false, Vec::new()),
             };

--- a/crates/ry-lsp/src/backend.rs
+++ b/crates/ry-lsp/src/backend.rs
@@ -11,8 +11,10 @@ use crate::diagnostics::{
     diagnostic_to_lsp, diagnostic_to_lsp_with_source, make_ignore_action, make_ignore_file_action,
 };
 use crate::folding::collect_folding_ranges;
-use crate::hints::{collect_completions, collect_inlay_hints, find_enclosing_call, get_signature};
-use crate::ident::find_ident_at_offset;
+use crate::hints::{
+    active_parameter, collect_completions, collect_inlay_hints, find_enclosing_call, get_signature,
+};
+use crate::ident::{find_ident_at_offset, is_valid_identifier};
 use crate::navigation::{
     collect_document_highlights, find_definition_locations, find_references_in_file,
 };
@@ -651,17 +653,10 @@ impl LanguageServer for Backend {
         };
 
         // Build the signature label like `round(x, digits)` and the
-        // per-parameter `ParameterInformation` list. The active
-        // parameter (highlighted by the editor) is clamped to the
-        // parameter count; if the user has typed more commas than
-        // there are formal parameters, we return `None` so the editor
-        // clears the popup rather than highlighting a non-existent
-        // parameter.
-        let active_param = if active_param < params_list.len() {
-            Some(active_param as u32)
-        } else {
-            None
-        };
+        // per-parameter `ParameterInformation` list. Extra arguments keep
+        // the final variadic parameter active; non-variadic signatures clear
+        // the highlight once the cursor moves past their final parameter.
+        let active_param = active_parameter(&params_list, active_param);
         let label = format!("{}({})", func_name, params_list.join(", "));
         let param_infos: Vec<ParameterInformation> = params_list
             .iter()
@@ -742,17 +737,9 @@ impl LanguageServer for Backend {
         let position = params.text_document_position.position;
         let new_name = params.new_name;
 
-        // A rename to an empty / whitespace-only name, or one that is
-        // not a valid R identifier, would corrupt the document. Reject
-        // it up front rather than silently "renaming" to garbage.
-        let is_valid_ident = !new_name.is_empty()
-            && new_name
-                .chars()
-                .all(|c| c.is_alphanumeric() || c == '_' || c == '.')
-            && !new_name
-                .chars()
-                .any(|c| c.is_whitespace() || c.is_control());
-        if !is_valid_ident {
+        // Rename inserts the supplied text without backticks, so reject names
+        // that are not syntactically valid unquoted R identifiers.
+        if !is_valid_identifier(&new_name) {
             return Ok(None);
         }
 

--- a/crates/ry-lsp/src/diagnostics.rs
+++ b/crates/ry-lsp/src/diagnostics.rs
@@ -9,6 +9,7 @@
 use std::collections::HashMap;
 
 use ry_checker::{Diagnostic as RyDiagnostic, Severity};
+use ry_core::RParser;
 use tower_lsp::lsp_types::{
     CodeAction, CodeActionKind, Diagnostic as LspDiagnostic, DiagnosticSeverity, NumberOrString,
     Position, Range, TextEdit, Url, WorkspaceEdit,
@@ -100,7 +101,22 @@ pub(super) fn make_ignore_action(
     let line = diag.range.start.line as usize;
     let line_text = text.lines().nth(line)?;
 
-    if line_text.contains("ry: ignore") {
+    // Avoid a redundant action when the line already carries a
+    // suppression directive. Check that the marker STARTS the comment
+    // body (after `#` and whitespace), not merely appears as a substring
+    // (so prose like "# See docs for ry: ignore" does not block the action).
+    let already_ignored = RParser::new()
+        .ok()
+        .and_then(|mut parser| parser.parse("<code-action>", line_text).ok())
+        .into_iter()
+        .flat_map(|file| file.comments)
+        .map(|comment| comment.body.trim_start().to_lowercase())
+        .any(|body| {
+            body.starts_with("ry: ignore")
+                || body.starts_with("ry:ignore")
+                || body.starts_with("noqa")
+        });
+    if already_ignored {
         return None;
     }
 
@@ -115,10 +131,12 @@ pub(super) fn make_ignore_action(
         line: diag.range.start.line,
         character: 0,
     };
-    let end = Position {
-        line: diag.range.start.line,
-        character: line_text.len() as u32,
-    };
+    // `line_text.len()` is a BYTE length but `Position.character` is a
+    // UTF-16 code-unit column, so convert the byte offset of the line's
+    // end to a proper column (a non-ASCII line would otherwise produce
+    // an out-of-range character).
+    let line_start = line_start_byte_offset(text, line);
+    let end = byte_offset_to_position(text, line_start + line_text.len());
 
     let mut changes = HashMap::new();
     changes.insert(
@@ -182,4 +200,16 @@ pub(super) fn make_ignore_file_action(uri: &Url, text: &str) -> Option<CodeActio
         }),
         ..Default::default()
     })
+}
+
+/// Byte offset of the first character of the given 0-indexed line.
+fn line_start_byte_offset(text: &str, line: usize) -> usize {
+    let mut offset = 0usize;
+    for (i, piece) in text.split_inclusive('\n').enumerate() {
+        if i == line {
+            break;
+        }
+        offset += piece.len();
+    }
+    offset
 }

--- a/crates/ry-lsp/src/hints.rs
+++ b/crates/ry-lsp/src/hints.rs
@@ -7,7 +7,7 @@ use tower_lsp::lsp_types::{
     InlayHintLabel, Position,
 };
 
-use crate::util::{byte_offset_to_position, position_to_byte_offset};
+use crate::util::{byte_offset_to_position, utf16_col_to_byte};
 
 /// Collect `InlayHint`s for every assignment whose target is a bare
 /// identifier with a known (non-opaque) inferred type. The hint is
@@ -146,9 +146,8 @@ pub(super) fn collect_completions(
             // index; resolve it to a byte offset before slicing so a
             // line with a non-ASCII character before the cursor cannot
             // panic (or truncate) the slice.
-            let until = position_to_byte_offset(text, position.line, position.character)
-                .unwrap_or(text.len());
-            let before_cursor = &line[..until.min(line.len())];
+            let until = utf16_col_to_byte(line, position.character).unwrap_or(line.len());
+            let before_cursor = &line[..until];
             // Strip the trailing `$` (and any whitespace between the
             // identifier and it) so `extract_last_identifier` lands
             // on the variable name.
@@ -277,7 +276,7 @@ pub(super) fn common_r_completions() -> Vec<CompletionItem> {
         FUNCTION_ENTRIES
             .iter()
             .filter(|(name, _)| {
-                base.is_none_or(|typeshed| {
+                base.as_ref().is_none_or(|typeshed| {
                     typeshed.functions.contains_key(*name)
                         || typeshed
                             .globals
@@ -341,8 +340,8 @@ pub(super) fn find_enclosing_call(text: &str, line: usize, col: usize) -> Option
     // non-ASCII character before the cursor cannot panic the slice.
     // A cursor past the last character (a common transient state
     // right after typing `(`) is clamped to the line end.
-    let until = position_to_byte_offset(text, line as u32, col as u32).unwrap_or(text.len());
-    let before_cursor = &line_str[..until.min(line_str.len())];
+    let until = utf16_col_to_byte(line_str, col as u32).unwrap_or(line_str.len());
+    let before_cursor = &line_str[..until];
 
     // Walk backward to find the last unmatched `(`. We track depth so
     // a `(` belonging to a nested call (e.g. the inner `(` in
@@ -407,4 +406,14 @@ pub(super) fn get_signature(name: &str) -> Option<Vec<String>> {
     let base = ry_typeshed::load_base_cached().ok()?;
     let signature = base.functions.get(name)?;
     Some(signature.param_names().map(str::to_owned).collect())
+}
+
+pub(super) fn active_parameter(params: &[String], active: usize) -> Option<u32> {
+    if active < params.len() {
+        Some(active as u32)
+    } else if params.last().is_some_and(|param| param == "...") {
+        Some((params.len() - 1) as u32)
+    } else {
+        None
+    }
 }

--- a/crates/ry-lsp/src/hints.rs
+++ b/crates/ry-lsp/src/hints.rs
@@ -7,7 +7,7 @@ use tower_lsp::lsp_types::{
     InlayHintLabel, Position,
 };
 
-use crate::util::byte_offset_to_position;
+use crate::util::{byte_offset_to_position, position_to_byte_offset};
 
 /// Collect `InlayHint`s for every assignment whose target is a bare
 /// identifier with a known (non-opaque) inferred type. The hint is
@@ -65,12 +65,10 @@ fn collect_inlay_hints_from_stmt(
                 }
                 // Place the hint right after the identifier name.
                 // `span.start + name.len()` lands on the first
-                // character past the identifier (in byte space,
-                // which `byte_offset_to_position` converts to an
-                // LSP `Position`). For ASCII identifiers this is
-                // exact; non-ASCII names would need a UTF-16-aware
-                // helper, matching the existing approximation in
-                // `byte_offset_to_position`.
+                // character past the identifier (the identifier's
+                // byte end); `byte_offset_to_position` converts it to
+                // a UTF-16 LSP `Position`, so non-ASCII identifiers
+                // are handled correctly too.
                 let pos = byte_offset_to_position(text, span.start + name.len());
                 hints.push(InlayHint {
                     position: pos,
@@ -144,13 +142,13 @@ pub(super) fn collect_completions(
         // list (no completions) rather than falling through to the
         // generic list, so the editor popup stays focused.
         if let Some(line) = text.lines().nth(position.line as usize) {
-            // `position.character` is a UTF-16 offset; we
-            // approximate it as a byte index (matching the rest of
-            // this file's ASCII assumption). Clamp to the line end
-            // so a cursor past the last char doesn't slice out of
-            // bounds.
-            let until = position.character.min(line.len() as u32) as usize;
-            let before_cursor = &line[..until];
+            // `position.character` is a UTF-16 offset, not a byte
+            // index; resolve it to a byte offset before slicing so a
+            // line with a non-ASCII character before the cursor cannot
+            // panic (or truncate) the slice.
+            let until = position_to_byte_offset(text, position.line, position.character)
+                .unwrap_or(text.len());
+            let before_cursor = &line[..until.min(line.len())];
             // Strip the trailing `$` (and any whitespace between the
             // identifier and it) so `extract_last_identifier` lands
             // on the variable name.
@@ -212,137 +210,90 @@ pub(super) fn collect_completions(
 
 /// Build a small, curated list of common base-R keywords and
 /// functions. Kept short on purpose: the task calls for a focused
-/// popup, and the typeshed's full function table isn't directly
-/// reachable from the LSP crate. These names cover the constructs R
-/// users type most often at the top level.
+/// popup, and dumping the typeshed's full function table (thousands of
+/// entries) would bury the common names under noise.
+///
+/// Keyword entries are pure R syntax, so they cannot come from the
+/// typeshed and stay curated. The function entries keep a curated name
+/// plus a one-line human hint (the typeshed has no descriptions), but
+/// every name is validated against the base typeshed: a function must
+/// appear in its `functions` map or `ambient_functions` globals or it
+/// is dropped, so the popup cannot offer a name the checker does not
+/// know. We use the full `CompletionItemKind::X` form (rather than a
+/// `use` alias) because `CompletionItemKind` is a tuple struct with
+/// associated constants, not an enum, so a glob import is not allowed.
 pub(super) fn common_r_completions() -> Vec<CompletionItem> {
-    // (name, kind, detail). The detail is a one-line human hint so
-    // the popup shows something useful next to each entry. We use the
-    // full `CompletionItemKind::X` form (rather than a `use` alias)
-    // because `CompletionItemKind` is a tuple struct with associated
-    // constants, not an enum, so a glob import is not allowed.
-    const ENTRIES: &[(&str, CompletionItemKind, &str)] = &[
+    const KEYWORD_ENTRIES: &[(&str, &str)] = &[
         // Keywords / control flow.
-        ("if", CompletionItemKind::KEYWORD, "conditional"),
-        (
-            "else",
-            CompletionItemKind::KEYWORD,
-            "conditional alternative",
-        ),
-        ("for", CompletionItemKind::KEYWORD, "for loop"),
-        ("while", CompletionItemKind::KEYWORD, "while loop"),
-        ("repeat", CompletionItemKind::KEYWORD, "repeat loop"),
-        (
-            "function",
-            CompletionItemKind::KEYWORD,
-            "function definition",
-        ),
-        (
-            "return",
-            CompletionItemKind::KEYWORD,
-            "return from function",
-        ),
-        ("break", CompletionItemKind::KEYWORD, "break out of loop"),
-        (
-            "next",
-            CompletionItemKind::KEYWORD,
-            "skip to next iteration",
-        ),
-        // Common base-R functions.
-        (
-            "c",
-            CompletionItemKind::FUNCTION,
-            "combine values into a vector",
-        ),
-        ("list", CompletionItemKind::FUNCTION, "create a list"),
-        (
-            "data.frame",
-            CompletionItemKind::FUNCTION,
-            "create a data frame",
-        ),
-        ("matrix", CompletionItemKind::FUNCTION, "create a matrix"),
-        ("vector", CompletionItemKind::FUNCTION, "create a vector"),
-        (
-            "length",
-            CompletionItemKind::FUNCTION,
-            "length of an object",
-        ),
-        ("names", CompletionItemKind::FUNCTION, "names of an object"),
-        ("mean", CompletionItemKind::FUNCTION, "arithmetic mean"),
-        ("sum", CompletionItemKind::FUNCTION, "sum of elements"),
-        ("min", CompletionItemKind::FUNCTION, "minimum"),
-        ("max", CompletionItemKind::FUNCTION, "maximum"),
-        ("print", CompletionItemKind::FUNCTION, "print an object"),
-        (
-            "str",
-            CompletionItemKind::FUNCTION,
-            "display the structure of an object",
-        ),
-        (
-            "library",
-            CompletionItemKind::FUNCTION,
-            "load an attached package",
-        ),
-        (
-            "require",
-            CompletionItemKind::FUNCTION,
-            "load an attached package",
-        ),
-        (
-            "sapply",
-            CompletionItemKind::FUNCTION,
-            "apply a function over a list or vector",
-        ),
-        (
-            "lapply",
-            CompletionItemKind::FUNCTION,
-            "apply a function over a list",
-        ),
-        (
-            "mapply",
-            CompletionItemKind::FUNCTION,
-            "apply a function over multiple arguments",
-        ),
-        (
-            "which",
-            CompletionItemKind::FUNCTION,
-            "indices of TRUE values",
-        ),
-        (
-            "is.na",
-            CompletionItemKind::FUNCTION,
-            "detect missing values",
-        ),
-        (
-            "as.integer",
-            CompletionItemKind::FUNCTION,
-            "coerce to integer",
-        ),
-        (
-            "as.numeric",
-            CompletionItemKind::FUNCTION,
-            "coerce to numeric",
-        ),
-        (
-            "as.character",
-            CompletionItemKind::FUNCTION,
-            "coerce to character",
-        ),
-        (
-            "as.logical",
-            CompletionItemKind::FUNCTION,
-            "coerce to logical",
-        ),
+        ("if", "conditional"),
+        ("else", "conditional alternative"),
+        ("for", "for loop"),
+        ("while", "while loop"),
+        ("repeat", "repeat loop"),
+        ("function", "function definition"),
+        ("return", "return from function"),
+        ("break", "break out of loop"),
+        ("next", "skip to next iteration"),
     ];
-    ENTRIES
+    // (name, detail). The detail is a one-line human hint so the
+    // popup shows something useful next to each entry.
+    const FUNCTION_ENTRIES: &[(&str, &str)] = &[
+        ("c", "combine values into a vector"),
+        ("list", "create a list"),
+        ("data.frame", "create a data frame"),
+        ("matrix", "create a matrix"),
+        ("vector", "create a vector"),
+        ("length", "length of an object"),
+        ("names", "names of an object"),
+        ("mean", "arithmetic mean"),
+        ("sum", "sum of elements"),
+        ("min", "minimum"),
+        ("max", "maximum"),
+        ("print", "print an object"),
+        ("str", "display the structure of an object"),
+        ("library", "load an attached package"),
+        ("require", "load an attached package"),
+        ("sapply", "apply a function over a list or vector"),
+        ("lapply", "apply a function over a list"),
+        ("mapply", "apply a function over multiple arguments"),
+        ("which", "indices of TRUE values"),
+        ("is.na", "detect missing values"),
+        ("as.integer", "coerce to integer"),
+        ("as.numeric", "coerce to numeric"),
+        ("as.character", "coerce to character"),
+        ("as.logical", "coerce to logical"),
+    ];
+    let base = ry_typeshed::load_base_cached().ok();
+    let mut items: Vec<CompletionItem> = KEYWORD_ENTRIES
         .iter()
-        .map(|(name, kind, detail)| CompletionItem {
+        .map(|(name, detail)| CompletionItem {
             label: (*name).to_string(),
-            kind: Some(*kind),
+            kind: Some(CompletionItemKind::KEYWORD),
             detail: Some((*detail).to_string()),
             ..Default::default()
         })
-        .collect()
+        .collect();
+    items.extend(
+        FUNCTION_ENTRIES
+            .iter()
+            .filter(|(name, _)| {
+                base.is_none_or(|typeshed| {
+                    typeshed.functions.contains_key(*name)
+                        || typeshed
+                            .globals
+                            .ambient_functions
+                            .iter()
+                            .any(|n| n == *name)
+                })
+            })
+            .map(|(name, detail)| CompletionItem {
+                label: (*name).to_string(),
+                kind: Some(CompletionItemKind::FUNCTION),
+                detail: Some((*detail).to_string()),
+                ..Default::default()
+            }),
+    );
+    items
 }
 
 /// Extract the identifier at the end of `s`, scanning backwards. An
@@ -385,12 +336,13 @@ pub(super) fn extract_last_identifier(s: &str) -> Option<String> {
 ///     call).
 pub(super) fn find_enclosing_call(text: &str, line: usize, col: usize) -> Option<(String, usize)> {
     let line_str = text.lines().nth(line)?;
-    // Clamp the column to the line length so a cursor past the last
-    // character (a common transient state right after typing `(`)
-    // doesn't slice out of bounds. `col` is treated as a byte index,
-    // matching the ASCII assumption used throughout this file.
-    let until = col.min(line_str.len());
-    let before_cursor = &line_str[..until];
+    // `col` is a UTF-16 code-unit column from the LSP request.
+    // Resolve it to a byte offset before slicing, so a line with a
+    // non-ASCII character before the cursor cannot panic the slice.
+    // A cursor past the last character (a common transient state
+    // right after typing `(`) is clamped to the line end.
+    let until = position_to_byte_offset(text, line as u32, col as u32).unwrap_or(text.len());
+    let before_cursor = &line_str[..until.min(line_str.len())];
 
     // Walk backward to find the last unmatched `(`. We track depth so
     // a `(` belonging to a nested call (e.g. the inner `(` in
@@ -444,63 +396,15 @@ pub(super) fn find_enclosing_call(text: &str, line: usize, col: usize) -> Option
 }
 
 /// Look up the formal parameter names of a base-R function for
-/// signature help. Returns `None` for functions outside the curated
-/// table (user-defined functions are out of scope; the checker's
+/// signature help. Returns `None` for functions outside the base
+/// typeshed (user-defined functions are out of scope; the checker's
 /// FnTable isn't reachable from the LSP crate).
 ///
-/// The table is a small hand-maintained list of the most common base-R
-/// functions with their conventional parameter names. `...` is used
-/// for variadic functions where naming the rest of the parameters
-/// would be misleading. This intentionally avoids the typeshed: it
-/// would require exposing `ry-typeshed`'s internal `params` arrays to
-/// the LSP crate, and the curated list covers the cases users hit most.
+/// The embedded base typeshed is the single source of truth for
+/// parameter names: there is no parallel hand-maintained table here,
+/// so the LSP cannot drift from what the checker resolves.
 pub(super) fn get_signature(name: &str) -> Option<Vec<String>> {
-    let params: &[&str] = match name {
-        "c" => &["..."],
-        "list" => &["..."],
-        "mean" => &["x", "trim", "na.rm"],
-        "sum" => &["..."],
-        "length" => &["x"],
-        "rep" => &["x", "times", "each"],
-        "seq" => &["from", "to", "by"],
-        "round" => &["x", "digits"],
-        "paste" => &["...", "sep", "collapse"],
-        "paste0" => &["...", "collapse"],
-        "sprintf" => &["fmt", "..."],
-        "lapply" => &["X", "FUN"],
-        "sapply" => &["X", "FUN"],
-        "vapply" => &["X", "FUN", "FUN.VALUE"],
-        "mapply" => &["FUN", "..."],
-        "Map" => &["f", "..."],
-        "Reduce" => &["f", "x", "accumulate"],
-        "grepl" => &["pattern", "x"],
-        "gsub" => &["pattern", "replacement", "x"],
-        "substr" => &["x", "start", "stop"],
-        "matrix" => &["data", "nrow", "ncol"],
-        "data.frame" => &["..."],
-        "factor" => &["x", "levels", "labels"],
-        "ifelse" => &["test", "yes", "no"],
-        "which" => &["x"],
-        "order" => &["..."],
-        "sort" => &["x"],
-        "unique" => &["x"],
-        "match" => &["x", "table"],
-        "names" => &["x"],
-        "nchar" => &["x"],
-        "toupper" => &["x"],
-        "tolower" => &["x"],
-        "print" => &["x"],
-        "cat" => &["..."],
-        "stop" => &["..."],
-        "warning" => &["..."],
-        "nrow" => &["x"],
-        "ncol" => &["x"],
-        "head" => &["x", "n"],
-        "tail" => &["x", "n"],
-        "cbind" => &["..."],
-        "rbind" => &["..."],
-        "merge" => &["x", "y"],
-        _ => return None,
-    };
-    Some(params.iter().map(|s| s.to_string()).collect())
+    let base = ry_typeshed::load_base_cached().ok()?;
+    let signature = base.functions.get(name)?;
+    Some(signature.param_names().map(str::to_owned).collect())
 }

--- a/crates/ry-lsp/src/ident.rs
+++ b/crates/ry-lsp/src/ident.rs
@@ -66,12 +66,13 @@ fn find_ident_in_stmt(s: &Stmt, offset: usize, best: &mut Option<(String, Span)>
             iter,
             body,
             name,
-            span,
+            name_span,
+            ..
         } => {
             find_ident_in_expr(iter, offset, best);
-            // The loop variable binding is a bare name (no inner span);
-            // use the statement span as a coarse fallback.
-            consider(name, *span, offset, best);
+            // The loop variable binding has no inner expression span, but
+            // `name_span` covers just the identifier.
+            consider(name, *name_span, offset, best);
             for s in body {
                 find_ident_in_stmt(s, offset, best);
             }

--- a/crates/ry-lsp/src/ident.rs
+++ b/crates/ry-lsp/src/ident.rs
@@ -152,12 +152,27 @@ fn find_ident_in_expr(e: &Expr, offset: usize, best: &mut Option<(String, Span)>
     }
 }
 
-/// True if `name` is a pure number or an R reserved word -- rename/hover/
-/// go-to-def ignore keywords and numeric literals.
-pub(super) fn is_numeric_or_keyword(name: &str) -> bool {
-    if name.parse::<f64>().is_ok() {
-        return true;
+/// True when `name` is a syntactically valid, unquoted R identifier.
+/// Backtick-quoted names are intentionally excluded because rename inserts
+/// the supplied text directly without adding quotes.
+pub(super) fn is_valid_identifier(name: &str) -> bool {
+    let mut chars = name.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    if !(first.is_alphabetic() || first == '.') {
+        return false;
     }
+    if first == '.' && chars.clone().next().is_some_and(char::is_numeric) {
+        return false;
+    }
+    if !chars.all(|ch| ch.is_alphanumeric() || ch == '_' || ch == '.') {
+        return false;
+    }
+    !is_reserved_word(name)
+}
+
+fn is_reserved_word(name: &str) -> bool {
     matches!(
         name,
         "if" | "else"
@@ -179,9 +194,29 @@ pub(super) fn is_numeric_or_keyword(name: &str) -> bool {
             | "NA_character_"
             | "Inf"
             | "NaN"
-            | "T"
-            | "F"
-            | "library"
-            | "require"
     )
+}
+
+/// True if `name` is a pure number or an R reserved word -- rename/hover/
+/// go-to-def ignore keywords and numeric literals.
+pub(super) fn is_numeric_or_keyword(name: &str) -> bool {
+    if name.parse::<f64>().is_ok() {
+        return true;
+    }
+    is_reserved_word(name) || matches!(name, "T" | "F" | "library" | "require")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_valid_identifier;
+
+    #[test]
+    fn validates_unquoted_r_identifiers() {
+        for valid in ["name", ".name", "snake_case", "café", "x2"] {
+            assert!(is_valid_identifier(valid), "expected valid: {valid}");
+        }
+        for invalid in ["", "2name", ".2name", "has space", "if", "TRUE", "a-b"] {
+            assert!(!is_valid_identifier(invalid), "expected invalid: {invalid}");
+        }
+    }
 }

--- a/crates/ry-lsp/src/navigation.rs
+++ b/crates/ry-lsp/src/navigation.rs
@@ -21,28 +21,29 @@ use crate::util::byte_offset_to_position;
 
 /// Find every definition site of `name` in `file`, returning each as an
 /// LSP `Location` inside `uri`.
-pub(super) fn find_definition_locations(file: &SourceFile, name: &str, uri: &Url) -> Vec<Location> {
+pub(super) fn find_definition_locations(
+    file: &SourceFile,
+    name: &str,
+    uri: &Url,
+    text: &str,
+) -> Vec<Location> {
     let mut spans: Vec<Span> = Vec::new();
     for stmt in &file.stmts {
         find_def_spans_in_stmt(stmt, name, &mut spans);
     }
     spans
         .into_iter()
-        .map(|sp| span_to_location(sp, name, uri))
+        .map(|sp| span_to_location(sp, name, uri, text))
         .collect()
 }
 
 /// Convert a definition-site `Span` into an LSP `Location`. The range
-/// highlights the identifier itself (col .. col + name.len()).
-fn span_to_location(span: Span, name: &str, uri: &Url) -> Location {
-    let start = Position {
-        line: span.line as u32,
-        character: span.col as u32,
-    };
-    let end = Position {
-        line: span.line as u32,
-        character: span.col as u32 + name.len() as u32,
-    };
+/// highlights the identifier itself (start .. start + name.len()).
+/// Columns are UTF-16 code units, converted from the span's byte
+/// offsets against the source text.
+fn span_to_location(span: Span, name: &str, uri: &Url, text: &str) -> Location {
+    let start = byte_offset_to_position(text, span.start);
+    let end = byte_offset_to_position(text, span.start + name.len());
     Location {
         uri: uri.clone(),
         range: Range { start, end },
@@ -87,11 +88,11 @@ fn find_def_spans_in_stmt(stmt: &Stmt, name: &str, out: &mut Vec<Span>) {
         Stmt::For {
             name: loop_var,
             body,
-            span,
+            name_span,
             ..
         } => {
             if loop_var == name {
-                out.push(*span);
+                out.push(*name_span);
             }
             for s in body {
                 find_def_spans_in_stmt(s, name, out);
@@ -237,10 +238,11 @@ fn find_ref_spans_in_stmt(stmt: &Stmt, name: &str, out: &mut Vec<Span>, include_
             name: loop_var,
             iter,
             body,
-            span,
+            name_span,
+            ..
         } => {
             if include_declaration && loop_var == name {
-                out.push(*span);
+                out.push(*name_span);
             }
             find_ref_spans_in_expr(iter, name, out, include_declaration);
             for s in body {
@@ -381,10 +383,11 @@ fn collect_highlight_entries_from_stmt(
             name: loop_var,
             iter,
             body,
-            span,
+            name_span,
+            ..
         } => {
             if loop_var == name {
-                out.push((*span, DocumentHighlightKind::WRITE));
+                out.push((*name_span, DocumentHighlightKind::WRITE));
             }
             collect_highlight_entries_from_expr(iter, name, out);
             for s in body {

--- a/crates/ry-lsp/src/selection.rs
+++ b/crates/ry-lsp/src/selection.rs
@@ -4,7 +4,7 @@ use ry_core::{SourceFile, Span};
 use tower_lsp::lsp_types::{Position, Range, SelectionRange};
 
 use crate::folding::span_of_stmt;
-use crate::util::{byte_offset_to_position, position_to_byte_offset_pos, span_to_range};
+use crate::util::{byte_offset_to_position, position_to_byte_offset_pos, span_to_range, utf16_len};
 
 /// Find the identifier (variable name) at a given line and column in
 /// the source text, returning BOTH the identifier string AND its LSP
@@ -26,28 +26,33 @@ pub(super) fn find_identifier_range_at_position(
     col: usize,
 ) -> Option<(String, Range)> {
     let line_str = text.lines().nth(line)?;
+    // `col` is a UTF-16 code-unit column (LSP), but the byte-based
+    // scan below indexes the line by bytes. Convert it so a line with
+    // a non-ASCII character before the cursor neither panics nor
+    // lands mid-character.
+    let byte_col = utf16_col_to_byte(line_str, col as u32)?;
     let bytes = line_str.as_bytes();
-    if bytes.is_empty() || col >= bytes.len() {
+    if bytes.is_empty() || byte_col >= bytes.len() {
         return None;
     }
     // The character at the cursor must be identifier-like.
     let is_ident_char = |b: u8| b.is_ascii_alphanumeric() || b == b'_' || b == b'.';
-    if !is_ident_char(bytes[col]) {
+    if !is_ident_char(bytes[byte_col]) {
         // Check if the cursor is just after an identifier (common when
         // the user places the cursor right at the end of a word).
-        if col > 0 && is_ident_char(bytes[col - 1]) {
-            // Expand from col-1 instead.
+        if byte_col > 0 && is_ident_char(bytes[byte_col - 1]) {
+            // Expand from byte_col-1 instead.
         } else {
             return None;
         }
     }
     // Expand left to find the start of the identifier.
-    let mut start = col;
+    let mut start = byte_col;
     while start > 0 && is_ident_char(bytes[start - 1]) {
         start -= 1;
     }
     // Expand right to find the end.
-    let mut end = col;
+    let mut end = byte_col;
     while end < bytes.len() && is_ident_char(bytes[end]) {
         end += 1;
     }
@@ -80,17 +85,39 @@ pub(super) fn find_identifier_range_at_position(
     ) {
         return None;
     }
+    // Convert the byte-exclusive boundaries back to UTF-16 character
+    // columns for the LSP range.
+    let start_char = byte_offset_to_position(line_str, start).character;
+    let end_char = byte_offset_to_position(line_str, end).character;
     let range = Range {
         start: Position {
             line: line as u32,
-            character: start as u32,
+            character: start_char,
         },
         end: Position {
             line: line as u32,
-            character: end as u32,
+            character: end_char,
         },
     };
     Some((ident.to_string(), range))
+}
+
+/// Convert a UTF-16 code-unit column (LSP) to a byte offset within a
+/// single line. Returns `None` when the column lands past the end of
+/// the line or inside a surrogate pair.
+fn utf16_col_to_byte(line: &str, utf16_col: u32) -> Option<usize> {
+    let mut col = 0u32;
+    for (byte, ch) in line.char_indices() {
+        if col == utf16_col {
+            return Some(byte);
+        }
+        let next_col = col + utf16_len(ch) as u32;
+        if utf16_col < next_col {
+            return None;
+        }
+        col = next_col;
+    }
+    (col == utf16_col).then_some(line.len())
 }
 /// Find the smallest enclosing statement whose `Span` contains the
 /// cursor position, returning its range as an LSP `Range`. Returns
@@ -106,7 +133,7 @@ pub(super) fn find_identifier_range_at_position(
 /// hop, and the file-level range provides the "expand all the way"
 /// step.
 fn find_enclosing_stmt_range(position: Position, file: &SourceFile, text: &str) -> Option<Range> {
-    let byte_offset = position_to_byte_offset_pos(text, position);
+    let byte_offset = position_to_byte_offset_pos(text, position)?;
     let mut best: Option<Span> = None;
     for stmt in &file.stmts {
         if let Some(span) = span_of_stmt(stmt) {

--- a/crates/ry-lsp/src/selection.rs
+++ b/crates/ry-lsp/src/selection.rs
@@ -4,7 +4,9 @@ use ry_core::{SourceFile, Span};
 use tower_lsp::lsp_types::{Position, Range, SelectionRange};
 
 use crate::folding::span_of_stmt;
-use crate::util::{byte_offset_to_position, position_to_byte_offset_pos, span_to_range, utf16_len};
+use crate::util::{
+    byte_offset_to_position, position_to_byte_offset_pos, span_to_range, utf16_col_to_byte,
+};
 
 /// Find the identifier (variable name) at a given line and column in
 /// the source text, returning BOTH the identifier string AND its LSP
@@ -102,23 +104,6 @@ pub(super) fn find_identifier_range_at_position(
     Some((ident.to_string(), range))
 }
 
-/// Convert a UTF-16 code-unit column (LSP) to a byte offset within a
-/// single line. Returns `None` when the column lands past the end of
-/// the line or inside a surrogate pair.
-fn utf16_col_to_byte(line: &str, utf16_col: u32) -> Option<usize> {
-    let mut col = 0u32;
-    for (byte, ch) in line.char_indices() {
-        if col == utf16_col {
-            return Some(byte);
-        }
-        let next_col = col + utf16_len(ch) as u32;
-        if utf16_col < next_col {
-            return None;
-        }
-        col = next_col;
-    }
-    (col == utf16_col).then_some(line.len())
-}
 /// Find the smallest enclosing statement whose `Span` contains the
 /// cursor position, returning its range as an LSP `Range`. Returns
 /// `None` when the cursor is not inside any statement (e.g. on a

--- a/crates/ry-lsp/src/symbols.rs
+++ b/crates/ry-lsp/src/symbols.rs
@@ -2,11 +2,9 @@
 
 use ry_checker::Scope;
 use ry_core::{Expr, Span, Stmt};
-use tower_lsp::lsp_types::{
-    DocumentSymbol, Location, Position, Range, SymbolInformation, SymbolKind, Url,
-};
+use tower_lsp::lsp_types::{DocumentSymbol, Location, Range, SymbolInformation, SymbolKind, Url};
 
-use crate::util::span_to_range;
+use crate::util::{byte_offset_to_position, span_to_range};
 
 /// Recursively flatten a tree of `DocumentSymbol`s (with their
 /// children) into a flat list of `SymbolInformation`s, attaching the
@@ -160,7 +158,7 @@ fn stmt_to_symbol(stmt: &Stmt, text: &str, scope: Option<&Scope>) -> Option<Docu
                 SymbolKind::VARIABLE
             };
             let detail = compute_detail(name, is_function, scope);
-            let selection_range = ident_to_range(*ident_span, name);
+            let selection_range = ident_to_range(text, *ident_span, name);
             let range = span_to_range(text, *span).unwrap_or(selection_range);
             // For function-valued assignments, the body's local
             // definitions become children of this symbol so the
@@ -188,10 +186,12 @@ fn stmt_to_symbol(stmt: &Stmt, text: &str, scope: Option<&Scope>) -> Option<Docu
             // completeness / future grammar changes. Children include
             // the parameters plus any nested definitions in the body.
             let detail = compute_detail(n, true, scope);
-            let selection_range = span_start_range(*span, n);
+            let selection_range = span_start_range(text, *span, n);
             let range = span_to_range(text, *span).unwrap_or(selection_range);
-            let mut children: Vec<DocumentSymbol> =
-                params.iter().filter_map(param_to_symbol).collect();
+            let mut children: Vec<DocumentSymbol> = params
+                .iter()
+                .filter_map(|p| param_to_symbol(p, text))
+                .collect();
             children.extend(collect_symbols(body, text, None));
             let children = if children.is_empty() {
                 None
@@ -218,7 +218,10 @@ fn stmt_to_symbol(stmt: &Stmt, text: &str, scope: Option<&Scope>) -> Option<Docu
 /// body has no bindings, so that non-function symbols stay flat.
 fn function_body_symbols(value: &Expr, text: &str) -> Option<Vec<DocumentSymbol>> {
     if let Expr::Function { params, body, .. } = value {
-        let mut children: Vec<DocumentSymbol> = params.iter().filter_map(param_to_symbol).collect();
+        let mut children: Vec<DocumentSymbol> = params
+            .iter()
+            .filter_map(|p| param_to_symbol(p, text))
+            .collect();
         children.extend(collect_symbols(body, text, None));
         if children.is_empty() {
             None
@@ -233,8 +236,8 @@ fn function_body_symbols(value: &Expr, text: &str) -> Option<Vec<DocumentSymbol>
 /// Build a `DocumentSymbol` for a function parameter. Parameters use
 /// `SymbolKind::VARIABLE` (LSP has no dedicated parameter kind) and
 /// their range covers exactly the parameter name.
-fn param_to_symbol(param: &ry_core::Param) -> Option<DocumentSymbol> {
-    let range = ident_to_range(param.span, &param.name);
+fn param_to_symbol(param: &ry_core::Param, text: &str) -> Option<DocumentSymbol> {
+    let range = ident_to_range(text, param.span, &param.name);
     Some(make_document_symbol(
         param.name.clone(),
         Some("parameter".to_string()),
@@ -259,26 +262,19 @@ fn compute_detail(name: &str, is_function: bool, scope: Option<&Scope>) -> Optio
 }
 
 /// Build an LSP `Range` covering exactly an identifier, using the
-/// identifier's `Span` for the start position and the name's length
-/// for the end column. This matches the convention used by
-/// `span_to_location` for go-to-definition.
-fn ident_to_range(span: Span, name: &str) -> Range {
-    let start = Position {
-        line: span.line as u32,
-        character: span.col as u32,
-    };
-    let end = Position {
-        line: span.line as u32,
-        character: span.col as u32 + name.len() as u32,
-    };
+/// identifier's `Span` start byte offset and the name's length for the
+/// end offset, converted to UTF-16 columns against the source text.
+fn ident_to_range(text: &str, span: Span, name: &str) -> Range {
+    let start = byte_offset_to_position(text, span.start);
+    let end = byte_offset_to_position(text, span.start + name.len());
     Range { start, end }
 }
 
 /// Build a `Range` anchored at a span's start position, spanning
 /// `name.len()` characters. Used for `Stmt::FunctionDef` where we
 /// only have the enclosing statement span (no dedicated name span).
-fn span_start_range(span: Span, name: &str) -> Range {
-    ident_to_range(span, name)
+fn span_start_range(text: &str, span: Span, name: &str) -> Range {
+    ident_to_range(text, span, name)
 }
 
 /// Construct a `DocumentSymbol` with all fields filled. The

--- a/crates/ry-lsp/src/tests.rs
+++ b/crates/ry-lsp/src/tests.rs
@@ -199,7 +199,7 @@ fn goto_def_finds_variable_assignment() {
     let mut parser = RParser::new().unwrap();
     let file = parser.parse("test.R", text).unwrap();
     let uri = Url::parse("file:///tmp/test.R").unwrap();
-    let locs = find_definition_locations(&file, "x", &uri);
+    let locs = find_definition_locations(&file, "x", &uri, text);
     assert_eq!(locs.len(), 1, "expected exactly one definition of x");
     let loc = &locs[0];
     assert_eq!(loc.uri, uri);
@@ -220,7 +220,7 @@ fn goto_def_finds_function_definition() {
     let mut parser = RParser::new().unwrap();
     let file = parser.parse("test.R", text).unwrap();
     let uri = Url::parse("file:///tmp/test.R").unwrap();
-    let locs = find_definition_locations(&file, "add", &uri);
+    let locs = find_definition_locations(&file, "add", &uri, text);
     assert_eq!(locs.len(), 1, "expected exactly one definition of add");
     let loc = &locs[0];
     assert_eq!(loc.range.start.line, 0);
@@ -237,7 +237,7 @@ fn goto_def_finds_local_definition_inside_function_body() {
     let mut parser = RParser::new().unwrap();
     let file = parser.parse("test.R", text).unwrap();
     let uri = Url::parse("file:///tmp/test.R").unwrap();
-    let locs = find_definition_locations(&file, "local", &uri);
+    let locs = find_definition_locations(&file, "local", &uri, text);
     assert_eq!(locs.len(), 1, "expected exactly one definition of local");
     let loc = &locs[0];
     assert_eq!(loc.range.start.line, 1);
@@ -253,7 +253,7 @@ fn goto_def_finds_reassignment_as_multiple_locations() {
     let mut parser = RParser::new().unwrap();
     let file = parser.parse("test.R", text).unwrap();
     let uri = Url::parse("file:///tmp/test.R").unwrap();
-    let locs = find_definition_locations(&file, "x", &uri);
+    let locs = find_definition_locations(&file, "x", &uri, text);
     assert_eq!(locs.len(), 2);
     assert_eq!(locs[0].range.start.line, 0);
     assert_eq!(locs[1].range.start.line, 1);
@@ -265,7 +265,7 @@ fn goto_def_returns_empty_for_undefined_name() {
     let mut parser = RParser::new().unwrap();
     let file = parser.parse("test.R", text).unwrap();
     let uri = Url::parse("file:///tmp/test.R").unwrap();
-    let locs = find_definition_locations(&file, "does_not_exist", &uri);
+    let locs = find_definition_locations(&file, "does_not_exist", &uri, text);
     assert!(locs.is_empty(), "expected no definitions");
 }
 
@@ -638,14 +638,14 @@ fn find_enclosing_call_returns_none_for_non_ident_func() {
 
 #[test]
 fn get_signature_returns_known_params() {
-    // `round` has the conventional `x, digits` parameters; the
-    // helper must surface them in order.
+    // The base typeshed is the source of truth: `round` declares
+    // `x, digits` plus `...` (forwarded to the default method).
     let params = get_signature("round").expect("round should have a signature");
-    assert_eq!(params, vec!["x", "digits"]);
+    assert_eq!(params, vec!["x", "digits", "..."]);
 
-    // `mean` has three formal parameters.
+    // `mean` declares `x` and `...` (trim/na.rm are method-level).
     let params = get_signature("mean").expect("mean should have a signature");
-    assert_eq!(params, vec!["x", "trim", "na.rm"]);
+    assert_eq!(params, vec!["x", "..."]);
 
     // Variadic functions collapse to `...`.
     let params = get_signature("c").expect("c should have a signature");
@@ -679,9 +679,9 @@ fn signature_help_label_and_active_param() {
 
     let params = get_signature(&name).expect("round should have a signature");
     let label = format!("{}({})", name, params.join(", "));
-    assert_eq!(label, "round(x, digits)");
+    assert_eq!(label, "round(x, digits, ...)");
     // The active parameter must be clamped to the parameter list
-    // length: with 2 params and active=1, the highlight should
+    // length: with 3 params and active=1, the highlight should
     // land on `digits`.
     let active_param = if active < params.len() {
         Some(active as u32)
@@ -697,8 +697,8 @@ fn signature_help_clamps_when_past_last_param() {
     // parameters (e.g. `round(1, 2, 3, `), the active-parameter
     // index should clamp to `None` so the editor clears the
     // highlight instead of pointing at a non-existent parameter.
-    // `round` has 2 params; typing 3 commas puts the cursor on a
-    // 4th parameter that doesn't exist.
+    // `round` has 3 params (x, digits, ...); typing 3 commas puts
+    // the cursor on a 4th parameter that doesn't exist.
     let text = "round(1, 2, 3, \n";
     // After the third comma (byte 14): active param 3.
     let (_, active) = find_enclosing_call(text, 0, 14).expect("should find call");
@@ -1246,6 +1246,45 @@ fn rename_edits_single_file_includes_declaration_and_usages() {
 }
 
 #[test]
+fn rename_edits_loop_variable_replaces_only_the_identifier() {
+    // Renaming a `for` loop variable must produce edits covering
+    // exactly the loop-variable identifier and its uses -- NOT the
+    // whole `for` statement. (Regression: the declaration site used
+    // to be the entire statement span, so the rename replaced the
+    // whole loop with the new name.)
+    let src = "for (i in 1:3) {\n  print(i)\n}\n";
+    let mut parser = RParser::new().unwrap();
+    let file = parser.parse("test.R", src).unwrap();
+    let edit = build_rename_edits(&[("test.R", &file, src)], "i", "idx");
+
+    let changes = edit.changes.expect("should have changes");
+    let edits = changes
+        .get(&path_to_uri("test.R"))
+        .expect("edits for test.R");
+    // One edit for the declaration (`i` in the header), one for the
+    // use inside the body.
+    assert_eq!(edits.len(), 2, "got {:?}", edits);
+    for e in edits {
+        assert_eq!(e.new_text, "idx");
+        // The range must cover exactly the 1-char identifier, so the
+        // whole loop is never rewritten.
+        assert_eq!(
+            e.range.end.character - e.range.start.character,
+            1,
+            "rename must replace only the identifier: {:?}",
+            e
+        );
+    }
+    let lines: Vec<u32> = edits.iter().map(|e| e.range.start.line).collect();
+    assert!(
+        lines.contains(&0),
+        "declaration edit on line 0: {:?}",
+        lines
+    );
+    assert!(lines.contains(&1), "usage edit on line 1: {:?}", lines);
+}
+
+#[test]
 fn rename_edits_across_files_group_by_uri() {
     // Simulate two open documents: a.R defines `helper`, b.R calls
     // it. Renaming `helper` to `h` must produce one edit in each
@@ -1338,6 +1377,11 @@ fn prepare_rename_returns_none_for_keywords_and_operators() {
         None,
         "pure numbers must not be renameable"
     );
+}
+
+#[test]
+fn prepare_rename_rejects_utf16_column_inside_surrogate_pair() {
+    assert_eq!(find_identifier_range_at_position("😀name", 0, 1), None);
 }
 
 #[test]
@@ -1690,6 +1734,22 @@ fn code_action_ignore_line_skips_already_suppressed() {
         make_ignore_action(&uri, &diag, text).is_none(),
         "should not offer an action for an already-suppressed line"
     );
+}
+
+#[test]
+fn code_action_ignore_line_ignores_hash_inside_string() {
+    let text = "x <- \"# not a comment\"\n";
+    let diag = lsp_diag(0, 0, 1, "RY040");
+    let uri = Url::parse("file:///tmp/test.R").unwrap();
+    assert!(make_ignore_action(&uri, &diag, text).is_some());
+}
+
+#[test]
+fn code_action_ignore_line_detects_noqa_after_string_hash() {
+    let text = "x <- \"# not a comment\"  # noqa\n";
+    let diag = lsp_diag(0, 0, 1, "RY040");
+    let uri = Url::parse("file:///tmp/test.R").unwrap();
+    assert!(make_ignore_action(&uri, &diag, text).is_none());
 }
 
 #[test]

--- a/crates/ry-lsp/src/tests.rs
+++ b/crates/ry-lsp/src/tests.rs
@@ -5,8 +5,8 @@ use crate::diagnostics::{
 };
 use crate::folding::collect_folding_ranges;
 use crate::hints::{
-    collect_completions, collect_inlay_hints, common_r_completions, extract_last_identifier,
-    find_enclosing_call, get_signature,
+    active_parameter, collect_completions, collect_inlay_hints, common_r_completions,
+    extract_last_identifier, find_enclosing_call, get_signature,
 };
 use crate::navigation::{
     build_rename_edits, collect_document_highlights, find_definition_locations,
@@ -562,6 +562,14 @@ fn trigger_context(ch: &str) -> Option<CompletionContext> {
 }
 
 #[test]
+fn dollar_completions_ignore_text_after_utf16_cursor_on_later_line() {
+    let src = "prefix <- 1\ndf <- data.frame(café = 1)\ndf$ trailing\n";
+    let position = Position::new(2, "df$".encode_utf16().count() as u32);
+    let items = completions(src, position, trigger_context("$"));
+    assert!(items.iter().any(|item| item.label == "café"), "{items:?}");
+}
+
+#[test]
 fn extract_last_identifier_basic() {
     // The variable name sits at the end of the input; the helper
     // must scan back to its start, stopping at the first non-ident
@@ -591,6 +599,15 @@ fn find_enclosing_call_basic_round() {
     let (name, active) = find_enclosing_call(text, 0, 6).expect("should find call");
     assert_eq!(name, "round");
     assert_eq!(active, 0);
+}
+
+#[test]
+fn find_enclosing_call_uses_line_local_utf16_column() {
+    let text = "first line\n😀round(x, trailing)\n";
+    let cursor = "😀round(x,".encode_utf16().count();
+    let (name, active) = find_enclosing_call(text, 1, cursor).expect("should find call");
+    assert_eq!(name, "round");
+    assert_eq!(active, 1);
 }
 
 #[test]
@@ -683,36 +700,19 @@ fn signature_help_label_and_active_param() {
     // The active parameter must be clamped to the parameter list
     // length: with 3 params and active=1, the highlight should
     // land on `digits`.
-    let active_param = if active < params.len() {
-        Some(active as u32)
-    } else {
-        None
-    };
-    assert_eq!(active_param, Some(1));
+    assert_eq!(active_parameter(&params, active), Some(1));
 }
 
 #[test]
-fn signature_help_clamps_when_past_last_param() {
-    // When the user has typed more commas than there are formal
-    // parameters (e.g. `round(1, 2, 3, `), the active-parameter
-    // index should clamp to `None` so the editor clears the
-    // highlight instead of pointing at a non-existent parameter.
-    // `round` has 3 params (x, digits, ...); typing 3 commas puts
-    // the cursor on a 4th parameter that doesn't exist.
+fn signature_help_keeps_variadic_parameter_active() {
     let text = "round(1, 2, 3, \n";
-    // After the third comma (byte 14): active param 3.
     let (_, active) = find_enclosing_call(text, 0, 14).expect("should find call");
     assert_eq!(active, 3);
     let params = get_signature("round").expect("round should have a signature");
-    let active_param = if active < params.len() {
-        Some(active as u32)
-    } else {
-        None
-    };
-    assert_eq!(
-        active_param, None,
-        "active param should clamp to None past the last formal"
-    );
+    assert_eq!(active_parameter(&params, active), Some(2));
+
+    let non_variadic = vec!["x".to_string(), "digits".to_string()];
+    assert_eq!(active_parameter(&non_variadic, active), None);
 }
 
 #[test]

--- a/crates/ry-lsp/src/util.rs
+++ b/crates/ry-lsp/src/util.rs
@@ -88,6 +88,24 @@ pub(crate) fn position_to_byte_offset_pos(text: &str, position: Position) -> Opt
     position_to_byte_offset(text, position.line, position.character)
 }
 
+/// Convert a UTF-16 code-unit column (LSP) to a byte offset within a
+/// single line. Returns `None` when the column lands past the end of
+/// the line or inside a surrogate pair.
+pub(crate) fn utf16_col_to_byte(line: &str, utf16_col: u32) -> Option<usize> {
+    let mut col = 0u32;
+    for (byte, ch) in line.char_indices() {
+        if col == utf16_col {
+            return Some(byte);
+        }
+        let next_col = col + utf16_len(ch) as u32;
+        if utf16_col < next_col {
+            return None;
+        }
+        col = next_col;
+    }
+    (col == utf16_col).then_some(line.len())
+}
+
 /// Convert a ry `Span` (byte offsets) to an LSP `Range` (UTF-16
 /// positions). Both endpoints go through `byte_offset_to_position` so
 /// the character column is a UTF-16 code-unit count and start/end are

--- a/crates/ry-lsp/src/util.rs
+++ b/crates/ry-lsp/src/util.rs
@@ -26,11 +26,16 @@ pub(crate) fn byte_offset_to_position(text: &str, byte_offset: usize) -> Positio
         if b >= byte_offset {
             break;
         }
-        if ch == '\n' {
-            line += 1;
-            col = 0;
-        } else {
-            col += utf16_len(ch) as u32;
+        match ch {
+            '\r' if text.as_bytes().get(b + 1) == Some(&b'\n') => {
+                // The `\r` of a CRLF line terminator is not a column
+                // character; the following `\n` handles the line break.
+            }
+            '\n' => {
+                line += 1;
+                col = 0;
+            }
+            _ => col += utf16_len(ch) as u32,
         }
     }
     Position {
@@ -55,11 +60,16 @@ pub(crate) fn position_to_byte_offset(text: &str, line: u32, utf16_col: u32) -> 
         if cur_line == line && cur_col >= utf16_col {
             return Some(b);
         }
-        if ch == '\n' {
-            cur_line += 1;
-            cur_col = 0;
-        } else {
-            cur_col += utf16_len(ch) as u32;
+        match ch {
+            '\r' if text.as_bytes().get(b + 1) == Some(&b'\n') => {
+                // CRLF: the `\r` is part of the line terminator, not a
+                // column character; only the `\n` resets the column.
+            }
+            '\n' => {
+                cur_line += 1;
+                cur_col = 0;
+            }
+            _ => cur_col += utf16_len(ch) as u32,
         }
     }
     if cur_line == line && cur_col >= utf16_col {
@@ -70,9 +80,12 @@ pub(crate) fn position_to_byte_offset(text: &str, line: u32, utf16_col: u32) -> 
 }
 
 /// Map an LSP `Position` to a byte offset. Wrapper over the line/col
-/// variant for callers that hold a `Position`.
-pub(crate) fn position_to_byte_offset_pos(text: &str, position: Position) -> usize {
-    position_to_byte_offset(text, position.line, position.character).unwrap_or(text.len())
+/// variant for callers that hold a `Position`. Returns `None` when the
+/// position does not fall inside the text (line past the end of the
+/// file, or a column past the end of its line), so callers can report
+/// "no result" instead of silently resolving against the last byte.
+pub(crate) fn position_to_byte_offset_pos(text: &str, position: Position) -> Option<usize> {
+    position_to_byte_offset(text, position.line, position.character)
 }
 
 /// Convert a ry `Span` (byte offsets) to an LSP `Range` (UTF-16


### PR DESCRIPTION
Part 3 of 4 in the wave-0 stack (split from `review/wave0-p1`). Base: PR #34.

Groups the cross-crate API changes with **every consumer** so the workspace stays green: `ry-cli → ry-lsp → {ry-checker, ry-core}`, and two changes each ripple into multiple crates. Splitting these any finer leaves a branch that doesn't build.

- **ry-checker (API):** `parse_suppressions_from_comments`/`filter_suppressed_with_comments` take `src` to resolve a standalone `# ry: ignore` to the actual next code line; `parse_rule_codes` stops at `]`; cache expanded severity tokens (`expanded_*`); JSON output includes `confidence`.
- **ry-core:** `Stmt::For::name_span`; `process_r_escapes` accepts variable-width `\u`/`\U` hex.
- **ry-cli:** pass `src` to suppression filter; skip symlinks in recursive collection; fix `.Rbuildignore` `\$` anchor.
- **ry-lsp:** `parsed_file` returns `(AST, text)` atomically (no stale-text race); `position_to_byte_offset_pos` returns `Option`; UTF-16 columns fixed across selection/hints/navigation/symbols/diagnostics; `name_span`; `did_close` re-publishes; rename validation; signature help + completions source the base typeshed.

**Workspace builds + all 754 tests pass.**