### PR TITLE
Plans 35–36 continuation: diagnostics and workspace isolation

### DIFF
--- a/.github/workflows/ecosystem.yml
+++ b/.github/workflows/ecosystem.yml
@@ -88,5 +88,7 @@ jobs:
           --manifest ecosystem/posit-packages.txt
           --ledger docs/corpus/posit-0.9.0.json
           --tier ${{ github.event_name == 'pull_request' && 'fast' || 'full' }}
+      - name: Readable Posit message drift integration test
+        run: python3 ecosystem/test_posit_messages.py
       - name: Posit ledger drift detection integration test
         run: ecosystem/test-posit-drift-detection.sh

--- a/crates/ry-checker/src/diagnostics.rs
+++ b/crates/ry-checker/src/diagnostics.rs
@@ -75,6 +75,12 @@ impl std::fmt::Display for Severity {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Fix {
+    pub span: Span,
+    pub replacement: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Diagnostic {
     pub severity: Severity,
     pub span: Span,
@@ -82,6 +88,7 @@ pub struct Diagnostic {
     pub code: &'static str,
     pub message: String,
     pub confidence: Confidence,
+    pub fix: Option<Fix>,
 }
 
 impl Diagnostic {
@@ -103,11 +110,17 @@ impl Diagnostic {
             } else {
                 Confidence::default_for(code)
             },
+            fix: None,
         }
     }
 
     pub fn with_confidence(mut self, confidence: Confidence) -> Self {
         self.confidence = confidence;
+        self
+    }
+
+    pub fn with_fix(mut self, fix: Fix) -> Self {
+        self.fix = Some(fix);
         self
     }
 

--- a/crates/ry-checker/src/format.rs
+++ b/crates/ry-checker/src/format.rs
@@ -35,6 +35,13 @@ impl OutputFormat {
 }
 
 #[derive(Debug, Serialize)]
+struct JsonFix<'a> {
+    start: usize,
+    end: usize,
+    replacement: &'a str,
+}
+
+#[derive(Debug, Serialize)]
 struct JsonDiagnostic<'a> {
     code: &'a str,
     severity: &'a str,
@@ -43,6 +50,8 @@ struct JsonDiagnostic<'a> {
     line: usize,
     column: usize,
     confidence: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    fix: Option<JsonFix<'a>>,
 }
 
 /// Render the diagnostics to a string. `srcs` maps `path` -> source text
@@ -137,6 +146,11 @@ pub fn render_with_color(
                         line,
                         column: col,
                         confidence: d.confidence.as_str(),
+                        fix: d.fix.as_ref().map(|fix| JsonFix {
+                            start: fix.span.start,
+                            end: fix.span.end,
+                            replacement: &fix.replacement,
+                        }),
                     }
                 })
                 .collect();
@@ -540,6 +554,30 @@ mod tests {
         // Github format uses the same conversion.
         let gh = render(&d, OutputFormat::Github, &srcs);
         assert!(gh.contains("col=5::"), "github col should be 5, got: {gh}");
+    }
+
+    #[test]
+    fn json_fix_is_additive_and_absent_keys_are_omitted() {
+        let plain = diag("RY040", Severity::Error);
+        let fixed = diag("RY034", Severity::Warning).with_fix(crate::Fix {
+            span: Span::new(4, 11, 0, 4),
+            replacement: "is.na(x)".to_string(),
+        });
+        let srcs = std::collections::HashMap::from([(
+            "x.R".to_string(),
+            "bad x == NA
+"
+            .to_string(),
+        )]);
+        let value: serde_json::Value =
+            serde_json::from_str(&render(&[plain, fixed], OutputFormat::Json, &srcs)).unwrap();
+        assert!(value[0].get("fix").is_none());
+        assert_eq!(
+            value[1]["fix"],
+            serde_json::json!({"start": 4, "end": 11, "replacement": "is.na(x)"})
+        );
+        assert_eq!(value[0]["code"], "RY040");
+        assert_eq!(value[0]["line"], 1);
     }
 
     #[test]

--- a/crates/ry-checker/src/infer/binop.rs
+++ b/crates/ry-checker/src/infer/binop.rs
@@ -8,6 +8,7 @@ impl Checker {
         rt: RType,
         span: Span,
         known_null_is_actionable: bool,
+        scalar_logical_fix: Option<Fix>,
     ) -> RType {
         // `:` sequence operator. Always produces a vector; mode depends
         // on operand modes per R's coercion (int:int -> int, otherwise
@@ -127,8 +128,8 @@ impl Checker {
                 lt.length.binary(rt.length)
             };
             if matches!(op, BinOpKind::AndAnd | BinOpKind::OrOr) {
-                self.emit_scalar_logical_length(op, lt.length, span);
-                self.emit_scalar_logical_length(op, rt.length, span);
+                self.emit_scalar_logical_length(op, lt.length, span, scalar_logical_fix.as_ref());
+                self.emit_scalar_logical_length(op, rt.length, span, scalar_logical_fix.as_ref());
             }
             return RType::new(Mode::Logical, length);
         }
@@ -311,6 +312,7 @@ impl Checker {
             }
             _ => self.infer(rhs, scope),
         };
+        let scalar_logical_fix = self.scalar_logical_operator_fix(op, lhs, rhs);
         let before = self.diagnostics.len();
         let result = self.infer_binop(
             op,
@@ -318,40 +320,63 @@ impl Checker {
             rt,
             span,
             known_null_arithmetic_operand(lhs, scope) || known_null_arithmetic_operand(rhs, scope),
+            scalar_logical_fix.clone(),
         );
         if rhs_parameter_vector
             && !self.diagnostics[before..]
                 .iter()
                 .any(|diagnostic| diagnostic.code == "RY032")
         {
-            self.emit(
-                Severity::Warning,
-                span,
-                "RY032",
-                format!(
-                    "`{}` operand depends on a parameter whose length is not known to be 1; current R errors for vectors",
-                    op_symbol(op)
-                ),
+            let message = format!(
+                "`{}` operand depends on a parameter whose length is not known to be 1; current R errors for vectors",
+                op_symbol(op)
             );
+            if let Some(fix) = scalar_logical_fix {
+                self.emit_with_fix(Severity::Warning, span, "RY032", message, fix);
+            } else {
+                self.emit(Severity::Warning, span, "RY032", message);
+            }
         }
         result
     }
 
-    fn emit_scalar_logical_length(&mut self, op: BinOpKind, length: Length, span: Span) {
+    fn emit_scalar_logical_length(
+        &mut self,
+        op: BinOpKind,
+        length: Length,
+        span: Span,
+        fix: Option<&Fix>,
+    ) {
         if let Length::Known(n) = length
             && n > 1
         {
-            self.emit(
-                Severity::Warning,
-                span,
-                "RY032",
-                format!(
-                    "`{}` applied to a length-{} operand; only the first element is used",
-                    op_symbol(op),
-                    n
-                ),
+            let message = format!(
+                "`{}` applied to a length-{} operand; only the first element is used",
+                op_symbol(op),
+                n
             );
+            if let Some(fix) = fix {
+                self.emit_with_fix(Severity::Warning, span, "RY032", message, fix.clone());
+            } else {
+                self.emit(Severity::Warning, span, "RY032", message);
+            }
         }
+    }
+
+    fn scalar_logical_operator_fix(&self, op: BinOpKind, lhs: &Expr, rhs: &Expr) -> Option<Fix> {
+        let replacement = match op {
+            BinOpKind::AndAnd => "&",
+            BinOpKind::OrOr => "|",
+            _ => return None,
+        };
+        let lhs_end = span_of(lhs).end;
+        let rhs_start = span_of(rhs).start;
+        let between = self.source.get(lhs_end..rhs_start)?;
+        let relative = between.find(op_symbol(op))?;
+        let start = lhs_end + relative;
+        let end = start + op_symbol(op).len();
+        let span = self.source_span(start, end)?;
+        self.fix(span, replacement)
     }
 
     // Desugar `lhs %>% rhs` (and `lhs |> rhs`, `lhs %<>% rhs`) into a

--- a/crates/ry-checker/src/infer/binop.rs
+++ b/crates/ry-checker/src/infer/binop.rs
@@ -292,27 +292,38 @@ impl Checker {
         // than recursing from the enclosing `if`) reports each site exactly
         // once no matter how the operators nest.
         self.check_class_equality_operand(lhs, scope);
-        self.check_class_equality_operand(rhs, scope);
         let lt = self.infer(lhs, scope);
         let narrowing = self.extract_type_narrowing(lhs, scope);
         let (then_scope, else_scope, _) = apply_narrowing(scope, &narrowing, true);
         let rhs_parameter_vector = self.short_circuit_parameter_vector(op, lhs, rhs, scope);
         let rt = match op {
             BinOpKind::AndAnd => {
+                self.check_class_equality_operand(rhs, &then_scope);
                 let mut rhs_scope = then_scope;
                 let rt = self.infer(rhs, &mut rhs_scope);
                 merge_condition_assignments(scope, &rhs_scope, rhs);
                 rt
             }
             BinOpKind::OrOr => {
+                self.check_class_equality_operand(rhs, &else_scope);
                 let mut rhs_scope = else_scope;
                 let rt = self.infer(rhs, &mut rhs_scope);
                 merge_condition_assignments(scope, &rhs_scope, rhs);
                 rt
             }
-            _ => self.infer(rhs, scope),
+            _ => {
+                self.check_class_equality_operand(rhs, scope);
+                self.infer(rhs, scope)
+            }
         };
-        let scalar_logical_fix = self.scalar_logical_operator_fix(op, lhs, rhs);
+        // A parameter guard relies on lazy short-circuit evaluation. Replacing
+        // it with `&` / `|` can eagerly evaluate an invalid RHS and change a
+        // valid result (for example `is.null(x) || x == "a"` for `x = NULL`).
+        let scalar_logical_fix = if rhs_parameter_vector {
+            None
+        } else {
+            self.scalar_logical_operator_fix(op, lhs, rhs)
+        };
         let before = self.diagnostics.len();
         let result = self.infer_binop(
             op,
@@ -331,11 +342,7 @@ impl Checker {
                 "`{}` operand depends on a parameter whose length is not known to be 1; current R errors for vectors",
                 op_symbol(op)
             );
-            if let Some(fix) = scalar_logical_fix {
-                self.emit_with_fix(Severity::Warning, span, "RY032", message, fix);
-            } else {
-                self.emit(Severity::Warning, span, "RY032", message);
-            }
+            self.emit(Severity::Warning, span, "RY032", message);
         }
         result
     }

--- a/crates/ry-checker/src/infer/binop.rs
+++ b/crates/ry-checker/src/infer/binop.rs
@@ -291,8 +291,8 @@ impl Checker {
         // sides are length-1 logical contexts. Scanning them here (rather
         // than recursing from the enclosing `if`) reports each site exactly
         // once no matter how the operators nest.
-        self.check_class_equality_operand(lhs);
-        self.check_class_equality_operand(rhs);
+        self.check_class_equality_operand(lhs, scope);
+        self.check_class_equality_operand(rhs, scope);
         let lt = self.infer(lhs, scope);
         let narrowing = self.extract_type_narrowing(lhs, scope);
         let (then_scope, else_scope, _) = apply_narrowing(scope, &narrowing, true);
@@ -369,14 +369,36 @@ impl Checker {
             BinOpKind::OrOr => "|",
             _ => return None,
         };
+        self.binary_operator_fix(lhs, rhs, op_symbol(op), replacement)
+    }
+
+    /// Build a narrow edit for the operator token between two parsed operands.
+    /// Only lexical trivia may precede the token, so prose in comments cannot
+    /// accidentally become the edit target.
+    pub(crate) fn binary_operator_fix(
+        &self,
+        lhs: &Expr,
+        rhs: &Expr,
+        operator: &str,
+        replacement: &str,
+    ) -> Option<Fix> {
+        self.binary_operator_span(lhs, rhs, operator)
+            .and_then(|span| self.fix(span, replacement))
+    }
+
+    pub(crate) fn binary_operator_span(
+        &self,
+        lhs: &Expr,
+        rhs: &Expr,
+        operator: &str,
+    ) -> Option<Span> {
         let lhs_end = span_of(lhs).end;
         let rhs_start = span_of(rhs).start;
         let between = self.source.get(lhs_end..rhs_start)?;
-        let relative = between.find(op_symbol(op))?;
+        let relative = skip_r_trivia(between);
+        between.get(relative..)?.strip_prefix(operator)?;
         let start = lhs_end + relative;
-        let end = start + op_symbol(op).len();
-        let span = self.source_span(start, end)?;
-        self.fix(span, replacement)
+        self.source_span(start, start + operator.len())
     }
 
     // Desugar `lhs %>% rhs` (and `lhs |> rhs`, `lhs %<>% rhs`) into a
@@ -399,6 +421,34 @@ impl Checker {
     // when it appears in an `Assign` statement; for a bare binop we
     // cannot reassign without a target expression, so we leave that to
     // a future pass.
+}
+
+/// Skip whitespace, R comments, and closing parentheses erased by AST
+/// lowering between an operand span and its binary operator. The next syntax
+/// token must be the operator represented by the AST; comment prose is never
+/// eligible as an edit target.
+fn skip_r_trivia(source: &str) -> usize {
+    let mut offset = 0;
+    loop {
+        let rest = &source[offset..];
+        let trimmed = rest.trim_start_matches(char::is_whitespace);
+        offset += rest.len() - trimmed.len();
+        let rest = &source[offset..];
+        if rest.starts_with(')') {
+            // Parenthesized expressions are transparent in the compact AST,
+            // so their closing delimiter can sit between an operand span and
+            // the binary operator token.
+            offset += 1;
+            continue;
+        }
+        if !rest.starts_with('#') {
+            return offset;
+        }
+        let Some(newline) = rest.find('\n') else {
+            return source.len();
+        };
+        offset += newline + 1;
+    }
 }
 
 /// Recognize the high-confidence parameter guard patterns found in package

--- a/crates/ry-checker/src/infer/call.rs
+++ b/crates/ry-checker/src/infer/call.rs
@@ -1,6 +1,27 @@
 use super::*;
 use crate::higher_order::s3_group_generic;
 
+fn comparison_outside_call_fix(
+    checker: &Checker,
+    call_span: Span,
+    argument_span: Span,
+    lhs: &Expr,
+    rhs: &Expr,
+    op: BinOpKind,
+) -> Option<Fix> {
+    let call = checker.source_text(call_span)?;
+    let lhs_source = checker.source_text(span_of(lhs))?;
+    let rhs_source = checker.source_text(span_of(rhs))?;
+    let relative_start = argument_span.start.checked_sub(call_span.start)?;
+    let relative_end = argument_span.end.checked_sub(call_span.start)?;
+    let before = call.get(..relative_start)?;
+    let after = call.get(relative_end..)?;
+    checker.fix(
+        call_span,
+        format!("{before}{lhs_source}{after} {} {rhs_source}", op_symbol(op)),
+    )
+}
+
 impl Checker {
     pub(crate) fn infer_call(
         &mut self,
@@ -171,7 +192,12 @@ impl Checker {
         // `sum(x > 0)` is the idiomatic R way to count matches, so `sum`
         // is deliberately excluded from this mis-parenthesization family.
         if matches!(lookup_name.as_str(), "length" | "nchar")
-            && let Some(Expr::BinOp { op, span, .. }) = args.first().map(|arg| &arg.value)
+            && let Some(Expr::BinOp {
+                op,
+                lhs,
+                rhs,
+                span: comparison_span,
+            }) = args.first().map(|arg| &arg.value)
             && matches!(
                 op,
                 BinOpKind::Lt
@@ -182,14 +208,15 @@ impl Checker {
                     | BinOpKind::Ne
             )
         {
-            self.emit(
-                Severity::Warning,
-                *span,
-                "RY093",
-                format!(
-                    "comparison is inside `{lookup_name}()`; compare `{lookup_name}(x)` instead"
-                ),
+            let message = format!(
+                "comparison is inside `{lookup_name}()`; compare `{lookup_name}(x)` instead"
             );
+            let fix = comparison_outside_call_fix(self, span, *comparison_span, lhs, rhs, *op);
+            if let Some(fix) = fix {
+                self.emit_with_fix(Severity::Warning, *comparison_span, "RY093", message, fix);
+            } else {
+                self.emit(Severity::Warning, *comparison_span, "RY093", message);
+            }
         }
 
         // Numeric math functions coerce logical comparisons to 0/1, which is
@@ -209,7 +236,12 @@ impl Checker {
                 | "ceiling"
                 | "round"
                 | "trunc"
-        ) && let Some(Expr::BinOp { op, span, .. }) = args.first().map(|arg| &arg.value)
+        ) && let Some(Expr::BinOp {
+            op,
+            lhs,
+            rhs,
+            span: comparison_span,
+        }) = args.first().map(|arg| &arg.value)
             && matches!(
                 op,
                 BinOpKind::Lt
@@ -220,12 +252,13 @@ impl Checker {
                     | BinOpKind::Ne
             )
         {
-            self.emit(
-                Severity::Warning,
-                *span,
-                "RY100",
-                "comparison directly inside a numeric math function is usually a parenthesization mistake; compare the math result instead",
-            );
+            let message = "comparison directly inside a numeric math function is usually a parenthesization mistake; compare the math result instead";
+            let fix = comparison_outside_call_fix(self, span, *comparison_span, lhs, rhs, *op);
+            if let Some(fix) = fix {
+                self.emit_with_fix(Severity::Warning, *comparison_span, "RY100", message, fix);
+            } else {
+                self.emit(Severity::Warning, *comparison_span, "RY100", message);
+            }
         }
 
         // `x["name"]` preserves a list container, whereas `x[["name"]]`
@@ -255,18 +288,22 @@ impl Checker {
                             | Expr::String(_, _)
                     )
             })
-            && let Expr::Index { base, .. } = &indexed.value
+            && let Expr::Index { base, args: index_args, .. } = &indexed.value
         {
             let base_type = self.infer(base, scope);
             let list_origin = matches!(base_type.mode, Mode::List)
                 || matches!(base.as_ref(), Expr::Ident { name, .. } if list_binding_origin(name, scope));
             if list_origin {
-                self.emit(
-                    Severity::Warning,
-                    indexed.span,
-                    "RY101",
-                    "single-bracket list subset remains a list, so `identical()` with an atomic scalar is always FALSE; use `[[` to extract the element",
-                );
+                let message = "single-bracket list subset remains a list, so `identical()` with an atomic scalar is always FALSE; use `[[` to extract the element";
+                let replacement = self
+                    .source_text(span_of(base))
+                    .zip(index_args.first().and_then(|argument| self.source_text(argument.span)))
+                    .map(|(base, argument)| format!("{base}[[{argument}]]"));
+                if let Some(fix) = replacement.and_then(|replacement| self.fix(indexed.span, replacement)) {
+                    self.emit_with_fix(Severity::Warning, indexed.span, "RY101", message, fix);
+                } else {
+                    self.emit(Severity::Warning, indexed.span, "RY101", message);
+                }
             }
         }
 

--- a/crates/ry-checker/src/infer/call.rs
+++ b/crates/ry-checker/src/infer/call.rs
@@ -4,21 +4,38 @@ use crate::higher_order::s3_group_generic;
 fn comparison_outside_call_fix(
     checker: &Checker,
     call_span: Span,
-    argument_span: Span,
+    comparison_span: Span,
     lhs: &Expr,
     rhs: &Expr,
     op: BinOpKind,
 ) -> Option<Fix> {
-    let call = checker.source_text(call_span)?;
-    let lhs_source = checker.source_text(span_of(lhs))?;
-    let rhs_source = checker.source_text(span_of(rhs))?;
-    let relative_start = argument_span.start.checked_sub(call_span.start)?;
-    let relative_end = argument_span.end.checked_sub(call_span.start)?;
-    let before = call.get(..relative_start)?;
-    let after = call.get(relative_end..)?;
+    let operator_span = checker.binary_operator_span(lhs, rhs, op_symbol(op))?;
+    let lhs_end = span_of(lhs).end;
+    if !(lhs_end <= operator_span.start
+        && operator_span.start < comparison_span.end
+        && comparison_span.end <= call_span.end)
+    {
+        return None;
+    }
+
+    // Rotate the original source slices rather than rebuilding either
+    // operand. Trivia before the comparison stays inside the call, while the
+    // exact operator/RHS spelling moves after its closing delimiters. This is
+    // valid for parenthesized arguments and retains all intervening comments.
+    let before_operator = checker.source.get(lhs_end..operator_span.start)?;
+    let call_tail = checker.source.get(comparison_span.end..call_span.end)?;
+    let comparison_tail = checker
+        .source
+        .get(operator_span.start..comparison_span.end)?;
+    let inside_trivia = if before_operator.trim().is_empty() {
+        ""
+    } else {
+        before_operator
+    };
+    let edit_span = checker.source_span(lhs_end, call_span.end)?;
     checker.fix(
-        call_span,
-        format!("{before}{lhs_source}{after} {} {rhs_source}", op_symbol(op)),
+        edit_span,
+        format!("{inside_trivia}{call_tail} {comparison_tail}"),
     )
 }
 

--- a/crates/ry-checker/src/infer/misc.rs
+++ b/crates/ry-checker/src/infer/misc.rs
@@ -1498,9 +1498,15 @@ impl Checker {
                 .unwrap_or_default();
             let message = format!("unknown argument `{argument_name}` to `{function_name}`{hint}");
             let fix = suggestion.and_then(|name| {
-                self.source_text(span_of(&argument.value))
-                    .map(|value| format!("{name} = {value}"))
-                    .and_then(|replacement| self.fix(argument.span, replacement))
+                let name_span = Span::new(
+                    argument.span.start,
+                    argument.span.start + argument_name.len(),
+                    argument.span.line,
+                    argument.span.col,
+                );
+                self.source_text(name_span)
+                    .filter(|source_name| *source_name == argument_name)
+                    .and_then(|_| self.fix(name_span, name.to_string()))
             });
             if let Some(fix) = fix {
                 self.emit_with_fix(Severity::Warning, argument.span, "RY090", message, fix);
@@ -1535,14 +1541,27 @@ impl Checker {
 }
 
 fn closest_parameter<'a>(argument: &str, parameters: &'a [&str]) -> Option<&'a str> {
-    parameters
-        .iter()
-        .copied()
-        .filter(|parameter| *parameter != "...")
-        .map(|parameter| (edit_distance(argument, parameter), parameter))
-        .filter(|(distance, _)| *distance <= 2)
-        .min_by_key(|(distance, parameter)| (*distance, *parameter))
-        .map(|(_, parameter)| parameter)
+    let mut closest = None;
+    let mut minimum_distance = usize::MAX;
+    let mut minimum_is_tied = false;
+
+    for parameter in parameters.iter().copied().filter(|name| *name != "...") {
+        let distance = edit_distance(argument, parameter);
+        if distance > 2 {
+            continue;
+        }
+        match distance.cmp(&minimum_distance) {
+            std::cmp::Ordering::Less => {
+                closest = Some(parameter);
+                minimum_distance = distance;
+                minimum_is_tied = false;
+            }
+            std::cmp::Ordering::Equal => minimum_is_tied = true,
+            std::cmp::Ordering::Greater => {}
+        }
+    }
+
+    if minimum_is_tied { None } else { closest }
 }
 
 fn edit_distance(left: &str, right: &str) -> usize {

--- a/crates/ry-checker/src/infer/misc.rs
+++ b/crates/ry-checker/src/infer/misc.rs
@@ -1496,12 +1496,17 @@ impl Checker {
             let hint = suggestion
                 .map(|name| format!("; did you mean `{name}`?"))
                 .unwrap_or_default();
-            self.emit(
-                Severity::Warning,
-                argument.span,
-                "RY090",
-                format!("unknown argument `{argument_name}` to `{function_name}`{hint}"),
-            );
+            let message = format!("unknown argument `{argument_name}` to `{function_name}`{hint}");
+            let fix = suggestion.and_then(|name| {
+                self.source_text(span_of(&argument.value))
+                    .map(|value| format!("{name} = {value}"))
+                    .and_then(|replacement| self.fix(argument.span, replacement))
+            });
+            if let Some(fix) = fix {
+                self.emit_with_fix(Severity::Warning, argument.span, "RY090", message, fix);
+            } else {
+                self.emit(Severity::Warning, argument.span, "RY090", message);
+            }
         }
     }
 

--- a/crates/ry-checker/src/infer/mod.rs
+++ b/crates/ry-checker/src/infer/mod.rs
@@ -1648,12 +1648,23 @@ impl Checker {
                 if matches!(op, BinOpKind::Eq | BinOpKind::Ne)
                     && (is_na_literal(lhs) || is_na_literal(rhs))
                 {
-                    self.emit(
-                        Severity::Warning,
-                        *span,
-                        "RY034",
-                        "comparison with `NA` always produces `NA`; use `is.na()` instead",
-                    );
+                    let operand = if is_na_literal(lhs) { rhs } else { lhs };
+                    let replacement = self.source_text(span_of(operand)).map(|operand| {
+                        if matches!(op, BinOpKind::Ne) {
+                            format!("!is.na({operand})")
+                        } else {
+                            format!("is.na({operand})")
+                        }
+                    });
+                    let message =
+                        "comparison with `NA` always produces `NA`; use `is.na()` instead";
+                    if let Some(fix) =
+                        replacement.and_then(|replacement| self.fix(*span, replacement))
+                    {
+                        self.emit_with_fix(Severity::Warning, *span, "RY034", message, fix);
+                    } else {
+                        self.emit(Severity::Warning, *span, "RY034", message);
+                    }
                 }
                 // Plan 31 W18 shape rules. Both read the operand syntax, so
                 // they run before `infer` collapses the operands to types.
@@ -1667,6 +1678,7 @@ impl Checker {
                     *span,
                     known_null_arithmetic_operand(lhs, scope)
                         || known_null_arithmetic_operand(rhs, scope),
+                    None,
                 )
             }
             Expr::UnaryOp { op, expr, span } => {

--- a/crates/ry-checker/src/infer/mod.rs
+++ b/crates/ry-checker/src/infer/mod.rs
@@ -355,9 +355,9 @@ impl Checker {
                 cond, then, else_, ..
             } => {
                 // RY103: an `if` condition is a length-1 logical context.
-                self.check_class_equality_operand(cond);
+                self.check_class_equality_operand(cond, scope);
                 let diagnostic_start = self.diagnostics.len();
-                let ct = self.infer(cond, scope);
+                let ct = self.infer_scalar_condition(cond, scope);
                 let has_ry100 = self.diagnostics[diagnostic_start..]
                     .iter()
                     .any(|diagnostic| diagnostic.code == "RY100");
@@ -468,9 +468,9 @@ impl Checker {
             }
             Stmt::While { cond, body, .. } => {
                 // RY103: a loop condition is a length-1 logical context.
-                self.check_class_equality_operand(cond);
+                self.check_class_equality_operand(cond, scope);
                 let diagnostic_start = self.diagnostics.len();
-                let ct = self.infer(cond, scope);
+                let ct = self.infer_scalar_condition(cond, scope);
                 let has_ry100 = self.diagnostics[diagnostic_start..]
                     .iter()
                     .any(|diagnostic| diagnostic.code == "RY100");
@@ -1436,6 +1436,21 @@ impl Checker {
                 RType::unknown()
             }
         }
+    }
+
+    /// Infer a scalar control-flow condition without advertising fixes that
+    /// vectorize its short-circuit operators. The RY032 warning remains valid,
+    /// but replacing `&&` / `||` with `&` / `|` can make `if` or `while`
+    /// receive a vector and fail for a different reason.
+    pub(crate) fn infer_scalar_condition(&mut self, e: &Expr, scope: &mut Scope) -> RType {
+        let diagnostic_start = self.diagnostics.len();
+        let ty = self.infer(e, scope);
+        for diagnostic in &mut self.diagnostics[diagnostic_start..] {
+            if diagnostic.code == "RY032" {
+                diagnostic.fix = None;
+            }
+        }
+        ty
     }
 
     /// Infer the type of an expression, emitting diagnostics for misuse.

--- a/crates/ry-checker/src/infer/pipe.rs
+++ b/crates/ry-checker/src/infer/pipe.rs
@@ -264,9 +264,9 @@ impl Checker {
     ) -> RType {
         // RY103: an `if` used in expression position still requires a
         // length-1 logical condition.
-        self.check_class_equality_operand(cond);
+        self.check_class_equality_operand(cond, scope);
         let diagnostic_start = self.diagnostics.len();
-        let ct = self.infer(cond, scope);
+        let ct = self.infer_scalar_condition(cond, scope);
         let has_ry100 = self.diagnostics[diagnostic_start..]
             .iter()
             .any(|diagnostic| diagnostic.code == "RY100");

--- a/crates/ry-checker/src/infer/recall.rs
+++ b/crates/ry-checker/src/infer/recall.rs
@@ -70,13 +70,9 @@ fn numeric_literal(expr: &Expr) -> Option<f64> {
 /// been typed instead. Only a bare identifier or a string literal qualifies:
 /// `list(x[[1]] <- 2)` and `list(names(y) <- z)` are replacement functions,
 /// not mistyped names.
-fn mistyped_element_name(target: &Expr) -> Option<(&str, String)> {
+fn mistyped_element_name(target: &Expr) -> Option<&str> {
     match target {
-        Expr::Ident { name, .. } => Some((name.as_str(), name.clone())),
-        // A string LHS keeps its quotes in the suggestion: `github-ref` is
-        // not a syntactic name, so `"github-ref" = ...` is the only fix that
-        // parses.
-        Expr::String(name, _) => Some((name.as_str(), format!("\"{name}\""))),
+        Expr::Ident { name, .. } | Expr::String(name, _) => Some(name.as_str()),
         _ => None,
     }
 }
@@ -101,33 +97,6 @@ fn call_argument(expr: &Expr) -> Option<&Expr> {
         return None;
     };
     args.first().map(|arg| &arg.value)
-}
-
-/// Render an expression back to a compact source string for diagnostic
-/// suggestions. Covers the common literal/identifier shapes; returns
-/// `None` for expressions that cannot be rendered without losing meaning,
-/// so the caller can omit the concrete suggestion rather than emit a
-/// broken one like `inherits(..., "widget")`.
-fn expr_to_source(expr: &Expr) -> Option<String> {
-    match expr {
-        Expr::Ident { name, .. } => Some(name.clone()),
-        Expr::String(s, _) => {
-            if s.contains('\0') {
-                return None;
-            }
-            let escaped = s
-                .replace('\\', "\\\\")
-                .replace('"', "\\\"")
-                .replace('\n', "\\n")
-                .replace('\r', "\\r")
-                .replace('\t', "\\t");
-            Some(format!("\"{}\"", escaped))
-        }
-        Expr::Integer(n, _) => Some(format!("{n}L")),
-        Expr::Double(n, _) => Some(n.to_string()),
-        Expr::Logical(b, _) => Some(b.to_string()),
-        _ => None,
-    }
 }
 
 impl Checker {
@@ -186,26 +155,32 @@ impl Checker {
             let Expr::BinOp {
                 op: BinOpKind::Assign,
                 lhs,
+                rhs,
                 span,
-                ..
             } = &argument.value
             else {
                 continue;
             };
-            let Some((name, spelling)) = mistyped_element_name(lhs) else {
+            let Some(name) = mistyped_element_name(lhs) else {
                 continue;
             };
             if matches!(lhs.as_ref(), Expr::Ident { .. }) && !builds_named_structure {
                 continue;
             }
-            self.emit(
-                Severity::Warning,
-                *span,
-                "RY102",
-                format!(
-                    "`<-` inside `{lookup_name}()` assigns `{name}` and leaves the element unnamed; write `{spelling} = ...` to name it"
-                ),
+            let lhs_source = self.source_text(span_of(lhs)).map(str::to_string);
+            let replacement = lhs_source
+                .as_deref()
+                .zip(self.source_text(span_of(rhs)))
+                .map(|(lhs, rhs)| format!("{lhs} = {rhs}"));
+            let spelling = lhs_source.unwrap_or_else(|| name.to_string());
+            let message = format!(
+                "`<-` inside `{lookup_name}()` assigns `{name}` and leaves the element unnamed; write `{spelling} = ...` to name it"
             );
+            if let Some(fix) = replacement.and_then(|replacement| self.fix(*span, replacement)) {
+                self.emit_with_fix(Severity::Warning, *span, "RY102", message, fix);
+            } else {
+                self.emit(Severity::Warning, *span, "RY102", message);
+            }
         }
     }
 
@@ -251,14 +226,19 @@ impl Checker {
             return;
         };
         let prefix = if matches!(op, BinOpKind::Eq) { "" } else { "!" };
-        let message = match (expr_to_source(arg_expr), expr_to_source(other_side)) {
-            (Some(arg_src), Some(class_src)) => {
-                let suggestion = format!("{prefix}inherits({arg_src}, {class_src})");
-                format!("`class()` returns a character vector, so this comparison is not length-1 for a multi-class object and the enclosing condition errors; use `{suggestion}`")
-            }
-            _ => "`class()` returns a character vector, so this comparison is not length-1 for a multi-class object and the enclosing condition errors; use `inherits()`".to_string(),
-        };
-        self.emit(Severity::Warning, *span, "RY103", message);
+        let suggestion = self
+            .source_text(span_of(arg_expr))
+            .zip(self.source_text(span_of(other_side)))
+            .map(|(arg, class)| format!("{prefix}inherits({arg}, {class})"));
+        let message = suggestion.as_ref().map_or_else(
+            || "`class()` returns a character vector, so this comparison is not length-1 for a multi-class object and the enclosing condition errors; use `inherits()`".to_string(),
+            |suggestion| format!("`class()` returns a character vector, so this comparison is not length-1 for a multi-class object and the enclosing condition errors; use `{suggestion}`"),
+        );
+        if let Some(fix) = suggestion.and_then(|replacement| self.fix(*span, replacement)) {
+            self.emit_with_fix(Severity::Warning, *span, "RY103", message, fix);
+        } else {
+            self.emit(Severity::Warning, *span, "RY103", message);
+        }
     }
 
     /// RY105: `length(x) <op> 0` where `x` is length 1 by construction, as in

--- a/crates/ry-checker/src/infer/recall.rs
+++ b/crates/ry-checker/src/infer/recall.rs
@@ -167,16 +167,11 @@ impl Checker {
             if matches!(lhs.as_ref(), Expr::Ident { .. }) && !builds_named_structure {
                 continue;
             }
-            let lhs_source = self.source_text(span_of(lhs)).map(str::to_string);
-            let replacement = lhs_source
-                .as_deref()
-                .zip(self.source_text(span_of(rhs)))
-                .map(|(lhs, rhs)| format!("{lhs} = {rhs}"));
-            let spelling = lhs_source.unwrap_or_else(|| name.to_string());
+            let spelling = self.source_text(span_of(lhs)).unwrap_or(name).to_string();
             let message = format!(
                 "`<-` inside `{lookup_name}()` assigns `{name}` and leaves the element unnamed; write `{spelling} = ...` to name it"
             );
-            if let Some(fix) = replacement.and_then(|replacement| self.fix(*span, replacement)) {
+            if let Some(fix) = self.binary_operator_fix(lhs, rhs, "<-", "=") {
                 self.emit_with_fix(Severity::Warning, *span, "RY102", message, fix);
             } else {
                 self.emit(Severity::Warning, *span, "RY102", message);
@@ -201,7 +196,7 @@ impl Checker {
     /// Silent for `class(x)[1] == "y"` (an `Index`, not a `Call`, and
     /// explicitly length-1) and for any use outside a scalar logical context,
     /// where a vector result is the point.
-    pub(crate) fn check_class_equality_operand(&mut self, expr: &Expr) {
+    pub(crate) fn check_class_equality_operand(&mut self, expr: &Expr, scope: &Scope) {
         let Expr::BinOp {
             op: op @ (BinOpKind::Eq | BinOpKind::Ne),
             lhs,
@@ -211,25 +206,31 @@ impl Checker {
         else {
             return;
         };
-        if !unary_call_to(lhs, "class") && !unary_call_to(rhs, "class") {
+        let lhs_is_class = unary_call_to(lhs, "class");
+        let rhs_is_class = unary_call_to(rhs, "class");
+        if !lhs_is_class && !rhs_is_class {
             return;
         }
-        // Build the suggestion from the actual operands: the class() call's
-        // first argument becomes inherits()'s first argument, and the other
-        // side of the comparison becomes the class name.
-        let (class_arg, other_side) = if unary_call_to(lhs, "class") {
-            (&lhs, rhs)
-        } else {
-            (&rhs, lhs)
-        };
-        let Some(arg_expr) = call_argument(class_arg) else {
-            return;
+
+        // The warning describes the risky comparison shape, but an automated
+        // rewrite additionally requires exactly one class() operand and proof
+        // that its callee is base::class rather than a qualified or shadowed
+        // function with unrelated semantics.
+        let fix_operands = match (lhs_is_class, rhs_is_class) {
+            (true, false) if self.is_base_class_call(lhs, scope) => Some((lhs, rhs)),
+            (false, true) if self.is_base_class_call(rhs, scope) => Some((rhs, lhs)),
+            _ => None,
         };
         let prefix = if matches!(op, BinOpKind::Eq) { "" } else { "!" };
-        let suggestion = self
-            .source_text(span_of(arg_expr))
-            .zip(self.source_text(span_of(other_side)))
-            .map(|(arg, class)| format!("{prefix}inherits({arg}, {class})"));
+        let suggestion = fix_operands
+            .and_then(|(class_call, other_side)| {
+                call_argument(class_call).map(|argument| (argument, other_side))
+            })
+            .and_then(|(argument, other_side)| {
+                self.source_text(span_of(argument))
+                    .zip(self.source_text(span_of(other_side)))
+            })
+            .map(|(argument, class)| format!("{prefix}inherits({argument}, {class})"));
         let message = suggestion.as_ref().map_or_else(
             || "`class()` returns a character vector, so this comparison is not length-1 for a multi-class object and the enclosing condition errors; use `inherits()`".to_string(),
             |suggestion| format!("`class()` returns a character vector, so this comparison is not length-1 for a multi-class object and the enclosing condition errors; use `{suggestion}`"),
@@ -238,6 +239,32 @@ impl Checker {
             self.emit_with_fix(Severity::Warning, *span, "RY103", message, fix);
         } else {
             self.emit(Severity::Warning, *span, "RY103", message);
+        }
+    }
+
+    fn is_base_class_call(&self, expr: &Expr, scope: &Scope) -> bool {
+        let Expr::Call { func, .. } = expr else {
+            return false;
+        };
+        let Some(name) = ident_name(func) else {
+            return false;
+        };
+        match name {
+            "base::class" | "base:::class" => true,
+            "class" => {
+                let lexically_unshadowed =
+                    scope.get("class").is_none() && !self.fn_table.fns.contains_key("class");
+                let imported_from_base = self
+                    .imported_from
+                    .get("class")
+                    .is_some_and(|package| package == "base");
+                lexically_unshadowed
+                    && (imported_from_base
+                        || (!self.external_bindings.contains("class")
+                            && self.bare_loaded.is_empty()
+                            && !scope.search_path_unknown))
+            }
+            _ => false,
         }
     }
 

--- a/crates/ry-checker/src/lib.rs
+++ b/crates/ry-checker/src/lib.rs
@@ -669,12 +669,6 @@ impl Checker {
         // run's diagnostics on top of the re-collected tables.
         self.diagnostics.clear();
 
-        // Parse errors first: a syntax error means the recovered tree is
-        // unreliable, so RY000 is the primary signal for broken input. We
-        // still run the checker on the recovered tree (downstream
-        // diagnostics may be noise, but ty takes the same approach).
-        self.emit_parse_errors(file);
-
         // Pass 1: collect function definitions into the FnTable. We don't
         // emit diagnostics yet - the body's `return` types depend on the
         // table being fully populated.

--- a/crates/ry-checker/src/lib.rs
+++ b/crates/ry-checker/src/lib.rs
@@ -30,10 +30,10 @@ pub use project::Project;
 // crate root for back-compat (callers and tests reference
 // `ry_checker::{Severity, Diagnostic, ...}` directly).
 pub use diagnostics::{
-    Confidence, Diagnostic, Severity, SeverityFilter, Suppression, apply_filter_to_diagnostics,
-    filter_default_disabled, filter_suppressed, filter_suppressed_with_comments,
-    has_file_suppression, has_file_suppression_from_comments, is_suppressed, parse_suppressions,
-    parse_suppressions_from_comments,
+    Confidence, Diagnostic, Fix, Severity, SeverityFilter, Suppression,
+    apply_filter_to_diagnostics, filter_default_disabled, filter_suppressed,
+    filter_suppressed_with_comments, has_file_suppression, has_file_suppression_from_comments,
+    is_suppressed, parse_suppressions, parse_suppressions_from_comments,
 };
 
 use crate::infer::semantic_argument_name;
@@ -583,6 +583,9 @@ pub struct Checker {
     user_stubs: Arc<BTreeMap<String, Typeshed>>,
     pub(crate) diagnostics: Vec<Diagnostic>,
     pub(crate) path: String,
+    /// Source text corresponding to `path`, set at every production check seam.
+    /// Structured fixes slice this exact text by parser spans.
+    pub(crate) source: String,
     // When true, `emit` is a no-op. Set during pass-2 (fixpoint) return-
     // type refinement and closure-signature building so the single
     // inference engine can be used for both the pure and the diagnostic
@@ -659,6 +662,7 @@ impl Checker {
 
     pub fn check(&mut self, file: &SourceFile) -> &[Diagnostic] {
         self.path = file.path.clone();
+        self.source.clone_from(&file.source);
 
         // Clear diagnostics FIRST so a second `check` on the same
         // instance starts fresh rather than accumulating the previous
@@ -693,6 +697,7 @@ impl Checker {
     // variable shows its type.
     pub fn check_with_scope(&mut self, file: &SourceFile) -> (Vec<Diagnostic>, Scope) {
         self.path = file.path.clone();
+        self.source.clone_from(&file.source);
         // Clear diagnostics FIRST so we start fresh (the caller may call
         // this multiple times on the same checker instance), THEN emit
         // parse errors. The previous order emitted RY000s and then wiped
@@ -749,6 +754,7 @@ impl Checker {
             user_stubs: Arc::new(BTreeMap::new()),
             diagnostics: Vec::new(),
             path: path.to_string(),
+            source: String::new(),
             discarding: false,
             validate_user_call_arguments: true,
             fn_table,
@@ -1146,6 +1152,7 @@ impl Checker {
     // first if you want only this file's diagnostics.
     pub(crate) fn emit_diagnostics(&mut self, file: &SourceFile) {
         self.path = file.path.clone();
+        self.source.clone_from(&file.source);
         self.emit_parse_errors(file);
         let mut scope = self.top_level_scope();
         for s in &file.stmts {

--- a/crates/ry-checker/src/suppress.rs
+++ b/crates/ry-checker/src/suppress.rs
@@ -346,6 +346,28 @@ impl Checker {
         code: &'static str,
         msg: impl Into<String>,
     ) {
+        self.emit_optional_fix(severity, span, code, msg, None);
+    }
+
+    pub(crate) fn emit_with_fix(
+        &mut self,
+        severity: Severity,
+        span: Span,
+        code: &'static str,
+        msg: impl Into<String>,
+        fix: Fix,
+    ) {
+        self.emit_optional_fix(severity, span, code, msg, Some(fix));
+    }
+
+    fn emit_optional_fix(
+        &mut self,
+        severity: Severity,
+        span: Span,
+        code: &'static str,
+        msg: impl Into<String>,
+        fix: Option<Fix>,
+    ) {
         if self.discarding {
             // Pass 2 (fixpoint) and closure-signature building run the
             // single inference engine in "discarding" mode: types are
@@ -354,8 +376,35 @@ impl Checker {
             // against the refined FnTable).
             return;
         }
-        self.diagnostics
-            .push(Diagnostic::new(severity, span, &self.path, code, msg));
+        let mut diagnostic = Diagnostic::new(severity, span, &self.path, code, msg);
+        diagnostic.fix = fix;
+        self.diagnostics.push(diagnostic);
+    }
+
+    /// Slice the exact parser input. Fix producers use AST spans and this
+    /// source seam; they never recover replacement text from a diagnostic
+    /// message or attempt to pretty-print an AST.
+    pub(crate) fn source_text(&self, span: Span) -> Option<&str> {
+        self.source.get(span.start..span.end)
+    }
+
+    pub(crate) fn source_span(&self, start: usize, end: usize) -> Option<Span> {
+        if start > end || !self.source.is_char_boundary(start) || !self.source.is_char_boundary(end)
+        {
+            return None;
+        }
+        let prefix = self.source.get(..start)?;
+        let line = prefix.bytes().filter(|byte| *byte == b'\n').count();
+        let line_start = prefix.rfind('\n').map_or(0, |offset| offset + 1);
+        Some(Span::new(start, end, line, start - line_start))
+    }
+
+    pub(crate) fn fix(&self, span: Span, replacement: impl Into<String>) -> Option<Fix> {
+        self.source_text(span)?;
+        Some(Fix {
+            span,
+            replacement: replacement.into(),
+        })
     }
 
     // Surface parse errors collected by `RParser` as `RY000`

--- a/crates/ry-checker/src/tests.rs
+++ b/crates/ry-checker/src/tests.rs
@@ -2117,6 +2117,7 @@ fn is_suppressed_matches_line_and_code() {
         code: "RY010",
         message: "test".into(),
         confidence: Confidence::Medium,
+        fix: None,
     };
     let diag_wrong_line = Diagnostic {
         span: Span {
@@ -2152,6 +2153,7 @@ fn is_suppressed_empty_rules_matches_any_code() {
         code: "RY999",
         message: "test".into(),
         confidence: Confidence::Medium,
+        fix: None,
     };
     assert!(is_suppressed(&diag, &supps));
 }

--- a/crates/ry-checker/src/tests.rs
+++ b/crates/ry-checker/src/tests.rs
@@ -6879,6 +6879,25 @@ fn public_check_with_scope_surfaces_ry000_on_broken_file() {
     );
 }
 
+#[test]
+fn public_check_emits_each_parse_error_once() {
+    let mut parser = RParser::new().unwrap();
+    let file = parser.parse("test.R", "f <- function( { 1 }\n").unwrap();
+    let expected = file.parse_errors.len();
+    assert!(expected > 0, "fixture must contain a parse error");
+    let mut checker = Checker::new("test.R");
+    let actual = checker
+        .check(&file)
+        .iter()
+        .filter(|diagnostic| diagnostic.code == "RY000")
+        .count();
+
+    assert_eq!(
+        actual, expected,
+        "each parser error must produce exactly one RY000"
+    );
+}
+
 // ===== search-path-unknown audit (W20/W21d) =====
 //
 // `mark_search_path_unknown()` suppresses RY010 (unbound-variable) for the

--- a/crates/ry-checker/tests/corpus.rs
+++ b/crates/ry-checker/tests/corpus.rs
@@ -101,7 +101,7 @@ fn load_fixtures() -> Vec<Fixture> {
     out
 }
 
-fn run(name: &str, src: &str) -> Vec<(String, Severity)> {
+fn run_diagnostics(name: &str, src: &str) -> Vec<ry_checker::Diagnostic> {
     let mut parser = RParser::new().expect("parser init");
     let file = parser
         .parse(name, src)
@@ -113,9 +113,11 @@ fn run(name: &str, src: &str) -> Vec<(String, Severity)> {
     // feature behave the same way the CLI / LSP do. Use the lexical
     // (comment-based) filter so a `#` inside a string literal is not
     // mistaken for a suppression directive.
-    let diags =
-        ry_checker::filter_suppressed_with_comments(c.take_diagnostics(), &file.comments, src);
-    diags
+    ry_checker::filter_suppressed_with_comments(c.take_diagnostics(), &file.comments, src)
+}
+
+fn run(name: &str, src: &str) -> Vec<(String, Severity)> {
+    run_diagnostics(name, src)
         .into_iter()
         .map(|d| (d.code.to_string(), d.severity))
         .collect()
@@ -195,6 +197,46 @@ fn corpus_check_each_fixture() {
             failures.join("\n  - ")
         );
     }
+}
+
+/// Reviewable message/fix gate for every checker fixture. This deliberately
+/// stores normalized fields rather than a digest or the ignored ecosystem
+/// `.full.txt` reports, so wording and replacement drift appears as a normal
+/// snapshot diff.
+#[test]
+fn checker_fixture_diagnostics_are_readable_snapshots() {
+    let snapshots = load_fixtures()
+        .into_iter()
+        .map(|fixture| {
+            let diagnostics = run_diagnostics(&fixture.name, &fixture.src)
+                .into_iter()
+                .map(|diagnostic| {
+                    serde_json::json!({
+                        "code": diagnostic.code,
+                        "severity": diagnostic.severity.as_str(),
+                        "span": {
+                            "start": diagnostic.span.start,
+                            "end": diagnostic.span.end,
+                            "line": diagnostic.span.line,
+                            "column": diagnostic.span.col,
+                        },
+                        "message": diagnostic.message,
+                        "fix": diagnostic.fix.map(|fix| serde_json::json!({
+                            "span": {
+                                "start": fix.span.start,
+                                "end": fix.span.end,
+                                "line": fix.span.line,
+                                "column": fix.span.col,
+                            },
+                            "replacement": fix.replacement,
+                        })),
+                    })
+                })
+                .collect::<Vec<_>>();
+            serde_json::json!({"fixture": fixture.name, "diagnostics": diagnostics})
+        })
+        .collect::<Vec<_>>();
+    insta::assert_yaml_snapshot!("checker_fixture_diagnostics", snapshots);
 }
 
 /// For visibility: list every fixture and what it currently emits. This

--- a/crates/ry-checker/tests/fixes.rs
+++ b/crates/ry-checker/tests/fixes.rs
@@ -1,0 +1,153 @@
+use ry_checker::{Checker, Diagnostic, Fix};
+use ry_core::{RParser, Span};
+use serde_json::{Value, json};
+
+struct Case {
+    code: &'static str,
+    source: &'static str,
+}
+
+const CASES: &[Case] = &[
+    Case {
+        code: "RY032",
+        source: "f <- function(x) x && c(TRUE, FALSE)\n",
+    },
+    Case {
+        code: "RY034",
+        source: "f <- function(x) x == NA\n",
+    },
+    Case {
+        code: "RY090",
+        source: "length(xx = 1L)\n",
+    },
+    Case {
+        code: "RY093",
+        source: "length(c(1L, 2L) > 0L)\n",
+    },
+    Case {
+        code: "RY100",
+        source: "f <- function(x) abs(x > 0L)\n",
+    },
+    Case {
+        code: "RY101",
+        source: "args <- list(font = \"mono\")\nidentical(args[\"font\"], \"mono\")\n",
+    },
+    Case {
+        code: "RY102",
+        source: "list(ok = 1L, \"wi\\\"dget\" <- 2L)\n",
+    },
+    Case {
+        code: "RY103",
+        source: "f <- function(x) if (class(x) == \"wi\\\"dget\") 1L else 2L\n",
+    },
+];
+
+fn check(source: &str) -> Vec<Diagnostic> {
+    let mut parser = RParser::new().expect("parser init");
+    let file = parser.parse("fix.R", source).expect("parse source");
+    let mut checker = Checker::new("fix.R");
+    checker.check(&file);
+    checker.take_diagnostics()
+}
+
+fn apply(source: &str, fix: &Fix) -> String {
+    assert!(fix.span.start <= fix.span.end);
+    assert!(source.is_char_boundary(fix.span.start));
+    assert!(source.is_char_boundary(fix.span.end));
+    format!(
+        "{}{}{}",
+        &source[..fix.span.start],
+        fix.replacement,
+        &source[fix.span.end..]
+    )
+}
+
+fn normalized(diagnostics: &[Diagnostic]) -> Vec<Value> {
+    diagnostics
+        .iter()
+        .map(|diagnostic| {
+            json!({
+                "code": diagnostic.code,
+                "severity": diagnostic.severity.as_str(),
+                "span": [diagnostic.span.start, diagnostic.span.end],
+                "message": diagnostic.message,
+                "fix": diagnostic.fix.as_ref().map(|fix| json!({
+                    "span": [fix.span.start, fix.span.end],
+                    "replacement": fix.replacement,
+                })),
+            })
+        })
+        .collect()
+}
+
+#[test]
+fn every_concrete_suggestion_is_a_structured_parse_clean_fix() {
+    let mut snapshots = Vec::new();
+    for case in CASES {
+        let before = check(case.source);
+        let diagnostic = before
+            .iter()
+            .find(|diagnostic| diagnostic.code == case.code)
+            .unwrap_or_else(|| panic!("{} did not fire: {before:?}", case.code));
+        let fix = diagnostic
+            .fix
+            .as_ref()
+            .unwrap_or_else(|| panic!("{} did not offer a structured fix", case.code));
+        let edited = apply(case.source, fix);
+
+        let mut parser = RParser::new().expect("parser init");
+        let parsed = parser
+            .parse("fixed.R", &edited)
+            .expect("parse edited source");
+        assert!(
+            parsed.parse_errors.is_empty(),
+            "{} fix produced RY000 parse regions: {:?}\nsource: {edited}",
+            case.code,
+            parsed.parse_errors,
+        );
+
+        let after = check(&edited);
+        assert!(
+            !after.iter().any(|diagnostic| diagnostic.code == case.code
+                && diagnostic.span.start <= fix.span.start
+                && diagnostic.span.end >= fix.span.start),
+            "{} still fires at the replaced location after applying {fix:?}: {after:?}\nsource: {edited}",
+            case.code,
+        );
+        snapshots.push(json!({
+            "code": case.code,
+            "source": case.source,
+            "before": normalized(&before),
+            "edited": edited,
+            "after": normalized(&after),
+        }));
+    }
+    insta::assert_yaml_snapshot!("structured_fix_oracle", snapshots);
+}
+
+#[test]
+fn ry103_escaped_string_fix_is_not_reconstructed_from_unescaped_ast_value() {
+    let source = r#"f <- function(x) if (class(x) == "quote: \" slash: \\") 1L else 2L
+"#;
+    let diagnostics = check(source);
+    let fix = diagnostics
+        .iter()
+        .find(|diagnostic| diagnostic.code == "RY103")
+        .and_then(|diagnostic| diagnostic.fix.as_ref())
+        .expect("RY103 structured fix");
+    let edited = apply(source, fix);
+    let mut parser = RParser::new().unwrap();
+    let parsed = parser.parse("fixed.R", &edited).unwrap();
+    assert!(parsed.parse_errors.is_empty(), "unparseable fix: {edited}");
+    assert!(edited.contains(r#"inherits(x, "quote: \" slash: \\")"#));
+}
+
+#[test]
+fn fix_is_minimal_public_data() {
+    let fix = Fix {
+        span: Span::new(1, 2, 0, 1),
+        replacement: "x".to_string(),
+    };
+    assert_eq!(fix.span.start, 1);
+    assert_eq!(fix.replacement, "x");
+}

--- a/crates/ry-checker/tests/fixes.rs
+++ b/crates/ry-checker/tests/fixes.rs
@@ -126,6 +126,163 @@ fn every_concrete_suggestion_is_a_structured_parse_clean_fix() {
 }
 
 #[test]
+fn ry032_does_not_offer_vectorizing_fix_in_scalar_conditions() {
+    for source in [
+        "f <- function(x) if (x && c(TRUE, FALSE)) 1L else 2L\n",
+        "f <- function(x) while (x || c(TRUE, FALSE)) break\n",
+        "f <- function(x) if (!(x && c(TRUE, FALSE))) 1L else 2L\n",
+    ] {
+        let diagnostics = check(source);
+        let diagnostic = diagnostics
+            .iter()
+            .find(|diagnostic| diagnostic.code == "RY032")
+            .unwrap_or_else(|| panic!("RY032 did not fire: {diagnostics:?}"));
+        assert!(
+            diagnostic.fix.is_none(),
+            "scalar condition must keep the warning but not offer a vectorizing fix: {diagnostic:?}"
+        );
+    }
+}
+
+#[test]
+fn ry032_fix_targets_the_syntax_operator_not_comment_text() {
+    for (source, expected) in [
+        (
+            "f <- function(x) (x # misleading &&\n  && c(TRUE, FALSE))\n",
+            "f <- function(x) (x # misleading &&\n  & c(TRUE, FALSE))\n",
+        ),
+        (
+            "f <- function(x) (x # misleading ||\n  || c(TRUE, FALSE))\n",
+            "f <- function(x) (x # misleading ||\n  | c(TRUE, FALSE))\n",
+        ),
+    ] {
+        let diagnostics = check(source);
+        let fix = diagnostics
+            .iter()
+            .find(|diagnostic| diagnostic.code == "RY032")
+            .and_then(|diagnostic| diagnostic.fix.as_ref())
+            .unwrap_or_else(|| panic!("RY032 did not offer a fix: {diagnostics:?}"));
+        assert_eq!(apply(source, fix), expected);
+    }
+}
+
+#[test]
+fn comparison_fixes_preserve_inter_operand_comments() {
+    for (code, source, expected) in [
+        (
+            "RY093",
+            "length(c(1L, 2L) # why compare here\n > 0L)\n",
+            "length(c(1L, 2L) # why compare here\n ) > 0L\n",
+        ),
+        (
+            "RY100",
+            "f <- function(x) abs(x > # threshold\n 0L)\n",
+            "f <- function(x) abs(x) > # threshold\n 0L\n",
+        ),
+    ] {
+        let diagnostics = check(source);
+        let fix = diagnostics
+            .iter()
+            .find(|diagnostic| diagnostic.code == code)
+            .and_then(|diagnostic| diagnostic.fix.as_ref())
+            .unwrap_or_else(|| panic!("{code} did not offer a fix: {diagnostics:?}"));
+        assert_eq!(apply(source, fix), expected);
+    }
+}
+
+#[test]
+fn parenthesized_comparison_fixes_are_parse_clean() {
+    for (code, source) in [
+        ("RY093", "length((c(1L, 2L) > 0L))\n"),
+        ("RY100", "f <- function(x) abs(((x) > (0L)))\n"),
+    ] {
+        let diagnostics = check(source);
+        let fix = diagnostics
+            .iter()
+            .find(|diagnostic| diagnostic.code == code)
+            .and_then(|diagnostic| diagnostic.fix.as_ref())
+            .unwrap_or_else(|| panic!("{code} did not offer a fix: {diagnostics:?}"));
+        let edited = apply(source, fix);
+        let mut parser = RParser::new().expect("parser init");
+        let parsed = parser
+            .parse("fixed.R", &edited)
+            .expect("parse fixed source");
+        assert!(
+            parsed.parse_errors.is_empty(),
+            "{code} produced invalid parenthesized output: {edited}"
+        );
+        assert!(
+            !check(&edited)
+                .iter()
+                .any(|diagnostic| diagnostic.code == code),
+            "{code} still fires after applying fix: {edited}"
+        );
+    }
+}
+
+#[test]
+fn ry102_fix_only_replaces_the_assignment_operator() {
+    let source = "list(\"a\" <- # keep this explanation\n  1L)\n";
+    let diagnostics = check(source);
+    let fix = diagnostics
+        .iter()
+        .find(|diagnostic| diagnostic.code == "RY102")
+        .and_then(|diagnostic| diagnostic.fix.as_ref())
+        .unwrap_or_else(|| panic!("RY102 did not offer a fix: {diagnostics:?}"));
+    assert_eq!(
+        apply(source, fix),
+        "list(\"a\" = # keep this explanation\n  1L)\n"
+    );
+    assert_eq!(&source[fix.span.start..fix.span.end], "<-");
+}
+
+#[test]
+fn ry103_only_fixes_calls_known_to_be_base_class() {
+    for source in [
+        "f <- function(x) if (otherpkg::class(x) == \"widget\") 1L else 2L\n",
+        "class <- function(x) \"widget\"\nf <- function(x) if (class(x) == \"widget\") 1L else 2L\n",
+        "f <- function(x, class) if (class(x) == \"widget\") 1L else 2L\n",
+        "library(otherpkg)\nf <- function(x) if (class(x) == \"widget\") 1L else 2L\n",
+    ] {
+        let diagnostics = check(source);
+        let diagnostic = diagnostics
+            .iter()
+            .find(|diagnostic| diagnostic.code == "RY103")
+            .unwrap_or_else(|| panic!("RY103 did not fire: {diagnostics:?}"));
+        assert!(
+            diagnostic.fix.is_none(),
+            "unsafe class callee must retain the warning without a fix: {diagnostic:?}"
+        );
+    }
+
+    let source = "f <- function(x) if (base::class(x) == \"widget\") 1L else 2L\n";
+    let diagnostics = check(source);
+    let fix = diagnostics
+        .iter()
+        .find(|diagnostic| diagnostic.code == "RY103")
+        .and_then(|diagnostic| diagnostic.fix.as_ref())
+        .unwrap_or_else(|| panic!("base::class should have a safe RY103 fix: {diagnostics:?}"));
+    assert_eq!(
+        apply(source, fix),
+        "f <- function(x) if (inherits(x, \"widget\")) 1L else 2L\n"
+    );
+}
+
+#[test]
+fn ry103_does_not_fix_a_comparison_between_two_class_calls() {
+    let source = "f <- function(x, y) if (class(x) == class(y)) 1L else 2L\n";
+    let diagnostics = check(source);
+    let diagnostic = diagnostics
+        .iter()
+        .find(|diagnostic| diagnostic.code == "RY103")
+        .unwrap_or_else(|| panic!("RY103 did not fire: {diagnostics:?}"));
+    assert!(
+        diagnostic.fix.is_none(),
+        "there is no single class name operand for inherits(): {diagnostic:?}"
+    );
+}
+
+#[test]
 fn ry103_escaped_string_fix_is_not_reconstructed_from_unescaped_ast_value() {
     let source = r#"f <- function(x) if (class(x) == "quote: \" slash: \\") 1L else 2L
 "#;

--- a/crates/ry-checker/tests/fixes.rs
+++ b/crates/ry-checker/tests/fixes.rs
@@ -151,3 +151,37 @@ fn fix_is_minimal_public_data() {
     assert_eq!(fix.span.start, 1);
     assert_eq!(fix.replacement, "x");
 }
+
+#[test]
+fn ry090_tied_nearest_parameters_warn_without_a_structured_fix() {
+    let diagnostics = check("f <- function(cat, car) 1L\nf(cap = 1L)\n");
+    let diagnostic = diagnostics
+        .iter()
+        .find(|diagnostic| diagnostic.code == "RY090")
+        .expect("RY090 warning for unmatched named argument");
+
+    assert!(
+        diagnostic.fix.is_none(),
+        "tied suggestion must not be fixed: {diagnostic:?}"
+    );
+}
+
+#[test]
+fn ry090_unique_parameter_fix_replaces_only_the_argument_name() {
+    let source = "f <- function(length) 1L\nf(lenght # keep\n = 1L)\n";
+    let diagnostics = check(source);
+    let diagnostic = diagnostics
+        .iter()
+        .find(|diagnostic| diagnostic.code == "RY090")
+        .expect("RY090 warning for unmatched named argument");
+    let fix = diagnostic
+        .fix
+        .as_ref()
+        .expect("unique suggestion must be fixed");
+
+    assert_eq!(&source[fix.span.start..fix.span.end], "lenght");
+    assert_eq!(
+        apply(source, fix),
+        "f <- function(length) 1L\nf(length # keep\n = 1L)\n"
+    );
+}

--- a/crates/ry-checker/tests/fixes.rs
+++ b/crates/ry-checker/tests/fixes.rs
@@ -145,6 +145,34 @@ fn ry032_does_not_offer_vectorizing_fix_in_scalar_conditions() {
 }
 
 #[test]
+fn ry032_guard_warning_does_not_offer_an_eager_evaluation_fix() {
+    let source = "f <- function(x) is.null(x) || x == \"a\"\n";
+    let diagnostics = check(source);
+    let diagnostic = diagnostics
+        .iter()
+        .find(|diagnostic| diagnostic.code == "RY032")
+        .unwrap_or_else(|| panic!("guarded parameter did not emit RY032: {diagnostics:?}"));
+    assert!(
+        diagnostic.fix.is_none(),
+        "a guard-based short circuit must not be rewritten to eager evaluation: {diagnostic:?}"
+    );
+}
+
+#[test]
+fn ry103_rhs_fix_uses_scope_after_short_circuit_lhs() {
+    let source = "custom <- function(x) \"widget\"\nf <- function(x) (class <- custom) && class(x) == \"widget\"\n";
+    let diagnostics = check(source);
+    let diagnostic = diagnostics
+        .iter()
+        .find(|diagnostic| diagnostic.code == "RY103")
+        .unwrap_or_else(|| panic!("RHS class comparison did not emit RY103: {diagnostics:?}"));
+    assert!(
+        diagnostic.fix.is_none(),
+        "the LHS rebinds class before the RHS executes: {diagnostic:?}"
+    );
+}
+
+#[test]
 fn ry032_fix_targets_the_syntax_operator_not_comment_text() {
     for (source, expected) in [
         (

--- a/crates/ry-checker/tests/snapshots/corpus__checker_fixture_diagnostics.snap
+++ b/crates/ry-checker/tests/snapshots/corpus__checker_fixture_diagnostics.snap
@@ -255,33 +255,6 @@ expression: snapshots
         end: 189
         line: 4
         start: 187
-    - code: RY000
-      fix: ~
-      message: "syntax error: unparseable region (recovered tree may be unreliable)"
-      severity: error
-      span:
-        column: 15
-        end: 170
-        line: 3
-        start: 169
-    - code: RY000
-      fix: ~
-      message: "syntax error: unparseable region (recovered tree may be unreliable)"
-      severity: error
-      span:
-        column: 8
-        end: 179
-        line: 4
-        start: 179
-    - code: RY000
-      fix: ~
-      message: "syntax error: unparseable region (recovered tree may be unreliable)"
-      severity: error
-      span:
-        column: 16
-        end: 189
-        line: 4
-        start: 187
     - code: RY010
       fix: ~
       message: "variable `syntax` is not bound in this scope"
@@ -472,10 +445,10 @@ expression: snapshots
 - diagnostics:
     - code: RY090
       fix:
-        replacement: x = 1L
+        replacement: x
         span:
           column: 7
-          end: 37
+          end: 32
           line: 1
           start: 30
       message: "unknown argument `xx` to `length`; did you mean `x`?"

--- a/crates/ry-checker/tests/snapshots/corpus__checker_fixture_diagnostics.snap
+++ b/crates/ry-checker/tests/snapshots/corpus__checker_fixture_diagnostics.snap
@@ -1,0 +1,1128 @@
+---
+source: crates/ry-checker/tests/corpus.rs
+expression: snapshots
+---
+- diagnostics:
+    - code: RY090
+      fix: ~
+      message: "unknown argument `al` to `choose`"
+      severity: warning
+      span:
+        column: 7
+        end: 77
+        line: 2
+        start: 70
+    - code: RY091
+      fix: ~
+      message: "missing required argument `alpha` in call to `choose`"
+      severity: warning
+      span:
+        column: 0
+        end: 78
+        line: 2
+        start: 63
+  fixture: err_ambiguous_partial_argument.R
+- diagnostics:
+    - code: RY092
+      fix: ~
+      message: "argument `x` to `mean` is `list`, expected numeric"
+      severity: error
+      span:
+        column: 5
+        end: 29
+        line: 1
+        start: 21
+  fixture: err_argument_list_type_mismatch.R
+- diagnostics:
+    - code: RY092
+      fix: ~
+      message: "argument `x` to `mean` is `character`, expected numeric"
+      severity: error
+      span:
+        column: 5
+        end: 34
+        line: 1
+        start: 21
+  fixture: err_argument_type_mismatch.R
+- diagnostics:
+    - code: RY070
+      fix: ~
+      message: "cannot call a value of mode `double`"
+      severity: error
+      span:
+        column: 5
+        end: 112
+        line: 2
+        start: 108
+    - code: RY070
+      fix: ~
+      message: "cannot call a value of mode `logical`"
+      severity: error
+      span:
+        column: 5
+        end: 124
+        line: 3
+        start: 118
+    - code: RY070
+      fix: ~
+      message: "cannot call a value of mode `NULL`"
+      severity: error
+      span:
+        column: 5
+        end: 136
+        line: 4
+        start: 130
+  fixture: err_call_literal.R
+- diagnostics:
+    - code: RY070
+      fix: ~
+      message: "`x` is `double`, not a function; cannot call it"
+      severity: error
+      span:
+        column: 5
+        end: 87
+        line: 3
+        start: 82
+  fixture: err_call_non_function.R
+- diagnostics:
+    - code: RY033
+      fix: ~
+      message: "comparing `character` with `double`; R coerces the numeric value to character and compares lexicographically, which is rarely intended"
+      severity: warning
+      span:
+        column: 7
+        end: 95
+        line: 2
+        start: 83
+  fixture: err_compare_mode_mismatch.R
+- diagnostics:
+    - code: RY061
+      fix: ~
+      message: "$ operator is invalid for atomic vectors of mode `character`"
+      severity: error
+      span:
+        column: 0
+        end: 39
+        line: 2
+        start: 34
+  fixture: err_dollar_assign_atomic.R
+- diagnostics:
+    - code: RY061
+      fix: ~
+      message: "$ operator is invalid for atomic vectors of mode `integer`"
+      severity: error
+      span:
+        column: 7
+        end: 98
+        line: 3
+        start: 90
+  fixture: err_dollar_on_atomic.R
+- diagnostics:
+    - code: RY040
+      fix: ~
+      message: "cannot apply arithmetic op to `character` and `double`"
+      severity: error
+      span:
+        column: 23
+        end: 186
+        line: 3
+        start: 175
+  fixture: err_fnbody_arith.R
+- diagnostics:
+    - code: RY040
+      fix: ~
+      message: "cannot apply arithmetic op to `character` and `double`"
+      severity: error
+      span:
+        column: 9
+        end: 203
+        line: 5
+        start: 192
+  fixture: err_fnbody_nested_if.R
+- diagnostics:
+    - code: RY010
+      fix: ~
+      message: "variable `undefined_variable_xyz` is not bound in this scope"
+      severity: warning
+      span:
+        column: 23
+        end: 148
+        line: 3
+        start: 126
+  fixture: err_fnbody_unbound.R
+- diagnostics:
+    - code: RY010
+      fix: ~
+      message: "variable `undefined_var` is not bound in this scope"
+      severity: warning
+      span:
+        column: 36
+        end: 199
+        line: 3
+        start: 186
+  fixture: err_ho_callback_unbound.R
+- diagnostics:
+    - code: RY040
+      fix: ~
+      message: "cannot apply arithmetic op to `integer` and `character`"
+      severity: error
+      span:
+        column: 7
+        end: 288
+        line: 5
+        start: 277
+  fixture: err_ho_sapply_infers_type.R
+- diagnostics:
+    - code: RY040
+      fix: ~
+      message: "cannot apply arithmetic op to `union` and `double`"
+      severity: error
+      span:
+        column: 7
+        end: 375
+        line: 7
+        start: 370
+  fixture: err_if_expr_join.R
+- diagnostics:
+    - code: RY092
+      fix: ~
+      message: "argument `value` to `check_string` is `character<len=2>`, expected character"
+      severity: error
+      span:
+        column: 13
+        end: 55
+        line: 2
+        start: 50
+  fixture: err_impossible_standalone_guard.R
+- diagnostics:
+    - code: RY070
+      fix: ~
+      message: "`x` is `NULL`, not a function; cannot call it"
+      severity: error
+      span:
+        column: 2
+        end: 296
+        line: 11
+        start: 292
+  fixture: err_is_null_narrowing_no_leak.R
+- diagnostics:
+    - code: RY040
+      fix: ~
+      message: "cannot apply arithmetic op to `integer` and `character`"
+      severity: error
+      span:
+        column: 7
+        end: 281
+        line: 6
+        start: 270
+  fixture: err_lapply_double_bracket.R
+- diagnostics:
+    - code: RY091
+      fix: ~
+      message: "missing required argument `x` in call to `length`"
+      severity: warning
+      span:
+        column: 0
+        end: 24
+        line: 1
+        start: 16
+  fixture: err_missing_required_argument.R
+- diagnostics:
+    - code: RY000
+      fix: ~
+      message: "syntax error: unparseable region (recovered tree may be unreliable)"
+      severity: error
+      span:
+        column: 15
+        end: 170
+        line: 3
+        start: 169
+    - code: RY000
+      fix: ~
+      message: "syntax error: unparseable region (recovered tree may be unreliable)"
+      severity: error
+      span:
+        column: 8
+        end: 179
+        line: 4
+        start: 179
+    - code: RY000
+      fix: ~
+      message: "syntax error: unparseable region (recovered tree may be unreliable)"
+      severity: error
+      span:
+        column: 16
+        end: 189
+        line: 4
+        start: 187
+    - code: RY000
+      fix: ~
+      message: "syntax error: unparseable region (recovered tree may be unreliable)"
+      severity: error
+      span:
+        column: 15
+        end: 170
+        line: 3
+        start: 169
+    - code: RY000
+      fix: ~
+      message: "syntax error: unparseable region (recovered tree may be unreliable)"
+      severity: error
+      span:
+        column: 8
+        end: 179
+        line: 4
+        start: 179
+    - code: RY000
+      fix: ~
+      message: "syntax error: unparseable region (recovered tree may be unreliable)"
+      severity: error
+      span:
+        column: 16
+        end: 189
+        line: 4
+        start: 187
+    - code: RY010
+      fix: ~
+      message: "variable `syntax` is not bound in this scope"
+      severity: warning
+      span:
+        column: 9
+        end: 186
+        line: 4
+        start: 180
+  fixture: err_parse_error.R
+- diagnostics:
+    - code: RY060
+      fix: ~
+      message: "column `x` not found in data frame schema; available columns: y, x_x"
+      severity: error
+      span:
+        column: 0
+        end: 62
+        line: 2
+        start: 54
+  fixture: err_partial_column_indexed_assignment.R
+- diagnostics:
+    - code: RY102
+      fix:
+        replacement: "\"github-ref\" = \"b\""
+        span:
+          column: 21
+          end: 377
+          line: 6
+          start: 358
+      message: "`<-` inside `list()` assigns `github-ref` and leaves the element unnamed; write `\"github-ref\" = ...` to name it"
+      severity: warning
+      span:
+        column: 21
+        end: 377
+        line: 6
+        start: 358
+    - code: RY103
+      fix:
+        replacement: "!inherits(df[[1]], t)"
+        span:
+          column: 21
+          end: 605
+          line: 10
+          start: 586
+      message: "`class()` returns a character vector, so this comparison is not length-1 for a multi-class object and the enclosing condition errors; use `!inherits(df[[1]], t)`"
+      severity: warning
+      span:
+        column: 21
+        end: 605
+        line: 10
+        start: 586
+    - code: RY105
+      fix: ~
+      message: "`u_dl` is a length-1 double, so `length(...)` is 1 here and this zero-length guard is always TRUE"
+      severity: warning
+      span:
+        column: 13
+        end: 1430
+        line: 30
+        start: 1414
+  fixture: err_plan31_recall_repro.R
+- diagnostics:
+    - code: RY080
+      fix: ~
+      message: "`map_dbl` expects `double` returns but the callback returns `character`; R will coerce silently"
+      severity: warning
+      span:
+        column: 6
+        end: 275
+        line: 5
+        start: 236
+  fixture: err_purrr_map_dbl_type_mismatch.R
+- diagnostics:
+    - code: RY098
+      fix: ~
+      message: "parameter `x` has a self-referential default that recurses when forced"
+      severity: warning
+      span:
+        column: 18
+        end: 114
+        line: 2
+        start: 113
+  fixture: err_recursive_default_forced_call.R
+- diagnostics:
+    - code: RY098
+      fix: ~
+      message: "parameter `x` has a self-referential default that recurses when forced"
+      severity: warning
+      span:
+        column: 18
+        end: 108
+        line: 2
+        start: 107
+  fixture: err_recursive_default_literal_branch.R
+- diagnostics:
+    - code: RY098
+      fix: ~
+      message: "parameter `x` has a self-referential default that recurses when forced"
+      severity: warning
+      span:
+        column: 18
+        end: 134
+        line: 3
+        start: 133
+  fixture: err_recursive_default_literal_false_block.R
+- diagnostics:
+    - code: RY098
+      fix: ~
+      message: "parameter `copy` has a self-referential default that recurses when forced"
+      severity: warning
+      span:
+        column: 29
+        end: 55
+        line: 1
+        start: 51
+    - code: RY098
+      fix: ~
+      message: "parameter `j` has a self-referential default that recurses when forced"
+      severity: warning
+      span:
+        column: 28
+        end: 91
+        line: 2
+        start: 90
+  fixture: err_recursive_parameter_default.R
+- diagnostics:
+    - code: RY070
+      fix: ~
+      message: "`x` is `integer`, not a function; cannot call it"
+      severity: error
+      span:
+        column: 0
+        end: 117
+        line: 4
+        start: 114
+  fixture: err_s7_callable_future_assignment.R
+- diagnostics:
+    - code: RY070
+      fix: ~
+      message: "`x` is `integer`, not a function; cannot call it"
+      severity: error
+      span:
+        column: 0
+        end: 121
+        line: 4
+        start: 118
+  fixture: err_s7_callable_reassigned.R
+- diagnostics:
+    - code: RY032
+      fix:
+        replacement: "&"
+        span:
+          column: 9
+          end: 113
+          line: 3
+          start: 111
+      message: "`&&` applied to a length-3 operand; only the first element is used"
+      severity: warning
+      span:
+        column: 7
+        end: 118
+        line: 3
+        start: 109
+  fixture: err_scalar_logical.R
+- diagnostics:
+    - code: RY040
+      fix: ~
+      message: "cannot apply arithmetic op to `union` and `double`"
+      severity: error
+      span:
+        column: 7
+        end: 335
+        line: 6
+        start: 330
+  fixture: err_switch_mixed.R
+- diagnostics:
+    - code: RY040
+      fix: ~
+      message: "cannot apply arithmetic op to `union` and `double`"
+      severity: error
+      span:
+        column: 5
+        end: 334
+        line: 7
+        start: 329
+  fixture: err_union_all_invalid.R
+- diagnostics:
+    - code: RY090
+      fix:
+        replacement: x = 1L
+        span:
+          column: 7
+          end: 37
+          line: 1
+          start: 30
+      message: "unknown argument `xx` to `length`; did you mean `x`?"
+      severity: warning
+      span:
+        column: 7
+        end: 37
+        line: 1
+        start: 30
+    - code: RY091
+      fix: ~
+      message: "missing required argument `x` in call to `length`"
+      severity: warning
+      span:
+        column: 0
+        end: 38
+        line: 1
+        start: 23
+  fixture: err_unknown_argument.R
+- diagnostics:
+    - code: RY091
+      fix: ~
+      message: "missing required argument `x` in call to `required`"
+      severity: warning
+      span:
+        column: 0
+        end: 67
+        line: 2
+        start: 57
+  fixture: err_user_fn_missing_required.R
+- diagnostics: []
+  fixture: ok_ambient_globals.R
+- diagnostics: []
+  fixture: ok_anon_lapply.R
+- diagnostics: []
+  fixture: ok_argument_diagnostics_suppressed.R
+- diagnostics: []
+  fixture: ok_argument_numeric_coercion.R
+- diagnostics: []
+  fixture: ok_argument_union_overlap.R
+- diagnostics: []
+  fixture: ok_arith.R
+- diagnostics: []
+  fixture: ok_assertion_refinement.R
+- diagnostics: []
+  fixture: ok_assign_literal.R
+- diagnostics: []
+  fixture: ok_block_expr_scope.R
+- diagnostics: []
+  fixture: ok_bound_var.R
+- diagnostics: []
+  fixture: ok_branch_binding_merge.R
+- diagnostics: []
+  fixture: ok_c_concat.R
+- diagnostics: []
+  fixture: ok_call_function.R
+- diagnostics: []
+  fixture: ok_call_skips_nonfunction_shadow.R
+- diagnostics: []
+  fixture: ok_closure_capture.R
+- diagnostics: []
+  fixture: ok_closure_factory.R
+- diagnostics: []
+  fixture: ok_compare.R
+- diagnostics: []
+  fixture: ok_compare_na_idiom.R
+- diagnostics: []
+  fixture: ok_compare_same_mode.R
+- diagnostics: []
+  fixture: ok_compare_union_no_mode_mismatch.R
+- diagnostics: []
+  fixture: ok_data_frame_constructor.R
+- diagnostics: []
+  fixture: ok_data_frame_derived_names.R
+- diagnostics: []
+  fixture: ok_dataset_iris.R
+- diagnostics: []
+  fixture: ok_dataset_mtcars.R
+- diagnostics: []
+  fixture: ok_df_bracket_string.R
+- diagnostics: []
+  fixture: ok_df_column_access.R
+- diagnostics: []
+  fixture: ok_df_column_assignment.R
+- diagnostics: []
+  fixture: ok_divisible_recycling.R
+- diagnostics: []
+  fixture: ok_dollar_missing_list.R
+- diagnostics: []
+  fixture: ok_dots_absorb_unknown_argument.R
+- diagnostics: []
+  fixture: ok_dplyr_join_schema.R
+- diagnostics: []
+  fixture: ok_dplyr_sequential_columns.R
+- diagnostics: []
+  fixture: ok_dplyr_unknown_schema_data_mask.R
+- diagnostics: []
+  fixture: ok_dynamic_data_frame_extract.R
+- diagnostics: []
+  fixture: ok_dynamic_field_write.R
+- diagnostics: []
+  fixture: ok_dynamic_list_extract.R
+- diagnostics: []
+  fixture: ok_exact_then_partial_argument_match.R
+- diagnostics: []
+  fixture: ok_factor_character_compare.R
+- diagnostics: []
+  fixture: ok_factor_class.R
+- diagnostics: []
+  fixture: ok_factor_comparison.R
+- diagnostics: []
+  fixture: ok_ffi_call_first_arg.R
+- diagnostics: []
+  fixture: ok_fn_explicit_return.R
+- diagnostics: []
+  fixture: ok_fnbody_sequential.R
+- diagnostics: []
+  fixture: ok_fractional_numeric_index_length.R
+- diagnostics: []
+  fixture: ok_function_def.R
+- diagnostics: []
+  fixture: ok_global_variables_declaration.R
+- diagnostics: []
+  fixture: ok_ho_filter_find.R
+- diagnostics: []
+  fixture: ok_ho_map.R
+- diagnostics: []
+  fixture: ok_ho_named_arg_binding.R
+- diagnostics: []
+  fixture: ok_ho_named_callback.R
+- diagnostics: []
+  fixture: ok_ho_reduce.R
+- diagnostics: []
+  fixture: ok_ho_sapply.R
+- diagnostics: []
+  fixture: ok_ho_typeshed_callback.R
+- diagnostics: []
+  fixture: ok_ho_vapply.R
+- diagnostics: []
+  fixture: ok_if_else_join.R
+- diagnostics: []
+  fixture: ok_if_expr.R
+- diagnostics: []
+  fixture: ok_if_expr_nested.R
+- diagnostics: []
+  fixture: ok_if_expr_no_else.R
+- diagnostics: []
+  fixture: ok_if_length_idiom.R
+- diagnostics: []
+  fixture: ok_if_logical.R
+- diagnostics: []
+  fixture: ok_if_unknown_length_condition.R
+- diagnostics: []
+  fixture: ok_ifelse_mode.R
+- diagnostics: []
+  fixture: ok_ignore_comment.R
+- diagnostics: []
+  fixture: ok_iife.R
+- diagnostics: []
+  fixture: ok_iife_with_args.R
+- diagnostics: []
+  fixture: ok_in_operator_length.R
+- diagnostics: []
+  fixture: ok_index_length_from_index.R
+- diagnostics: []
+  fixture: ok_is_function_guard.R
+- diagnostics: []
+  fixture: ok_is_null_guard_narrowing.R
+- diagnostics: []
+  fixture: ok_lapply_list_arith.R
+- diagnostics: []
+  fixture: ok_lazy_default_reachability.R
+- diagnostics: []
+  fixture: ok_list_atomic_equality.R
+- diagnostics: []
+  fixture: ok_list_named_columns.R
+- diagnostics: []
+  fixture: ok_local_standalone_errors.R
+- diagnostics: []
+  fixture: ok_logical_mask_length.R
+- diagnostics: []
+  fixture: ok_logical_op.R
+- diagnostics: []
+  fixture: ok_loops.R
+- diagnostics: []
+  fixture: ok_mirai_minimal.R
+- diagnostics: []
+  fixture: ok_multi_assign.R
+- diagnostics: []
+  fixture: ok_named_args_match.R
+- diagnostics: []
+  fixture: ok_named_args_mixed.R
+- diagnostics: []
+  fixture: ok_narrow_is_character.R
+- diagnostics: []
+  fixture: ok_narrow_is_numeric.R
+- diagnostics: []
+  fixture: ok_narrow_not_is_null.R
+- diagnostics: []
+  fixture: ok_nested_return.R
+- diagnostics: []
+  fixture: ok_no_s3_collision.R
+- diagnostics: []
+  fixture: ok_nse_dplyr_arrange_groupby.R
+- diagnostics: []
+  fixture: ok_nse_dplyr_filter.R
+- diagnostics: []
+  fixture: ok_nse_dplyr_mutate.R
+- diagnostics: []
+  fixture: ok_nse_dplyr_pipe_chain.R
+- diagnostics: []
+  fixture: ok_nse_dplyr_summarise.R
+- diagnostics: []
+  fixture: ok_nse_dplyr_summarize_alias.R
+- diagnostics: []
+  fixture: ok_nse_embrace.R
+- diagnostics: []
+  fixture: ok_nse_function_alias.R
+- diagnostics: []
+  fixture: ok_nse_pipe_subset.R
+- diagnostics: []
+  fixture: ok_nse_subset.R
+- diagnostics: []
+  fixture: ok_nse_transform.R
+- diagnostics: []
+  fixture: ok_nse_with.R
+- diagnostics: []
+  fixture: ok_nse_within.R
+- diagnostics: []
+  fixture: ok_null_default_always_supplied.R
+- diagnostics: []
+  fixture: ok_null_default_callback_rebind.R
+- diagnostics: []
+  fixture: ok_package_qualified_resolution.R
+- diagnostics: []
+  fixture: ok_parameter_default_other_formal.R
+- diagnostics: []
+  fixture: ok_parameter_default_quoted_self.R
+- diagnostics: []
+  fixture: ok_partial_argument_match.R
+- diagnostics: []
+  fixture: ok_paste_length.R
+- diagnostics: []
+  fixture: ok_pipe_assign_rebinds.R
+- diagnostics: []
+  fixture: ok_pipe_bare_fn.R
+- diagnostics: []
+  fixture: ok_pipe_base.R
+- diagnostics: []
+  fixture: ok_pipe_chain.R
+- diagnostics: []
+  fixture: ok_pipe_magrittr.R
+- diagnostics: []
+  fixture: ok_pipe_placeholder.R
+- diagnostics: []
+  fixture: ok_plan31_recall_negative_controls.R
+- diagnostics: []
+  fixture: ok_purrr_in_parallel.R
+- diagnostics: []
+  fixture: ok_purrr_map_dbl.R
+- diagnostics: []
+  fixture: ok_qualified_call_not_shadowed.R
+- diagnostics: []
+  fixture: ok_qualified_nse_aes.R
+- diagnostics: []
+  fixture: ok_quoted_formula_symbols.R
+- diagnostics: []
+  fixture: ok_r6_class_body_bindings.R
+- diagnostics: []
+  fixture: ok_raw_operations.R
+- diagnostics: []
+  fixture: ok_recursion.R
+- diagnostics: []
+  fixture: ok_recursive_default_captured.R
+- diagnostics: []
+  fixture: ok_recursive_default_conditional_return.R
+- diagnostics: []
+  fixture: ok_recursive_default_lazy_call.R
+- diagnostics: []
+  fixture: ok_recursive_default_missing.R
+- diagnostics: []
+  fixture: ok_recursive_default_qualified_defuser.R
+- diagnostics: []
+  fixture: ok_recursive_default_replaced.R
+- diagnostics: []
+  fixture: ok_recursive_default_shadowed_defuser.R
+- diagnostics: []
+  fixture: ok_recursive_default_shadowed_strict.R
+- diagnostics: []
+  fixture: ok_recursive_default_short_circuit.R
+- diagnostics: []
+  fixture: ok_recursive_default_unforced_branch.R
+- diagnostics: []
+  fixture: ok_recursive_default_unreachable_block.R
+- diagnostics: []
+  fixture: ok_recursive_default_user_defuser.R
+- diagnostics: []
+  fixture: ok_s3_data_frame.R
+- diagnostics: []
+  fixture: ok_s3_dispatch.R
+- diagnostics: []
+  fixture: ok_s4_terra_named_vector.R
+- diagnostics: []
+  fixture: ok_s7_class_callable.R
+- diagnostics: []
+  fixture: ok_sapply_unknown_callback_arithmetic.R
+- diagnostics: []
+  fixture: ok_scalar_logical.R
+- diagnostics: []
+  fixture: ok_scalar_single_bracket_index.R
+- diagnostics: []
+  fixture: ok_seq_for_loop.R
+- diagnostics: []
+  fixture: ok_short_circuit_narrowing.R
+- diagnostics: []
+  fixture: ok_standalone_guard_uncertain_and_collisions.R
+- diagnostics:
+    - code: RY040
+      fix: ~
+      message: "cannot apply arithmetic op to `double` and `character`"
+      severity: error
+      span:
+        column: 29
+        end: 344
+        line: 6
+        start: 337
+  fixture: ok_string_containing_hash_noqa.R
+- diagnostics: []
+  fixture: ok_subsetting.R
+- diagnostics: []
+  fixture: ok_survfit_quantile_fields.R
+- diagnostics: []
+  fixture: ok_switch_integer.R
+- diagnostics: []
+  fixture: ok_t6_append_and_null_guard.R
+- diagnostics: []
+  fixture: ok_t6_length_inference.R
+- diagnostics: []
+  fixture: ok_testthat_block_scope.R
+- diagnostics: []
+  fixture: ok_tidyselect_negative_string.R
+- diagnostics: []
+  fixture: ok_trycatch.R
+- diagnostics: []
+  fixture: ok_typeshed_coercion.R
+- diagnostics: []
+  fixture: ok_typeshed_cumulative.R
+- diagnostics: []
+  fixture: ok_typeshed_datasets_expanded.R
+- diagnostics: []
+  fixture: ok_typeshed_math.R
+- diagnostics: []
+  fixture: ok_typeshed_predicates.R
+- diagnostics: []
+  fixture: ok_typeshed_sets.R
+- diagnostics: []
+  fixture: ok_typeshed_stats.R
+- diagnostics: []
+  fixture: ok_typeshed_string.R
+- diagnostics: []
+  fixture: ok_unary_minus.R
+- diagnostics: []
+  fixture: ok_unary_not.R
+- diagnostics: []
+  fixture: ok_union_element_condition.R
+- diagnostics: []
+  fixture: ok_union_if_arith.R
+- diagnostics: []
+  fixture: ok_unknown_argument_type.R
+- diagnostics: []
+  fixture: ok_user_fn_argument_matching.R
+- diagnostics: []
+  fixture: ok_user_fn_missing_lazy_formal.R
+- diagnostics: []
+  fixture: ok_user_fn_return.R
+- diagnostics: []
+  fixture: ok_vector_constructors.R
+- diagnostics: []
+  fixture: ok_vector_mode_literal.R
+- diagnostics: []
+  fixture: ok_walrus_bind.R
+- diagnostics: []
+  fixture: ok_with_unknown_object.R
+- diagnostics:
+    - code: RY001
+      fix: ~
+      message: "`if` condition is `character<len=1>`, expected length-1 logical"
+      severity: error
+      span:
+        column: 4
+        end: 126
+        line: 3
+        start: 123
+  fixture: ry001_if_condition.R
+- diagnostics:
+    - code: RY003
+      fix: ~
+      message: "`if` condition is `integer`; R coerces nonzero to TRUE"
+      severity: info
+      span:
+        column: 4
+        end: 330
+        line: 6
+        start: 328
+  fixture: ry001_numeric_condition.R
+- diagnostics:
+    - code: RY002
+      fix: ~
+      message: "`if` condition has length 2; R requires a length-1 condition"
+      severity: warning
+      span:
+        column: 4
+        end: 110
+        line: 2
+        start: 96
+  fixture: ry002_if_length.R
+- diagnostics:
+    - code: RY010
+      fix: ~
+      message: "variable `undefined_thing` is not bound in this scope"
+      severity: warning
+      span:
+        column: 5
+        end: 92
+        line: 2
+        start: 77
+  fixture: ry010_unbound.R
+- diagnostics:
+    - code: RY020
+      fix: ~
+      message: "cannot apply unary `-` to `raw`"
+      severity: error
+      span:
+        column: 0
+        end: 23
+        line: 1
+        start: 16
+  fixture: ry020_raw_unary.R
+- diagnostics:
+    - code: RY020
+      fix: ~
+      message: "cannot apply unary `-` to `character`"
+      severity: error
+      span:
+        column: 5
+        end: 82
+        line: 2
+        start: 74
+  fixture: ry020_unary_minus.R
+- diagnostics:
+    - code: RY021
+      fix: ~
+      message: "cannot apply `!` to `character`"
+      severity: error
+      span:
+        column: 5
+        end: 87
+        line: 2
+        start: 79
+  fixture: ry021_unary_not.R
+- diagnostics: []
+  fixture: ry030_compare.R
+- diagnostics:
+    - code: RY031
+      fix: ~
+      message: "logical op applied to `character` and `logical`"
+      severity: error
+      span:
+        column: 5
+        end: 99
+        line: 2
+        start: 89
+  fixture: ry031_logical_op.R
+- diagnostics:
+    - code: RY034
+      fix:
+        replacement: is.na(x)
+        span:
+          column: 0
+          end: 44
+          line: 2
+          start: 37
+      message: "comparison with `NA` always produces `NA`; use `is.na()` instead"
+      severity: warning
+      span:
+        column: 0
+        end: 44
+        line: 2
+        start: 37
+    - code: RY034
+      fix:
+        replacement: "!is.na(x)"
+        span:
+          column: 0
+          end: 58
+          line: 3
+          start: 45
+      message: "comparison with `NA` always produces `NA`; use `is.na()` instead"
+      severity: warning
+      span:
+        column: 0
+        end: 58
+        line: 3
+        start: 45
+  fixture: ry034_compare_na.R
+- diagnostics:
+    - code: RY040
+      fix: ~
+      message: "cannot apply arithmetic op to `character` and `integer`"
+      severity: error
+      span:
+        column: 5
+        end: 92
+        line: 2
+        start: 84
+  fixture: ry040_arith.R
+- diagnostics:
+    - code: RY040
+      fix: ~
+      message: "cannot apply arithmetic op to `raw` and `raw`"
+      severity: error
+      span:
+        column: 0
+        end: 38
+        line: 1
+        start: 23
+    - code: RY040
+      fix: ~
+      message: "cannot apply arithmetic op to `raw` and `integer`"
+      severity: error
+      span:
+        column: 0
+        end: 53
+        line: 2
+        start: 39
+  fixture: ry040_raw_arithmetic.R
+- diagnostics:
+    - code: RY040
+      fix: ~
+      message: "cannot apply arithmetic op to `character` and `integer`"
+      severity: error
+      span:
+        column: 5
+        end: 202
+        line: 6
+        start: 191
+  fixture: ry040_user_fn_return.R
+- diagnostics:
+    - code: RY041
+      fix: ~
+      message: vector lengths 3 and 2 do not divide evenly; R will recycle with a warning
+      severity: warning
+      span:
+        column: 0
+        end: 38
+        line: 1
+        start: 16
+  fixture: ry041_non_divisible_recycling.R
+- diagnostics:
+    - code: RY042
+      fix: ~
+      message: "arithmetic on a factor produces `NA`; operate on its levels or convert it explicitly"
+      severity: warning
+      span:
+        column: 0
+        end: 39
+        line: 1
+        start: 16
+  fixture: ry042_factor_arithmetic.R
+- diagnostics:
+    - code: RY050
+      fix: ~
+      message: "S3 generic `Summary` called on value with classes [undefined] but no matching method is defined"
+      severity: warning
+      span:
+        column: 0
+        end: 331
+        line: 6
+        start: 321
+  fixture: ry050_missing_method.R
+- diagnostics:
+    - code: RY060
+      fix: ~
+      message: "column `nonexistent` not found in data frame schema; available columns: am, carb, cyl, disp, drat, ..."
+      severity: error
+      span:
+        column: 7
+        end: 189
+        line: 4
+        start: 175
+  fixture: ry060_undefined_column.R
+- diagnostics: []
+  fixture: ry095_ry096_real_shapes.R
+- diagnostics:
+    - code: RY096
+      fix: ~
+      message: "`hasArg(threshold)` names a parameter that is not a formal; it is always FALSE"
+      severity: warning
+      span:
+        column: 6
+        end: 207
+        line: 4
+        start: 190
+  fixture: ry096_hasarg_no_dots.R
+- diagnostics: []
+  fixture: ry098_default_forced_before_assignment.R
+- diagnostics:
+    - code: RY001
+      fix: ~
+      message: "`if` condition is `NULL<len=0>`, expected length-1 logical"
+      severity: error
+      span:
+        column: 6
+        end: 61
+        line: 2
+        start: 57
+  fixture: warn_forwarded_null_default_condition.R
+- diagnostics:
+    - code: RY001
+      fix: ~
+      message: "`if` condition is `NULL<len=0>`, expected length-1 logical"
+      severity: error
+      span:
+        column: 6
+        end: 74
+        line: 2
+        start: 68
+  fixture: warn_null_default_condition.R
+- diagnostics:
+    - code: RY003
+      fix: ~
+      message: "`if` condition is `double`; R coerces nonzero to TRUE"
+      severity: info
+      span:
+        column: 4
+        end: 32
+        line: 1
+        start: 20
+  fixture: warn_numeric_min_condition.R
+- diagnostics:
+    - code: RY002
+      fix: ~
+      message: "`if` condition has length 2; R requires a length-1 condition"
+      severity: warning
+      span:
+        column: 4
+        end: 48
+        line: 2
+        start: 39
+  fixture: warn_t6_negative_subscript.R

--- a/crates/ry-checker/tests/snapshots/corpus__checker_fixture_diagnostics.snap
+++ b/crates/ry-checker/tests/snapshots/corpus__checker_fixture_diagnostics.snap
@@ -279,12 +279,12 @@ expression: snapshots
 - diagnostics:
     - code: RY102
       fix:
-        replacement: "\"github-ref\" = \"b\""
+        replacement: "="
         span:
-          column: 21
-          end: 377
+          column: 34
+          end: 373
           line: 6
-          start: 358
+          start: 371
       message: "`<-` inside `list()` assigns `github-ref` and leaves the element unnamed; write `\"github-ref\" = ...` to name it"
       severity: warning
       span:

--- a/crates/ry-checker/tests/snapshots/fixes__structured_fix_oracle.snap
+++ b/crates/ry-checker/tests/snapshots/fixes__structured_fix_oracle.snap
@@ -61,9 +61,9 @@ expression: snapshots
   before:
     - code: RY093
       fix:
-        replacement: "length(c(1L, 2L)) > 0L"
+        replacement: ) > 0L
         span:
-          - 0
+          - 16
           - 22
       message: "comparison is inside `length()`; compare `length(x)` instead"
       severity: warning
@@ -77,9 +77,9 @@ expression: snapshots
   before:
     - code: RY100
       fix:
-        replacement: abs(x) > 0L
+        replacement: ) > 0L
         span:
-          - 17
+          - 22
           - 28
       message: comparison directly inside a numeric math function is usually a parenthesization mistake; compare the math result instead
       severity: warning
@@ -109,10 +109,10 @@ expression: snapshots
   before:
     - code: RY102
       fix:
-        replacement: "\"wi\\\"dget\" = 2L"
+        replacement: "="
         span:
-          - 14
-          - 30
+          - 25
+          - 27
       message: "`<-` inside `list()` assigns `wi\"dget` and leaves the element unnamed; write `\"wi\\\"dget\" = ...` to name it"
       severity: warning
       span:

--- a/crates/ry-checker/tests/snapshots/fixes__structured_fix_oracle.snap
+++ b/crates/ry-checker/tests/snapshots/fixes__structured_fix_oracle.snap
@@ -1,0 +1,139 @@
+---
+source: crates/ry-checker/tests/fixes.rs
+expression: snapshots
+---
+- after: []
+  before:
+    - code: RY032
+      fix:
+        replacement: "&"
+        span:
+          - 19
+          - 21
+      message: "`&&` applied to a length-2 operand; only the first element is used"
+      severity: warning
+      span:
+        - 17
+        - 36
+  code: RY032
+  edited: "f <- function(x) x & c(TRUE, FALSE)\n"
+  source: "f <- function(x) x && c(TRUE, FALSE)\n"
+- after: []
+  before:
+    - code: RY034
+      fix:
+        replacement: is.na(x)
+        span:
+          - 17
+          - 24
+      message: "comparison with `NA` always produces `NA`; use `is.na()` instead"
+      severity: warning
+      span:
+        - 17
+        - 24
+  code: RY034
+  edited: "f <- function(x) is.na(x)\n"
+  source: "f <- function(x) x == NA\n"
+- after: []
+  before:
+    - code: RY090
+      fix:
+        replacement: x = 1L
+        span:
+          - 7
+          - 14
+      message: "unknown argument `xx` to `length`; did you mean `x`?"
+      severity: warning
+      span:
+        - 7
+        - 14
+    - code: RY091
+      fix: ~
+      message: "missing required argument `x` in call to `length`"
+      severity: warning
+      span:
+        - 0
+        - 15
+  code: RY090
+  edited: "length(x = 1L)\n"
+  source: "length(xx = 1L)\n"
+- after: []
+  before:
+    - code: RY093
+      fix:
+        replacement: "length(c(1L, 2L)) > 0L"
+        span:
+          - 0
+          - 22
+      message: "comparison is inside `length()`; compare `length(x)` instead"
+      severity: warning
+      span:
+        - 7
+        - 21
+  code: RY093
+  edited: "length(c(1L, 2L)) > 0L\n"
+  source: "length(c(1L, 2L) > 0L)\n"
+- after: []
+  before:
+    - code: RY100
+      fix:
+        replacement: abs(x) > 0L
+        span:
+          - 17
+          - 28
+      message: comparison directly inside a numeric math function is usually a parenthesization mistake; compare the math result instead
+      severity: warning
+      span:
+        - 21
+        - 27
+  code: RY100
+  edited: "f <- function(x) abs(x) > 0L\n"
+  source: "f <- function(x) abs(x > 0L)\n"
+- after: []
+  before:
+    - code: RY101
+      fix:
+        replacement: "args[[\"font\"]]"
+        span:
+          - 38
+          - 50
+      message: "single-bracket list subset remains a list, so `identical()` with an atomic scalar is always FALSE; use `[[` to extract the element"
+      severity: warning
+      span:
+        - 38
+        - 50
+  code: RY101
+  edited: "args <- list(font = \"mono\")\nidentical(args[[\"font\"]], \"mono\")\n"
+  source: "args <- list(font = \"mono\")\nidentical(args[\"font\"], \"mono\")\n"
+- after: []
+  before:
+    - code: RY102
+      fix:
+        replacement: "\"wi\\\"dget\" = 2L"
+        span:
+          - 14
+          - 30
+      message: "`<-` inside `list()` assigns `wi\"dget` and leaves the element unnamed; write `\"wi\\\"dget\" = ...` to name it"
+      severity: warning
+      span:
+        - 14
+        - 30
+  code: RY102
+  edited: "list(ok = 1L, \"wi\\\"dget\" = 2L)\n"
+  source: "list(ok = 1L, \"wi\\\"dget\" <- 2L)\n"
+- after: []
+  before:
+    - code: RY103
+      fix:
+        replacement: "inherits(x, \"wi\\\"dget\")"
+        span:
+          - 21
+          - 43
+      message: "`class()` returns a character vector, so this comparison is not length-1 for a multi-class object and the enclosing condition errors; use `inherits(x, \"wi\\\"dget\")`"
+      severity: warning
+      span:
+        - 21
+        - 43
+  code: RY103
+  edited: "f <- function(x) if (inherits(x, \"wi\\\"dget\")) 1L else 2L\n"
+  source: "f <- function(x) if (class(x) == \"wi\\\"dget\") 1L else 2L\n"

--- a/crates/ry-checker/tests/snapshots/fixes__structured_fix_oracle.snap
+++ b/crates/ry-checker/tests/snapshots/fixes__structured_fix_oracle.snap
@@ -38,10 +38,10 @@ expression: snapshots
   before:
     - code: RY090
       fix:
-        replacement: x = 1L
+        replacement: x
         span:
           - 7
-          - 14
+          - 9
       message: "unknown argument `xx` to `length`; did you mean `x`?"
       severity: warning
       span:

--- a/crates/ry-checker/tests/testkit.rs
+++ b/crates/ry-checker/tests/testkit.rs
@@ -1,8 +1,8 @@
 use ry_checker::Project;
 use ry_core::RParser;
 use ry_testkit::{
-    Driver, DriverError, FixtureProject, ObservedDiagnostic, ObservedPosition, ObservedRange,
-    PositionEncoding, normalize_path,
+    Driver, DriverError, FixtureProject, ObservedDiagnostic, ObservedFix, ObservedPosition,
+    ObservedRange, PositionEncoding, normalize_path,
 };
 
 struct ProjectDriver;
@@ -14,6 +14,7 @@ impl Driver for ProjectDriver {
     ) -> Result<Vec<ObservedDiagnostic>, DriverError> {
         let mut parser = RParser::new()?;
         let mut project = Project::new();
+        let mut sources = std::collections::HashMap::new();
         for path in fixture.files()? {
             if !matches!(
                 path.extension().and_then(|extension| extension.to_str()),
@@ -23,28 +24,53 @@ impl Driver for ProjectDriver {
             }
             let relative = normalize_path(&path, fixture.root());
             let source = std::fs::read_to_string(&path)?;
+            sources.insert(relative.clone(), source.clone());
             project.add_file(relative.clone(), parser.parse(&relative, &source)?);
         }
         Ok(project
             .check()
             .into_iter()
             .flat_map(|(_, diagnostics)| diagnostics)
-            .map(|diagnostic| ObservedDiagnostic {
-                path: normalize_path(&diagnostic.path, fixture.root()),
-                code: diagnostic.code.to_string(),
-                severity: diagnostic.severity.as_str().to_string(),
-                message: diagnostic.message,
-                range: ObservedRange {
-                    start: ObservedPosition {
-                        line: diagnostic.span.line as u32,
-                        character: diagnostic.span.col as u32,
-                        encoding: PositionEncoding::Utf8Byte,
+            .map(|diagnostic| {
+                let fix = diagnostic.fix.as_ref().and_then(|fix| {
+                    let source = sources.get(&diagnostic.path)?;
+                    Some(ObservedFix {
+                        range: ObservedRange {
+                            start: byte_offset_position(source, fix.span.start),
+                            end: Some(byte_offset_position(source, fix.span.end)),
+                        },
+                        replacement: fix.replacement.clone(),
+                    })
+                });
+                ObservedDiagnostic {
+                    path: normalize_path(&diagnostic.path, fixture.root()),
+                    code: diagnostic.code.to_string(),
+                    severity: diagnostic.severity.as_str().to_string(),
+                    message: diagnostic.message,
+                    range: ObservedRange {
+                        start: ObservedPosition {
+                            line: diagnostic.span.line as u32,
+                            character: diagnostic.span.col as u32,
+                            encoding: PositionEncoding::Utf8Byte,
+                        },
+                        end: None,
                     },
-                    end: None,
-                },
-                confidence: Some(diagnostic.confidence.as_str().to_string()),
+                    confidence: Some(diagnostic.confidence.as_str().to_string()),
+                    fix,
+                }
             })
             .collect())
+    }
+}
+
+fn byte_offset_position(source: &str, offset: usize) -> ObservedPosition {
+    let prefix = &source[..offset];
+    let line = prefix.bytes().filter(|byte| *byte == b'\n').count() as u32;
+    let line_start = prefix.rfind('\n').map_or(0, |position| position + 1);
+    ObservedPosition {
+        line,
+        character: (offset - line_start) as u32,
+        encoding: PositionEncoding::Utf8Byte,
     }
 }
 

--- a/crates/ry-cli/tests/lsp_testkit.rs
+++ b/crates/ry-cli/tests/lsp_testkit.rs
@@ -1,6 +1,6 @@
 use ry_testkit::{
-    Driver, DriverError, FixtureProject, JsonRpcProcess, ObservedDiagnostic, ObservedPosition,
-    ObservedRange, PositionEncoding, normalize_path,
+    Driver, DriverError, FixtureProject, JsonRpcProcess, ObservedDiagnostic, ObservedFix,
+    ObservedPosition, ObservedRange, PositionEncoding, normalize_path,
 };
 use serde_json::{Value, json};
 use std::path::Path;
@@ -102,9 +102,28 @@ fn lsp_diagnostics(
                     end: Some(lsp_position(end)?),
                 },
                 confidence: None,
+                fix: lsp_fix(value)?,
             })
         })
         .collect()
+}
+
+fn lsp_fix(value: &Value) -> Result<Option<ObservedFix>, DriverError> {
+    value
+        .pointer("/data/fix")
+        .map(|fix| {
+            Ok(ObservedFix {
+                range: ObservedRange {
+                    start: lsp_position(&fix["range"]["start"])?,
+                    end: Some(lsp_position(&fix["range"]["end"])?),
+                },
+                replacement: fix["replacement"]
+                    .as_str()
+                    .ok_or("fix replacement is not a string")?
+                    .to_string(),
+            })
+        })
+        .transpose()
 }
 
 fn lsp_position(value: &Value) -> Result<ObservedPosition, DriverError> {

--- a/crates/ry-cli/tests/testkit.rs
+++ b/crates/ry-cli/tests/testkit.rs
@@ -1,6 +1,6 @@
 use ry_testkit::{
-    CliProcess, Driver, DriverError, FixtureProject, ObservedDiagnostic, ObservedPosition,
-    ObservedRange, PositionEncoding, normalize_path,
+    CliProcess, Driver, DriverError, FixtureProject, ObservedDiagnostic, ObservedFix,
+    ObservedPosition, ObservedRange, PositionEncoding, normalize_path,
 };
 use serde_json::Value;
 use std::path::Path;
@@ -37,8 +37,31 @@ impl Driver for CliDriver {
 fn cli_diagnostic(value: Value, root: &Path) -> Result<ObservedDiagnostic, DriverError> {
     let line = required_u64(&value, "line")? as u32;
     let column = required_u64(&value, "column")? as u32;
+    let path = required_str(&value, "path")?;
+    let source_path = Path::new(path);
+    let source_path = if source_path.is_absolute() {
+        source_path.to_path_buf()
+    } else {
+        root.join(source_path)
+    };
+    let source = std::fs::read_to_string(source_path)?;
+    let fix = value
+        .get("fix")
+        .map(|fix| -> Result<ObservedFix, DriverError> {
+            Ok(ObservedFix {
+                range: ObservedRange {
+                    start: byte_offset_position(&source, required_u64(fix, "start")? as usize)?,
+                    end: Some(byte_offset_position(
+                        &source,
+                        required_u64(fix, "end")? as usize,
+                    )?),
+                },
+                replacement: required_str(fix, "replacement")?.to_string(),
+            })
+        })
+        .transpose()?;
     Ok(ObservedDiagnostic {
-        path: normalize_path(required_str(&value, "path")?, root),
+        path: normalize_path(path, root),
         code: required_str(&value, "code")?.to_string(),
         severity: required_str(&value, "severity")?.to_string(),
         message: required_str(&value, "message")?.to_string(),
@@ -54,6 +77,21 @@ fn cli_diagnostic(value: Value, root: &Path) -> Result<ObservedDiagnostic, Drive
             .get("confidence")
             .and_then(Value::as_str)
             .map(str::to_string),
+        fix,
+    })
+}
+
+fn byte_offset_position(source: &str, offset: usize) -> Result<ObservedPosition, DriverError> {
+    if offset > source.len() || !source.is_char_boundary(offset) {
+        return Err(format!("fix byte offset {offset} is not a source boundary").into());
+    }
+    let prefix = &source[..offset];
+    let line = prefix.bytes().filter(|byte| *byte == b'\n').count() as u32;
+    let line_start = prefix.rfind('\n').map_or(0, |position| position + 1);
+    Ok(ObservedPosition {
+        line,
+        character: (offset - line_start) as u32,
+        encoding: PositionEncoding::Utf8Byte,
     })
 }
 

--- a/crates/ry-core/src/ast.rs
+++ b/crates/ry-core/src/ast.rs
@@ -10,6 +10,9 @@ use crate::types::RType;
 #[derive(Debug, Clone, Default)]
 pub struct SourceFile {
     pub path: String,
+    /// Original UTF-8 text. Checker fixes slice this production parse input by
+    /// AST spans rather than attempting to print or scrape diagnostic prose.
+    pub source: String,
     pub stmts: Vec<Stmt>,
     /// Parse errors (tree-sitter `ERROR` / `MISSING` nodes) discovered
     /// during parsing. Each entry's span points at the broken region.

--- a/crates/ry-core/src/parser.rs
+++ b/crates/ry-core/src/parser.rs
@@ -84,6 +84,7 @@ impl RParser {
         Ok((
             SourceFile {
                 path: path.to_string(),
+                source: src.to_string(),
                 stmts,
                 parse_errors,
                 comments,

--- a/crates/ry-lsp/src/diagnostics.rs
+++ b/crates/ry-lsp/src/diagnostics.rs
@@ -22,6 +22,22 @@ use crate::util::byte_offset_to_position;
 /// as a fallback (tests, missing source text); the production
 /// diagnostics path uses [`diagnostic_to_lsp_with_source`].
 pub(super) fn diagnostic_to_lsp(d: RyDiagnostic) -> LspDiagnostic {
+    let data = d.fix.as_ref().map(|fix| {
+        let fix_start = Position {
+            line: fix.span.line as u32,
+            character: fix.span.col as u32,
+        };
+        let fix_end = Position {
+            line: fix.span.line as u32,
+            character: (fix.span.col + fix.span.end.saturating_sub(fix.span.start)) as u32,
+        };
+        serde_json::json!({
+            "fix": {
+                "range": {"start": fix_start, "end": fix_end},
+                "replacement": fix.replacement,
+            }
+        })
+    });
     let start = Position {
         line: d.span.line as u32,
         character: d.span.col as u32,
@@ -41,6 +57,7 @@ pub(super) fn diagnostic_to_lsp(d: RyDiagnostic) -> LspDiagnostic {
         code: Some(NumberOrString::String(d.code.to_string())),
         source: Some("ry".to_string()),
         message: d.message,
+        data,
         ..Default::default()
     }
 }
@@ -52,6 +69,16 @@ pub(super) fn diagnostic_to_lsp(d: RyDiagnostic) -> LspDiagnostic {
 /// token. Zero-width spans are extended by one character so the squiggle
 /// is still visible.
 pub(super) fn diagnostic_to_lsp_with_source(d: &RyDiagnostic, text: &str) -> LspDiagnostic {
+    let data = d.fix.as_ref().map(|fix| {
+        let start = byte_offset_to_position(text, fix.span.start);
+        let end = byte_offset_to_position(text, fix.span.end);
+        serde_json::json!({
+            "fix": {
+                "range": {"start": start, "end": end},
+                "replacement": fix.replacement,
+            }
+        })
+    });
     let start = byte_offset_to_position(text, d.span.start);
     let end = byte_offset_to_position(text, d.span.end);
     let end = if start == end {
@@ -73,6 +100,7 @@ pub(super) fn diagnostic_to_lsp_with_source(d: &RyDiagnostic, text: &str) -> Lsp
         code: Some(NumberOrString::String(d.code.to_string())),
         source: Some("ry".to_string()),
         message: d.message.clone(),
+        data,
         ..Default::default()
     }
 }

--- a/crates/ry-lsp/src/diagnostics.rs
+++ b/crates/ry-lsp/src/diagnostics.rs
@@ -22,22 +22,6 @@ use crate::util::byte_offset_to_position;
 /// as a fallback (tests, missing source text); the production
 /// diagnostics path uses [`diagnostic_to_lsp_with_source`].
 pub(super) fn diagnostic_to_lsp(d: RyDiagnostic) -> LspDiagnostic {
-    let data = d.fix.as_ref().map(|fix| {
-        let fix_start = Position {
-            line: fix.span.line as u32,
-            character: fix.span.col as u32,
-        };
-        let fix_end = Position {
-            line: fix.span.line as u32,
-            character: (fix.span.col + fix.span.end.saturating_sub(fix.span.start)) as u32,
-        };
-        serde_json::json!({
-            "fix": {
-                "range": {"start": fix_start, "end": fix_end},
-                "replacement": fix.replacement,
-            }
-        })
-    });
     let start = Position {
         line: d.span.line as u32,
         character: d.span.col as u32,
@@ -57,7 +41,9 @@ pub(super) fn diagnostic_to_lsp(d: RyDiagnostic) -> LspDiagnostic {
         code: Some(NumberOrString::String(d.code.to_string())),
         source: Some("ry".to_string()),
         message: d.message,
-        data,
+        // A fix span contains byte offsets. Without source text they cannot be
+        // converted safely to LSP UTF-16 positions (or across line breaks).
+        data: None,
         ..Default::default()
     }
 }

--- a/crates/ry-lsp/src/tests.rs
+++ b/crates/ry-lsp/src/tests.rs
@@ -15,7 +15,7 @@ use crate::navigation::{
 use crate::selection::{build_selection_range, find_identifier_range_at_position};
 use crate::symbols::{collect_symbols, flatten_symbols_to_symbol_info};
 use crate::util::*;
-use ry_checker::{Diagnostic, Severity};
+use ry_checker::{Diagnostic, Fix, Severity};
 use ry_core::{RParser, SourceFile, Span};
 use tower_lsp::lsp_types::Diagnostic as LspDiagnostic;
 use tower_lsp::lsp_types::*;
@@ -41,6 +41,24 @@ fn converts_error_diagnostic() {
         Some(NumberOrString::String(s)) => assert_eq!(s, "RY040"),
         other => panic!("expected String code, got {:?}", other),
     }
+}
+
+#[test]
+fn no_source_diagnostic_omits_fix_data() {
+    let d = Diagnostic::new(
+        Severity::Warning,
+        Span::new(7, 8, 0, 7),
+        "test.R",
+        "RY032",
+        "test",
+    )
+    .with_fix(Fix {
+        // A multiline byte span cannot be reconstructed from line/column alone.
+        span: Span::new(7, 15, 0, 7),
+        replacement: "replacement".to_string(),
+    });
+    let lsp = diagnostic_to_lsp(d);
+    assert_eq!(lsp.data, None);
 }
 
 #[test]

--- a/crates/ry-lsp/tests/protocol.rs
+++ b/crates/ry-lsp/tests/protocol.rs
@@ -7,6 +7,15 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct PublishedFix {
+    start_line: u32,
+    start_byte_column: u32,
+    end_line: u32,
+    end_byte_column: u32,
+    replacement: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 struct Published {
     path: String,
     code: String,
@@ -14,6 +23,7 @@ struct Published {
     message: String,
     line: u32,
     byte_column: u32,
+    fix: Option<PublishedFix>,
 }
 
 fn workspace_root() -> PathBuf {
@@ -67,6 +77,17 @@ fn cli_diagnostics(fixture: &FixtureProject, extra: &[&str]) -> Vec<Published> {
                 encoding: PositionEncoding::UnicodeScalar,
             };
             let position = normalize_position(&source, &scalar).unwrap();
+            let fix = value.get("fix").map(|fix| {
+                let start = byte_offset_position(&source, fix["start"].as_u64().unwrap() as usize);
+                let end = byte_offset_position(&source, fix["end"].as_u64().unwrap() as usize);
+                PublishedFix {
+                    start_line: start.0,
+                    start_byte_column: start.1,
+                    end_line: end.0,
+                    end_byte_column: end.1,
+                    replacement: fix["replacement"].as_str().unwrap().to_string(),
+                }
+            });
             Published {
                 path: relative,
                 code: value["code"].as_str().unwrap().to_string(),
@@ -74,11 +95,20 @@ fn cli_diagnostics(fixture: &FixtureProject, extra: &[&str]) -> Vec<Published> {
                 message: value["message"].as_str().unwrap().to_string(),
                 line: position.line,
                 byte_column: position.character,
+                fix,
             }
         })
         .collect();
     diagnostics.sort();
     diagnostics
+}
+
+fn byte_offset_position(source: &str, offset: usize) -> (u32, u32) {
+    assert!(offset <= source.len() && source.is_char_boundary(offset));
+    let prefix = &source[..offset];
+    let line = prefix.bytes().filter(|byte| *byte == b'\n').count() as u32;
+    let line_start = prefix.rfind('\n').map_or(0, |position| position + 1);
+    (line, (offset - line_start) as u32)
 }
 
 fn file_uri(path: &Path) -> String {
@@ -178,6 +208,33 @@ fn published_from_lsp(message: &Value, path: &Path, root: &Path) -> Vec<Publishe
                 },
             )
             .unwrap();
+            let fix = value.pointer("/data/fix").map(|fix| {
+                let start = normalize_position(
+                    &source,
+                    &ObservedPosition {
+                        line: fix["range"]["start"]["line"].as_u64().unwrap() as u32,
+                        character: fix["range"]["start"]["character"].as_u64().unwrap() as u32,
+                        encoding: PositionEncoding::Utf16,
+                    },
+                )
+                .unwrap();
+                let end = normalize_position(
+                    &source,
+                    &ObservedPosition {
+                        line: fix["range"]["end"]["line"].as_u64().unwrap() as u32,
+                        character: fix["range"]["end"]["character"].as_u64().unwrap() as u32,
+                        encoding: PositionEncoding::Utf16,
+                    },
+                )
+                .unwrap();
+                PublishedFix {
+                    start_line: start.line,
+                    start_byte_column: start.character,
+                    end_line: end.line,
+                    end_byte_column: end.character,
+                    replacement: fix["replacement"].as_str().unwrap().to_string(),
+                }
+            });
             Published {
                 path: relative.clone(),
                 code: value["code"].as_str().unwrap().to_string(),
@@ -192,6 +249,7 @@ fn published_from_lsp(message: &Value, path: &Path, root: &Path) -> Vec<Publishe
                 message: value["message"].as_str().unwrap().to_string(),
                 line: position.line,
                 byte_column: position.character,
+                fix,
             }
         })
         .collect()
@@ -265,6 +323,49 @@ fn cli_and_run_with_publish_the_same_single_root_matrix() {
         let lsp = runtime.block_on(run_with_diagnostics(&fixture, target, settings));
         assert_eq!(lsp, cli, "published diagnostics differ for {fixture_name}");
     }
+}
+
+#[test]
+fn structured_fixes_have_cli_and_lsp_publication_parity() {
+    let fixture = FixtureProject::empty().unwrap();
+    fixture
+        .write_file(
+            "fixes.R",
+            r#"emoji <- "😀"
+f <- function(x) {
+  a <- x && c(TRUE, FALSE)
+  b <- x == NA
+  c <- abs(x > 0L)
+  if (class(x) == "wi\"dget") 1L else 2L
+}
+length(xx = 1L)
+length(c(1L, 2L) > 0L)
+args <- list(font = "mono")
+identical(args["font"], "mono")
+list(ok = 1L, "wi\"dget" <- 2L)
+"#,
+        )
+        .unwrap();
+    let cli = cli_diagnostics(&fixture, &[]);
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    let lsp = runtime.block_on(run_with_diagnostics(&fixture, "fixes.R", json!({})));
+    assert_eq!(lsp, cli);
+
+    let fixed_codes = cli
+        .iter()
+        .filter_map(|diagnostic| diagnostic.fix.as_ref().map(|_| diagnostic.code.as_str()))
+        .collect::<std::collections::BTreeSet<_>>();
+    assert_eq!(
+        fixed_codes,
+        [
+            "RY032", "RY034", "RY090", "RY093", "RY100", "RY101", "RY102", "RY103"
+        ]
+        .into_iter()
+        .collect()
+    );
 }
 
 #[test]

--- a/crates/ry-lsp/tests/protocol.rs
+++ b/crates/ry-lsp/tests/protocol.rs
@@ -331,14 +331,13 @@ fn structured_fixes_have_cli_and_lsp_publication_parity() {
     fixture
         .write_file(
             "fixes.R",
-            r#"emoji <- "😀"
+            r#"emoji <- "😀"; length(xx = 1L)
 f <- function(x) {
   a <- x && c(TRUE, FALSE)
   b <- x == NA
   c <- abs(x > 0L)
   if (class(x) == "wi\"dget") 1L else 2L
 }
-length(xx = 1L)
 length(c(1L, 2L) > 0L)
 args <- list(font = "mono")
 identical(args["font"], "mono")
@@ -353,6 +352,17 @@ list(ok = 1L, "wi\"dget" <- 2L)
         .unwrap();
     let lsp = runtime.block_on(run_with_diagnostics(&fixture, "fixes.R", json!({})));
     assert_eq!(lsp, cli);
+
+    // RY090's fix follows an astral character on the same line. Its byte
+    // column (24) differs from its LSP UTF-16 column (22), so parity here
+    // exercises the conversion rather than merely crossing a prior line.
+    let astral_fix = cli
+        .iter()
+        .find(|diagnostic| diagnostic.code == "RY090")
+        .and_then(|diagnostic| diagnostic.fix.as_ref())
+        .expect("RY090 after the astral character should publish a fix");
+    assert_eq!(astral_fix.start_line, 0);
+    assert_eq!(astral_fix.start_byte_column, 24);
 
     let fixed_codes = cli
         .iter()

--- a/crates/ry-lsp/tests/testkit.rs
+++ b/crates/ry-lsp/tests/testkit.rs
@@ -1,6 +1,6 @@
 use ry_testkit::{
-    AsyncJsonRpcClient, Driver, DriverError, FixtureProject, ObservedDiagnostic, ObservedPosition,
-    ObservedRange, PositionEncoding, normalize_path,
+    AsyncJsonRpcClient, Driver, DriverError, FixtureProject, ObservedDiagnostic, ObservedFix,
+    ObservedPosition, ObservedRange, PositionEncoding, normalize_path,
 };
 use serde_json::{Value, json};
 use std::path::Path;
@@ -127,9 +127,28 @@ fn lsp_diagnostics(
                     end: Some(lsp_position(end)?),
                 },
                 confidence: None,
+                fix: lsp_fix(value)?,
             })
         })
         .collect()
+}
+
+fn lsp_fix(value: &Value) -> Result<Option<ObservedFix>, DriverError> {
+    value
+        .pointer("/data/fix")
+        .map(|fix| {
+            Ok(ObservedFix {
+                range: ObservedRange {
+                    start: lsp_position(&fix["range"]["start"])?,
+                    end: Some(lsp_position(&fix["range"]["end"])?),
+                },
+                replacement: fix["replacement"]
+                    .as_str()
+                    .ok_or("fix replacement is not a string")?
+                    .to_string(),
+            })
+        })
+        .transpose()
 }
 
 fn lsp_position(value: &Value) -> Result<ObservedPosition, DriverError> {

--- a/crates/ry-testkit/src/lib.rs
+++ b/crates/ry-testkit/src/lib.rs
@@ -11,7 +11,7 @@ mod process;
 pub use fixture::FixtureProject;
 pub use json_rpc::{AsyncJsonRpcClient, JsonRpcProcess};
 pub use observed::{
-    Driver, DriverError, ObservedDiagnostic, ObservedPosition, ObservedRange, PositionEncoding,
-    normalize_path, normalize_position,
+    Driver, DriverError, ObservedDiagnostic, ObservedFix, ObservedPosition, ObservedRange,
+    PositionEncoding, normalize_path, normalize_position,
 };
 pub use process::CliProcess;

--- a/crates/ry-testkit/src/observed.rs
+++ b/crates/ry-testkit/src/observed.rs
@@ -41,6 +41,12 @@ pub struct ObservedRange {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ObservedFix {
+    pub range: ObservedRange,
+    pub replacement: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ObservedDiagnostic {
     pub path: String,
     pub code: String,
@@ -49,6 +55,8 @@ pub struct ObservedDiagnostic {
     pub range: ObservedRange,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub confidence: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fix: Option<ObservedFix>,
 }
 
 /// Make an observed path stable without resolving symlinks or requiring it to exist.

--- a/docs/corpus/README.md
+++ b/docs/corpus/README.md
@@ -21,6 +21,19 @@ P35-W4 audit of parser `?`, `.ok()?`, and `None` propagation. Its executable R1
 and R6 gates live in `crates/ry-checker/tests/invariants.rs` and cover all
 checker fixtures plus a deterministic sample of the vendored ecosystem sources.
 
+## Readable message and fix ledger
+
+[`posit-messages-0.9.json`](posit-messages-0.9.json) records the message,
+severity, and optional structured fix for all 729 reviewed Posit diagnostics.
+Each entry is keyed by the same stable `(package, code, path, line, column)`
+identity as `posit-0.9.0.json`; it is intentionally readable JSON rather than a
+digest or an ignored `.full.txt` report.
+
+`ecosystem/run.sh` regenerates this companion from the production
+`ry check --output-format json` results. Posit `--check` runs compare the
+processed tier against the committed entries and print a unified diff for any
+message or replacement drift. A full non-check run updates all entries.
+
 ## Reconciliation modes
 
 `ecosystem/run.sh` reconciles the hermetic root reports it generates

--- a/docs/corpus/posit-messages-0.9.json
+++ b/docs/corpus/posit-messages-0.9.json
@@ -1277,7 +1277,7 @@
       "line": 60,
       "column": 25,
       "severity": "warning",
-      "message": "unknown argument `z` to `intersect`; did you mean `x`?"
+      "message": "unknown argument `z` to `intersect`"
     },
     "dplyr::RY091::R/data-mask.R:112:7": {
       "package": "dplyr",
@@ -2348,7 +2348,12 @@
       "line": 36,
       "column": 23,
       "severity": "warning",
-      "message": "comparison directly inside a numeric math function is usually a parenthesization mistake; compare the math result instead"
+      "message": "comparison directly inside a numeric math function is usually a parenthesization mistake; compare the math result instead",
+      "fix": {
+        "start": 1239,
+        "end": 1245,
+        "replacement": ") <= 1"
+      }
     },
     "ggplot2::RY100::tests/testthat/test-axis-secondary.R:37:23": {
       "package": "ggplot2",
@@ -2357,7 +2362,12 @@
       "line": 37,
       "column": 23,
       "severity": "warning",
-      "message": "comparison directly inside a numeric math function is usually a parenthesization mistake; compare the math result instead"
+      "message": "comparison directly inside a numeric math function is usually a parenthesization mistake; compare the math result instead",
+      "fix": {
+        "start": 1322,
+        "end": 1328,
+        "replacement": ") <= 1"
+      }
     },
     "ggplot2::RY100::tests/testthat/test-axis-secondary.R:56:23": {
       "package": "ggplot2",
@@ -2366,7 +2376,12 @@
       "line": 56,
       "column": 23,
       "severity": "warning",
-      "message": "comparison directly inside a numeric math function is usually a parenthesization mistake; compare the math result instead"
+      "message": "comparison directly inside a numeric math function is usually a parenthesization mistake; compare the math result instead",
+      "fix": {
+        "start": 2050,
+        "end": 2056,
+        "replacement": ") <= 1"
+      }
     },
     "ggplot2::RY100::tests/testthat/test-axis-secondary.R:57:23": {
       "package": "ggplot2",
@@ -2375,7 +2390,12 @@
       "line": 57,
       "column": 23,
       "severity": "warning",
-      "message": "comparison directly inside a numeric math function is usually a parenthesization mistake; compare the math result instead"
+      "message": "comparison directly inside a numeric math function is usually a parenthesization mistake; compare the math result instead",
+      "fix": {
+        "start": 2133,
+        "end": 2139,
+        "replacement": ") <= 1"
+      }
     },
     "glue::RY040::tests/testthat/test-glue.R:595:20": {
       "package": "glue",
@@ -3635,7 +3655,12 @@
       "line": 25,
       "column": 73,
       "severity": "warning",
-      "message": "comparison with `NA` always produces `NA`; use `is.na()` instead"
+      "message": "comparison with `NA` always produces `NA`; use `is.na()` instead",
+      "fix": {
+        "start": 502,
+        "end": 509,
+        "replacement": "is.na(x)"
+      }
     },
     "lintr::RY034::tests/testthat/dummy_packages/package/data-raw/default_linter_testcode.R:25:73": {
       "package": "lintr",
@@ -3644,7 +3669,12 @@
       "line": 25,
       "column": 73,
       "severity": "warning",
-      "message": "comparison with `NA` always produces `NA`; use `is.na()` instead"
+      "message": "comparison with `NA` always produces `NA`; use `is.na()` instead",
+      "fix": {
+        "start": 502,
+        "end": 509,
+        "replacement": "is.na(x)"
+      }
     },
     "lintr::RY034::tests/testthat/dummy_packages/package/inst/data-raw/default_linter_testcode.R:25:73": {
       "package": "lintr",
@@ -3653,7 +3683,12 @@
       "line": 25,
       "column": 73,
       "severity": "warning",
-      "message": "comparison with `NA` always produces `NA`; use `is.na()` instead"
+      "message": "comparison with `NA` always produces `NA`; use `is.na()` instead",
+      "fix": {
+        "start": 502,
+        "end": 509,
+        "replacement": "is.na(x)"
+      }
     },
     "lintr::RY060::tests/testthat/test-linter_tags.R:172:24": {
       "package": "lintr",
@@ -4004,7 +4039,12 @@
       "line": 30,
       "column": 20,
       "severity": "warning",
-      "message": "comparison is inside `length()`; compare `length(x)` instead"
+      "message": "comparison is inside `length()`; compare `length(x)` instead",
+      "fix": {
+        "start": 1083,
+        "end": 1089,
+        "replacement": ") == 1"
+      }
     },
     "pak::RY093::R/package.R:176:20": {
       "package": "pak",
@@ -4013,7 +4053,12 @@
       "line": 176,
       "column": 20,
       "severity": "warning",
-      "message": "comparison is inside `length()`; compare `length(x)` instead"
+      "message": "comparison is inside `length()`; compare `length(x)` instead",
+      "fix": {
+        "start": 5520,
+        "end": 5526,
+        "replacement": ") == 1"
+      }
     },
     "pak::RY093::R/package.R:293:20": {
       "package": "pak",
@@ -4022,7 +4067,12 @@
       "line": 293,
       "column": 20,
       "severity": "warning",
-      "message": "comparison is inside `length()`; compare `length(x)` instead"
+      "message": "comparison is inside `length()`; compare `length(x)` instead",
+      "fix": {
+        "start": 8536,
+        "end": 8542,
+        "replacement": ") == 1"
+      }
     },
     "pak::RY102::R/pak-sitrep-data.R:41:5": {
       "package": "pak",
@@ -4031,7 +4081,12 @@
       "line": 41,
       "column": 5,
       "severity": "warning",
-      "message": "`<-` inside `list()` assigns `github-ref` and leaves the element unnamed; write `\"github-ref\" = ...` to name it"
+      "message": "`<-` inside `list()` assigns `github-ref` and leaves the element unnamed; write `\"github-ref\" = ...` to name it",
+      "fix": {
+        "start": 1225,
+        "end": 1227,
+        "replacement": "="
+      }
     },
     "pak::RY105::R/confirmation.R:42:14": {
       "package": "pak",
@@ -5678,7 +5733,12 @@
       "line": 138,
       "column": 18,
       "severity": "warning",
-      "message": "comparison is inside `length()`; compare `length(x)` instead"
+      "message": "comparison is inside `length()`; compare `length(x)` instead",
+      "fix": {
+        "start": 4304,
+        "end": 4310,
+        "replacement": ") != 0"
+      }
     },
     "shiny-r::RY105::tests/testthat/test-non-blocking.R:127:15": {
       "package": "shiny-r",

--- a/docs/corpus/posit-messages-0.9.json
+++ b/docs/corpus/posit-messages-0.9.json
@@ -1,0 +1,6890 @@
+{
+  "schema_version": 1,
+  "corpus": "posit",
+  "ry_version": "0.9.0-dev",
+  "identity_fields": [
+    "package",
+    "code",
+    "path",
+    "line",
+    "column"
+  ],
+  "findings": {
+    "blogdown::RY010::R/serve.R:164:22": {
+      "package": "blogdown",
+      "code": "RY010",
+      "path": "R/serve.R",
+      "line": 164,
+      "column": 22,
+      "severity": "warning",
+      "message": "variable `proc` is not bound in this scope"
+    },
+    "blogdown::RY010::R/serve.R:166:38": {
+      "package": "blogdown",
+      "code": "RY010",
+      "path": "R/serve.R",
+      "line": 166,
+      "column": 38,
+      "severity": "warning",
+      "message": "variable `proc` is not bound in this scope"
+    },
+    "blogdown::RY032::R/utils.R:618:7": {
+      "package": "blogdown",
+      "code": "RY032",
+      "path": "R/utils.R",
+      "line": 618,
+      "column": 7,
+      "severity": "warning",
+      "message": "`||` operand depends on a parameter whose length is not known to be 1; current R errors for vectors",
+      "fix": {
+        "start": 23664,
+        "end": 23666,
+        "replacement": "|"
+      }
+    },
+    "blogdown::RY105::R/hugo.R:380:9": {
+      "package": "blogdown",
+      "code": "RY105",
+      "path": "R/hugo.R",
+      "line": 380,
+      "column": 9,
+      "severity": "warning",
+      "message": "`expdir` is a length-1 character, so `length(...)` is 1 here and this zero-length guard is always FALSE"
+    },
+    "bookdown::RY105::R/html.R:1069:9": {
+      "package": "bookdown",
+      "code": "RY105",
+      "path": "R/html.R",
+      "line": 1069,
+      "column": 9,
+      "severity": "warning",
+      "message": "`target` is a length-1 character, so `length(...)` is 1 here and this zero-length guard is always FALSE"
+    },
+    "bookdown::RY105::R/html.R:1138:9": {
+      "package": "bookdown",
+      "code": "RY105",
+      "path": "R/html.R",
+      "line": 1138,
+      "column": 9,
+      "severity": "warning",
+      "message": "`z` is a length-1 character, so `length(...)` is 1 here and this zero-length guard is always FALSE"
+    },
+    "bookdown::RY105::R/html.R:878:9": {
+      "package": "bookdown",
+      "code": "RY105",
+      "path": "R/html.R",
+      "line": 878,
+      "column": 9,
+      "severity": "warning",
+      "message": "`tag` is a length-1 character, so `length(...)` is 1 here and this zero-length guard is always FALSE"
+    },
+    "bookdown::RY105::R/html.R:965:9": {
+      "package": "bookdown",
+      "code": "RY105",
+      "path": "R/html.R",
+      "line": 965,
+      "column": 9,
+      "severity": "warning",
+      "message": "`x` is a length-1 character, so `length(...)` is 1 here and this zero-length guard is always FALSE"
+    },
+    "bookdown::RY105::R/utils.R:441:9": {
+      "package": "bookdown",
+      "code": "RY105",
+      "path": "R/utils.R",
+      "line": 441,
+      "column": 9,
+      "severity": "warning",
+      "message": "`ps` is a length-1 character, so `length(...)` is 1 here and this zero-length guard is always FALSE"
+    },
+    "broom::RY030::tests/testthat/test-metafor.R:129:15": {
+      "package": "broom",
+      "code": "RY030",
+      "path": "tests/testthat/test-metafor.R",
+      "line": 129,
+      "column": 15,
+      "severity": "error",
+      "message": "cannot compare `function` with `character`"
+    },
+    "broom::RY030::tests/testthat/test-survival-survfit.R:18:13": {
+      "package": "broom",
+      "code": "RY030",
+      "path": "tests/testthat/test-survival-survfit.R",
+      "line": 18,
+      "column": 13,
+      "severity": "error",
+      "message": "cannot compare `function` with `double`"
+    },
+    "broom::RY032::R/utilities.R:459:9": {
+      "package": "broom",
+      "code": "RY032",
+      "path": "R/utilities.R",
+      "line": 459,
+      "column": 9,
+      "severity": "warning",
+      "message": "`||` operand depends on a parameter whose length is not known to be 1; current R errors for vectors",
+      "fix": {
+        "start": 13165,
+        "end": 13167,
+        "replacement": "|"
+      }
+    },
+    "broom::RY032::R/utilities.R:485:9": {
+      "package": "broom",
+      "code": "RY032",
+      "path": "R/utilities.R",
+      "line": 485,
+      "column": 9,
+      "severity": "warning",
+      "message": "`||` operand depends on a parameter whose length is not known to be 1; current R errors for vectors",
+      "fix": {
+        "start": 13958,
+        "end": 13960,
+        "replacement": "|"
+      }
+    },
+    "broom::RY032::R/utilities.R:501:9": {
+      "package": "broom",
+      "code": "RY032",
+      "path": "R/utilities.R",
+      "line": 501,
+      "column": 9,
+      "severity": "warning",
+      "message": "`||` operand depends on a parameter whose length is not known to be 1; current R errors for vectors",
+      "fix": {
+        "start": 14402,
+        "end": 14404,
+        "replacement": "|"
+      }
+    },
+    "broom::RY033::R/deprecated-0-7-0.R:290:11": {
+      "package": "broom",
+      "code": "RY033",
+      "path": "R/deprecated-0-7-0.R",
+      "line": 290,
+      "column": 11,
+      "severity": "warning",
+      "message": "comparing `character` with `integer`; R coerces the numeric value to character and compares lexicographically, which is rarely intended"
+    },
+    "broom::RY033::R/utilities.R:108:11": {
+      "package": "broom",
+      "code": "RY033",
+      "path": "R/utilities.R",
+      "line": 108,
+      "column": 11,
+      "severity": "warning",
+      "message": "comparing `character` with `integer`; R coerces the numeric value to character and compares lexicographically, which is rarely intended"
+    },
+    "broom::RY061::R/gmm.R:96:11": {
+      "package": "broom",
+      "code": "RY061",
+      "path": "R/gmm.R",
+      "line": 96,
+      "column": 11,
+      "severity": "error",
+      "message": "$ operator is invalid for atomic vectors of mode `double`"
+    },
+    "bslib::RY010::R/accordion.R:168:10": {
+      "package": "bslib",
+      "code": "RY010",
+      "path": "R/accordion.R",
+      "line": 168,
+      "column": 10,
+      "severity": "warning",
+      "message": "variable `tags` is not bound in this scope"
+    },
+    "bslib::RY010::R/bs-dependencies.R:245:22": {
+      "package": "bslib",
+      "code": "RY010",
+      "path": "R/bs-dependencies.R",
+      "line": 245,
+      "column": 22,
+      "severity": "warning",
+      "message": "variable `sass_partial` is not bound in this scope"
+    },
+    "bslib::RY010::R/bs-dependencies.R:288:11": {
+      "package": "bslib",
+      "code": "RY010",
+      "path": "R/bs-dependencies.R",
+      "line": 288,
+      "column": 11,
+      "severity": "warning",
+      "message": "variable `htmlDependency` is not bound in this scope"
+    },
+    "bslib::RY010::R/bs-theme-layers.R:114:13": {
+      "package": "bslib",
+      "code": "RY010",
+      "path": "R/bs-theme-layers.R",
+      "line": 114,
+      "column": 13,
+      "severity": "warning",
+      "message": "variable `sass_layer` is not bound in this scope"
+    },
+    "bslib::RY010::R/bs-theme-preview.R:107:9": {
+      "package": "bslib",
+      "code": "RY010",
+      "path": "R/bs-theme-preview.R",
+      "line": 107,
+      "column": 9,
+      "severity": "warning",
+      "message": "variable `tags` is not bound in this scope"
+    },
+    "bslib::RY010::R/bs-theme-preview.R:109:11": {
+      "package": "bslib",
+      "code": "RY010",
+      "path": "R/bs-theme-preview.R",
+      "line": 109,
+      "column": 11,
+      "severity": "warning",
+      "message": "variable `tags` is not bound in this scope"
+    },
+    "bslib::RY010::R/bs-theme-preview.R:134:11": {
+      "package": "bslib",
+      "code": "RY010",
+      "path": "R/bs-theme-preview.R",
+      "line": 134,
+      "column": 11,
+      "severity": "warning",
+      "message": "variable `tags` is not bound in this scope"
+    },
+    "bslib::RY010::R/bs-theme-preview.R:141:11": {
+      "package": "bslib",
+      "code": "RY010",
+      "path": "R/bs-theme-preview.R",
+      "line": 141,
+      "column": 11,
+      "severity": "warning",
+      "message": "variable `tags` is not bound in this scope"
+    },
+    "bslib::RY010::R/bs-theme-preview.R:152:9": {
+      "package": "bslib",
+      "code": "RY010",
+      "path": "R/bs-theme-preview.R",
+      "line": 152,
+      "column": 9,
+      "severity": "warning",
+      "message": "variable `tags` is not bound in this scope"
+    },
+    "bslib::RY010::R/bs-theme-preview.R:153:9": {
+      "package": "bslib",
+      "code": "RY010",
+      "path": "R/bs-theme-preview.R",
+      "line": 153,
+      "column": 9,
+      "severity": "warning",
+      "message": "variable `tags` is not bound in this scope"
+    },
+    "bslib::RY010::R/bs-theme-preview.R:163:15": {
+      "package": "bslib",
+      "code": "RY010",
+      "path": "R/bs-theme-preview.R",
+      "line": 163,
+      "column": 15,
+      "severity": "warning",
+      "message": "variable `tags` is not bound in this scope"
+    },
+    "bslib::RY010::R/bs-theme-preview.R:172:13": {
+      "package": "bslib",
+      "code": "RY010",
+      "path": "R/bs-theme-preview.R",
+      "line": 172,
+      "column": 13,
+      "severity": "warning",
+      "message": "variable `tags` is not bound in this scope"
+    },
+    "bslib::RY010::R/bs-theme-preview.R:185:12": {
+      "package": "bslib",
+      "code": "RY010",
+      "path": "R/bs-theme-preview.R",
+      "line": 185,
+      "column": 12,
+      "severity": "warning",
+      "message": "variable `tags` is not bound in this scope"
+    },
+    "bslib::RY010::R/bs-theme-preview.R:267:11": {
+      "package": "bslib",
+      "code": "RY010",
+      "path": "R/bs-theme-preview.R",
+      "line": 267,
+      "column": 11,
+      "severity": "warning",
+      "message": "variable `tags` is not bound in this scope"
+    },
+    "bslib::RY010::R/bs-theme-preview.R:276:13": {
+      "package": "bslib",
+      "code": "RY010",
+      "path": "R/bs-theme-preview.R",
+      "line": 276,
+      "column": 13,
+      "severity": "warning",
+      "message": "variable `tags` is not bound in this scope"
+    },
+    "bslib::RY010::R/bs-theme-preview.R:627:5": {
+      "package": "bslib",
+      "code": "RY010",
+      "path": "R/bs-theme-preview.R",
+      "line": 627,
+      "column": 5,
+      "severity": "warning",
+      "message": "variable `tags` is not bound in this scope"
+    },
+    "bslib::RY010::R/bs-theme-preview.R:90:9": {
+      "package": "bslib",
+      "code": "RY010",
+      "path": "R/bs-theme-preview.R",
+      "line": 90,
+      "column": 9,
+      "severity": "warning",
+      "message": "variable `tags` is not bound in this scope"
+    },
+    "bslib::RY010::R/bs-theme-preview.R:91:9": {
+      "package": "bslib",
+      "code": "RY010",
+      "path": "R/bs-theme-preview.R",
+      "line": 91,
+      "column": 9,
+      "severity": "warning",
+      "message": "variable `tags` is not bound in this scope"
+    },
+    "bslib::RY010::R/buttons.R:146:3": {
+      "package": "bslib",
+      "code": "RY010",
+      "path": "R/buttons.R",
+      "line": 146,
+      "column": 3,
+      "severity": "warning",
+      "message": "variable `tags` is not bound in this scope"
+    },
+    "bslib::RY010::R/card.R:357:12": {
+      "package": "bslib",
+      "code": "RY010",
+      "path": "R/card.R",
+      "line": 357,
+      "column": 12,
+      "severity": "warning",
+      "message": "variable `tags` is not bound in this scope"
+    },
+    "bslib::RY010::R/card.R:380:7": {
+      "package": "bslib",
+      "code": "RY010",
+      "path": "R/card.R",
+      "line": 380,
+      "column": 7,
+      "severity": "warning",
+      "message": "variable `tags` is not bound in this scope"
+    },
+    "bslib::RY010::R/card.R:441:5": {
+      "package": "bslib",
+      "code": "RY010",
+      "path": "R/card.R",
+      "line": 441,
+      "column": 5,
+      "severity": "warning",
+      "message": "variable `tags` is not bound in this scope"
+    },
+    "bslib::RY010::R/card.R:454:3": {
+      "package": "bslib",
+      "code": "RY010",
+      "path": "R/card.R",
+      "line": 454,
+      "column": 3,
+      "severity": "warning",
+      "message": "variable `tags` is not bound in this scope"
+    },
+    "bslib::RY010::R/input-submit.R:128:7": {
+      "package": "bslib",
+      "code": "RY010",
+      "path": "R/input-submit.R",
+      "line": 128,
+      "column": 7,
+      "severity": "warning",
+      "message": "variable `tags` is not bound in this scope"
+    },
+    "bslib::RY010::R/input-submit.R:138:7": {
+      "package": "bslib",
+      "code": "RY010",
+      "path": "R/input-submit.R",
+      "line": 138,
+      "column": 7,
+      "severity": "warning",
+      "message": "variable `tags` is not bound in this scope"
+    },
+    "bslib::RY010::R/input-switch.R:108:7": {
+      "package": "bslib",
+      "code": "RY010",
+      "path": "R/input-switch.R",
+      "line": 108,
+      "column": 7,
+      "severity": "warning",
+      "message": "variable `tags` is not bound in this scope"
+    },
+    "bslib::RY010::R/input-switch.R:115:7": {
+      "package": "bslib",
+      "code": "RY010",
+      "path": "R/input-switch.R",
+      "line": 115,
+      "column": 7,
+      "severity": "warning",
+      "message": "variable `tags` is not bound in this scope"
+    },
+    "bslib::RY010::R/input-switch.R:118:9": {
+      "package": "bslib",
+      "code": "RY010",
+      "path": "R/input-switch.R",
+      "line": 118,
+      "column": 9,
+      "severity": "warning",
+      "message": "variable `tags` is not bound in this scope"
+    },
+    "bslib::RY010::R/nav-items.R:72:3": {
+      "package": "bslib",
+      "code": "RY010",
+      "path": "R/nav-items.R",
+      "line": 72,
+      "column": 3,
+      "severity": "warning",
+      "message": "variable `tags` is not bound in this scope"
+    },
+    "bslib::RY010::R/navs-legacy.R:338:9": {
+      "package": "bslib",
+      "code": "RY010",
+      "path": "R/navs-legacy.R",
+      "line": 338,
+      "column": 9,
+      "severity": "warning",
+      "message": "variable `tags` is not bound in this scope"
+    },
+    "bslib::RY010::R/navs-legacy.R:431:5": {
+      "package": "bslib",
+      "code": "RY010",
+      "path": "R/navs-legacy.R",
+      "line": 431,
+      "column": 5,
+      "severity": "warning",
+      "message": "variable `tags` is not bound in this scope"
+    },
+    "bslib::RY010::R/navs-legacy.R:516:3": {
+      "package": "bslib",
+      "code": "RY010",
+      "path": "R/navs-legacy.R",
+      "line": 516,
+      "column": 3,
+      "severity": "warning",
+      "message": "variable `tags` is not bound in this scope"
+    },
+    "bslib::RY010::R/navs-legacy.R:622:5": {
+      "package": "bslib",
+      "code": "RY010",
+      "path": "R/navs-legacy.R",
+      "line": 622,
+      "column": 5,
+      "severity": "warning",
+      "message": "variable `tags` is not bound in this scope"
+    },
+    "bslib::RY010::R/navs-legacy.R:624:5": {
+      "package": "bslib",
+      "code": "RY010",
+      "path": "R/navs-legacy.R",
+      "line": 624,
+      "column": 5,
+      "severity": "warning",
+      "message": "variable `tags` is not bound in this scope"
+    },
+    "bslib::RY010::R/navs-legacy.R:667:17": {
+      "package": "bslib",
+      "code": "RY010",
+      "path": "R/navs-legacy.R",
+      "line": 667,
+      "column": 17,
+      "severity": "warning",
+      "message": "variable `tags` is not bound in this scope"
+    },
+    "bslib::RY010::R/navs-legacy.R:674:17": {
+      "package": "bslib",
+      "code": "RY010",
+      "path": "R/navs-legacy.R",
+      "line": 674,
+      "column": 17,
+      "severity": "warning",
+      "message": "variable `tags` is not bound in this scope"
+    },
+    "bslib::RY010::R/navs-legacy.R:783:3": {
+      "package": "bslib",
+      "code": "RY010",
+      "path": "R/navs-legacy.R",
+      "line": 783,
+      "column": 3,
+      "severity": "warning",
+      "message": "variable `tags` is not bound in this scope"
+    },
+    "bslib::RY010::R/navs-legacy.R:784:5": {
+      "package": "bslib",
+      "code": "RY010",
+      "path": "R/navs-legacy.R",
+      "line": 784,
+      "column": 5,
+      "severity": "warning",
+      "message": "variable `tags` is not bound in this scope"
+    },
+    "bslib::RY010::R/navs-legacy.R:813:15": {
+      "package": "bslib",
+      "code": "RY010",
+      "path": "R/navs-legacy.R",
+      "line": 813,
+      "column": 15,
+      "severity": "warning",
+      "message": "variable `tags` is not bound in this scope"
+    },
+    "bslib::RY010::R/navs-legacy.R:815:5": {
+      "package": "bslib",
+      "code": "RY010",
+      "path": "R/navs-legacy.R",
+      "line": 815,
+      "column": 5,
+      "severity": "warning",
+      "message": "variable `tags` is not bound in this scope"
+    },
+    "bslib::RY010::R/navs-legacy.R:824:7": {
+      "package": "bslib",
+      "code": "RY010",
+      "path": "R/navs-legacy.R",
+      "line": 824,
+      "column": 7,
+      "severity": "warning",
+      "message": "variable `tags` is not bound in this scope"
+    },
+    "bslib::RY010::R/navs.R:141:52": {
+      "package": "bslib",
+      "code": "RY010",
+      "path": "R/navs.R",
+      "line": 141,
+      "column": 52,
+      "severity": "warning",
+      "message": "variable `tags` is not bound in this scope"
+    },
+    "bslib::RY010::R/navs.R:67:43": {
+      "package": "bslib",
+      "code": "RY010",
+      "path": "R/navs.R",
+      "line": 67,
+      "column": 43,
+      "severity": "warning",
+      "message": "variable `tags` is not bound in this scope"
+    },
+    "bslib::RY010::R/offcanvas.R:229:7": {
+      "package": "bslib",
+      "code": "RY010",
+      "path": "R/offcanvas.R",
+      "line": 229,
+      "column": 7,
+      "severity": "warning",
+      "message": "variable `tags` is not bound in this scope"
+    },
+    "bslib::RY010::R/offcanvas.R:236:5": {
+      "package": "bslib",
+      "code": "RY010",
+      "path": "R/offcanvas.R",
+      "line": 236,
+      "column": 5,
+      "severity": "warning",
+      "message": "variable `tags` is not bound in this scope"
+    },
+    "bslib::RY010::R/offcanvas.R:245:5": {
+      "package": "bslib",
+      "code": "RY010",
+      "path": "R/offcanvas.R",
+      "line": 245,
+      "column": 5,
+      "severity": "warning",
+      "message": "variable `tags` is not bound in this scope"
+    },
+    "bslib::RY010::R/offcanvas.R:249:5": {
+      "package": "bslib",
+      "code": "RY010",
+      "path": "R/offcanvas.R",
+      "line": 249,
+      "column": 5,
+      "severity": "warning",
+      "message": "variable `tags` is not bound in this scope"
+    },
+    "bslib::RY010::R/offcanvas.R:280:7": {
+      "package": "bslib",
+      "code": "RY010",
+      "path": "R/offcanvas.R",
+      "line": 280,
+      "column": 7,
+      "severity": "warning",
+      "message": "variable `tags` is not bound in this scope"
+    },
+    "bslib::RY010::R/offcanvas.R:301:13": {
+      "package": "bslib",
+      "code": "RY010",
+      "path": "R/offcanvas.R",
+      "line": 301,
+      "column": 13,
+      "severity": "warning",
+      "message": "variable `tags` is not bound in this scope"
+    },
+    "bslib::RY010::R/page.R:189:15": {
+      "package": "bslib",
+      "code": "RY010",
+      "path": "R/page.R",
+      "line": 189,
+      "column": 15,
+      "severity": "warning",
+      "message": "variable `tags` is not bound in this scope"
+    },
+    "bslib::RY010::R/page.R:189:5": {
+      "package": "bslib",
+      "code": "RY010",
+      "path": "R/page.R",
+      "line": 189,
+      "column": 5,
+      "severity": "warning",
+      "message": "variable `tags` is not bound in this scope"
+    },
+    "bslib::RY010::R/page.R:199:21": {
+      "package": "bslib",
+      "code": "RY010",
+      "path": "R/page.R",
+      "line": 199,
+      "column": 21,
+      "severity": "warning",
+      "message": "variable `validateCssUnit` is not bound in this scope"
+    },
+    "bslib::RY010::R/page.R:28:7": {
+      "package": "bslib",
+      "code": "RY010",
+      "path": "R/page.R",
+      "line": 28,
+      "column": 7,
+      "severity": "warning",
+      "message": "variable `tags` is not bound in this scope"
+    },
+    "bslib::RY010::R/page.R:305:11": {
+      "package": "bslib",
+      "code": "RY010",
+      "path": "R/page.R",
+      "line": 305,
+      "column": 11,
+      "severity": "warning",
+      "message": "variable `tags` is not bound in this scope"
+    },
+    "bslib::RY010::R/popover.R:145:5": {
+      "package": "bslib",
+      "code": "RY010",
+      "path": "R/popover.R",
+      "line": 145,
+      "column": 5,
+      "severity": "warning",
+      "message": "variable `tags` is not bound in this scope"
+    },
+    "bslib::RY010::R/sidebar.R:140:14": {
+      "package": "bslib",
+      "code": "RY010",
+      "path": "R/sidebar.R",
+      "line": 140,
+      "column": 14,
+      "severity": "warning",
+      "message": "variable `tags` is not bound in this scope"
+    },
+    "bslib::RY010::R/sidebar.R:213:5": {
+      "package": "bslib",
+      "code": "RY010",
+      "path": "R/sidebar.R",
+      "line": 213,
+      "column": 5,
+      "severity": "warning",
+      "message": "variable `tags` is not bound in this scope"
+    },
+    "bslib::RY010::R/sidebar.R:224:18": {
+      "package": "bslib",
+      "code": "RY010",
+      "path": "R/sidebar.R",
+      "line": 224,
+      "column": 18,
+      "severity": "warning",
+      "message": "variable `tags` is not bound in this scope"
+    },
+    "bslib::RY010::R/sidebar.R:230:5": {
+      "package": "bslib",
+      "code": "RY010",
+      "path": "R/sidebar.R",
+      "line": 230,
+      "column": 5,
+      "severity": "warning",
+      "message": "variable `tags` is not bound in this scope"
+    },
+    "bslib::RY010::R/sidebar.R:480:3": {
+      "package": "bslib",
+      "code": "RY010",
+      "path": "R/sidebar.R",
+      "line": 480,
+      "column": 3,
+      "severity": "warning",
+      "message": "variable `tags` is not bound in this scope"
+    },
+    "bslib::RY010::R/toast.R:324:5": {
+      "package": "bslib",
+      "code": "RY010",
+      "path": "R/toast.R",
+      "line": 324,
+      "column": 5,
+      "severity": "warning",
+      "message": "variable `tags` is not bound in this scope"
+    },
+    "bslib::RY010::R/toast.R:378:19": {
+      "package": "bslib",
+      "code": "RY010",
+      "path": "R/toast.R",
+      "line": 378,
+      "column": 19,
+      "severity": "warning",
+      "message": "variable `tags` is not bound in this scope"
+    },
+    "bslib::RY010::R/toolbar.R:642:17": {
+      "package": "bslib",
+      "code": "RY010",
+      "path": "R/toolbar.R",
+      "line": 642,
+      "column": 17,
+      "severity": "warning",
+      "message": "variable `tags` is not bound in this scope"
+    },
+    "bslib::RY010::R/toolbar.R:659:17": {
+      "package": "bslib",
+      "code": "RY010",
+      "path": "R/toolbar.R",
+      "line": 659,
+      "column": 17,
+      "severity": "warning",
+      "message": "variable `tags` is not bound in this scope"
+    },
+    "bslib::RY010::R/toolbar.R:665:5": {
+      "package": "bslib",
+      "code": "RY010",
+      "path": "R/toolbar.R",
+      "line": 665,
+      "column": 5,
+      "severity": "warning",
+      "message": "variable `tags` is not bound in this scope"
+    },
+    "bslib::RY010::R/toolbar.R:675:16": {
+      "package": "bslib",
+      "code": "RY010",
+      "path": "R/toolbar.R",
+      "line": 675,
+      "column": 16,
+      "severity": "warning",
+      "message": "variable `tags` is not bound in this scope"
+    },
+    "bslib::RY010::R/tooltip.R:119:5": {
+      "package": "bslib",
+      "code": "RY010",
+      "path": "R/tooltip.R",
+      "line": 119,
+      "column": 5,
+      "severity": "warning",
+      "message": "variable `tags` is not bound in this scope"
+    },
+    "bslib::RY010::R/utils-deps.R:55:22": {
+      "package": "bslib",
+      "code": "RY010",
+      "path": "R/utils-deps.R",
+      "line": 55,
+      "column": 22,
+      "severity": "warning",
+      "message": "variable `sass_file` is not bound in this scope"
+    },
+    "bslib::RY010::R/value-box.R:118:14": {
+      "package": "bslib",
+      "code": "RY010",
+      "path": "R/value-box.R",
+      "line": 118,
+      "column": 14,
+      "severity": "warning",
+      "message": "variable `tags` is not bound in this scope"
+    },
+    "bslib::RY010::R/value-box.R:121:14": {
+      "package": "bslib",
+      "code": "RY010",
+      "path": "R/value-box.R",
+      "line": 121,
+      "column": 14,
+      "severity": "warning",
+      "message": "variable `tags` is not bound in this scope"
+    },
+    "cli::RY010::R/defer.R:92:25": {
+      "package": "cli",
+      "code": "RY010",
+      "path": "R/defer.R",
+      "line": 92,
+      "column": 25,
+      "severity": "warning",
+      "message": "variable `execute_handlers` is not bound in this scope"
+    },
+    "cli::RY010::R/errors.R:1083:34": {
+      "package": "cli",
+      "code": "RY010",
+      "path": "R/errors.R",
+      "line": 1083,
+      "column": 34,
+      "severity": "warning",
+      "message": "variable `format_srcref_plain` is not bound in this scope"
+    },
+    "cli::RY010::R/errors.R:1090:27": {
+      "package": "cli",
+      "code": "RY010",
+      "path": "R/errors.R",
+      "line": 1090,
+      "column": 27,
+      "severity": "warning",
+      "message": "variable `format_trace_call_plain` is not bound in this scope"
+    },
+    "cli::RY010::R/errors.R:545:40": {
+      "package": "cli",
+      "code": "RY010",
+      "path": "R/errors.R",
+      "line": 545,
+      "column": 40,
+      "severity": "warning",
+      "message": "variable `invisible_frames` is not bound in this scope"
+    },
+    "cli::RY010::R/errors.R:547:20": {
+      "package": "cli",
+      "code": "RY010",
+      "path": "R/errors.R",
+      "line": 547,
+      "column": 20,
+      "severity": "warning",
+      "message": "variable `invisible_frames` is not bound in this scope"
+    },
+    "cli::RY010::R/errors.R:627:30": {
+      "package": "cli",
+      "code": "RY010",
+      "path": "R/errors.R",
+      "line": 627,
+      "column": 30,
+      "severity": "warning",
+      "message": "variable `err_env` is not bound in this scope"
+    },
+    "cli::RY010::R/errors.R:671:24": {
+      "package": "cli",
+      "code": "RY010",
+      "path": "R/errors.R",
+      "line": 671,
+      "column": 24,
+      "severity": "warning",
+      "message": "variable `err_env` is not bound in this scope"
+    },
+    "cli::RY010::R/numbers.R:5:19": {
+      "package": "cli",
+      "code": "RY010",
+      "path": "R/numbers.R",
+      "line": 5,
+      "column": 19,
+      "severity": "warning",
+      "message": "variable `pretty_num_default` is not bound in this scope"
+    },
+    "cli::RY010::R/numbers.R:6:17": {
+      "package": "cli",
+      "code": "RY010",
+      "path": "R/numbers.R",
+      "line": 6,
+      "column": 17,
+      "severity": "warning",
+      "message": "variable `pretty_num_nopad` is not bound in this scope"
+    },
+    "cli::RY010::R/numbers.R:7:13": {
+      "package": "cli",
+      "code": "RY010",
+      "path": "R/numbers.R",
+      "line": 7,
+      "column": 13,
+      "severity": "warning",
+      "message": "variable `pretty_num_6` is not bound in this scope"
+    },
+    "cli::RY010::R/sizes.R:5:19": {
+      "package": "cli",
+      "code": "RY010",
+      "path": "R/sizes.R",
+      "line": 5,
+      "column": 19,
+      "severity": "warning",
+      "message": "variable `pretty_bytes_default` is not bound in this scope"
+    },
+    "cli::RY010::R/sizes.R:6:17": {
+      "package": "cli",
+      "code": "RY010",
+      "path": "R/sizes.R",
+      "line": 6,
+      "column": 17,
+      "severity": "warning",
+      "message": "variable `pretty_bytes_nopad` is not bound in this scope"
+    },
+    "cli::RY010::R/sizes.R:7:13": {
+      "package": "cli",
+      "code": "RY010",
+      "path": "R/sizes.R",
+      "line": 7,
+      "column": 13,
+      "severity": "warning",
+      "message": "variable `pretty_bytes_6` is not bound in this scope"
+    },
+    "cli::RY032::R/ansi-hyperlink.R:165:7": {
+      "package": "cli",
+      "code": "RY032",
+      "path": "R/ansi-hyperlink.R",
+      "line": 165,
+      "column": 7,
+      "severity": "warning",
+      "message": "`||` operand depends on a parameter whose length is not known to be 1; current R errors for vectors",
+      "fix": {
+        "start": 6578,
+        "end": 6580,
+        "replacement": "|"
+      }
+    },
+    "cli::RY032::R/containers.R:45:7": {
+      "package": "cli",
+      "code": "RY032",
+      "path": "R/containers.R",
+      "line": 45,
+      "column": 7,
+      "severity": "warning",
+      "message": "`||` operand depends on a parameter whose length is not known to be 1; current R errors for vectors",
+      "fix": {
+        "start": 1149,
+        "end": 1151,
+        "replacement": "|"
+      }
+    },
+    "cli::RY032::R/rules.R:187:14": {
+      "package": "cli",
+      "code": "RY032",
+      "path": "R/rules.R",
+      "line": 187,
+      "column": 14,
+      "severity": "warning",
+      "message": "`&&` operand depends on a parameter whose length is not known to be 1; current R errors for vectors",
+      "fix": {
+        "start": 4887,
+        "end": 4889,
+        "replacement": "&"
+      }
+    },
+    "cli::RY032::R/status-bar.R:256:7": {
+      "package": "cli",
+      "code": "RY032",
+      "path": "R/status-bar.R",
+      "line": 256,
+      "column": 7,
+      "severity": "warning",
+      "message": "`&&` operand depends on a parameter whose length is not known to be 1; current R errors for vectors",
+      "fix": {
+        "start": 9323,
+        "end": 9325,
+        "replacement": "&"
+      }
+    },
+    "cli::RY032::R/status-bar.R:259:7": {
+      "package": "cli",
+      "code": "RY032",
+      "path": "R/status-bar.R",
+      "line": 259,
+      "column": 7,
+      "severity": "warning",
+      "message": "`&&` operand depends on a parameter whose length is not known to be 1; current R errors for vectors",
+      "fix": {
+        "start": 9428,
+        "end": 9430,
+        "replacement": "&"
+      }
+    },
+    "cli::RY032::R/status-bar.R:262:7": {
+      "package": "cli",
+      "code": "RY032",
+      "path": "R/status-bar.R",
+      "line": 262,
+      "column": 7,
+      "severity": "warning",
+      "message": "`&&` operand depends on a parameter whose length is not known to be 1; current R errors for vectors",
+      "fix": {
+        "start": 9547,
+        "end": 9549,
+        "replacement": "&"
+      }
+    },
+    "cli::RY032::R/status-bar.R:364:7": {
+      "package": "cli",
+      "code": "RY032",
+      "path": "R/status-bar.R",
+      "line": 364,
+      "column": 7,
+      "severity": "warning",
+      "message": "`||` operand depends on a parameter whose length is not known to be 1; current R errors for vectors",
+      "fix": {
+        "start": 12003,
+        "end": 12005,
+        "replacement": "|"
+      }
+    },
+    "cli::RY032::R/status-bar.R:451:7": {
+      "package": "cli",
+      "code": "RY032",
+      "path": "R/status-bar.R",
+      "line": 451,
+      "column": 7,
+      "severity": "warning",
+      "message": "`||` operand depends on a parameter whose length is not known to be 1; current R errors for vectors",
+      "fix": {
+        "start": 14653,
+        "end": 14655,
+        "replacement": "|"
+      }
+    },
+    "cli::RY033::R/onload.R:44:22": {
+      "package": "cli",
+      "code": "RY033",
+      "path": "R/onload.R",
+      "line": 44,
+      "column": 22,
+      "severity": "warning",
+      "message": "comparing `character` with `double`; R coerces the numeric value to character and compares lexicographically, which is rarely intended"
+    },
+    "cli::RY040::tests/testthat/test-defer.R:4:11": {
+      "package": "cli",
+      "code": "RY040",
+      "path": "tests/testthat/test-defer.R",
+      "line": 4,
+      "column": 11,
+      "severity": "error",
+      "message": "cannot apply arithmetic op to `double` and `character`"
+    },
+    "dbplyr::RY090::tests/testthat/test-query-set-op.R:7:37": {
+      "package": "dbplyr",
+      "code": "RY090",
+      "path": "tests/testthat/test-query-set-op.R",
+      "line": 7,
+      "column": 37,
+      "severity": "warning",
+      "message": "unknown argument `all` to `intersect`"
+    },
+    "dbplyr::RY090::tests/testthat/test-verb-set-ops.R:106:30": {
+      "package": "dbplyr",
+      "code": "RY090",
+      "path": "tests/testthat/test-verb-set-ops.R",
+      "line": 106,
+      "column": 30,
+      "severity": "warning",
+      "message": "unknown argument `copy` to `intersect`"
+    },
+    "dbplyr::RY090::tests/testthat/test-verb-set-ops.R:114:30": {
+      "package": "dbplyr",
+      "code": "RY090",
+      "path": "tests/testthat/test-verb-set-ops.R",
+      "line": 114,
+      "column": 30,
+      "severity": "warning",
+      "message": "unknown argument `copy` to `intersect`"
+    },
+    "dbplyr::RY092::tests/testthat/test-verb-summarise.R:258:30": {
+      "package": "dbplyr",
+      "code": "RY092",
+      "path": "tests/testthat/test-verb-summarise.R",
+      "line": 258,
+      "column": 30,
+      "severity": "error",
+      "message": "argument `x` to `mean` is `function`, expected numeric"
+    },
+    "dplyr::RY002::tests/testthat/test-mutate.R:793:16": {
+      "package": "dplyr",
+      "code": "RY002",
+      "path": "tests/testthat/test-mutate.R",
+      "line": 793,
+      "column": 16,
+      "severity": "warning",
+      "message": "`if` condition has length 2; R requires a length-1 condition"
+    },
+    "dplyr::RY002::tests/testthat/test-summarise.R:321:11": {
+      "package": "dplyr",
+      "code": "RY002",
+      "path": "tests/testthat/test-summarise.R",
+      "line": 321,
+      "column": 11,
+      "severity": "warning",
+      "message": "`if` condition has length 2; R requires a length-1 condition"
+    },
+    "dplyr::RY002::tests/testthat/test-summarise.R:331:38": {
+      "package": "dplyr",
+      "code": "RY002",
+      "path": "tests/testthat/test-summarise.R",
+      "line": 331,
+      "column": 38,
+      "severity": "warning",
+      "message": "`if` condition has length 2; R requires a length-1 condition"
+    },
+    "dplyr::RY010::R/conditions.R:310:14": {
+      "package": "dplyr",
+      "code": "RY010",
+      "path": "R/conditions.R",
+      "line": 310,
+      "column": 14,
+      "severity": "warning",
+      "message": "variable `error_call_forced` is not bound in this scope"
+    },
+    "dplyr::RY010::R/summarise.R:342:34": {
+      "package": "dplyr",
+      "code": "RY010",
+      "path": "R/summarise.R",
+      "line": 342,
+      "column": 34,
+      "severity": "warning",
+      "message": "variable `group_sizes` is not bound in this scope"
+    },
+    "dplyr::RY040::tests/testthat/test-conditions.R:10:20": {
+      "package": "dplyr",
+      "code": "RY040",
+      "path": "tests/testthat/test-conditions.R",
+      "line": 10,
+      "column": 20,
+      "severity": "error",
+      "message": "cannot apply arithmetic op to `double` and `character`"
+    },
+    "dplyr::RY040::tests/testthat/test-conditions.R:11:19": {
+      "package": "dplyr",
+      "code": "RY040",
+      "path": "tests/testthat/test-conditions.R",
+      "line": 11,
+      "column": 19,
+      "severity": "error",
+      "message": "cannot apply arithmetic op to `double` and `character`"
+    },
+    "dplyr::RY040::tests/testthat/test-conditions.R:21:21": {
+      "package": "dplyr",
+      "code": "RY040",
+      "path": "tests/testthat/test-conditions.R",
+      "line": 21,
+      "column": 21,
+      "severity": "error",
+      "message": "cannot apply arithmetic op to `double` and `character`"
+    },
+    "dplyr::RY040::tests/testthat/test-conditions.R:4:20": {
+      "package": "dplyr",
+      "code": "RY040",
+      "path": "tests/testthat/test-conditions.R",
+      "line": 4,
+      "column": 20,
+      "severity": "error",
+      "message": "cannot apply arithmetic op to `double` and `character`"
+    },
+    "dplyr::RY040::tests/testthat/test-conditions.R:5:23": {
+      "package": "dplyr",
+      "code": "RY040",
+      "path": "tests/testthat/test-conditions.R",
+      "line": 5,
+      "column": 23,
+      "severity": "error",
+      "message": "cannot apply arithmetic op to `double` and `character`"
+    },
+    "dplyr::RY040::tests/testthat/test-conditions.R:6:23": {
+      "package": "dplyr",
+      "code": "RY040",
+      "path": "tests/testthat/test-conditions.R",
+      "line": 6,
+      "column": 23,
+      "severity": "error",
+      "message": "cannot apply arithmetic op to `double` and `character`"
+    },
+    "dplyr::RY040::tests/testthat/test-conditions.R:7:38": {
+      "package": "dplyr",
+      "code": "RY040",
+      "path": "tests/testthat/test-conditions.R",
+      "line": 7,
+      "column": 38,
+      "severity": "error",
+      "message": "cannot apply arithmetic op to `double` and `character`"
+    },
+    "dplyr::RY040::tests/testthat/test-conditions.R:8:20": {
+      "package": "dplyr",
+      "code": "RY040",
+      "path": "tests/testthat/test-conditions.R",
+      "line": 8,
+      "column": 20,
+      "severity": "error",
+      "message": "cannot apply arithmetic op to `double` and `character`"
+    },
+    "dplyr::RY040::tests/testthat/test-conditions.R:9:21": {
+      "package": "dplyr",
+      "code": "RY040",
+      "path": "tests/testthat/test-conditions.R",
+      "line": 9,
+      "column": 21,
+      "severity": "error",
+      "message": "cannot apply arithmetic op to `double` and `character`"
+    },
+    "dplyr::RY040::tests/testthat/test-count-tally.R:139:38": {
+      "package": "dplyr",
+      "code": "RY040",
+      "path": "tests/testthat/test-count-tally.R",
+      "line": 139,
+      "column": 38,
+      "severity": "error",
+      "message": "cannot apply arithmetic op to `double` and `character`"
+    },
+    "dplyr::RY040::tests/testthat/test-count-tally.R:173:38": {
+      "package": "dplyr",
+      "code": "RY040",
+      "path": "tests/testthat/test-count-tally.R",
+      "line": 173,
+      "column": 38,
+      "severity": "error",
+      "message": "cannot apply arithmetic op to `double` and `character`"
+    },
+    "dplyr::RY040::tests/testthat/test-count-tally.R:214:42": {
+      "package": "dplyr",
+      "code": "RY040",
+      "path": "tests/testthat/test-count-tally.R",
+      "line": 214,
+      "column": 42,
+      "severity": "error",
+      "message": "cannot apply arithmetic op to `double` and `character`"
+    },
+    "dplyr::RY040::tests/testthat/test-count-tally.R:245:42": {
+      "package": "dplyr",
+      "code": "RY040",
+      "path": "tests/testthat/test-count-tally.R",
+      "line": 245,
+      "column": 42,
+      "severity": "error",
+      "message": "cannot apply arithmetic op to `double` and `character`"
+    },
+    "dplyr::RY040::tests/testthat/test-mutate.R:408:23": {
+      "package": "dplyr",
+      "code": "RY040",
+      "path": "tests/testthat/test-mutate.R",
+      "line": 408,
+      "column": 23,
+      "severity": "error",
+      "message": "cannot apply arithmetic op to `list` and `double`"
+    },
+    "dplyr::RY040::tests/testthat/test-mutate.R:410:36": {
+      "package": "dplyr",
+      "code": "RY040",
+      "path": "tests/testthat/test-mutate.R",
+      "line": 410,
+      "column": 36,
+      "severity": "error",
+      "message": "cannot apply arithmetic op to `list` and `double`"
+    },
+    "dplyr::RY040::tests/testthat/test-select.R:167:34": {
+      "package": "dplyr",
+      "code": "RY040",
+      "path": "tests/testthat/test-select.R",
+      "line": 167,
+      "column": 34,
+      "severity": "error",
+      "message": "cannot apply arithmetic op to `double` and `character`"
+    },
+    "dplyr::RY040::tests/testthat/test-slice.R:94:15": {
+      "package": "dplyr",
+      "code": "RY040",
+      "path": "tests/testthat/test-slice.R",
+      "line": 94,
+      "column": 15,
+      "severity": "error",
+      "message": "cannot apply arithmetic op to `double` and `character`"
+    },
+    "dplyr::RY040::tests/testthat/test-slice.R:95:28": {
+      "package": "dplyr",
+      "code": "RY040",
+      "path": "tests/testthat/test-slice.R",
+      "line": 95,
+      "column": 28,
+      "severity": "error",
+      "message": "cannot apply arithmetic op to `double` and `character`"
+    },
+    "dplyr::RY060::tests/testthat/test-group-by.R:26:16": {
+      "package": "dplyr",
+      "code": "RY060",
+      "path": "tests/testthat/test-group-by.R",
+      "line": 26,
+      "column": 16,
+      "severity": "error",
+      "message": "column `big` not found in data frame schema; available columns: x, g"
+    },
+    "dplyr::RY060::tests/testthat/test-group-by.R:40:16": {
+      "package": "dplyr",
+      "code": "RY060",
+      "path": "tests/testthat/test-group-by.R",
+      "line": 40,
+      "column": 16,
+      "severity": "error",
+      "message": "column `big` not found in data frame schema; available columns: x, g"
+    },
+    "dplyr::RY060::tests/testthat/test-mutate.R:794:16": {
+      "package": "dplyr",
+      "code": "RY060",
+      "path": "tests/testthat/test-mutate.R",
+      "line": 794,
+      "column": 16,
+      "severity": "error",
+      "message": "column `z` not found in data frame schema; available columns: x, g"
+    },
+    "dplyr::RY090::tests/testthat/test-sets.R:60:25": {
+      "package": "dplyr",
+      "code": "RY090",
+      "path": "tests/testthat/test-sets.R",
+      "line": 60,
+      "column": 25,
+      "severity": "warning",
+      "message": "unknown argument `z` to `intersect`; did you mean `x`?",
+      "fix": {
+        "start": 2110,
+        "end": 2115,
+        "replacement": "x = 3"
+      }
+    },
+    "dplyr::RY091::R/data-mask.R:112:7": {
+      "package": "dplyr",
+      "code": "RY091",
+      "path": "R/data-mask.R",
+      "line": 112,
+      "column": 7,
+      "severity": "warning",
+      "message": "missing required argument `expr` in call to `eval`"
+    },
+    "dplyr::RY091::R/data-mask.R:117:7": {
+      "package": "dplyr",
+      "code": "RY091",
+      "path": "R/data-mask.R",
+      "line": 117,
+      "column": 7,
+      "severity": "warning",
+      "message": "missing required argument `expr` in call to `eval`"
+    },
+    "dplyr::RY091::R/data-mask.R:131:7": {
+      "package": "dplyr",
+      "code": "RY091",
+      "path": "R/data-mask.R",
+      "line": 131,
+      "column": 7,
+      "severity": "warning",
+      "message": "missing required argument `expr` in call to `eval`"
+    },
+    "ellmer::RY010::R/chat-structured.R:2:37": {
+      "package": "ellmer",
+      "code": "RY010",
+      "path": "R/chat-structured.R",
+      "line": 2,
+      "column": 37,
+      "severity": "warning",
+      "message": "variable `S7_inherits` is not bound in this scope"
+    },
+    "ellmer::RY010::R/chat-tools.R:279:39": {
+      "package": "ellmer",
+      "code": "RY010",
+      "path": "R/chat-tools.R",
+      "line": 279,
+      "column": 39,
+      "severity": "warning",
+      "message": "variable `S7_inherits` is not bound in this scope"
+    },
+    "ellmer::RY010::R/chat.R:1038:37": {
+      "package": "ellmer",
+      "code": "RY010",
+      "path": "R/chat.R",
+      "line": 1038,
+      "column": 37,
+      "severity": "warning",
+      "message": "variable `S7_inherits` is not bound in this scope"
+    },
+    "ellmer::RY010::R/content-replay.R:115:32": {
+      "package": "ellmer",
+      "code": "RY010",
+      "path": "R/content-replay.R",
+      "line": 115,
+      "column": 32,
+      "severity": "warning",
+      "message": "variable `S7_inherits` is not bound in this scope"
+    },
+    "ellmer::RY010::R/content.R:213:17": {
+      "package": "ellmer",
+      "code": "RY010",
+      "path": "R/content.R",
+      "line": 213,
+      "column": 17,
+      "severity": "warning",
+      "message": "variable `class_list` is not bound in this scope"
+    },
+    "ellmer::RY010::R/content.R:215:13": {
+      "package": "ellmer",
+      "code": "RY010",
+      "path": "R/content.R",
+      "line": 215,
+      "column": 13,
+      "severity": "warning",
+      "message": "variable `class_list` is not bound in this scope"
+    },
+    "ellmer::RY010::R/content.R:263:13": {
+      "package": "ellmer",
+      "code": "RY010",
+      "path": "R/content.R",
+      "line": 263,
+      "column": 13,
+      "severity": "warning",
+      "message": "variable `class_any` is not bound in this scope"
+    },
+    "ellmer::RY010::R/content.R:265:22": {
+      "package": "ellmer",
+      "code": "RY010",
+      "path": "R/content.R",
+      "line": 265,
+      "column": 22,
+      "severity": "warning",
+      "message": "variable `class_character` is not bound in this scope"
+    },
+    "ellmer::RY010::R/content.R:280:13": {
+      "package": "ellmer",
+      "code": "RY010",
+      "path": "R/content.R",
+      "line": 280,
+      "column": 13,
+      "severity": "warning",
+      "message": "variable `class_list` is not bound in this scope"
+    },
+    "ellmer::RY010::R/content.R:356:12": {
+      "package": "ellmer",
+      "code": "RY010",
+      "path": "R/content.R",
+      "line": 356,
+      "column": 12,
+      "severity": "warning",
+      "message": "variable `class_any` is not bound in this scope"
+    },
+    "ellmer::RY010::R/content.R:412:13": {
+      "package": "ellmer",
+      "code": "RY010",
+      "path": "R/content.R",
+      "line": 412,
+      "column": 13,
+      "severity": "warning",
+      "message": "variable `class_list` is not bound in this scope"
+    },
+    "ellmer::RY010::R/otel.R:258:32": {
+      "package": "ellmer",
+      "code": "RY010",
+      "path": "R/otel.R",
+      "line": 258,
+      "column": 32,
+      "severity": "warning",
+      "message": "variable `S7_inherits` is not bound in this scope"
+    },
+    "ellmer::RY010::R/provider-aws.R:189:13": {
+      "package": "ellmer",
+      "code": "RY010",
+      "path": "R/provider-aws.R",
+      "line": 189,
+      "column": 13,
+      "severity": "warning",
+      "message": "variable `class_list` is not bound in this scope"
+    },
+    "ellmer::RY010::R/provider-claude.R:139:20": {
+      "package": "ellmer",
+      "code": "RY010",
+      "path": "R/provider-claude.R",
+      "line": 139,
+      "column": 20,
+      "severity": "warning",
+      "message": "variable `class_character` is not bound in this scope"
+    },
+    "ellmer::RY010::R/provider-deepseek.R:102:34": {
+      "package": "ellmer",
+      "code": "RY010",
+      "path": "R/provider-deepseek.R",
+      "line": 102,
+      "column": 34,
+      "severity": "warning",
+      "message": "variable `S7_inherits` is not bound in this scope"
+    },
+    "ellmer::RY010::R/provider-deepseek.R:118:32": {
+      "package": "ellmer",
+      "code": "RY010",
+      "path": "R/provider-deepseek.R",
+      "line": 118,
+      "column": 32,
+      "severity": "warning",
+      "message": "variable `S7_inherits` is not bound in this scope"
+    },
+    "ellmer::RY010::R/provider-openai-compatible.R:138:38": {
+      "package": "ellmer",
+      "code": "RY010",
+      "path": "R/provider-openai-compatible.R",
+      "line": 138,
+      "column": 38,
+      "severity": "warning",
+      "message": "variable `class_logical` is not bound in this scope"
+    },
+    "ellmer::RY010::R/provider-openai-compatible.R:430:38": {
+      "package": "ellmer",
+      "code": "RY010",
+      "path": "R/provider-openai-compatible.R",
+      "line": 430,
+      "column": 38,
+      "severity": "warning",
+      "message": "variable `S7_inherits` is not bound in this scope"
+    },
+    "ellmer::RY010::R/provider-openai.R:142:20": {
+      "package": "ellmer",
+      "code": "RY010",
+      "path": "R/provider-openai.R",
+      "line": 142,
+      "column": 20,
+      "severity": "warning",
+      "message": "variable `class_character` is not bound in this scope"
+    },
+    "ellmer::RY010::R/provider.R:226:32": {
+      "package": "ellmer",
+      "code": "RY010",
+      "path": "R/provider.R",
+      "line": 226,
+      "column": 32,
+      "severity": "warning",
+      "message": "variable `class_list` is not bound in this scope"
+    },
+    "ellmer::RY010::R/provider.R:38:14": {
+      "package": "ellmer",
+      "code": "RY010",
+      "path": "R/provider.R",
+      "line": 38,
+      "column": 14,
+      "severity": "warning",
+      "message": "variable `class_list` is not bound in this scope"
+    },
+    "ellmer::RY010::R/provider.R:39:18": {
+      "package": "ellmer",
+      "code": "RY010",
+      "path": "R/provider.R",
+      "line": 39,
+      "column": 18,
+      "severity": "warning",
+      "message": "variable `class_list` is not bound in this scope"
+    },
+    "ellmer::RY010::R/provider.R:40:21": {
+      "package": "ellmer",
+      "code": "RY010",
+      "path": "R/provider.R",
+      "line": 40,
+      "column": 21,
+      "severity": "warning",
+      "message": "variable `class_character` is not bound in this scope"
+    },
+    "ellmer::RY010::R/provider.R:41:19": {
+      "package": "ellmer",
+      "code": "RY010",
+      "path": "R/provider.R",
+      "line": 41,
+      "column": 19,
+      "severity": "warning",
+      "message": "variable `class_function` is not bound in this scope"
+    },
+    "ellmer::RY010::R/schema.R:107:20": {
+      "package": "ellmer",
+      "code": "RY010",
+      "path": "R/schema.R",
+      "line": 107,
+      "column": 20,
+      "severity": "warning",
+      "message": "variable `class_data.frame` is not bound in this scope"
+    },
+    "ellmer::RY010::R/schema.R:115:20": {
+      "package": "ellmer",
+      "code": "RY010",
+      "path": "R/schema.R",
+      "line": 115,
+      "column": 20,
+      "severity": "warning",
+      "message": "variable `class_list` is not bound in this scope"
+    },
+    "ellmer::RY010::R/schema.R:119:20": {
+      "package": "ellmer",
+      "code": "RY010",
+      "path": "R/schema.R",
+      "line": 119,
+      "column": 20,
+      "severity": "warning",
+      "message": "variable `class_any` is not bound in this scope"
+    },
+    "ellmer::RY010::R/schema.R:49:20": {
+      "package": "ellmer",
+      "code": "RY010",
+      "path": "R/schema.R",
+      "line": 49,
+      "column": 20,
+      "severity": "warning",
+      "message": "variable `class_logical` is not bound in this scope"
+    },
+    "ellmer::RY010::R/schema.R:59:20": {
+      "package": "ellmer",
+      "code": "RY010",
+      "path": "R/schema.R",
+      "line": 59,
+      "column": 20,
+      "severity": "warning",
+      "message": "variable `class_numeric` is not bound in this scope"
+    },
+    "ellmer::RY010::R/schema.R:68:20": {
+      "package": "ellmer",
+      "code": "RY010",
+      "path": "R/schema.R",
+      "line": 68,
+      "column": 20,
+      "severity": "warning",
+      "message": "variable `class_character` is not bound in this scope"
+    },
+    "ellmer::RY010::R/schema.R:77:20": {
+      "package": "ellmer",
+      "code": "RY010",
+      "path": "R/schema.R",
+      "line": 77,
+      "column": 20,
+      "severity": "warning",
+      "message": "variable `class_factor` is not bound in this scope"
+    },
+    "ellmer::RY010::R/schema.R:86:20": {
+      "package": "ellmer",
+      "code": "RY010",
+      "path": "R/schema.R",
+      "line": 86,
+      "column": 20,
+      "severity": "warning",
+      "message": "variable `class_Date` is not bound in this scope"
+    },
+    "ellmer::RY010::R/schema.R:95:20": {
+      "package": "ellmer",
+      "code": "RY010",
+      "path": "R/schema.R",
+      "line": 95,
+      "column": 20,
+      "severity": "warning",
+      "message": "variable `class_POSIXt` is not bound in this scope"
+    },
+    "ellmer::RY010::R/tools-built-in.R:10:12": {
+      "package": "ellmer",
+      "code": "RY010",
+      "path": "R/tools-built-in.R",
+      "line": 10,
+      "column": 12,
+      "severity": "warning",
+      "message": "variable `class_any` is not bound in this scope"
+    },
+    "ellmer::RY010::R/tools-built-in.R:25:12": {
+      "package": "ellmer",
+      "code": "RY010",
+      "path": "R/tools-built-in.R",
+      "line": 25,
+      "column": 12,
+      "severity": "warning",
+      "message": "variable `class_list` is not bound in this scope"
+    },
+    "ellmer::RY010::R/tools-built-in.R:43:12": {
+      "package": "ellmer",
+      "code": "RY010",
+      "path": "R/tools-built-in.R",
+      "line": 43,
+      "column": 12,
+      "severity": "warning",
+      "message": "variable `class_character` is not bound in this scope"
+    },
+    "ellmer::RY010::R/tools-built-in.R:44:12": {
+      "package": "ellmer",
+      "code": "RY010",
+      "path": "R/tools-built-in.R",
+      "line": 44,
+      "column": 12,
+      "severity": "warning",
+      "message": "variable `class_list` is not bound in this scope"
+    },
+    "ellmer::RY010::R/tools-built-in.R:69:12": {
+      "package": "ellmer",
+      "code": "RY010",
+      "path": "R/tools-built-in.R",
+      "line": 69,
+      "column": 12,
+      "severity": "warning",
+      "message": "variable `class_list` is not bound in this scope"
+    },
+    "ellmer::RY010::R/tools-built-in.R:88:12": {
+      "package": "ellmer",
+      "code": "RY010",
+      "path": "R/tools-built-in.R",
+      "line": 88,
+      "column": 12,
+      "severity": "warning",
+      "message": "variable `class_list` is not bound in this scope"
+    },
+    "ellmer::RY010::R/tools-built-in.R:9:19": {
+      "package": "ellmer",
+      "code": "RY010",
+      "path": "R/tools-built-in.R",
+      "line": 9,
+      "column": 19,
+      "severity": "warning",
+      "message": "variable `class_list` is not bound in this scope"
+    },
+    "ellmer::RY010::R/tools-def.R:173:50": {
+      "package": "ellmer",
+      "code": "RY010",
+      "path": "R/tools-def.R",
+      "line": 173,
+      "column": 50,
+      "severity": "warning",
+      "message": "variable `S7_inherits` is not bound in this scope"
+    },
+    "ellmer::RY010::R/tools-def.R:209:12": {
+      "package": "ellmer",
+      "code": "RY010",
+      "path": "R/tools-def.R",
+      "line": 209,
+      "column": 12,
+      "severity": "warning",
+      "message": "variable `class_function` is not bound in this scope"
+    },
+    "ellmer::RY010::R/tools-def.R:215:19": {
+      "package": "ellmer",
+      "code": "RY010",
+      "path": "R/tools-def.R",
+      "line": 215,
+      "column": 19,
+      "severity": "warning",
+      "message": "variable `class_list` is not bound in this scope"
+    },
+    "ellmer::RY010::R/turns.R:133:12": {
+      "package": "ellmer",
+      "code": "RY010",
+      "path": "R/turns.R",
+      "line": 133,
+      "column": 12,
+      "severity": "warning",
+      "message": "variable `class_list` is not bound in this scope"
+    },
+    "ellmer::RY010::R/turns.R:135:7": {
+      "package": "ellmer",
+      "code": "RY010",
+      "path": "R/turns.R",
+      "line": 135,
+      "column": 7,
+      "severity": "warning",
+      "message": "variable `class_numeric` is not bound in this scope"
+    },
+    "ellmer::RY010::R/turns.R:146:15": {
+      "package": "ellmer",
+      "code": "RY010",
+      "path": "R/turns.R",
+      "line": 146,
+      "column": 15,
+      "severity": "warning",
+      "message": "variable `class_character` is not bound in this scope"
+    },
+    "ellmer::RY010::R/turns.R:293:37": {
+      "package": "ellmer",
+      "code": "RY010",
+      "path": "R/turns.R",
+      "line": 293,
+      "column": 37,
+      "severity": "warning",
+      "message": "variable `S7_inherits` is not bound in this scope"
+    },
+    "ellmer::RY010::R/turns.R:323:37": {
+      "package": "ellmer",
+      "code": "RY010",
+      "path": "R/turns.R",
+      "line": 323,
+      "column": 37,
+      "severity": "warning",
+      "message": "variable `S7_inherits` is not bound in this scope"
+    },
+    "ellmer::RY010::R/turns.R:36:15": {
+      "package": "ellmer",
+      "code": "RY010",
+      "path": "R/turns.R",
+      "line": 36,
+      "column": 15,
+      "severity": "warning",
+      "message": "variable `class_character` is not bound in this scope"
+    },
+    "ellmer::RY010::R/turns.R:40:15": {
+      "package": "ellmer",
+      "code": "RY010",
+      "path": "R/turns.R",
+      "line": 40,
+      "column": 15,
+      "severity": "warning",
+      "message": "variable `class_character` is not bound in this scope"
+    },
+    "ellmer::RY010::R/turns.R:79:15": {
+      "package": "ellmer",
+      "code": "RY010",
+      "path": "R/turns.R",
+      "line": 79,
+      "column": 15,
+      "severity": "warning",
+      "message": "variable `class_character` is not bound in this scope"
+    },
+    "ellmer::RY010::R/turns.R:99:15": {
+      "package": "ellmer",
+      "code": "RY010",
+      "path": "R/turns.R",
+      "line": 99,
+      "column": 15,
+      "severity": "warning",
+      "message": "variable `class_character` is not bound in this scope"
+    },
+    "ellmer::RY010::R/types.R:43:14": {
+      "package": "ellmer",
+      "code": "RY010",
+      "path": "R/types.R",
+      "line": 43,
+      "column": 14,
+      "severity": "warning",
+      "message": "variable `class_character` is not bound in this scope"
+    },
+    "ellmer::RY010::R/types.R:64:12": {
+      "package": "ellmer",
+      "code": "RY010",
+      "path": "R/types.R",
+      "line": 64,
+      "column": 12,
+      "severity": "warning",
+      "message": "variable `class_list` is not bound in this scope"
+    },
+    "ellmer::RY010::R/utils-S7.R:101:36": {
+      "package": "ellmer",
+      "code": "RY010",
+      "path": "R/utils-S7.R",
+      "line": 101,
+      "column": 36,
+      "severity": "warning",
+      "message": "variable `class_double` is not bound in this scope"
+    },
+    "ellmer::RY010::R/utils-S7.R:101:54": {
+      "package": "ellmer",
+      "code": "RY010",
+      "path": "R/utils-S7.R",
+      "line": 101,
+      "column": 54,
+      "severity": "warning",
+      "message": "variable `class_double` is not bound in this scope"
+    },
+    "ellmer::RY010::R/utils-S7.R:135:36": {
+      "package": "ellmer",
+      "code": "RY010",
+      "path": "R/utils-S7.R",
+      "line": 135,
+      "column": 36,
+      "severity": "warning",
+      "message": "variable `class_double` is not bound in this scope"
+    },
+    "ellmer::RY010::R/utils-S7.R:135:54": {
+      "package": "ellmer",
+      "code": "RY010",
+      "path": "R/utils-S7.R",
+      "line": 135,
+      "column": 54,
+      "severity": "warning",
+      "message": "variable `class_double` is not bound in this scope"
+    },
+    "ellmer::RY010::R/utils-S7.R:31:36": {
+      "package": "ellmer",
+      "code": "RY010",
+      "path": "R/utils-S7.R",
+      "line": 31,
+      "column": 36,
+      "severity": "warning",
+      "message": "variable `class_logical` is not bound in this scope"
+    },
+    "ellmer::RY010::R/utils-S7.R:31:55": {
+      "package": "ellmer",
+      "code": "RY010",
+      "path": "R/utils-S7.R",
+      "line": 31,
+      "column": 55,
+      "severity": "warning",
+      "message": "variable `class_logical` is not bound in this scope"
+    },
+    "ellmer::RY010::R/utils-S7.R:64:13": {
+      "package": "ellmer",
+      "code": "RY010",
+      "path": "R/utils-S7.R",
+      "line": 64,
+      "column": 13,
+      "severity": "warning",
+      "message": "variable `class_list` is not bound in this scope"
+    },
+    "ellmer::RY010::R/utils-S7.R:6:36": {
+      "package": "ellmer",
+      "code": "RY010",
+      "path": "R/utils-S7.R",
+      "line": 6,
+      "column": 36,
+      "severity": "warning",
+      "message": "variable `class_character` is not bound in this scope"
+    },
+    "ellmer::RY010::R/utils-S7.R:6:57": {
+      "package": "ellmer",
+      "code": "RY010",
+      "path": "R/utils-S7.R",
+      "line": 6,
+      "column": 57,
+      "severity": "warning",
+      "message": "variable `class_character` is not bound in this scope"
+    },
+    "ellmer::RY032::R/provider-openai-compatible.R:79:7": {
+      "package": "ellmer",
+      "code": "RY032",
+      "path": "R/provider-openai-compatible.R",
+      "line": 79,
+      "column": 7,
+      "severity": "warning",
+      "message": "`||` operand depends on a parameter whose length is not known to be 1; current R errors for vectors",
+      "fix": {
+        "start": 3242,
+        "end": 3244,
+        "replacement": "|"
+      }
+    },
+    "flexdashboard::RY001::R/flex_dashboard.R:381:11": {
+      "package": "flexdashboard",
+      "code": "RY001",
+      "path": "R/flex_dashboard.R",
+      "line": 381,
+      "column": 11,
+      "severity": "warning",
+      "message": "`if` condition is `logical<len=0>`, expected length-1 logical"
+    },
+    "flexdashboard::RY001::R/flex_dashboard.R:401:13": {
+      "package": "flexdashboard",
+      "code": "RY001",
+      "path": "R/flex_dashboard.R",
+      "line": 401,
+      "column": 13,
+      "severity": "warning",
+      "message": "`if` condition is `logical<len=0>`, expected length-1 logical"
+    },
+    "flexdashboard::RY010::R/bslib.R:34:24": {
+      "package": "flexdashboard",
+      "code": "RY010",
+      "path": "R/bslib.R",
+      "line": 34,
+      "column": 24,
+      "severity": "warning",
+      "message": "variable `bs_theme` is not bound in this scope"
+    },
+    "flexdashboard::RY010::R/valuebox.R:58:10": {
+      "package": "flexdashboard",
+      "code": "RY010",
+      "path": "R/valuebox.R",
+      "line": 58,
+      "column": 10,
+      "severity": "warning",
+      "message": "variable `tags` is not bound in this scope"
+    },
+    "flexdashboard::RY033::R/flex_dashboard.R:173:7": {
+      "package": "flexdashboard",
+      "code": "RY033",
+      "path": "R/flex_dashboard.R",
+      "line": 173,
+      "column": 7,
+      "severity": "warning",
+      "message": "comparing `logical` with `character`; R coerces the numeric value to character and compares lexicographically, which is rarely intended"
+    },
+    "flexdashboard::RY105::R/flex_dashboard.R:633:9": {
+      "package": "flexdashboard",
+      "code": "RY105",
+      "path": "R/flex_dashboard.R",
+      "line": 633,
+      "column": 9,
+      "severity": "warning",
+      "message": "`match` is a length-1 character, so `length(...)` is 1 here and this zero-length guard is always TRUE"
+    },
+    "ggplot2::RY001::R/bin.R:101:14": {
+      "package": "ggplot2",
+      "code": "RY001",
+      "path": "R/bin.R",
+      "line": 101,
+      "column": 14,
+      "severity": "warning",
+      "message": "`if` condition is `logical<len=0>`, expected length-1 logical"
+    },
+    "ggplot2::RY010::R/facet-.R:1074:28": {
+      "package": "ggplot2",
+      "code": "RY010",
+      "path": "R/facet-.R",
+      "line": 1074,
+      "column": 28,
+      "severity": "warning",
+      "message": "variable `vec_is_list` is not bound in this scope"
+    },
+    "ggplot2::RY010::R/guide-axis-stack.R:35:25": {
+      "package": "ggplot2",
+      "code": "RY010",
+      "path": "R/guide-axis-stack.R",
+      "line": 35,
+      "column": 25,
+      "severity": "warning",
+      "message": "variable `is.unit` is not bound in this scope"
+    },
+    "ggplot2::RY010::R/guide-custom.R:43:22": {
+      "package": "ggplot2",
+      "code": "RY010",
+      "path": "R/guide-custom.R",
+      "line": 43,
+      "column": 22,
+      "severity": "warning",
+      "message": "variable `is.grob` is not bound in this scope"
+    },
+    "ggplot2::RY010::R/guide-custom.R:44:23": {
+      "package": "ggplot2",
+      "code": "RY010",
+      "path": "R/guide-custom.R",
+      "line": 44,
+      "column": 23,
+      "severity": "warning",
+      "message": "variable `is.unit` is not bound in this scope"
+    },
+    "ggplot2::RY010::R/guide-custom.R:45:24": {
+      "package": "ggplot2",
+      "code": "RY010",
+      "path": "R/guide-custom.R",
+      "line": 45,
+      "column": 24,
+      "severity": "warning",
+      "message": "variable `is.unit` is not bound in this scope"
+    },
+    "ggplot2::RY010::R/plot-render.R:297:19": {
+      "package": "ggplot2",
+      "code": "RY010",
+      "path": "R/plot-render.R",
+      "line": 297,
+      "column": 19,
+      "severity": "warning",
+      "message": "variable `vjust` is not bound in this scope"
+    },
+    "ggplot2::RY010::R/plot-render.R:64:12": {
+      "package": "ggplot2",
+      "code": "RY010",
+      "path": "R/plot-render.R",
+      "line": 64,
+      "column": 12,
+      "severity": "warning",
+      "message": "variable `as.gtable` is not bound in this scope"
+    },
+    "ggplot2::RY010::R/plot-render.R:65:12": {
+      "package": "ggplot2",
+      "code": "RY010",
+      "path": "R/plot-render.R",
+      "line": 65,
+      "column": 12,
+      "severity": "warning",
+      "message": "variable `as.gtable` is not bound in this scope"
+    },
+    "ggplot2::RY010::R/plot-render.R:82:46": {
+      "package": "ggplot2",
+      "code": "RY010",
+      "path": "R/plot-render.R",
+      "line": 82,
+      "column": 46,
+      "severity": "warning",
+      "message": "variable `gtable_width` is not bound in this scope"
+    },
+    "ggplot2::RY010::R/plot-render.R:83:46": {
+      "package": "ggplot2",
+      "code": "RY010",
+      "path": "R/plot-render.R",
+      "line": 83,
+      "column": 46,
+      "severity": "warning",
+      "message": "variable `gtable_height` is not bound in this scope"
+    },
+    "ggplot2::RY010::R/scale-.R:1015:11": {
+      "package": "ggplot2",
+      "code": "RY010",
+      "path": "R/scale-.R",
+      "line": 1015,
+      "column": 11,
+      "severity": "warning",
+      "message": "variable `ContinuousRange` is not bound in this scope"
+    },
+    "ggplot2::RY010::R/scale-.R:1017:14": {
+      "package": "ggplot2",
+      "code": "RY010",
+      "path": "R/scale-.R",
+      "line": 1017,
+      "column": 14,
+      "severity": "warning",
+      "message": "variable `rescale` is not bound in this scope"
+    },
+    "ggplot2::RY010::R/scale-.R:1018:9": {
+      "package": "ggplot2",
+      "code": "RY010",
+      "path": "R/scale-.R",
+      "line": 1018,
+      "column": 9,
+      "severity": "warning",
+      "message": "variable `censor` is not bound in this scope"
+    },
+    "ggplot2::RY010::R/scale-.R:108:75": {
+      "package": "ggplot2",
+      "code": "RY010",
+      "path": "R/scale-.R",
+      "line": 108,
+      "column": 75,
+      "severity": "warning",
+      "message": "variable `rescale` is not bound in this scope"
+    },
+    "ggplot2::RY010::R/scale-.R:109:36": {
+      "package": "ggplot2",
+      "code": "RY010",
+      "path": "R/scale-.R",
+      "line": 109,
+      "column": 36,
+      "severity": "warning",
+      "message": "variable `censor` is not bound in this scope"
+    },
+    "ggplot2::RY010::R/scale-.R:1493:11": {
+      "package": "ggplot2",
+      "code": "RY010",
+      "path": "R/scale-.R",
+      "line": 1493,
+      "column": 11,
+      "severity": "warning",
+      "message": "variable `ContinuousRange` is not bound in this scope"
+    },
+    "ggplot2::RY010::R/scale-.R:1495:14": {
+      "package": "ggplot2",
+      "code": "RY010",
+      "path": "R/scale-.R",
+      "line": 1495,
+      "column": 14,
+      "severity": "warning",
+      "message": "variable `rescale` is not bound in this scope"
+    },
+    "ggplot2::RY010::R/scale-.R:1496:9": {
+      "package": "ggplot2",
+      "code": "RY010",
+      "path": "R/scale-.R",
+      "line": 1496,
+      "column": 9,
+      "severity": "warning",
+      "message": "variable `squish` is not bound in this scope"
+    },
+    "ggplot2::RY010::R/scale-.R:164:13": {
+      "package": "ggplot2",
+      "code": "RY010",
+      "path": "R/scale-.R",
+      "line": 164,
+      "column": 13,
+      "severity": "warning",
+      "message": "variable `ContinuousRange` is not bound in this scope"
+    },
+    "ggplot2::RY010::R/scale-.R:269:13": {
+      "package": "ggplot2",
+      "code": "RY010",
+      "path": "R/scale-.R",
+      "line": 269,
+      "column": 13,
+      "severity": "warning",
+      "message": "variable `DiscreteRange` is not bound in this scope"
+    },
+    "ggplot2::RY010::R/scale-.R:315:37": {
+      "package": "ggplot2",
+      "code": "RY010",
+      "path": "R/scale-.R",
+      "line": 315,
+      "column": 37,
+      "severity": "warning",
+      "message": "variable `rescale` is not bound in this scope"
+    },
+    "ggplot2::RY010::R/scale-.R:315:52": {
+      "package": "ggplot2",
+      "code": "RY010",
+      "path": "R/scale-.R",
+      "line": 315,
+      "column": 52,
+      "severity": "warning",
+      "message": "variable `squish` is not bound in this scope"
+    },
+    "ggplot2::RY010::R/scale-.R:370:13": {
+      "package": "ggplot2",
+      "code": "RY010",
+      "path": "R/scale-.R",
+      "line": 370,
+      "column": 13,
+      "severity": "warning",
+      "message": "variable `ContinuousRange` is not bound in this scope"
+    },
+    "ggplot2::RY010::R/scale-.R:474:11": {
+      "package": "ggplot2",
+      "code": "RY010",
+      "path": "R/scale-.R",
+      "line": 474,
+      "column": 11,
+      "severity": "warning",
+      "message": "variable `Range` is not bound in this scope"
+    },
+    "ggplot2::RY010::R/scale-binned.R:30:53": {
+      "package": "ggplot2",
+      "code": "RY010",
+      "path": "R/scale-binned.R",
+      "line": 30,
+      "column": 53,
+      "severity": "warning",
+      "message": "variable `squish` is not bound in this scope"
+    },
+    "ggplot2::RY010::R/scale-binned.R:50:53": {
+      "package": "ggplot2",
+      "code": "RY010",
+      "path": "R/scale-binned.R",
+      "line": 50,
+      "column": 53,
+      "severity": "warning",
+      "message": "variable `squish` is not bound in this scope"
+    },
+    "ggplot2::RY010::R/scale-continuous.R:112:57": {
+      "package": "ggplot2",
+      "code": "RY010",
+      "path": "R/scale-continuous.R",
+      "line": 112,
+      "column": 57,
+      "severity": "warning",
+      "message": "variable `censor` is not bound in this scope"
+    },
+    "ggplot2::RY010::R/scale-continuous.R:85:57": {
+      "package": "ggplot2",
+      "code": "RY010",
+      "path": "R/scale-continuous.R",
+      "line": 85,
+      "column": 57,
+      "severity": "warning",
+      "message": "variable `censor` is not bound in this scope"
+    },
+    "ggplot2::RY010::R/scale-date.R:115:32": {
+      "package": "ggplot2",
+      "code": "RY010",
+      "path": "R/scale-date.R",
+      "line": 115,
+      "column": 32,
+      "severity": "warning",
+      "message": "variable `censor` is not bound in this scope"
+    },
+    "ggplot2::RY010::R/scale-date.R:153:36": {
+      "package": "ggplot2",
+      "code": "RY010",
+      "path": "R/scale-date.R",
+      "line": 153,
+      "column": 36,
+      "severity": "warning",
+      "message": "variable `censor` is not bound in this scope"
+    },
+    "ggplot2::RY010::R/scale-date.R:193:36": {
+      "package": "ggplot2",
+      "code": "RY010",
+      "path": "R/scale-date.R",
+      "line": 193,
+      "column": 36,
+      "severity": "warning",
+      "message": "variable `censor` is not bound in this scope"
+    },
+    "ggplot2::RY010::R/scale-date.R:233:32": {
+      "package": "ggplot2",
+      "code": "RY010",
+      "path": "R/scale-date.R",
+      "line": 233,
+      "column": 32,
+      "severity": "warning",
+      "message": "variable `censor` is not bound in this scope"
+    },
+    "ggplot2::RY010::R/scale-date.R:272:32": {
+      "package": "ggplot2",
+      "code": "RY010",
+      "path": "R/scale-date.R",
+      "line": 272,
+      "column": 32,
+      "severity": "warning",
+      "message": "variable `censor` is not bound in this scope"
+    },
+    "ggplot2::RY010::R/scale-date.R:78:32": {
+      "package": "ggplot2",
+      "code": "RY010",
+      "path": "R/scale-date.R",
+      "line": 78,
+      "column": 32,
+      "severity": "warning",
+      "message": "variable `censor` is not bound in this scope"
+    },
+    "ggplot2::RY010::R/scale-discrete-.R:104:17": {
+      "package": "ggplot2",
+      "code": "RY010",
+      "path": "R/scale-discrete-.R",
+      "line": 104,
+      "column": 17,
+      "severity": "warning",
+      "message": "variable `ContinuousRange` is not bound in this scope"
+    },
+    "ggplot2::RY010::R/scale-discrete-.R:87:17": {
+      "package": "ggplot2",
+      "code": "RY010",
+      "path": "R/scale-discrete-.R",
+      "line": 87,
+      "column": 17,
+      "severity": "warning",
+      "message": "variable `ContinuousRange` is not bound in this scope"
+    },
+    "ggplot2::RY010::R/scale-size.R:135:16": {
+      "package": "ggplot2",
+      "code": "RY010",
+      "path": "R/scale-size.R",
+      "line": 135,
+      "column": 16,
+      "severity": "warning",
+      "message": "variable `rescale_max` is not bound in this scope"
+    },
+    "ggplot2::RY010::R/scale-size.R:145:16": {
+      "package": "ggplot2",
+      "code": "RY010",
+      "path": "R/scale-size.R",
+      "line": 145,
+      "column": 16,
+      "severity": "warning",
+      "message": "variable `rescale_max` is not bound in this scope"
+    },
+    "ggplot2::RY010::R/stat-contour.R:142:17": {
+      "package": "ggplot2",
+      "code": "RY010",
+      "path": "R/stat-contour.R",
+      "line": 142,
+      "column": 17,
+      "severity": "warning",
+      "message": "variable `fullseq` is not bound in this scope"
+    },
+    "ggplot2::RY010::R/utilities.R:556:53": {
+      "package": "ggplot2",
+      "code": "RY010",
+      "path": "R/utilities.R",
+      "line": 556,
+      "column": 53,
+      "severity": "warning",
+      "message": "variable `vec_unique_count` is not bound in this scope"
+    },
+    "ggplot2::RY010::R/utilities.R:563:53": {
+      "package": "ggplot2",
+      "code": "RY010",
+      "path": "R/utilities.R",
+      "line": 563,
+      "column": 53,
+      "severity": "warning",
+      "message": "variable `vec_unique_count` is not bound in this scope"
+    },
+    "ggplot2::RY040::tests/testthat/test-geom-curve.R:17:8": {
+      "package": "ggplot2",
+      "code": "RY040",
+      "path": "tests/testthat/test-geom-curve.R",
+      "line": 17,
+      "column": 8,
+      "severity": "error",
+      "message": "arithmetic with `NULL` produces `numeric(0)`; the operand is known to be NULL"
+    },
+    "ggplot2::RY061::R/geom-boxplot.R:164:19": {
+      "package": "ggplot2",
+      "code": "RY061",
+      "path": "R/geom-boxplot.R",
+      "line": 164,
+      "column": 19,
+      "severity": "error",
+      "message": "$ operator is invalid for atomic vectors of mode `character`"
+    },
+    "ggplot2::RY061::R/geom-boxplot.R:166:7": {
+      "package": "ggplot2",
+      "code": "RY061",
+      "path": "R/geom-boxplot.R",
+      "line": 166,
+      "column": 7,
+      "severity": "error",
+      "message": "$ operator is invalid for atomic vectors of mode `character`"
+    },
+    "ggplot2::RY100::tests/testthat/test-axis-secondary.R:36:23": {
+      "package": "ggplot2",
+      "code": "RY100",
+      "path": "tests/testthat/test-axis-secondary.R",
+      "line": 36,
+      "column": 23,
+      "severity": "warning",
+      "message": "comparison directly inside a numeric math function is usually a parenthesization mistake; compare the math result instead",
+      "fix": {
+        "start": 1183,
+        "end": 1245,
+        "replacement": "abs(breaks$major_source - round(breaks$sec.major_source)) <= 1"
+      }
+    },
+    "ggplot2::RY100::tests/testthat/test-axis-secondary.R:37:23": {
+      "package": "ggplot2",
+      "code": "RY100",
+      "path": "tests/testthat/test-axis-secondary.R",
+      "line": 37,
+      "column": 23,
+      "severity": "warning",
+      "message": "comparison directly inside a numeric math function is usually a parenthesization mistake; compare the math result instead",
+      "fix": {
+        "start": 1266,
+        "end": 1328,
+        "replacement": "abs(breaks$minor_source - round(breaks$sec.minor_source)) <= 1"
+      }
+    },
+    "ggplot2::RY100::tests/testthat/test-axis-secondary.R:56:23": {
+      "package": "ggplot2",
+      "code": "RY100",
+      "path": "tests/testthat/test-axis-secondary.R",
+      "line": 56,
+      "column": 23,
+      "severity": "warning",
+      "message": "comparison directly inside a numeric math function is usually a parenthesization mistake; compare the math result instead",
+      "fix": {
+        "start": 1994,
+        "end": 2056,
+        "replacement": "abs(breaks$major_source - round(breaks$sec.major_source)) <= 1"
+      }
+    },
+    "ggplot2::RY100::tests/testthat/test-axis-secondary.R:57:23": {
+      "package": "ggplot2",
+      "code": "RY100",
+      "path": "tests/testthat/test-axis-secondary.R",
+      "line": 57,
+      "column": 23,
+      "severity": "warning",
+      "message": "comparison directly inside a numeric math function is usually a parenthesization mistake; compare the math result instead",
+      "fix": {
+        "start": 2077,
+        "end": 2139,
+        "replacement": "abs(breaks$minor_source - round(breaks$sec.minor_source)) <= 1"
+      }
+    },
+    "glue::RY040::tests/testthat/test-glue.R:595:20": {
+      "package": "glue",
+      "code": "RY040",
+      "path": "tests/testthat/test-glue.R",
+      "line": 595,
+      "column": 20,
+      "severity": "error",
+      "message": "arithmetic with `NULL` produces `numeric(0)`; the operand is known to be NULL"
+    },
+    "gt::RY001::R/fmt.R:166:7": {
+      "package": "gt",
+      "code": "RY001",
+      "path": "R/fmt.R",
+      "line": 166,
+      "column": 7,
+      "severity": "warning",
+      "message": "`if` condition is `logical<len=0>`, expected length-1 logical"
+    },
+    "gt::RY010::R/data_color.R:1520:23": {
+      "package": "gt",
+      "code": "RY010",
+      "path": "R/data_color.R",
+      "line": 1520,
+      "column": 23,
+      "severity": "warning",
+      "message": "variable `css_colors` is not bound in this scope"
+    },
+    "gt::RY010::R/data_color.R:1520:35": {
+      "package": "gt",
+      "code": "RY010",
+      "path": "R/data_color.R",
+      "line": 1520,
+      "column": 35,
+      "severity": "warning",
+      "message": "variable `css_colors` is not bound in this scope"
+    },
+    "gt::RY010::R/dt_summary.R:176:59": {
+      "package": "gt",
+      "code": "RY010",
+      "path": "R/dt_summary.R",
+      "line": 176,
+      "column": 59,
+      "severity": "warning",
+      "message": "variable `grand_summary_col` is not bound in this scope"
+    },
+    "gt::RY010::R/fmt.R:166:19": {
+      "package": "gt",
+      "code": "RY010",
+      "path": "R/fmt.R",
+      "line": 166,
+      "column": 19,
+      "severity": "warning",
+      "message": "variable `default_locales` is not bound in this scope"
+    },
+    "gt::RY010::R/fmt.R:167:15": {
+      "package": "gt",
+      "code": "RY010",
+      "path": "R/fmt.R",
+      "line": 167,
+      "column": 15,
+      "severity": "warning",
+      "message": "variable `default_locales` is not bound in this scope"
+    },
+    "gt::RY010::R/fmt.R:167:31": {
+      "package": "gt",
+      "code": "RY010",
+      "path": "R/fmt.R",
+      "line": 167,
+      "column": 31,
+      "severity": "warning",
+      "message": "variable `default_locales` is not bound in this scope"
+    },
+    "gt::RY010::R/fmt.R:184:21": {
+      "package": "gt",
+      "code": "RY010",
+      "path": "R/fmt.R",
+      "line": 184,
+      "column": 21,
+      "severity": "warning",
+      "message": "variable `locales` is not bound in this scope"
+    },
+    "gt::RY010::R/fmt.R:184:42": {
+      "package": "gt",
+      "code": "RY010",
+      "path": "R/fmt.R",
+      "line": 184,
+      "column": 42,
+      "severity": "warning",
+      "message": "variable `default_locales` is not bound in this scope"
+    },
+    "gt::RY010::R/fmt.R:214:5": {
+      "package": "gt",
+      "code": "RY010",
+      "path": "R/fmt.R",
+      "line": 214,
+      "column": 5,
+      "severity": "warning",
+      "message": "variable `currency_symbols` is not bound in this scope"
+    },
+    "gt::RY010::R/fmt.R:215:5": {
+      "package": "gt",
+      "code": "RY010",
+      "path": "R/fmt.R",
+      "line": 215,
+      "column": 5,
+      "severity": "warning",
+      "message": "variable `currencies` is not bound in this scope"
+    },
+    "gt::RY010::R/fmt.R:216:5": {
+      "package": "gt",
+      "code": "RY010",
+      "path": "R/fmt.R",
+      "line": 216,
+      "column": 5,
+      "severity": "warning",
+      "message": "variable `currencies` is not bound in this scope"
+    },
+    "gt::RY010::R/fmt.R:254:15": {
+      "package": "gt",
+      "code": "RY010",
+      "path": "R/fmt.R",
+      "line": 254,
+      "column": 15,
+      "severity": "warning",
+      "message": "variable `locales` is not bound in this scope"
+    },
+    "gt::RY010::R/fmt.R:254:29": {
+      "package": "gt",
+      "code": "RY010",
+      "path": "R/fmt.R",
+      "line": 254,
+      "column": 29,
+      "severity": "warning",
+      "message": "variable `locales` is not bound in this scope"
+    },
+    "gt::RY010::R/fmt.R:277:10": {
+      "package": "gt",
+      "code": "RY010",
+      "path": "R/fmt.R",
+      "line": 277,
+      "column": 10,
+      "severity": "warning",
+      "message": "variable `locales` is not bound in this scope"
+    },
+    "gt::RY010::R/fmt.R:277:26": {
+      "package": "gt",
+      "code": "RY010",
+      "path": "R/fmt.R",
+      "line": 277,
+      "column": 26,
+      "severity": "warning",
+      "message": "variable `locales` is not bound in this scope"
+    },
+    "gt::RY010::R/fmt.R:296:10": {
+      "package": "gt",
+      "code": "RY010",
+      "path": "R/fmt.R",
+      "line": 296,
+      "column": 10,
+      "severity": "warning",
+      "message": "variable `locales` is not bound in this scope"
+    },
+    "gt::RY010::R/fmt.R:296:42": {
+      "package": "gt",
+      "code": "RY010",
+      "path": "R/fmt.R",
+      "line": 296,
+      "column": 42,
+      "severity": "warning",
+      "message": "variable `locales` is not bound in this scope"
+    },
+    "gt::RY010::R/fmt.R:312:20": {
+      "package": "gt",
+      "code": "RY010",
+      "path": "R/fmt.R",
+      "line": 312,
+      "column": 20,
+      "severity": "warning",
+      "message": "variable `locales` is not bound in this scope"
+    },
+    "gt::RY010::R/fmt.R:312:42": {
+      "package": "gt",
+      "code": "RY010",
+      "path": "R/fmt.R",
+      "line": 312,
+      "column": 42,
+      "severity": "warning",
+      "message": "variable `locales` is not bound in this scope"
+    },
+    "gt::RY010::R/fmt.R:332:13": {
+      "package": "gt",
+      "code": "RY010",
+      "path": "R/fmt.R",
+      "line": 332,
+      "column": 13,
+      "severity": "warning",
+      "message": "variable `locales` is not bound in this scope"
+    },
+    "gt::RY010::R/fmt.R:332:35": {
+      "package": "gt",
+      "code": "RY010",
+      "path": "R/fmt.R",
+      "line": 332,
+      "column": 35,
+      "severity": "warning",
+      "message": "variable `locales` is not bound in this scope"
+    },
+    "gt::RY010::R/fmt.R:353:10": {
+      "package": "gt",
+      "code": "RY010",
+      "path": "R/fmt.R",
+      "line": 353,
+      "column": 10,
+      "severity": "warning",
+      "message": "variable `locales` is not bound in this scope"
+    },
+    "gt::RY010::R/fmt.R:353:28": {
+      "package": "gt",
+      "code": "RY010",
+      "path": "R/fmt.R",
+      "line": 353,
+      "column": 28,
+      "severity": "warning",
+      "message": "variable `locales` is not bound in this scope"
+    },
+    "gt::RY010::R/fmt.R:375:38": {
+      "package": "gt",
+      "code": "RY010",
+      "path": "R/fmt.R",
+      "line": 375,
+      "column": 38,
+      "severity": "warning",
+      "message": "variable `spelled_num` is not bound in this scope"
+    },
+    "gt::RY010::R/fmt.R:394:3": {
+      "package": "gt",
+      "code": "RY010",
+      "path": "R/fmt.R",
+      "line": 394,
+      "column": 3,
+      "severity": "warning",
+      "message": "variable `spelled_num` is not bound in this scope"
+    },
+    "gt::RY010::R/fmt.R:409:10": {
+      "package": "gt",
+      "code": "RY010",
+      "path": "R/fmt.R",
+      "line": 409,
+      "column": 10,
+      "severity": "warning",
+      "message": "variable `locales` is not bound in this scope"
+    },
+    "gt::RY010::R/fmt.R:409:37": {
+      "package": "gt",
+      "code": "RY010",
+      "path": "R/fmt.R",
+      "line": 409,
+      "column": 37,
+      "severity": "warning",
+      "message": "variable `locales` is not bound in this scope"
+    },
+    "gt::RY010::R/fmt.R:503:23": {
+      "package": "gt",
+      "code": "RY010",
+      "path": "R/fmt.R",
+      "line": 503,
+      "column": 23,
+      "severity": "warning",
+      "message": "variable `currency_symbols` is not bound in this scope"
+    },
+    "gt::RY010::R/format_data.R:10832:29": {
+      "package": "gt",
+      "code": "RY010",
+      "path": "R/format_data.R",
+      "line": 10832,
+      "column": 29,
+      "severity": "warning",
+      "message": "variable `currencies` is not bound in this scope"
+    },
+    "gt::RY010::R/format_data.R:5399:5": {
+      "package": "gt",
+      "code": "RY010",
+      "path": "R/format_data.R",
+      "line": 5399,
+      "column": 5,
+      "severity": "warning",
+      "message": "variable `durations` is not bound in this scope"
+    },
+    "gt::RY010::R/format_data.R:5400:7": {
+      "package": "gt",
+      "code": "RY010",
+      "path": "R/format_data.R",
+      "line": 5400,
+      "column": 7,
+      "severity": "warning",
+      "message": "variable `durations` is not bound in this scope"
+    },
+    "gt::RY010::R/format_data.R:5403:18": {
+      "package": "gt",
+      "code": "RY010",
+      "path": "R/format_data.R",
+      "line": 5403,
+      "column": 18,
+      "severity": "warning",
+      "message": "variable `durations` is not bound in this scope"
+    },
+    "gt::RY010::R/format_data.R:5405:32": {
+      "package": "gt",
+      "code": "RY010",
+      "path": "R/format_data.R",
+      "line": 5405,
+      "column": 32,
+      "severity": "warning",
+      "message": "variable `durations` is not bound in this scope"
+    },
+    "gt::RY010::R/format_data.R:9078:7": {
+      "package": "gt",
+      "code": "RY010",
+      "path": "R/format_data.R",
+      "line": 9078,
+      "column": 7,
+      "severity": "warning",
+      "message": "variable `country_names` is not bound in this scope"
+    },
+    "gt::RY010::R/format_data.R:9079:7": {
+      "package": "gt",
+      "code": "RY010",
+      "path": "R/format_data.R",
+      "line": 9079,
+      "column": 7,
+      "severity": "warning",
+      "message": "variable `country_names` is not bound in this scope"
+    },
+    "gt::RY010::R/format_data.R:9558:7": {
+      "package": "gt",
+      "code": "RY010",
+      "path": "R/format_data.R",
+      "line": 9558,
+      "column": 7,
+      "severity": "warning",
+      "message": "variable `country_names` is not bound in this scope"
+    },
+    "gt::RY010::R/format_data.R:9559:7": {
+      "package": "gt",
+      "code": "RY010",
+      "path": "R/format_data.R",
+      "line": 9559,
+      "column": 7,
+      "severity": "warning",
+      "message": "variable `country_names` is not bound in this scope"
+    },
+    "gt::RY010::R/format_data.R:9560:7": {
+      "package": "gt",
+      "code": "RY010",
+      "path": "R/format_data.R",
+      "line": 9560,
+      "column": 7,
+      "severity": "warning",
+      "message": "variable `country_names_additional` is not bound in this scope"
+    },
+    "gt::RY010::R/format_data.R:9561:7": {
+      "package": "gt",
+      "code": "RY010",
+      "path": "R/format_data.R",
+      "line": 9561,
+      "column": 7,
+      "severity": "warning",
+      "message": "variable `country_names_additional` is not bound in this scope"
+    },
+    "gt::RY010::R/helpers.R:747:19": {
+      "package": "gt",
+      "code": "RY010",
+      "path": "R/helpers.R",
+      "line": 747,
+      "column": 19,
+      "severity": "warning",
+      "message": "variable `conversion_factors` is not bound in this scope"
+    },
+    "gt::RY010::R/helpers.R:750:17": {
+      "package": "gt",
+      "code": "RY010",
+      "path": "R/helpers.R",
+      "line": 750,
+      "column": 17,
+      "severity": "warning",
+      "message": "variable `conversion_factors` is not bound in this scope"
+    },
+    "gt::RY010::R/helpers.R:760:7": {
+      "package": "gt",
+      "code": "RY010",
+      "path": "R/helpers.R",
+      "line": 760,
+      "column": 7,
+      "severity": "warning",
+      "message": "variable `conversion_factors` is not bound in this scope"
+    },
+    "gt::RY010::R/helpers.R:761:7": {
+      "package": "gt",
+      "code": "RY010",
+      "path": "R/helpers.R",
+      "line": 761,
+      "column": 7,
+      "severity": "warning",
+      "message": "variable `conversion_factors` is not bound in this scope"
+    },
+    "gt::RY010::R/helpers.R:762:9": {
+      "package": "gt",
+      "code": "RY010",
+      "path": "R/helpers.R",
+      "line": 762,
+      "column": 9,
+      "severity": "warning",
+      "message": "variable `conversion_factors` is not bound in this scope"
+    },
+    "gt::RY010::R/info_tables.R:1083:5": {
+      "package": "gt",
+      "code": "RY010",
+      "path": "R/info_tables.R",
+      "line": 1083,
+      "column": 5,
+      "severity": "warning",
+      "message": "variable `google_styles_tbl` is not bound in this scope"
+    },
+    "gt::RY010::R/info_tables.R:1100:5": {
+      "package": "gt",
+      "code": "RY010",
+      "path": "R/info_tables.R",
+      "line": 1100,
+      "column": 5,
+      "severity": "warning",
+      "message": "variable `google_styles_tbl` is not bound in this scope"
+    },
+    "gt::RY010::R/info_tables.R:1112:5": {
+      "package": "gt",
+      "code": "RY010",
+      "path": "R/info_tables.R",
+      "line": 1112,
+      "column": 5,
+      "severity": "warning",
+      "message": "variable `google_font_tbl` is not bound in this scope"
+    },
+    "gt::RY010::R/info_tables.R:1650:5": {
+      "package": "gt",
+      "code": "RY010",
+      "path": "R/info_tables.R",
+      "line": 1650,
+      "column": 5,
+      "severity": "warning",
+      "message": "variable `conversion_factors` is not bound in this scope"
+    },
+    "gt::RY010::R/info_tables.R:494:23": {
+      "package": "gt",
+      "code": "RY010",
+      "path": "R/info_tables.R",
+      "line": 494,
+      "column": 23,
+      "severity": "warning",
+      "message": "variable `currencies` is not bound in this scope"
+    },
+    "gt::RY010::R/info_tables.R:497:15": {
+      "package": "gt",
+      "code": "RY010",
+      "path": "R/info_tables.R",
+      "line": 497,
+      "column": 15,
+      "severity": "warning",
+      "message": "variable `currencies` is not bound in this scope"
+    },
+    "gt::RY010::R/info_tables.R:594:16": {
+      "package": "gt",
+      "code": "RY010",
+      "path": "R/info_tables.R",
+      "line": 594,
+      "column": 16,
+      "severity": "warning",
+      "message": "variable `currency_symbols` is not bound in this scope"
+    },
+    "gt::RY010::R/info_tables.R:743:29": {
+      "package": "gt",
+      "code": "RY010",
+      "path": "R/info_tables.R",
+      "line": 743,
+      "column": 29,
+      "severity": "warning",
+      "message": "variable `locales` is not bound in this scope"
+    },
+    "gt::RY010::R/info_tables.R:743:60": {
+      "package": "gt",
+      "code": "RY010",
+      "path": "R/info_tables.R",
+      "line": 743,
+      "column": 60,
+      "severity": "warning",
+      "message": "variable `locales` is not bound in this scope"
+    },
+    "gt::RY010::R/info_tables.R:746:12": {
+      "package": "gt",
+      "code": "RY010",
+      "path": "R/info_tables.R",
+      "line": 746,
+      "column": 12,
+      "severity": "warning",
+      "message": "variable `locales` is not bound in this scope"
+    },
+    "gt::RY010::R/info_tables.R:943:19": {
+      "package": "gt",
+      "code": "RY010",
+      "path": "R/info_tables.R",
+      "line": 943,
+      "column": 19,
+      "severity": "warning",
+      "message": "variable `palettes_strips` is not bound in this scope"
+    },
+    "gt::RY010::R/opts.R:121:49": {
+      "package": "gt",
+      "code": "RY010",
+      "path": "R/opts.R",
+      "line": 121,
+      "column": 49,
+      "severity": "warning",
+      "message": "variable `styles_colors_params` is not bound in this scope"
+    },
+    "gt::RY010::R/opts.R:131:30": {
+      "package": "gt",
+      "code": "RY010",
+      "path": "R/opts.R",
+      "line": 131,
+      "column": 30,
+      "severity": "warning",
+      "message": "variable `styles_colors_params` is not bound in this scope"
+    },
+    "gt::RY010::R/render_as_i_html.R:928:20": {
+      "package": "gt",
+      "code": "RY010",
+      "path": "R/render_as_i_html.R",
+      "line": 928,
+      "column": 20,
+      "severity": "warning",
+      "message": "variable `locales` is not bound in this scope"
+    },
+    "gt::RY010::R/render_as_i_html.R:928:28": {
+      "package": "gt",
+      "code": "RY010",
+      "path": "R/render_as_i_html.R",
+      "line": 928,
+      "column": 28,
+      "severity": "warning",
+      "message": "variable `locales` is not bound in this scope"
+    },
+    "gt::RY010::R/utils.R:441:17": {
+      "package": "gt",
+      "code": "RY010",
+      "path": "R/utils.R",
+      "line": 441,
+      "column": 17,
+      "severity": "warning",
+      "message": "variable `tf_words` is not bound in this scope"
+    },
+    "gt::RY010::R/utils.R:442:18": {
+      "package": "gt",
+      "code": "RY010",
+      "path": "R/utils.R",
+      "line": 442,
+      "column": 18,
+      "severity": "warning",
+      "message": "variable `tf_words` is not bound in this scope"
+    },
+    "gt::RY010::R/utils.R:471:24": {
+      "package": "gt",
+      "code": "RY010",
+      "path": "R/utils.R",
+      "line": 471,
+      "column": 24,
+      "severity": "warning",
+      "message": "variable `currency_symbols` is not bound in this scope"
+    },
+    "gt::RY010::R/utils.R:475:9": {
+      "package": "gt",
+      "code": "RY010",
+      "path": "R/utils.R",
+      "line": 475,
+      "column": 9,
+      "severity": "warning",
+      "message": "variable `currency_symbols` is not bound in this scope"
+    },
+    "gt::RY010::R/utils.R:476:9": {
+      "package": "gt",
+      "code": "RY010",
+      "path": "R/utils.R",
+      "line": 476,
+      "column": 9,
+      "severity": "warning",
+      "message": "variable `currency_symbols` is not bound in this scope"
+    },
+    "gt::RY010::R/utils.R:479:31": {
+      "package": "gt",
+      "code": "RY010",
+      "path": "R/utils.R",
+      "line": 479,
+      "column": 31,
+      "severity": "warning",
+      "message": "variable `currencies` is not bound in this scope"
+    },
+    "gt::RY010::R/utils.R:483:9": {
+      "package": "gt",
+      "code": "RY010",
+      "path": "R/utils.R",
+      "line": 483,
+      "column": 9,
+      "severity": "warning",
+      "message": "variable `currencies` is not bound in this scope"
+    },
+    "gt::RY010::R/utils.R:484:9": {
+      "package": "gt",
+      "code": "RY010",
+      "path": "R/utils.R",
+      "line": 484,
+      "column": 9,
+      "severity": "warning",
+      "message": "variable `currencies` is not bound in this scope"
+    },
+    "gt::RY010::R/utils.R:493:31": {
+      "package": "gt",
+      "code": "RY010",
+      "path": "R/utils.R",
+      "line": 493,
+      "column": 31,
+      "severity": "warning",
+      "message": "variable `currencies` is not bound in this scope"
+    },
+    "gt::RY010::R/utils.R:497:9": {
+      "package": "gt",
+      "code": "RY010",
+      "path": "R/utils.R",
+      "line": 497,
+      "column": 9,
+      "severity": "warning",
+      "message": "variable `currencies` is not bound in this scope"
+    },
+    "gt::RY010::R/utils.R:499:16": {
+      "package": "gt",
+      "code": "RY010",
+      "path": "R/utils.R",
+      "line": 499,
+      "column": 16,
+      "severity": "warning",
+      "message": "variable `currencies` is not bound in this scope"
+    },
+    "gt::RY010::R/utils.R:499:42": {
+      "package": "gt",
+      "code": "RY010",
+      "path": "R/utils.R",
+      "line": 499,
+      "column": 42,
+      "severity": "warning",
+      "message": "variable `currencies` is not bound in this scope"
+    },
+    "gt::RY010::R/utils.R:636:24": {
+      "package": "gt",
+      "code": "RY010",
+      "path": "R/utils.R",
+      "line": 636,
+      "column": 24,
+      "severity": "warning",
+      "message": "variable `currencies` is not bound in this scope"
+    },
+    "gt::RY010::R/utils.R:640:9": {
+      "package": "gt",
+      "code": "RY010",
+      "path": "R/utils.R",
+      "line": 640,
+      "column": 9,
+      "severity": "warning",
+      "message": "variable `currencies` is not bound in this scope"
+    },
+    "gt::RY010::R/utils.R:642:9": {
+      "package": "gt",
+      "code": "RY010",
+      "path": "R/utils.R",
+      "line": 642,
+      "column": 9,
+      "severity": "warning",
+      "message": "variable `currencies` is not bound in this scope"
+    },
+    "gt::RY010::R/utils.R:645:31": {
+      "package": "gt",
+      "code": "RY010",
+      "path": "R/utils.R",
+      "line": 645,
+      "column": 31,
+      "severity": "warning",
+      "message": "variable `currencies` is not bound in this scope"
+    },
+    "gt::RY010::R/utils.R:650:9": {
+      "package": "gt",
+      "code": "RY010",
+      "path": "R/utils.R",
+      "line": 650,
+      "column": 9,
+      "severity": "warning",
+      "message": "variable `currencies` is not bound in this scope"
+    },
+    "gt::RY010::R/utils.R:651:16": {
+      "package": "gt",
+      "code": "RY010",
+      "path": "R/utils.R",
+      "line": 651,
+      "column": 16,
+      "severity": "warning",
+      "message": "variable `currencies` is not bound in this scope"
+    },
+    "gt::RY010::R/utils.R:651:42": {
+      "package": "gt",
+      "code": "RY010",
+      "path": "R/utils.R",
+      "line": 651,
+      "column": 42,
+      "severity": "warning",
+      "message": "variable `currencies` is not bound in this scope"
+    },
+    "gt::RY030::tests/testthat/test-fmt.R:146:17": {
+      "package": "gt",
+      "code": "RY030",
+      "path": "tests/testthat/test-fmt.R",
+      "line": 146,
+      "column": 17,
+      "severity": "error",
+      "message": "cannot compare `function` with `character`"
+    },
+    "gt::RY030::tests/testthat/test-fmt.R:169:17": {
+      "package": "gt",
+      "code": "RY030",
+      "path": "tests/testthat/test-fmt.R",
+      "line": 169,
+      "column": 17,
+      "severity": "error",
+      "message": "cannot compare `function` with `character`"
+    },
+    "gt::RY030::tests/testthat/test-fmt.R:193:17": {
+      "package": "gt",
+      "code": "RY030",
+      "path": "tests/testthat/test-fmt.R",
+      "line": 193,
+      "column": 17,
+      "severity": "error",
+      "message": "cannot compare `function` with `character`"
+    },
+    "gt::RY030::tests/testthat/test-fmt.R:218:17": {
+      "package": "gt",
+      "code": "RY030",
+      "path": "tests/testthat/test-fmt.R",
+      "line": 218,
+      "column": 17,
+      "severity": "error",
+      "message": "cannot compare `function` with `character`"
+    },
+    "gt::RY030::tests/testthat/test-fmt_auto.R:21:19": {
+      "package": "gt",
+      "code": "RY030",
+      "path": "tests/testthat/test-fmt_auto.R",
+      "line": 21,
+      "column": 19,
+      "severity": "error",
+      "message": "cannot compare `function` with `character`"
+    },
+    "gt::RY030::tests/testthat/test-fmt_auto.R:21:41": {
+      "package": "gt",
+      "code": "RY030",
+      "path": "tests/testthat/test-fmt_auto.R",
+      "line": 21,
+      "column": 41,
+      "severity": "error",
+      "message": "cannot compare `function` with `character`"
+    },
+    "gt::RY030::tests/testthat/test-l_fmt.R:143:17": {
+      "package": "gt",
+      "code": "RY030",
+      "path": "tests/testthat/test-l_fmt.R",
+      "line": 143,
+      "column": 17,
+      "severity": "error",
+      "message": "cannot compare `function` with `character`"
+    },
+    "gt::RY030::tests/testthat/test-l_fmt.R:166:17": {
+      "package": "gt",
+      "code": "RY030",
+      "path": "tests/testthat/test-l_fmt.R",
+      "line": 166,
+      "column": 17,
+      "severity": "error",
+      "message": "cannot compare `function` with `character`"
+    },
+    "gt::RY030::tests/testthat/test-l_fmt.R:190:17": {
+      "package": "gt",
+      "code": "RY030",
+      "path": "tests/testthat/test-l_fmt.R",
+      "line": 190,
+      "column": 17,
+      "severity": "error",
+      "message": "cannot compare `function` with `character`"
+    },
+    "gt::RY030::tests/testthat/test-l_fmt.R:219:17": {
+      "package": "gt",
+      "code": "RY030",
+      "path": "tests/testthat/test-l_fmt.R",
+      "line": 219,
+      "column": 17,
+      "severity": "error",
+      "message": "cannot compare `function` with `character`"
+    },
+    "gt::RY030::tests/testthat/test-resolver.R:161:35": {
+      "package": "gt",
+      "code": "RY030",
+      "path": "tests/testthat/test-resolver.R",
+      "line": 161,
+      "column": 35,
+      "severity": "error",
+      "message": "cannot compare `function` with `double`"
+    },
+    "gt::RY030::tests/testthat/test-summary_rows.R:1610:19": {
+      "package": "gt",
+      "code": "RY030",
+      "path": "tests/testthat/test-summary_rows.R",
+      "line": 1610,
+      "column": 19,
+      "severity": "error",
+      "message": "cannot compare `function` with `character`"
+    },
+    "gt::RY030::tests/testthat/test-summary_rows.R:1610:41": {
+      "package": "gt",
+      "code": "RY030",
+      "path": "tests/testthat/test-summary_rows.R",
+      "line": 1610,
+      "column": 41,
+      "severity": "error",
+      "message": "cannot compare `function` with `character`"
+    },
+    "gt::RY030::tests/testthat/test-summary_rows.R:6:5": {
+      "package": "gt",
+      "code": "RY030",
+      "path": "tests/testthat/test-summary_rows.R",
+      "line": 6,
+      "column": 5,
+      "severity": "error",
+      "message": "cannot compare `function` with `character`"
+    },
+    "gt::RY030::tests/testthat/test-summary_rows.R:7:5": {
+      "package": "gt",
+      "code": "RY030",
+      "path": "tests/testthat/test-summary_rows.R",
+      "line": 7,
+      "column": 5,
+      "severity": "error",
+      "message": "cannot compare `function` with `character`"
+    },
+    "gt::RY030::tests/testthat/test-summary_rows.R:818:19": {
+      "package": "gt",
+      "code": "RY030",
+      "path": "tests/testthat/test-summary_rows.R",
+      "line": 818,
+      "column": 19,
+      "severity": "error",
+      "message": "cannot compare `function` with `character`"
+    },
+    "gt::RY030::tests/testthat/test-summary_rows.R:818:41": {
+      "package": "gt",
+      "code": "RY030",
+      "path": "tests/testthat/test-summary_rows.R",
+      "line": 818,
+      "column": 41,
+      "severity": "error",
+      "message": "cannot compare `function` with `character`"
+    },
+    "gt::RY030::tests/testthat/test-tab_footnote.R:660:7": {
+      "package": "gt",
+      "code": "RY030",
+      "path": "tests/testthat/test-tab_footnote.R",
+      "line": 660,
+      "column": 7,
+      "severity": "error",
+      "message": "cannot compare `function` with `character`"
+    },
+    "gt::RY030::tests/testthat/test-tab_footnote.R:661:7": {
+      "package": "gt",
+      "code": "RY030",
+      "path": "tests/testthat/test-tab_footnote.R",
+      "line": 661,
+      "column": 7,
+      "severity": "error",
+      "message": "cannot compare `function` with `character`"
+    },
+    "gt::RY030::tests/testthat/test-tab_style_body.R:6:19": {
+      "package": "gt",
+      "code": "RY030",
+      "path": "tests/testthat/test-tab_style_body.R",
+      "line": 6,
+      "column": 19,
+      "severity": "error",
+      "message": "cannot compare `function` with `character`"
+    },
+    "gt::RY030::tests/testthat/test-tab_style_body.R:6:41": {
+      "package": "gt",
+      "code": "RY030",
+      "path": "tests/testthat/test-tab_style_body.R",
+      "line": 6,
+      "column": 41,
+      "severity": "error",
+      "message": "cannot compare `function` with `character`"
+    },
+    "gt::RY032::R/opts.R:117:9": {
+      "package": "gt",
+      "code": "RY032",
+      "path": "R/opts.R",
+      "line": 117,
+      "column": 9,
+      "severity": "warning",
+      "message": "`&&` operand depends on a parameter whose length is not known to be 1; current R errors for vectors",
+      "fix": {
+        "start": 3448,
+        "end": 3450,
+        "replacement": "&"
+      }
+    },
+    "gt::RY032::R/opts.R:121:9": {
+      "package": "gt",
+      "code": "RY032",
+      "path": "R/opts.R",
+      "line": 121,
+      "column": 9,
+      "severity": "warning",
+      "message": "`&&` operand depends on a parameter whose length is not known to be 1; current R errors for vectors",
+      "fix": {
+        "start": 3583,
+        "end": 3585,
+        "replacement": "&"
+      }
+    },
+    "gt::RY032::R/render_as_i_html.R:922:7": {
+      "package": "gt",
+      "code": "RY032",
+      "path": "R/render_as_i_html.R",
+      "line": 922,
+      "column": 7,
+      "severity": "warning",
+      "message": "`||` operand depends on a parameter whose length is not known to be 1; current R errors for vectors",
+      "fix": {
+        "start": 28717,
+        "end": 28719,
+        "replacement": "|"
+      }
+    },
+    "gt::RY032::R/utils_render_latex.R:44:7": {
+      "package": "gt",
+      "code": "RY032",
+      "path": "R/utils_render_latex.R",
+      "line": 44,
+      "column": 7,
+      "severity": "warning",
+      "message": "`&&` operand depends on a parameter whose length is not known to be 1; current R errors for vectors",
+      "fix": {
+        "start": 1073,
+        "end": 1075,
+        "replacement": "&"
+      }
+    },
+    "gt::RY032::R/utils_render_rtf.R:795:7": {
+      "package": "gt",
+      "code": "RY032",
+      "path": "R/utils_render_rtf.R",
+      "line": 795,
+      "column": 7,
+      "severity": "warning",
+      "message": "`&&` operand depends on a parameter whose length is not known to be 1; current R errors for vectors",
+      "fix": {
+        "start": 19659,
+        "end": 19661,
+        "replacement": "&"
+      }
+    },
+    "gt::RY032::R/utils_render_xml.R:744:7": {
+      "package": "gt",
+      "code": "RY032",
+      "path": "R/utils_render_xml.R",
+      "line": 744,
+      "column": 7,
+      "severity": "warning",
+      "message": "`&&` operand depends on a parameter whose length is not known to be 1; current R errors for vectors",
+      "fix": {
+        "start": 14805,
+        "end": 14807,
+        "replacement": "&"
+      }
+    },
+    "gt::RY061::R/utils_render_latex.R:2149:47": {
+      "package": "gt",
+      "code": "RY061",
+      "path": "R/utils_render_latex.R",
+      "line": 2149,
+      "column": 47,
+      "severity": "error",
+      "message": "$ operator is invalid for atomic vectors of mode `character`"
+    },
+    "gt::RY061::R/utils_render_latex.R:2149:57": {
+      "package": "gt",
+      "code": "RY061",
+      "path": "R/utils_render_latex.R",
+      "line": 2149,
+      "column": 57,
+      "severity": "error",
+      "message": "$ operator is invalid for atomic vectors of mode `character`"
+    },
+    "gt::RY092::R/tab_options.R:1054:26": {
+      "package": "gt",
+      "code": "RY092",
+      "path": "R/tab_options.R",
+      "line": 1054,
+      "column": 26,
+      "severity": "error",
+      "message": "argument `option` to `check_string` is `logical<len=1>`, expected character"
+    },
+    "gt::RY098::R/cols_align.R:198:17": {
+      "package": "gt",
+      "code": "RY098",
+      "path": "R/cols_align.R",
+      "line": 198,
+      "column": 17,
+      "severity": "warning",
+      "message": "parameter `col_classes` has a self-referential default that recurses when forced"
+    },
+    "httr::RY032::R/content-parse.r:57:7": {
+      "package": "httr",
+      "code": "RY032",
+      "path": "R/content-parse.r",
+      "line": 57,
+      "column": 7,
+      "severity": "warning",
+      "message": "`||` operand depends on a parameter whose length is not known to be 1; current R errors for vectors",
+      "fix": {
+        "start": 1335,
+        "end": 1337,
+        "replacement": "|"
+      }
+    },
+    "httr::RY070::R/callback.R:100:5": {
+      "package": "httr",
+      "code": "RY070",
+      "path": "R/callback.R",
+      "line": 100,
+      "column": 5,
+      "severity": "error",
+      "message": "`callback` is `NULL`, not a function; cannot call it"
+    },
+    "infer::RY040::R/get_p_value.R:213:21": {
+      "package": "infer",
+      "code": "RY040",
+      "path": "R/get_p_value.R",
+      "line": 213,
+      "column": 21,
+      "severity": "error",
+      "message": "cannot apply arithmetic op to `double` and `character`"
+    },
+    "keras3::RY010::R/model-training.R:596:35": {
+      "package": "keras3",
+      "code": "RY010",
+      "path": "R/model-training.R",
+      "line": 596,
+      "column": 35,
+      "severity": "warning",
+      "message": "variable `dtype` is not bound in this scope"
+    },
+    "keras3::RY010::R/model-training.R:605:40": {
+      "package": "keras3",
+      "code": "RY010",
+      "path": "R/model-training.R",
+      "line": 605,
+      "column": 40,
+      "severity": "warning",
+      "message": "variable `dtype` is not bound in this scope"
+    },
+    "keras3::RY010::R/model-training.R:606:39": {
+      "package": "keras3",
+      "code": "RY010",
+      "path": "R/model-training.R",
+      "line": 606,
+      "column": 39,
+      "severity": "warning",
+      "message": "variable `dtype` is not bound in this scope"
+    },
+    "keras3::RY010::R/op-subset.R:110:52": {
+      "package": "keras3",
+      "code": "RY010",
+      "path": "R/op-subset.R",
+      "line": 110,
+      "column": 52,
+      "severity": "warning",
+      "message": "variable `x_rank` is not bound in this scope"
+    },
+    "keras3::RY010::R/op-subset.R:123:55": {
+      "package": "keras3",
+      "code": "RY010",
+      "path": "R/op-subset.R",
+      "line": 123,
+      "column": 55,
+      "severity": "warning",
+      "message": "variable `x_rank` is not bound in this scope"
+    },
+    "keras3::RY010::R/op-subset.R:199:30": {
+      "package": "keras3",
+      "code": "RY010",
+      "path": "R/op-subset.R",
+      "line": 199,
+      "column": 30,
+      "severity": "warning",
+      "message": "variable `x_shape` is not bound in this scope"
+    },
+    "keras3::RY010::R/op-subset.R:209:43": {
+      "package": "keras3",
+      "code": "RY010",
+      "path": "R/op-subset.R",
+      "line": 209,
+      "column": 43,
+      "severity": "warning",
+      "message": "variable `x_shape` is not bound in this scope"
+    },
+    "keras3::RY010::R/op-subset.R:211:44": {
+      "package": "keras3",
+      "code": "RY010",
+      "path": "R/op-subset.R",
+      "line": 211,
+      "column": 44,
+      "severity": "warning",
+      "message": "variable `x_shape` is not bound in this scope"
+    },
+    "keras3::RY010::R/op-subset.R:81:39": {
+      "package": "keras3",
+      "code": "RY010",
+      "path": "R/op-subset.R",
+      "line": 81,
+      "column": 39,
+      "severity": "warning",
+      "message": "variable `x_rank` is not bound in this scope"
+    },
+    "keras3::RY010::R/op-subset.R:94:42": {
+      "package": "keras3",
+      "code": "RY010",
+      "path": "R/op-subset.R",
+      "line": 94,
+      "column": 42,
+      "severity": "warning",
+      "message": "variable `x_rank` is not bound in this scope"
+    },
+    "keras3::RY010::R/py-classes.R:220:5": {
+      "package": "keras3",
+      "code": "RY010",
+      "path": "R/py-classes.R",
+      "line": 220,
+      "column": 5,
+      "severity": "warning",
+      "message": "variable `class_privates` is not bound in this scope"
+    },
+    "keras3::RY010::R/py-classes.R:245:5": {
+      "package": "keras3",
+      "code": "RY010",
+      "path": "R/py-classes.R",
+      "line": 245,
+      "column": 5,
+      "severity": "warning",
+      "message": "variable `class_privates` is not bound in this scope"
+    },
+    "keras3::RY010::R/py-classes.R:249:5": {
+      "package": "keras3",
+      "code": "RY010",
+      "path": "R/py-classes.R",
+      "line": 249,
+      "column": 5,
+      "severity": "warning",
+      "message": "variable `class_privates` is not bound in this scope"
+    },
+    "keras3::RY032::R/install.R:315:7": {
+      "package": "keras3",
+      "code": "RY032",
+      "path": "R/install.R",
+      "line": 315,
+      "column": 7,
+      "severity": "warning",
+      "message": "`||` operand depends on a parameter whose length is not known to be 1; current R errors for vectors",
+      "fix": {
+        "start": 9589,
+        "end": 9591,
+        "replacement": "|"
+      }
+    },
+    "leaflet::RY032::R/colors.R:326:7": {
+      "package": "leaflet",
+      "code": "RY032",
+      "path": "R/colors.R",
+      "line": 326,
+      "column": 7,
+      "severity": "warning",
+      "message": "`&&` operand depends on a parameter whose length is not known to be 1; current R errors for vectors",
+      "fix": {
+        "start": 12378,
+        "end": 12380,
+        "replacement": "&"
+      }
+    },
+    "leaflet::RY032::R/colors.R:333:14": {
+      "package": "leaflet",
+      "code": "RY032",
+      "path": "R/colors.R",
+      "line": 333,
+      "column": 14,
+      "severity": "warning",
+      "message": "`&&` operand depends on a parameter whose length is not known to be 1; current R errors for vectors",
+      "fix": {
+        "start": 12663,
+        "end": 12665,
+        "replacement": "&"
+      }
+    },
+    "leaflet::RY032::R/layers.R:349:13": {
+      "package": "leaflet",
+      "code": "RY032",
+      "path": "R/layers.R",
+      "line": 349,
+      "column": 13,
+      "severity": "warning",
+      "message": "`&&` operand depends on a parameter whose length is not known to be 1; current R errors for vectors",
+      "fix": {
+        "start": 12330,
+        "end": 12332,
+        "replacement": "&"
+      }
+    },
+    "learnr::RY010::R/question_text.R:122:7": {
+      "package": "learnr",
+      "code": "RY010",
+      "path": "R/question_text.R",
+      "line": 122,
+      "column": 7,
+      "severity": "warning",
+      "message": "variable `textInput` is not bound in this scope"
+    },
+    "learnr::RY105::R/run.R:290:7": {
+      "package": "learnr",
+      "code": "RY105",
+      "path": "R/run.R",
+      "line": 290,
+      "column": 7,
+      "severity": "warning",
+      "message": "`rmds` is a length-1 character, so `length(...)` is 1 here and this zero-length guard is always FALSE"
+    },
+    "lintr::RY000::inst/example/bad.R:11:1": {
+      "package": "lintr",
+      "code": "RY000",
+      "path": "inst/example/bad.R",
+      "line": 11,
+      "column": 1,
+      "severity": "error",
+      "message": "syntax error: unparseable region (recovered tree may be unreliable)"
+    },
+    "lintr::RY000::tests/testthat/dummy_packages/RConfigInvalid/lintr_test_config.R:3:1": {
+      "package": "lintr",
+      "code": "RY000",
+      "path": "tests/testthat/dummy_packages/RConfigInvalid/lintr_test_config.R",
+      "line": 3,
+      "column": 1,
+      "severity": "error",
+      "message": "syntax error: unparseable region (recovered tree may be unreliable)"
+    },
+    "lintr::RY010::tests/testthat/dummy_packages/RConfig/tests/testthat.R:5:18": {
+      "package": "lintr",
+      "code": "RY010",
+      "path": "tests/testthat/dummy_packages/RConfig/tests/testthat.R",
+      "line": 5,
+      "column": 18,
+      "severity": "warning",
+      "message": "variable `x` is not bound in this scope"
+    },
+    "lintr::RY010::tests/testthat/dummy_packages/RConfigInvalid/lintr_test_config.R:3:1": {
+      "package": "lintr",
+      "code": "RY010",
+      "path": "tests/testthat/dummy_packages/RConfigInvalid/lintr_test_config.R",
+      "line": 3,
+      "column": 1,
+      "severity": "warning",
+      "message": "variable `` is not bound in this scope"
+    },
+    "lintr::RY032::R/get_source_expressions.R:583:7": {
+      "package": "lintr",
+      "code": "RY032",
+      "path": "R/get_source_expressions.R",
+      "line": 583,
+      "column": 7,
+      "severity": "warning",
+      "message": "`||` operand depends on a parameter whose length is not known to be 1; current R errors for vectors",
+      "fix": {
+        "start": 20210,
+        "end": 20212,
+        "replacement": "|"
+      }
+    },
+    "lintr::RY032::R/utils.R:183:7": {
+      "package": "lintr",
+      "code": "RY032",
+      "path": "R/utils.R",
+      "line": 183,
+      "column": 7,
+      "severity": "warning",
+      "message": "`||` operand depends on a parameter whose length is not known to be 1; current R errors for vectors",
+      "fix": {
+        "start": 5183,
+        "end": 5185,
+        "replacement": "|"
+      }
+    },
+    "lintr::RY034::tests/testthat/dummy_packages/package/R/default_linter_testcode.R:25:73": {
+      "package": "lintr",
+      "code": "RY034",
+      "path": "tests/testthat/dummy_packages/package/R/default_linter_testcode.R",
+      "line": 25,
+      "column": 73,
+      "severity": "warning",
+      "message": "comparison with `NA` always produces `NA`; use `is.na()` instead",
+      "fix": {
+        "start": 502,
+        "end": 509,
+        "replacement": "is.na(x)"
+      }
+    },
+    "lintr::RY034::tests/testthat/dummy_packages/package/data-raw/default_linter_testcode.R:25:73": {
+      "package": "lintr",
+      "code": "RY034",
+      "path": "tests/testthat/dummy_packages/package/data-raw/default_linter_testcode.R",
+      "line": 25,
+      "column": 73,
+      "severity": "warning",
+      "message": "comparison with `NA` always produces `NA`; use `is.na()` instead",
+      "fix": {
+        "start": 502,
+        "end": 509,
+        "replacement": "is.na(x)"
+      }
+    },
+    "lintr::RY034::tests/testthat/dummy_packages/package/inst/data-raw/default_linter_testcode.R:25:73": {
+      "package": "lintr",
+      "code": "RY034",
+      "path": "tests/testthat/dummy_packages/package/inst/data-raw/default_linter_testcode.R",
+      "line": 25,
+      "column": 73,
+      "severity": "warning",
+      "message": "comparison with `NA` always produces `NA`; use `is.na()` instead",
+      "fix": {
+        "start": 502,
+        "end": 509,
+        "replacement": "is.na(x)"
+      }
+    },
+    "lintr::RY060::tests/testthat/test-linter_tags.R:172:24": {
+      "package": "lintr",
+      "code": "RY060",
+      "path": "tests/testthat/test-linter_tags.R",
+      "line": 172,
+      "column": 24,
+      "severity": "error",
+      "message": "column `tag` not found in data frame schema; available columns: filename, line_number, column_number, type, message, ..."
+    },
+    "lintr::RY060::tests/testthat/test-linter_tags.R:178:15": {
+      "package": "lintr",
+      "code": "RY060",
+      "path": "tests/testthat/test-linter_tags.R",
+      "line": 178,
+      "column": 15,
+      "severity": "error",
+      "message": "column `tag` not found in data frame schema; available columns: filename, line_number, column_number, type, message, ..."
+    },
+    "lubridate::RY010::R/ops-compare.r:20:64": {
+      "package": "lubridate",
+      "code": "RY010",
+      "path": "R/ops-compare.r",
+      "line": 20,
+      "column": 64,
+      "severity": "warning",
+      "message": "variable `.Generic` is not bound in this scope"
+    },
+    "lubridate::RY010::R/ops-compare.r:55:14": {
+      "package": "lubridate",
+      "code": "RY010",
+      "path": "R/ops-compare.r",
+      "line": 55,
+      "column": 14,
+      "severity": "warning",
+      "message": "variable `.Generic` is not bound in this scope"
+    },
+    "lubridate::RY010::R/vctrs.R:107:3": {
+      "package": "lubridate",
+      "code": "RY010",
+      "path": "R/vctrs.R",
+      "line": 107,
+      "column": 3,
+      "severity": "warning",
+      "message": "variable `lubridate_shared_empty_duration` is not bound in this scope"
+    },
+    "lubridate::RY010::R/vctrs.R:112:3": {
+      "package": "lubridate",
+      "code": "RY010",
+      "path": "R/vctrs.R",
+      "line": 112,
+      "column": 3,
+      "severity": "warning",
+      "message": "variable `lubridate_shared_empty_duration` is not bound in this scope"
+    },
+    "lubridate::RY010::R/vctrs.R:117:3": {
+      "package": "lubridate",
+      "code": "RY010",
+      "path": "R/vctrs.R",
+      "line": 117,
+      "column": 3,
+      "severity": "warning",
+      "message": "variable `lubridate_shared_empty_duration` is not bound in this scope"
+    },
+    "lubridate::RY010::R/vctrs.R:64:3": {
+      "package": "lubridate",
+      "code": "RY010",
+      "path": "R/vctrs.R",
+      "line": 64,
+      "column": 3,
+      "severity": "warning",
+      "message": "variable `lubridate_shared_empty_period` is not bound in this scope"
+    },
+    "pak::RY001::R/json.R:100:13": {
+      "package": "pak",
+      "code": "RY001",
+      "path": "R/json.R",
+      "line": 100,
+      "column": 13,
+      "severity": "warning",
+      "message": "`if` condition is `logical<len=0>`, expected length-1 logical"
+    },
+    "pak::RY001::R/json.R:108:13": {
+      "package": "pak",
+      "code": "RY001",
+      "path": "R/json.R",
+      "line": 108,
+      "column": 13,
+      "severity": "warning",
+      "message": "`if` condition is `logical<len=0>`, expected length-1 logical"
+    },
+    "pak::RY001::R/json.R:118:13": {
+      "package": "pak",
+      "code": "RY001",
+      "path": "R/json.R",
+      "line": 118,
+      "column": 13,
+      "severity": "warning",
+      "message": "`if` condition is `logical<len=0>`, expected length-1 logical"
+    },
+    "pak::RY001::R/json.R:120:20": {
+      "package": "pak",
+      "code": "RY001",
+      "path": "R/json.R",
+      "line": 120,
+      "column": 20,
+      "severity": "warning",
+      "message": "`if` condition is `logical<len=0>`, expected length-1 logical"
+    },
+    "pak::RY001::R/json.R:135:14": {
+      "package": "pak",
+      "code": "RY001",
+      "path": "R/json.R",
+      "line": 135,
+      "column": 14,
+      "severity": "warning",
+      "message": "loop condition is `logical<len=0>`, expected length-1 logical"
+    },
+    "pak::RY001::R/json.R:141:13": {
+      "package": "pak",
+      "code": "RY001",
+      "path": "R/json.R",
+      "line": 141,
+      "column": 13,
+      "severity": "warning",
+      "message": "`if` condition is `logical<len=0>`, expected length-1 logical"
+    },
+    "pak::RY001::R/json.R:143:20": {
+      "package": "pak",
+      "code": "RY001",
+      "path": "R/json.R",
+      "line": 143,
+      "column": 20,
+      "severity": "warning",
+      "message": "`if` condition is `logical<len=0>`, expected length-1 logical"
+    },
+    "pak::RY001::R/json.R:81:11": {
+      "package": "pak",
+      "code": "RY001",
+      "path": "R/json.R",
+      "line": 81,
+      "column": 11,
+      "severity": "warning",
+      "message": "`if` condition is `logical<len=0>`, expected length-1 logical"
+    },
+    "pak::RY001::R/json.R:83:18": {
+      "package": "pak",
+      "code": "RY001",
+      "path": "R/json.R",
+      "line": 83,
+      "column": 18,
+      "severity": "warning",
+      "message": "`if` condition is `logical<len=0>`, expected length-1 logical"
+    },
+    "pak::RY001::R/json.R:98:14": {
+      "package": "pak",
+      "code": "RY001",
+      "path": "R/json.R",
+      "line": 98,
+      "column": 14,
+      "severity": "warning",
+      "message": "loop condition is `logical<len=0>`, expected length-1 logical"
+    },
+    "pak::RY010::R/compat-vctrs.R:231:16": {
+      "package": "pak",
+      "code": "RY010",
+      "path": "R/compat-vctrs.R",
+      "line": 231,
+      "column": 16,
+      "severity": "warning",
+      "message": "variable `vec_cast` is not bound in this scope"
+    },
+    "pak::RY010::R/compat-vctrs.R:382:21": {
+      "package": "pak",
+      "code": "RY010",
+      "path": "R/compat-vctrs.R",
+      "line": 382,
+      "column": 21,
+      "severity": "warning",
+      "message": "variable `vec_ptype` is not bound in this scope"
+    },
+    "pak::RY010::R/compat-vctrs.R:383:21": {
+      "package": "pak",
+      "code": "RY010",
+      "path": "R/compat-vctrs.R",
+      "line": 383,
+      "column": 21,
+      "severity": "warning",
+      "message": "variable `vec_ptype2` is not bound in this scope"
+    },
+    "pak::RY010::R/config.R:288:46": {
+      "package": "pak",
+      "code": "RY010",
+      "path": "R/config.R",
+      "line": 288,
+      "column": 46,
+      "severity": "warning",
+      "message": "variable `print_config` is not bound in this scope"
+    },
+    "pak::RY010::R/config.R:289:43": {
+      "package": "pak",
+      "code": "RY010",
+      "path": "R/config.R",
+      "line": 289,
+      "column": 43,
+      "severity": "warning",
+      "message": "variable `print_config` is not bound in this scope"
+    },
+    "pak::RY010::R/errors.R:1068:34": {
+      "package": "pak",
+      "code": "RY010",
+      "path": "R/errors.R",
+      "line": 1068,
+      "column": 34,
+      "severity": "warning",
+      "message": "variable `format_srcref_plain` is not bound in this scope"
+    },
+    "pak::RY010::R/errors.R:1075:27": {
+      "package": "pak",
+      "code": "RY010",
+      "path": "R/errors.R",
+      "line": 1075,
+      "column": 27,
+      "severity": "warning",
+      "message": "variable `format_trace_call_plain` is not bound in this scope"
+    },
+    "pak::RY010::R/errors.R:541:40": {
+      "package": "pak",
+      "code": "RY010",
+      "path": "R/errors.R",
+      "line": 541,
+      "column": 40,
+      "severity": "warning",
+      "message": "variable `invisible_frames` is not bound in this scope"
+    },
+    "pak::RY010::R/errors.R:543:20": {
+      "package": "pak",
+      "code": "RY010",
+      "path": "R/errors.R",
+      "line": 543,
+      "column": 20,
+      "severity": "warning",
+      "message": "variable `invisible_frames` is not bound in this scope"
+    },
+    "pak::RY010::R/errors.R:620:30": {
+      "package": "pak",
+      "code": "RY010",
+      "path": "R/errors.R",
+      "line": 620,
+      "column": 30,
+      "severity": "warning",
+      "message": "variable `err_env` is not bound in this scope"
+    },
+    "pak::RY010::R/errors.R:664:24": {
+      "package": "pak",
+      "code": "RY010",
+      "path": "R/errors.R",
+      "line": 664,
+      "column": 24,
+      "severity": "warning",
+      "message": "variable `err_env` is not bound in this scope"
+    },
+    "pak::RY010::R/pak-sitrep-data.R:27:20": {
+      "package": "pak",
+      "code": "RY010",
+      "path": "R/pak-sitrep-data.R",
+      "line": 27,
+      "column": 20,
+      "severity": "warning",
+      "message": "variable `target_platform` is not bound in this scope"
+    },
+    "pak::RY010::R/pak-sitrep-data.R:28:7": {
+      "package": "pak",
+      "code": "RY010",
+      "path": "R/pak-sitrep-data.R",
+      "line": 28,
+      "column": 7,
+      "severity": "warning",
+      "message": "variable `target_platform` is not bound in this scope"
+    },
+    "pak::RY010::R/pak-sitrep-data.R:32:26": {
+      "package": "pak",
+      "code": "RY010",
+      "path": "R/pak-sitrep-data.R",
+      "line": 32,
+      "column": 26,
+      "severity": "warning",
+      "message": "variable `build_platform` is not bound in this scope"
+    },
+    "pak::RY010::R/pak-sitrep-data.R:33:7": {
+      "package": "pak",
+      "code": "RY010",
+      "path": "R/pak-sitrep-data.R",
+      "line": 33,
+      "column": 7,
+      "severity": "warning",
+      "message": "variable `build_platform` is not bound in this scope"
+    },
+    "pak::RY010::R/pak-sitrep-data.R:37:26": {
+      "package": "pak",
+      "code": "RY010",
+      "path": "R/pak-sitrep-data.R",
+      "line": 37,
+      "column": 26,
+      "severity": "warning",
+      "message": "variable `build_platform` is not bound in this scope"
+    },
+    "pak::RY010::R/pak-sitrep-data.R:38:27": {
+      "package": "pak",
+      "code": "RY010",
+      "path": "R/pak-sitrep-data.R",
+      "line": 38,
+      "column": 27,
+      "severity": "warning",
+      "message": "variable `target_platform` is not bound in this scope"
+    },
+    "pak::RY010::R/sizes.R:5:19": {
+      "package": "pak",
+      "code": "RY010",
+      "path": "R/sizes.R",
+      "line": 5,
+      "column": 19,
+      "severity": "warning",
+      "message": "variable `pretty_bytes_default` is not bound in this scope"
+    },
+    "pak::RY010::R/sizes.R:6:17": {
+      "package": "pak",
+      "code": "RY010",
+      "path": "R/sizes.R",
+      "line": 6,
+      "column": 17,
+      "severity": "warning",
+      "message": "variable `pretty_bytes_nopad` is not bound in this scope"
+    },
+    "pak::RY010::R/sizes.R:7:13": {
+      "package": "pak",
+      "code": "RY010",
+      "path": "R/sizes.R",
+      "line": 7,
+      "column": 13,
+      "severity": "warning",
+      "message": "variable `pretty_bytes_6` is not bound in this scope"
+    },
+    "pak::RY093::R/deps-explain.R:30:20": {
+      "package": "pak",
+      "code": "RY093",
+      "path": "R/deps-explain.R",
+      "line": 30,
+      "column": 20,
+      "severity": "warning",
+      "message": "comparison is inside `length()`; compare `length(x)` instead",
+      "fix": {
+        "start": 1073,
+        "end": 1089,
+        "replacement": "length(pkg) == 1"
+      }
+    },
+    "pak::RY093::R/package.R:176:20": {
+      "package": "pak",
+      "code": "RY093",
+      "path": "R/package.R",
+      "line": 176,
+      "column": 20,
+      "severity": "warning",
+      "message": "comparison is inside `length()`; compare `length(x)` instead",
+      "fix": {
+        "start": 5510,
+        "end": 5526,
+        "replacement": "length(pkg) == 1"
+      }
+    },
+    "pak::RY093::R/package.R:293:20": {
+      "package": "pak",
+      "code": "RY093",
+      "path": "R/package.R",
+      "line": 293,
+      "column": 20,
+      "severity": "warning",
+      "message": "comparison is inside `length()`; compare `length(x)` instead",
+      "fix": {
+        "start": 8526,
+        "end": 8542,
+        "replacement": "length(pkg) == 1"
+      }
+    },
+    "pak::RY102::R/pak-sitrep-data.R:41:5": {
+      "package": "pak",
+      "code": "RY102",
+      "path": "R/pak-sitrep-data.R",
+      "line": 41,
+      "column": 5,
+      "severity": "warning",
+      "message": "`<-` inside `list()` assigns `github-ref` and leaves the element unnamed; write `\"github-ref\" = ...` to name it",
+      "fix": {
+        "start": 1212,
+        "end": 1257,
+        "replacement": "\"github-ref\" = Sys.getenv(\"GITHUB_REF\", \"-\")"
+      }
+    },
+    "pak::RY105::R/confirmation.R:42:14": {
+      "package": "pak",
+      "code": "RY105",
+      "path": "R/confirmation.R",
+      "line": 42,
+      "column": 14,
+      "severity": "warning",
+      "message": "`u_dl` is a length-1 double, so `length(...)` is 1 here and this zero-length guard is always TRUE"
+    },
+    "parsnip::RY030::tests/testthat/test-predict_formats.R:173:58": {
+      "package": "parsnip",
+      "code": "RY030",
+      "path": "tests/testthat/test-predict_formats.R",
+      "line": 173,
+      "column": 58,
+      "severity": "error",
+      "message": "cannot compare `function` with `character`"
+    },
+    "parsnip::RY030::tests/testthat/test-predict_formats.R:181:52": {
+      "package": "parsnip",
+      "code": "RY030",
+      "path": "tests/testthat/test-predict_formats.R",
+      "line": 181,
+      "column": 52,
+      "severity": "error",
+      "message": "cannot compare `function` with `character`"
+    },
+    "pkgdown::RY010::R/config.R:171:7": {
+      "package": "pkgdown",
+      "code": "RY010",
+      "path": "R/config.R",
+      "line": 171,
+      "column": 7,
+      "severity": "warning",
+      "message": "variable `ffi_standalone_check_number_1.0.7` is not bound in this scope"
+    },
+    "pkgdown::RY061::R/package.R:18:29": {
+      "package": "pkgdown",
+      "code": "RY061",
+      "path": "R/package.R",
+      "line": 18,
+      "column": 29,
+      "severity": "error",
+      "message": "$ operator is invalid for atomic vectors of mode `character`"
+    },
+    "pkgdown::RY061::R/package.R:18:5": {
+      "package": "pkgdown",
+      "code": "RY061",
+      "path": "R/package.R",
+      "line": 18,
+      "column": 5,
+      "severity": "error",
+      "message": "$ operator is invalid for atomic vectors of mode `character`"
+    },
+    "pkgdown::RY070::R/templates.R:57:5": {
+      "package": "pkgdown",
+      "code": "RY070",
+      "path": "R/templates.R",
+      "line": 57,
+      "column": 5,
+      "severity": "error",
+      "message": "`path` is `NULL`, not a function; cannot call it"
+    },
+    "pkgdown::RY070::tests/testthat/helper.R:24:15": {
+      "package": "pkgdown",
+      "code": "RY070",
+      "path": "tests/testthat/helper.R",
+      "line": 24,
+      "column": 15,
+      "severity": "error",
+      "message": "`path` is `union`, not a function; cannot call it"
+    },
+    "pkgdown::RY070::tests/testthat/helper.R:25:14": {
+      "package": "pkgdown",
+      "code": "RY070",
+      "path": "tests/testthat/helper.R",
+      "line": 25,
+      "column": 14,
+      "severity": "error",
+      "message": "`path` is `union`, not a function; cannot call it"
+    },
+    "pkgdown::RY070::tests/testthat/helper.R:26:15": {
+      "package": "pkgdown",
+      "code": "RY070",
+      "path": "tests/testthat/helper.R",
+      "line": 26,
+      "column": 15,
+      "severity": "error",
+      "message": "`path` is `union`, not a function; cannot call it"
+    },
+    "pkgdown::RY091::R/topics.R:271:16": {
+      "package": "pkgdown",
+      "code": "RY091",
+      "path": "R/topics.R",
+      "line": 271,
+      "column": 16,
+      "severity": "warning",
+      "message": "missing required argument `call` in call to `error_call`"
+    },
+    "pkgdown::RY105::R/render.R:219:7": {
+      "package": "pkgdown",
+      "code": "RY105",
+      "path": "R/render.R",
+      "line": 219,
+      "column": 7,
+      "severity": "warning",
+      "message": "`template` is a length-1 character, so `length(...)` is 1 here and this zero-length guard is always FALSE"
+    },
+    "plumber::RY032::R/plumber.R:1360:7": {
+      "package": "plumber",
+      "code": "RY032",
+      "path": "R/plumber.R",
+      "line": 1360,
+      "column": 7,
+      "severity": "warning",
+      "message": "`||` operand depends on a parameter whose length is not known to be 1; current R errors for vectors",
+      "fix": {
+        "start": 49164,
+        "end": 49166,
+        "replacement": "|"
+      }
+    },
+    "plumber::RY033::R/plumber.R:474:82": {
+      "package": "plumber",
+      "code": "RY033",
+      "path": "R/plumber.R",
+      "line": 474,
+      "column": 82,
+      "severity": "warning",
+      "message": "comparing `character` with `double`; R coerces the numeric value to character and compares lexicographically, which is rarely intended"
+    },
+    "purrr::RY032::R/deprec-prepend.R:34:7": {
+      "package": "purrr",
+      "code": "RY032",
+      "path": "R/deprec-prepend.R",
+      "line": 34,
+      "column": 7,
+      "severity": "warning",
+      "message": "`||` operand depends on a parameter whose length is not known to be 1; current R errors for vectors",
+      "fix": {
+        "start": 1101,
+        "end": 1103,
+        "replacement": "|"
+      }
+    },
+    "purrr::RY080::tests/testthat/test-map.R:82:20": {
+      "package": "purrr",
+      "code": "RY080",
+      "path": "tests/testthat/test-map.R",
+      "line": 82,
+      "column": 20,
+      "severity": "warning",
+      "message": "`map_chr` expects `character` returns but the callback returns `logical`; R will coerce silently"
+    },
+    "purrr::RY080::tests/testthat/test-parallel.R:120:20": {
+      "package": "purrr",
+      "code": "RY080",
+      "path": "tests/testthat/test-parallel.R",
+      "line": 120,
+      "column": 20,
+      "severity": "warning",
+      "message": "`map_chr` expects `character` returns but the callback returns `logical`; R will coerce silently"
+    },
+    "recipes::RY033::tests/testthat/test-skipping.R:43:28": {
+      "package": "recipes",
+      "code": "RY033",
+      "path": "tests/testthat/test-skipping.R",
+      "line": 43,
+      "column": 28,
+      "severity": "warning",
+      "message": "comparing `integer` with `character`; R coerces the numeric value to character and compares lexicographically, which is rarely intended"
+    },
+    "recipes::RY033::tests/testthat/test-skipping.R:44:28": {
+      "package": "recipes",
+      "code": "RY033",
+      "path": "tests/testthat/test-skipping.R",
+      "line": 44,
+      "column": 28,
+      "severity": "warning",
+      "message": "comparing `integer` with `character`; R coerces the numeric value to character and compares lexicographically, which is rarely intended"
+    },
+    "recipes::RY033::tests/testthat/test-skipping.R:45:28": {
+      "package": "recipes",
+      "code": "RY033",
+      "path": "tests/testthat/test-skipping.R",
+      "line": 45,
+      "column": 28,
+      "severity": "warning",
+      "message": "comparing `integer` with `character`; R coerces the numeric value to character and compares lexicographically, which is rarely intended"
+    },
+    "recipes::RY033::tests/testthat/test-skipping.R:46:28": {
+      "package": "recipes",
+      "code": "RY033",
+      "path": "tests/testthat/test-skipping.R",
+      "line": 46,
+      "column": 28,
+      "severity": "warning",
+      "message": "comparing `integer` with `character`; R coerces the numeric value to character and compares lexicographically, which is rarely intended"
+    },
+    "recipes::RY033::tests/testthat/test-skipping.R:47:28": {
+      "package": "recipes",
+      "code": "RY033",
+      "path": "tests/testthat/test-skipping.R",
+      "line": 47,
+      "column": 28,
+      "severity": "warning",
+      "message": "comparing `integer` with `character`; R coerces the numeric value to character and compares lexicographically, which is rarely intended"
+    },
+    "recipes::RY033::tests/testthat/test-skipping.R:48:28": {
+      "package": "recipes",
+      "code": "RY033",
+      "path": "tests/testthat/test-skipping.R",
+      "line": 48,
+      "column": 28,
+      "severity": "warning",
+      "message": "comparing `integer` with `character`; R coerces the numeric value to character and compares lexicographically, which is rarely intended"
+    },
+    "recipes::RY033::tests/testthat/test-skipping.R:49:28": {
+      "package": "recipes",
+      "code": "RY033",
+      "path": "tests/testthat/test-skipping.R",
+      "line": 49,
+      "column": 28,
+      "severity": "warning",
+      "message": "comparing `integer` with `character`; R coerces the numeric value to character and compares lexicographically, which is rarely intended"
+    },
+    "recipes::RY033::tests/testthat/test-skipping.R:50:28": {
+      "package": "recipes",
+      "code": "RY033",
+      "path": "tests/testthat/test-skipping.R",
+      "line": 50,
+      "column": 28,
+      "severity": "warning",
+      "message": "comparing `integer` with `character`; R coerces the numeric value to character and compares lexicographically, which is rarely intended"
+    },
+    "recipes::RY033::tests/testthat/test-skipping.R:51:28": {
+      "package": "recipes",
+      "code": "RY033",
+      "path": "tests/testthat/test-skipping.R",
+      "line": 51,
+      "column": 28,
+      "severity": "warning",
+      "message": "comparing `integer` with `character`; R coerces the numeric value to character and compares lexicographically, which is rarely intended"
+    },
+    "recipes::RY033::tests/testthat/test-skipping.R:52:28": {
+      "package": "recipes",
+      "code": "RY033",
+      "path": "tests/testthat/test-skipping.R",
+      "line": 52,
+      "column": 28,
+      "severity": "warning",
+      "message": "comparing `integer` with `character`; R coerces the numeric value to character and compares lexicographically, which is rarely intended"
+    },
+    "recipes::RY033::tests/testthat/test-skipping.R:53:28": {
+      "package": "recipes",
+      "code": "RY033",
+      "path": "tests/testthat/test-skipping.R",
+      "line": 53,
+      "column": 28,
+      "severity": "warning",
+      "message": "comparing `integer` with `character`; R coerces the numeric value to character and compares lexicographically, which is rarely intended"
+    },
+    "recipes::RY033::tests/testthat/test-skipping.R:54:28": {
+      "package": "recipes",
+      "code": "RY033",
+      "path": "tests/testthat/test-skipping.R",
+      "line": 54,
+      "column": 28,
+      "severity": "warning",
+      "message": "comparing `integer` with `character`; R coerces the numeric value to character and compares lexicographically, which is rarely intended"
+    },
+    "recipes::RY033::tests/testthat/test-skipping.R:55:28": {
+      "package": "recipes",
+      "code": "RY033",
+      "path": "tests/testthat/test-skipping.R",
+      "line": 55,
+      "column": 28,
+      "severity": "warning",
+      "message": "comparing `integer` with `character`; R coerces the numeric value to character and compares lexicographically, which is rarely intended"
+    },
+    "recipes::RY033::tests/testthat/test-skipping.R:58:28": {
+      "package": "recipes",
+      "code": "RY033",
+      "path": "tests/testthat/test-skipping.R",
+      "line": 58,
+      "column": 28,
+      "severity": "warning",
+      "message": "comparing `integer` with `character`; R coerces the numeric value to character and compares lexicographically, which is rarely intended"
+    },
+    "recipes::RY033::tests/testthat/test-skipping.R:59:28": {
+      "package": "recipes",
+      "code": "RY033",
+      "path": "tests/testthat/test-skipping.R",
+      "line": 59,
+      "column": 28,
+      "severity": "warning",
+      "message": "comparing `integer` with `character`; R coerces the numeric value to character and compares lexicographically, which is rarely intended"
+    },
+    "recipes::RY033::tests/testthat/test-skipping.R:60:28": {
+      "package": "recipes",
+      "code": "RY033",
+      "path": "tests/testthat/test-skipping.R",
+      "line": 60,
+      "column": 28,
+      "severity": "warning",
+      "message": "comparing `integer` with `character`; R coerces the numeric value to character and compares lexicographically, which is rarely intended"
+    },
+    "recipes::RY033::tests/testthat/test-skipping.R:61:28": {
+      "package": "recipes",
+      "code": "RY033",
+      "path": "tests/testthat/test-skipping.R",
+      "line": 61,
+      "column": 28,
+      "severity": "warning",
+      "message": "comparing `integer` with `character`; R coerces the numeric value to character and compares lexicographically, which is rarely intended"
+    },
+    "recipes::RY033::tests/testthat/test-skipping.R:62:28": {
+      "package": "recipes",
+      "code": "RY033",
+      "path": "tests/testthat/test-skipping.R",
+      "line": 62,
+      "column": 28,
+      "severity": "warning",
+      "message": "comparing `integer` with `character`; R coerces the numeric value to character and compares lexicographically, which is rarely intended"
+    },
+    "recipes::RY033::tests/testthat/test-skipping.R:63:28": {
+      "package": "recipes",
+      "code": "RY033",
+      "path": "tests/testthat/test-skipping.R",
+      "line": 63,
+      "column": 28,
+      "severity": "warning",
+      "message": "comparing `integer` with `character`; R coerces the numeric value to character and compares lexicographically, which is rarely intended"
+    },
+    "recipes::RY033::tests/testthat/test-skipping.R:64:28": {
+      "package": "recipes",
+      "code": "RY033",
+      "path": "tests/testthat/test-skipping.R",
+      "line": 64,
+      "column": 28,
+      "severity": "warning",
+      "message": "comparing `integer` with `character`; R coerces the numeric value to character and compares lexicographically, which is rarely intended"
+    },
+    "recipes::RY033::tests/testthat/test-skipping.R:65:28": {
+      "package": "recipes",
+      "code": "RY033",
+      "path": "tests/testthat/test-skipping.R",
+      "line": 65,
+      "column": 28,
+      "severity": "warning",
+      "message": "comparing `integer` with `character`; R coerces the numeric value to character and compares lexicographically, which is rarely intended"
+    },
+    "recipes::RY033::tests/testthat/test-skipping.R:66:28": {
+      "package": "recipes",
+      "code": "RY033",
+      "path": "tests/testthat/test-skipping.R",
+      "line": 66,
+      "column": 28,
+      "severity": "warning",
+      "message": "comparing `integer` with `character`; R coerces the numeric value to character and compares lexicographically, which is rarely intended"
+    },
+    "recipes::RY033::tests/testthat/test-skipping.R:67:28": {
+      "package": "recipes",
+      "code": "RY033",
+      "path": "tests/testthat/test-skipping.R",
+      "line": 67,
+      "column": 28,
+      "severity": "warning",
+      "message": "comparing `integer` with `character`; R coerces the numeric value to character and compares lexicographically, which is rarely intended"
+    },
+    "recipes::RY033::tests/testthat/test-skipping.R:68:28": {
+      "package": "recipes",
+      "code": "RY033",
+      "path": "tests/testthat/test-skipping.R",
+      "line": 68,
+      "column": 28,
+      "severity": "warning",
+      "message": "comparing `integer` with `character`; R coerces the numeric value to character and compares lexicographically, which is rarely intended"
+    },
+    "recipes::RY033::tests/testthat/test-skipping.R:69:28": {
+      "package": "recipes",
+      "code": "RY033",
+      "path": "tests/testthat/test-skipping.R",
+      "line": 69,
+      "column": 28,
+      "severity": "warning",
+      "message": "comparing `integer` with `character`; R coerces the numeric value to character and compares lexicographically, which is rarely intended"
+    },
+    "recipes::RY033::tests/testthat/test-skipping.R:70:28": {
+      "package": "recipes",
+      "code": "RY033",
+      "path": "tests/testthat/test-skipping.R",
+      "line": 70,
+      "column": 28,
+      "severity": "warning",
+      "message": "comparing `integer` with `character`; R coerces the numeric value to character and compares lexicographically, which is rarely intended"
+    },
+    "recipes::RY033::tests/testthat/test-skipping.R:71:28": {
+      "package": "recipes",
+      "code": "RY033",
+      "path": "tests/testthat/test-skipping.R",
+      "line": 71,
+      "column": 28,
+      "severity": "warning",
+      "message": "comparing `integer` with `character`; R coerces the numeric value to character and compares lexicographically, which is rarely intended"
+    },
+    "recipes::RY033::tests/testthat/test-skipping.R:72:28": {
+      "package": "recipes",
+      "code": "RY033",
+      "path": "tests/testthat/test-skipping.R",
+      "line": 72,
+      "column": 28,
+      "severity": "warning",
+      "message": "comparing `integer` with `character`; R coerces the numeric value to character and compares lexicographically, which is rarely intended"
+    },
+    "renv::RY001::R/bootstrap.R:800:7": {
+      "package": "renv",
+      "code": "RY001",
+      "path": "R/bootstrap.R",
+      "line": 800,
+      "column": 7,
+      "severity": "warning",
+      "message": "`if` condition is `character<len=1>`, expected length-1 logical"
+    },
+    "renv::RY001::R/cache.R:538:7": {
+      "package": "renv",
+      "code": "RY001",
+      "path": "R/cache.R",
+      "line": 538,
+      "column": 7,
+      "severity": "warning",
+      "message": "`if` condition is `character<len=1>`, expected length-1 logical"
+    },
+    "renv::RY001::R/parse.R:3:7": {
+      "package": "renv",
+      "code": "RY001",
+      "path": "R/parse.R",
+      "line": 3,
+      "column": 7,
+      "severity": "warning",
+      "message": "`if` condition is `logical<len=0>`, expected length-1 logical"
+    },
+    "renv::RY001::R/snapshot.R:1153:7": {
+      "package": "renv",
+      "code": "RY001",
+      "path": "R/snapshot.R",
+      "line": 1153,
+      "column": 7,
+      "severity": "warning",
+      "message": "`if` condition is `logical<len=0>`, expected length-1 logical"
+    },
+    "renv::RY001::R/snapshot.R:1158:7": {
+      "package": "renv",
+      "code": "RY001",
+      "path": "R/snapshot.R",
+      "line": 1158,
+      "column": 7,
+      "severity": "warning",
+      "message": "`if` condition is `logical<len=0>`, expected length-1 logical"
+    },
+    "renv::RY001::R/utils.R:90:9": {
+      "package": "renv",
+      "code": "RY001",
+      "path": "R/utils.R",
+      "line": 90,
+      "column": 9,
+      "severity": "warning",
+      "message": "`if` condition is `NULL<len=0>`, expected length-1 logical"
+    },
+    "renv::RY001::inst/resources/activate.R:16:7": {
+      "package": "renv",
+      "code": "RY001",
+      "path": "inst/resources/activate.R",
+      "line": 16,
+      "column": 7,
+      "severity": "warning",
+      "message": "`if` condition is `character<len=1>`, expected length-1 logical"
+    },
+    "renv::RY001::inst/resources/activate.R:960:9": {
+      "package": "renv",
+      "code": "RY001",
+      "path": "inst/resources/activate.R",
+      "line": 960,
+      "column": 9,
+      "severity": "warning",
+      "message": "`if` condition is `character<len=1>`, expected length-1 logical"
+    },
+    "renv::RY010::tests/testthat/resources/import.R:11:14": {
+      "package": "renv",
+      "code": "RY010",
+      "path": "tests/testthat/resources/import.R",
+      "line": 11,
+      "column": 14,
+      "severity": "warning",
+      "message": "variable `f1` is not bound in this scope"
+    },
+    "renv::RY010::tests/testthat/resources/import.R:11:18": {
+      "package": "renv",
+      "code": "RY010",
+      "path": "tests/testthat/resources/import.R",
+      "line": 11,
+      "column": 18,
+      "severity": "warning",
+      "message": "variable `x2` is not bound in this scope"
+    },
+    "renv::RY010::tests/testthat/resources/import.R:12:14": {
+      "package": "renv",
+      "code": "RY010",
+      "path": "tests/testthat/resources/import.R",
+      "line": 12,
+      "column": 14,
+      "severity": "warning",
+      "message": "variable `f1` is not bound in this scope"
+    },
+    "renv::RY010::tests/testthat/resources/import.R:12:18": {
+      "package": "renv",
+      "code": "RY010",
+      "path": "tests/testthat/resources/import.R",
+      "line": 12,
+      "column": 18,
+      "severity": "warning",
+      "message": "variable `f2` is not bound in this scope"
+    },
+    "renv::RY010::tests/testthat/resources/import.R:12:22": {
+      "package": "renv",
+      "code": "RY010",
+      "path": "tests/testthat/resources/import.R",
+      "line": 12,
+      "column": 22,
+      "severity": "warning",
+      "message": "variable `f3` is not bound in this scope"
+    },
+    "renv::RY010::tests/testthat/resources/import.R:12:26": {
+      "package": "renv",
+      "code": "RY010",
+      "path": "tests/testthat/resources/import.R",
+      "line": 12,
+      "column": 26,
+      "severity": "warning",
+      "message": "variable `x3` is not bound in this scope"
+    },
+    "renv::RY010::tests/testthat/resources/import.R:13:14": {
+      "package": "renv",
+      "code": "RY010",
+      "path": "tests/testthat/resources/import.R",
+      "line": 13,
+      "column": 14,
+      "severity": "warning",
+      "message": "variable `f1` is not bound in this scope"
+    },
+    "renv::RY010::tests/testthat/resources/import.R:16:14": {
+      "package": "renv",
+      "code": "RY010",
+      "path": "tests/testthat/resources/import.R",
+      "line": 16,
+      "column": 14,
+      "severity": "warning",
+      "message": "variable `f1` is not bound in this scope"
+    },
+    "renv::RY010::tests/testthat/resources/import.R:16:18": {
+      "package": "renv",
+      "code": "RY010",
+      "path": "tests/testthat/resources/import.R",
+      "line": 16,
+      "column": 18,
+      "severity": "warning",
+      "message": "variable `f2` is not bound in this scope"
+    },
+    "renv::RY010::tests/testthat/resources/import.R:16:22": {
+      "package": "renv",
+      "code": "RY010",
+      "path": "tests/testthat/resources/import.R",
+      "line": 16,
+      "column": 22,
+      "severity": "warning",
+      "message": "variable `f3` is not bound in this scope"
+    },
+    "renv::RY010::tests/testthat/resources/import.R:17:30": {
+      "package": "renv",
+      "code": "RY010",
+      "path": "tests/testthat/resources/import.R",
+      "line": 17,
+      "column": 30,
+      "severity": "warning",
+      "message": "variable `f1` is not bound in this scope"
+    },
+    "renv::RY010::tests/testthat/resources/import.R:17:34": {
+      "package": "renv",
+      "code": "RY010",
+      "path": "tests/testthat/resources/import.R",
+      "line": 17,
+      "column": 34,
+      "severity": "warning",
+      "message": "variable `f2` is not bound in this scope"
+    },
+    "renv::RY010::tests/testthat/resources/import.R:17:46": {
+      "package": "renv",
+      "code": "RY010",
+      "path": "tests/testthat/resources/import.R",
+      "line": 17,
+      "column": 46,
+      "severity": "warning",
+      "message": "variable `e` is not bound in this scope"
+    },
+    "renv::RY010::tests/testthat/resources/import.R:20:14": {
+      "package": "renv",
+      "code": "RY010",
+      "path": "tests/testthat/resources/import.R",
+      "line": 20,
+      "column": 14,
+      "severity": "warning",
+      "message": "variable `f1` is not bound in this scope"
+    },
+    "renv::RY010::tests/testthat/resources/import.R:20:18": {
+      "package": "renv",
+      "code": "RY010",
+      "path": "tests/testthat/resources/import.R",
+      "line": 20,
+      "column": 18,
+      "severity": "warning",
+      "message": "variable `f2` is not bound in this scope"
+    },
+    "renv::RY010::tests/testthat/resources/import.R:20:22": {
+      "package": "renv",
+      "code": "RY010",
+      "path": "tests/testthat/resources/import.R",
+      "line": 20,
+      "column": 22,
+      "severity": "warning",
+      "message": "variable `x4` is not bound in this scope"
+    },
+    "renv::RY010::tests/testthat/resources/import.R:21:14": {
+      "package": "renv",
+      "code": "RY010",
+      "path": "tests/testthat/resources/import.R",
+      "line": 21,
+      "column": 14,
+      "severity": "warning",
+      "message": "variable `f1` is not bound in this scope"
+    },
+    "renv::RY010::tests/testthat/resources/import.R:21:18": {
+      "package": "renv",
+      "code": "RY010",
+      "path": "tests/testthat/resources/import.R",
+      "line": 21,
+      "column": 18,
+      "severity": "warning",
+      "message": "variable `x5` is not bound in this scope"
+    },
+    "renv::RY010::tests/testthat/resources/import.R:22:14": {
+      "package": "renv",
+      "code": "RY010",
+      "path": "tests/testthat/resources/import.R",
+      "line": 22,
+      "column": 14,
+      "severity": "warning",
+      "message": "variable `f1` is not bound in this scope"
+    },
+    "renv::RY010::tests/testthat/resources/import.R:25:6": {
+      "package": "renv",
+      "code": "RY010",
+      "path": "tests/testthat/resources/import.R",
+      "line": 25,
+      "column": 6,
+      "severity": "warning",
+      "message": "variable `A` is not bound in this scope"
+    },
+    "renv::RY010::tests/testthat/resources/import.R:28:14": {
+      "package": "renv",
+      "code": "RY010",
+      "path": "tests/testthat/resources/import.R",
+      "line": 28,
+      "column": 14,
+      "severity": "warning",
+      "message": "variable `B` is not bound in this scope"
+    },
+    "renv::RY010::tests/testthat/resources/import.R:5:14": {
+      "package": "renv",
+      "code": "RY010",
+      "path": "tests/testthat/resources/import.R",
+      "line": 5,
+      "column": 14,
+      "severity": "warning",
+      "message": "variable `a` is not bound in this scope"
+    },
+    "renv::RY010::tests/testthat/resources/import.R:5:17": {
+      "package": "renv",
+      "code": "RY010",
+      "path": "tests/testthat/resources/import.R",
+      "line": 5,
+      "column": 17,
+      "severity": "warning",
+      "message": "variable `f1` is not bound in this scope"
+    },
+    "renv::RY010::tests/testthat/resources/import.R:5:21": {
+      "package": "renv",
+      "code": "RY010",
+      "path": "tests/testthat/resources/import.R",
+      "line": 5,
+      "column": 21,
+      "severity": "warning",
+      "message": "variable `f2` is not bound in this scope"
+    },
+    "renv::RY010::tests/testthat/resources/import.R:5:25": {
+      "package": "renv",
+      "code": "RY010",
+      "path": "tests/testthat/resources/import.R",
+      "line": 5,
+      "column": 25,
+      "severity": "warning",
+      "message": "variable `f3` is not bound in this scope"
+    },
+    "renv::RY010::tests/testthat/resources/import.R:6:14": {
+      "package": "renv",
+      "code": "RY010",
+      "path": "tests/testthat/resources/import.R",
+      "line": 6,
+      "column": 14,
+      "severity": "warning",
+      "message": "variable `f1` is not bound in this scope"
+    },
+    "renv::RY010::tests/testthat/resources/import.R:6:26": {
+      "package": "renv",
+      "code": "RY010",
+      "path": "tests/testthat/resources/import.R",
+      "line": 6,
+      "column": 26,
+      "severity": "warning",
+      "message": "variable `b` is not bound in this scope"
+    },
+    "renv::RY010::tests/testthat/resources/import.R:9:14": {
+      "package": "renv",
+      "code": "RY010",
+      "path": "tests/testthat/resources/import.R",
+      "line": 9,
+      "column": 14,
+      "severity": "warning",
+      "message": "variable `f1` is not bound in this scope"
+    },
+    "renv::RY010::tests/testthat/resources/import.R:9:18": {
+      "package": "renv",
+      "code": "RY010",
+      "path": "tests/testthat/resources/import.R",
+      "line": 9,
+      "column": 18,
+      "severity": "warning",
+      "message": "variable `f2` is not bound in this scope"
+    },
+    "renv::RY010::tests/testthat/resources/import.R:9:22": {
+      "package": "renv",
+      "code": "RY010",
+      "path": "tests/testthat/resources/import.R",
+      "line": 9,
+      "column": 22,
+      "severity": "warning",
+      "message": "variable `f3` is not bound in this scope"
+    },
+    "renv::RY010::tests/testthat/resources/modules.R:11:8": {
+      "package": "renv",
+      "code": "RY010",
+      "path": "tests/testthat/resources/modules.R",
+      "line": 11,
+      "column": 8,
+      "severity": "warning",
+      "message": "variable `f` is not bound in this scope"
+    },
+    "renv::RY010::tests/testthat/resources/modules.R:16:17": {
+      "package": "renv",
+      "code": "RY010",
+      "path": "tests/testthat/resources/modules.R",
+      "line": 16,
+      "column": 17,
+      "severity": "warning",
+      "message": "variable `H` is not bound in this scope"
+    },
+    "renv::RY010::tests/testthat/resources/modules.R:3:9": {
+      "package": "renv",
+      "code": "RY010",
+      "path": "tests/testthat/resources/modules.R",
+      "line": 3,
+      "column": 9,
+      "severity": "warning",
+      "message": "variable `B` is not bound in this scope"
+    },
+    "renv::RY010::tests/testthat/resources/modules.R:5:9": {
+      "package": "renv",
+      "code": "RY010",
+      "path": "tests/testthat/resources/modules.R",
+      "line": 5,
+      "column": 9,
+      "severity": "warning",
+      "message": "variable `symbol` is not bound in this scope"
+    },
+    "renv::RY010::tests/testthat/resources/pacman.R:10:16": {
+      "package": "renv",
+      "code": "RY010",
+      "path": "tests/testthat/resources/pacman.R",
+      "line": 10,
+      "column": 16,
+      "severity": "warning",
+      "message": "variable `A` is not bound in this scope"
+    },
+    "renv::RY010::tests/testthat/resources/pacman.R:11:15": {
+      "package": "renv",
+      "code": "RY010",
+      "path": "tests/testthat/resources/pacman.R",
+      "line": 11,
+      "column": 15,
+      "severity": "warning",
+      "message": "variable `B` is not bound in this scope"
+    },
+    "renv::RY010::tests/testthat/resources/pacman.R:3:16": {
+      "package": "renv",
+      "code": "RY010",
+      "path": "tests/testthat/resources/pacman.R",
+      "line": 3,
+      "column": 16,
+      "severity": "warning",
+      "message": "variable `a` is not bound in this scope"
+    },
+    "renv::RY010::tests/testthat/resources/pacman.R:5:16": {
+      "package": "renv",
+      "code": "RY010",
+      "path": "tests/testthat/resources/pacman.R",
+      "line": 5,
+      "column": 16,
+      "severity": "warning",
+      "message": "variable `e` is not bound in this scope"
+    },
+    "renv::RY010::tests/testthat/resources/targets.R:2:27": {
+      "package": "renv",
+      "code": "RY010",
+      "path": "tests/testthat/resources/targets.R",
+      "line": 2,
+      "column": 27,
+      "severity": "warning",
+      "message": "variable `oops` is not bound in this scope"
+    },
+    "renv::RY031::R/sandbox.R:244:11": {
+      "package": "renv",
+      "code": "RY031",
+      "path": "R/sandbox.R",
+      "line": 244,
+      "column": 11,
+      "severity": "error",
+      "message": "logical op applied to `opaque` and `character`"
+    },
+    "renv::RY031::R/sandbox.R:255:11": {
+      "package": "renv",
+      "code": "RY031",
+      "path": "R/sandbox.R",
+      "line": 255,
+      "column": 11,
+      "severity": "error",
+      "message": "logical op applied to `opaque` and `character`"
+    },
+    "renv::RY032::R/available-packages.R:685:7": {
+      "package": "renv",
+      "code": "RY032",
+      "path": "R/available-packages.R",
+      "line": 685,
+      "column": 7,
+      "severity": "warning",
+      "message": "`||` operand depends on a parameter whose length is not known to be 1; current R errors for vectors",
+      "fix": {
+        "start": 18376,
+        "end": 18378,
+        "replacement": "|"
+      }
+    },
+    "renv::RY032::R/bootstrap.R:981:7": {
+      "package": "renv",
+      "code": "RY032",
+      "path": "R/bootstrap.R",
+      "line": 981,
+      "column": 7,
+      "severity": "warning",
+      "message": "`||` operand depends on a parameter whose length is not known to be 1; current R errors for vectors",
+      "fix": {
+        "start": 25658,
+        "end": 25660,
+        "replacement": "|"
+      }
+    },
+    "renv::RY032::R/json-write.R:60:12": {
+      "package": "renv",
+      "code": "RY032",
+      "path": "R/json-write.R",
+      "line": 60,
+      "column": 12,
+      "severity": "warning",
+      "message": "`||` operand depends on a parameter whose length is not known to be 1; current R errors for vectors",
+      "fix": {
+        "start": 1973,
+        "end": 1975,
+        "replacement": "|"
+      }
+    },
+    "renv::RY032::R/type.R:5:7": {
+      "package": "renv",
+      "code": "RY032",
+      "path": "R/type.R",
+      "line": 5,
+      "column": 7,
+      "severity": "warning",
+      "message": "`||` operand depends on a parameter whose length is not known to be 1; current R errors for vectors",
+      "fix": {
+        "start": 108,
+        "end": 110,
+        "replacement": "|"
+      }
+    },
+    "renv::RY032::R/utils.R:24:7": {
+      "package": "renv",
+      "code": "RY032",
+      "path": "R/utils.R",
+      "line": 24,
+      "column": 7,
+      "severity": "warning",
+      "message": "`&&` operand depends on a parameter whose length is not known to be 1; current R errors for vectors",
+      "fix": {
+        "start": 495,
+        "end": 497,
+        "replacement": "&"
+      }
+    },
+    "renv::RY032::inst/resources/activate.R:1141:9": {
+      "package": "renv",
+      "code": "RY032",
+      "path": "inst/resources/activate.R",
+      "line": 1141,
+      "column": 9,
+      "severity": "warning",
+      "message": "`||` operand depends on a parameter whose length is not known to be 1; current R errors for vectors",
+      "fix": {
+        "start": 32046,
+        "end": 32048,
+        "replacement": "|"
+      }
+    },
+    "renv::RY070::R/package.R:367:12": {
+      "package": "renv",
+      "code": "RY070",
+      "path": "R/package.R",
+      "line": 367,
+      "column": 12,
+      "severity": "error",
+      "message": "`callback` is `NULL`, not a function; cannot call it"
+    },
+    "renv::RY070::R/package.R:370:25": {
+      "package": "renv",
+      "code": "RY070",
+      "path": "R/package.R",
+      "line": 370,
+      "column": 25,
+      "severity": "error",
+      "message": "`callback` is `NULL`, not a function; cannot call it"
+    },
+    "reticulate::RY001::R/py_require.R:579:7": {
+      "package": "reticulate",
+      "code": "RY001",
+      "path": "R/py_require.R",
+      "line": 579,
+      "column": 7,
+      "severity": "warning",
+      "message": "`if` condition is `logical<len=0>`, expected length-1 logical"
+    },
+    "reticulate::RY010::R/wrapper.R:89:9": {
+      "package": "reticulate",
+      "code": "RY010",
+      "path": "R/wrapper.R",
+      "line": 89,
+      "column": 9,
+      "severity": "warning",
+      "message": "variable `wrapper` is not bound in this scope"
+    },
+    "reticulate::RY010::R/wrapper.R:90:3": {
+      "package": "reticulate",
+      "code": "RY010",
+      "path": "R/wrapper.R",
+      "line": 90,
+      "column": 3,
+      "severity": "warning",
+      "message": "variable `wrapper` is not bound in this scope"
+    },
+    "reticulate::RY032::R/package.R:36:5": {
+      "package": "reticulate",
+      "code": "RY032",
+      "path": "R/package.R",
+      "line": 36,
+      "column": 5,
+      "severity": "warning",
+      "message": "`||` operand depends on a parameter whose length is not known to be 1; current R errors for vectors",
+      "fix": {
+        "start": 1329,
+        "end": 1331,
+        "replacement": "|"
+      }
+    },
+    "reticulate::RY032::R/py_require.R:591:9": {
+      "package": "reticulate",
+      "code": "RY032",
+      "path": "R/py_require.R",
+      "line": 591,
+      "column": 9,
+      "severity": "warning",
+      "message": "`||` operand depends on a parameter whose length is not known to be 1; current R errors for vectors",
+      "fix": {
+        "start": 21213,
+        "end": 21215,
+        "replacement": "|"
+      }
+    },
+    "reticulate::RY032::tests/testthat/test-python-pandas.R:382:27": {
+      "package": "reticulate",
+      "code": "RY032",
+      "path": "tests/testthat/test-python-pandas.R",
+      "line": 382,
+      "column": 27,
+      "severity": "warning",
+      "message": "`||` operand depends on a parameter whose length is not known to be 1; current R errors for vectors",
+      "fix": {
+        "start": 9686,
+        "end": 9688,
+        "replacement": "|"
+      }
+    },
+    "rlang::RY001::R/cnd-abort.R:548:7": {
+      "package": "rlang",
+      "code": "RY001",
+      "path": "R/cnd-abort.R",
+      "line": 548,
+      "column": 7,
+      "severity": "warning",
+      "message": "`if` condition is `NULL<len=0>`, expected length-1 logical"
+    },
+    "rlang::RY001::R/trace.R:531:7": {
+      "package": "rlang",
+      "code": "RY001",
+      "path": "R/trace.R",
+      "line": 531,
+      "column": 7,
+      "severity": "warning",
+      "message": "`if` condition is `logical<len=0>`, expected length-1 logical"
+    },
+    "rlang::RY001::R/trace.R:540:7": {
+      "package": "rlang",
+      "code": "RY001",
+      "path": "R/trace.R",
+      "line": 540,
+      "column": 7,
+      "severity": "warning",
+      "message": "`if` condition is `logical<len=0>`, expected length-1 logical"
+    },
+    "rlang::RY010::R/cnd-abort.R:855:10": {
+      "package": "rlang",
+      "code": "RY010",
+      "path": "R/cnd-abort.R",
+      "line": 855,
+      "column": 10,
+      "severity": "warning",
+      "message": "variable `has_cli_format` is not bound in this scope"
+    },
+    "rlang::RY010::R/env-special.R:220:16": {
+      "package": "rlang",
+      "code": "RY010",
+      "path": "R/env-special.R",
+      "line": 220,
+      "column": 16,
+      "severity": "warning",
+      "message": "variable `base_pkg_env` is not bound in this scope"
+    },
+    "rlang::RY010::R/import-standalone-defer.R:91:23": {
+      "package": "rlang",
+      "code": "RY010",
+      "path": "R/import-standalone-defer.R",
+      "line": 91,
+      "column": 23,
+      "severity": "warning",
+      "message": "variable `execute_handlers` is not bound in this scope"
+    },
+    "rlang::RY010::R/standalone-sizes.R:14:19": {
+      "package": "rlang",
+      "code": "RY010",
+      "path": "R/standalone-sizes.R",
+      "line": 14,
+      "column": 19,
+      "severity": "warning",
+      "message": "variable `pretty_bytes_default` is not bound in this scope"
+    },
+    "rlang::RY010::R/standalone-sizes.R:15:17": {
+      "package": "rlang",
+      "code": "RY010",
+      "path": "R/standalone-sizes.R",
+      "line": 15,
+      "column": 17,
+      "severity": "warning",
+      "message": "variable `pretty_bytes_nopad` is not bound in this scope"
+    },
+    "rlang::RY010::R/standalone-sizes.R:16:13": {
+      "package": "rlang",
+      "code": "RY010",
+      "path": "R/standalone-sizes.R",
+      "line": 16,
+      "column": 13,
+      "severity": "warning",
+      "message": "variable `pretty_bytes_6` is not bound in this scope"
+    },
+    "rlang::RY010::R/trace.R:1125:8": {
+      "package": "rlang",
+      "code": "RY010",
+      "path": "R/trace.R",
+      "line": 1125,
+      "column": 8,
+      "severity": "warning",
+      "message": "variable `has_cli_start_app` is not bound in this scope"
+    },
+    "rlang::RY010::R/trace.R:1137:16": {
+      "package": "rlang",
+      "code": "RY010",
+      "path": "R/trace.R",
+      "line": 1137,
+      "column": 16,
+      "severity": "warning",
+      "message": "variable `theme_error_highlight` is not bound in this scope"
+    },
+    "rlang::RY010::R/trace.R:1139:16": {
+      "package": "rlang",
+      "code": "RY010",
+      "path": "R/trace.R",
+      "line": 1139,
+      "column": 16,
+      "severity": "warning",
+      "message": "variable `theme_error_arg_highlight` is not bound in this scope"
+    },
+    "rlang::RY040::tests/testthat/test-cnd-entrace.R:284:28": {
+      "package": "rlang",
+      "code": "RY040",
+      "path": "tests/testthat/test-cnd-entrace.R",
+      "line": 284,
+      "column": 28,
+      "severity": "error",
+      "message": "cannot apply arithmetic op to `double` and `character`"
+    },
+    "rlang::RY061::tests/testthat/test-nse-defuse.R:829:20": {
+      "package": "rlang",
+      "code": "RY061",
+      "path": "tests/testthat/test-nse-defuse.R",
+      "line": 829,
+      "column": 20,
+      "severity": "error",
+      "message": "$ operator is invalid for atomic vectors of mode `double`"
+    },
+    "rlang::RY061::tests/testthat/test-nse-defuse.R:830:20": {
+      "package": "rlang",
+      "code": "RY061",
+      "path": "tests/testthat/test-nse-defuse.R",
+      "line": 830,
+      "column": 20,
+      "severity": "error",
+      "message": "$ operator is invalid for atomic vectors of mode `double`"
+    },
+    "rlang::RY061::tests/testthat/test-nse-defuse.R:831:20": {
+      "package": "rlang",
+      "code": "RY061",
+      "path": "tests/testthat/test-nse-defuse.R",
+      "line": 831,
+      "column": 20,
+      "severity": "error",
+      "message": "$ operator is invalid for atomic vectors of mode `double`"
+    },
+    "rlang::RY061::tests/testthat/test-nse-defuse.R:832:20": {
+      "package": "rlang",
+      "code": "RY061",
+      "path": "tests/testthat/test-nse-defuse.R",
+      "line": 832,
+      "column": 20,
+      "severity": "error",
+      "message": "$ operator is invalid for atomic vectors of mode `double`"
+    },
+    "rlang::RY070::tests/testthat/helper-locale.R:134:5": {
+      "package": "rlang",
+      "code": "RY070",
+      "path": "tests/testthat/helper-locale.R",
+      "line": 134,
+      "column": 5,
+      "severity": "error",
+      "message": "`skip` is `logical`, not a function; cannot call it"
+    },
+    "rlang::RY091::tests/testthat/test-trace.R:325:5": {
+      "package": "rlang",
+      "code": "RY091",
+      "path": "tests/testthat/test-trace.R",
+      "line": 325,
+      "column": 5,
+      "severity": "warning",
+      "message": "missing required argument `expr` in call to `eval`"
+    },
+    "rmarkdown::RY032::R/pandoc.R:210:38": {
+      "package": "rmarkdown",
+      "code": "RY032",
+      "path": "R/pandoc.R",
+      "line": 210,
+      "column": 38,
+      "severity": "warning",
+      "message": "`||` operand depends on a parameter whose length is not known to be 1; current R errors for vectors",
+      "fix": {
+        "start": 6658,
+        "end": 6660,
+        "replacement": "|"
+      }
+    },
+    "rmarkdown::RY032::R/pandoc.R:653:33": {
+      "package": "rmarkdown",
+      "code": "RY032",
+      "path": "R/pandoc.R",
+      "line": 653,
+      "column": 33,
+      "severity": "warning",
+      "message": "`||` operand depends on a parameter whose length is not known to be 1; current R errors for vectors",
+      "fix": {
+        "start": 21005,
+        "end": 21007,
+        "replacement": "|"
+      }
+    },
+    "rmarkdown::RY105::R/html_dependencies.R:245:9": {
+      "package": "rmarkdown",
+      "code": "RY105",
+      "path": "R/html_dependencies.R",
+      "line": 245,
+      "column": 9,
+      "severity": "warning",
+      "message": "`match` is a length-1 character, so `length(...)` is 1 here and this zero-length guard is always TRUE"
+    },
+    "rmarkdown::RY105::R/jupyter.R:109:7": {
+      "package": "rmarkdown",
+      "code": "RY105",
+      "path": "R/jupyter.R",
+      "line": 109,
+      "column": 7,
+      "severity": "warning",
+      "message": "`fmt` is a length-1 character, so `length(...)` is 1 here and this zero-length guard is always FALSE"
+    },
+    "shiny-r::RY000::inst/app_template/app.R:15:3": {
+      "package": "shiny-r",
+      "code": "RY000",
+      "path": "inst/app_template/app.R",
+      "line": 15,
+      "column": 3,
+      "severity": "error",
+      "message": "syntax error: unparseable region (recovered tree may be unreliable)"
+    },
+    "shiny-r::RY000::inst/app_template/app.R:25:3": {
+      "package": "shiny-r",
+      "code": "RY000",
+      "path": "inst/app_template/app.R",
+      "line": 25,
+      "column": 3,
+      "severity": "error",
+      "message": "syntax error: unparseable region (recovered tree may be unreliable)"
+    },
+    "shiny-r::RY000::inst/app_template/app.R:27:3": {
+      "package": "shiny-r",
+      "code": "RY000",
+      "path": "inst/app_template/app.R",
+      "line": 27,
+      "column": 3,
+      "severity": "error",
+      "message": "syntax error: unparseable region (recovered tree may be unreliable)"
+    },
+    "shiny-r::RY010::R/graph.R:61:3": {
+      "package": "shiny-r",
+      "code": "RY010",
+      "path": "R/graph.R",
+      "line": 61,
+      "column": 3,
+      "severity": "warning",
+      "message": "variable `rLog` is not bound in this scope"
+    },
+    "shiny-r::RY010::R/graph.R:77:3": {
+      "package": "shiny-r",
+      "code": "RY010",
+      "path": "R/graph.R",
+      "line": 77,
+      "column": 3,
+      "severity": "warning",
+      "message": "variable `rLog` is not bound in this scope"
+    },
+    "shiny-r::RY010::R/graph.R:98:3": {
+      "package": "shiny-r",
+      "code": "RY010",
+      "path": "R/graph.R",
+      "line": 98,
+      "column": 3,
+      "severity": "warning",
+      "message": "variable `rLog` is not bound in this scope"
+    },
+    "shiny-r::RY010::R/middleware-shiny.R:35:7": {
+      "package": "shiny-r",
+      "code": "RY010",
+      "path": "R/middleware-shiny.R",
+      "line": 35,
+      "column": 7,
+      "severity": "warning",
+      "message": "variable `rLog` is not bound in this scope"
+    },
+    "shiny-r::RY010::R/middleware-shiny.R:5:9": {
+      "package": "shiny-r",
+      "code": "RY010",
+      "path": "R/middleware-shiny.R",
+      "line": 5,
+      "column": 9,
+      "severity": "warning",
+      "message": "variable `rLog` is not bound in this scope"
+    },
+    "shiny-r::RY010::R/otel-collect.R:24:7": {
+      "package": "shiny-r",
+      "code": "RY010",
+      "path": "R/otel-collect.R",
+      "line": 24,
+      "column": 7,
+      "severity": "warning",
+      "message": "variable `IS_SHINY_LOCAL_PKG` is not bound in this scope"
+    },
+    "shiny-r::RY010::R/react.R:106:7": {
+      "package": "shiny-r",
+      "code": "RY010",
+      "path": "R/react.R",
+      "line": 106,
+      "column": 7,
+      "severity": "warning",
+      "message": "variable `rLog` is not bound in this scope"
+    },
+    "shiny-r::RY010::R/react.R:108:13": {
+      "package": "shiny-r",
+      "code": "RY010",
+      "path": "R/react.R",
+      "line": 108,
+      "column": 13,
+      "severity": "warning",
+      "message": "variable `IS_SHINY_LOCAL_PKG` is not bound in this scope"
+    },
+    "shiny-r::RY010::R/react.R:123:15": {
+      "package": "shiny-r",
+      "code": "RY010",
+      "path": "R/react.R",
+      "line": 123,
+      "column": 15,
+      "severity": "warning",
+      "message": "variable `rLog` is not bound in this scope"
+    },
+    "shiny-r::RY010::R/react.R:124:23": {
+      "package": "shiny-r",
+      "code": "RY010",
+      "path": "R/react.R",
+      "line": 124,
+      "column": 23,
+      "severity": "warning",
+      "message": "variable `rLog` is not bound in this scope"
+    },
+    "shiny-r::RY010::R/react.R:143:7": {
+      "package": "shiny-r",
+      "code": "RY010",
+      "path": "R/react.R",
+      "line": 143,
+      "column": 7,
+      "severity": "warning",
+      "message": "variable `rLog` is not bound in this scope"
+    },
+    "shiny-r::RY010::R/react.R:144:15": {
+      "package": "shiny-r",
+      "code": "RY010",
+      "path": "R/react.R",
+      "line": 144,
+      "column": 15,
+      "severity": "warning",
+      "message": "variable `rLog` is not bound in this scope"
+    },
+    "shiny-r::RY010::R/react.R:243:9": {
+      "package": "shiny-r",
+      "code": "RY010",
+      "path": "R/react.R",
+      "line": 243,
+      "column": 9,
+      "severity": "warning",
+      "message": "variable `rLog` is not bound in this scope"
+    },
+    "shiny-r::RY010::R/react.R:284:29": {
+      "package": "shiny-r",
+      "code": "RY010",
+      "path": "R/react.R",
+      "line": 284,
+      "column": 29,
+      "severity": "warning",
+      "message": "variable `rLog` is not bound in this scope"
+    },
+    "shiny-r::RY010::R/reactives.R:1062:7": {
+      "package": "shiny-r",
+      "code": "RY010",
+      "path": "R/reactives.R",
+      "line": 1062,
+      "column": 7,
+      "severity": "warning",
+      "message": "variable `rLog` is not bound in this scope"
+    },
+    "shiny-r::RY010::R/reactives.R:124:7": {
+      "package": "shiny-r",
+      "code": "RY010",
+      "path": "R/reactives.R",
+      "line": 124,
+      "column": 7,
+      "severity": "warning",
+      "message": "variable `rLog` is not bound in this scope"
+    },
+    "shiny-r::RY010::R/reactives.R:1419:7": {
+      "package": "shiny-r",
+      "code": "RY010",
+      "path": "R/reactives.R",
+      "line": 1419,
+      "column": 7,
+      "severity": "warning",
+      "message": "variable `rLog` is not bound in this scope"
+    },
+    "shiny-r::RY010::R/reactives.R:155:7": {
+      "package": "shiny-r",
+      "code": "RY010",
+      "path": "R/reactives.R",
+      "line": 155,
+      "column": 7,
+      "severity": "warning",
+      "message": "variable `rLog` is not bound in this scope"
+    },
+    "shiny-r::RY010::R/reactives.R:162:7": {
+      "package": "shiny-r",
+      "code": "RY010",
+      "path": "R/reactives.R",
+      "line": 162,
+      "column": 7,
+      "severity": "warning",
+      "message": "variable `rLog` is not bound in this scope"
+    },
+    "shiny-r::RY010::R/reactives.R:169:7": {
+      "package": "shiny-r",
+      "code": "RY010",
+      "path": "R/reactives.R",
+      "line": 169,
+      "column": 7,
+      "severity": "warning",
+      "message": "variable `rLog` is not bound in this scope"
+    },
+    "shiny-r::RY010::R/reactives.R:2016:3": {
+      "package": "shiny-r",
+      "code": "RY010",
+      "path": "R/reactives.R",
+      "line": 2016,
+      "column": 3,
+      "severity": "warning",
+      "message": "variable `rLog` is not bound in this scope"
+    },
+    "shiny-r::RY010::R/reactives.R:2372:16": {
+      "package": "shiny-r",
+      "code": "RY010",
+      "path": "R/reactives.R",
+      "line": 2372,
+      "column": 16,
+      "severity": "warning",
+      "message": "variable `rLog` is not bound in this scope"
+    },
+    "shiny-r::RY010::R/reactives.R:24:11": {
+      "package": "shiny-r",
+      "code": "RY010",
+      "path": "R/reactives.R",
+      "line": 24,
+      "column": 11,
+      "severity": "warning",
+      "message": "variable `rLog` is not bound in this scope"
+    },
+    "shiny-r::RY010::R/reactives.R:438:47": {
+      "package": "shiny-r",
+      "code": "RY010",
+      "path": "R/reactives.R",
+      "line": 438,
+      "column": 47,
+      "severity": "warning",
+      "message": "variable `rLog` is not bound in this scope"
+    },
+    "shiny-r::RY010::R/reactives.R:439:51": {
+      "package": "shiny-r",
+      "code": "RY010",
+      "path": "R/reactives.R",
+      "line": 439,
+      "column": 51,
+      "severity": "warning",
+      "message": "variable `rLog` is not bound in this scope"
+    },
+    "shiny-r::RY010::R/reactives.R:440:48": {
+      "package": "shiny-r",
+      "code": "RY010",
+      "path": "R/reactives.R",
+      "line": 440,
+      "column": 48,
+      "severity": "warning",
+      "message": "variable `rLog` is not bound in this scope"
+    },
+    "shiny-r::RY010::R/reactives.R:44:9": {
+      "package": "shiny-r",
+      "code": "RY010",
+      "path": "R/reactives.R",
+      "line": 44,
+      "column": 9,
+      "severity": "warning",
+      "message": "variable `rLog` is not bound in this scope"
+    },
+    "shiny-r::RY010::R/reactives.R:458:9": {
+      "package": "shiny-r",
+      "code": "RY010",
+      "path": "R/reactives.R",
+      "line": 458,
+      "column": 9,
+      "severity": "warning",
+      "message": "variable `rLog` is not bound in this scope"
+    },
+    "shiny-r::RY010::R/reactives.R:460:23": {
+      "package": "shiny-r",
+      "code": "RY010",
+      "path": "R/reactives.R",
+      "line": 460,
+      "column": 23,
+      "severity": "warning",
+      "message": "variable `rLog` is not bound in this scope"
+    },
+    "shiny-r::RY010::R/reactives.R:46:11": {
+      "package": "shiny-r",
+      "code": "RY010",
+      "path": "R/reactives.R",
+      "line": 46,
+      "column": 11,
+      "severity": "warning",
+      "message": "variable `rLog` is not bound in this scope"
+    },
+    "shiny-r::RY010::R/reactives.R:536:9": {
+      "package": "shiny-r",
+      "code": "RY010",
+      "path": "R/reactives.R",
+      "line": 536,
+      "column": 9,
+      "severity": "warning",
+      "message": "variable `rLog` is not bound in this scope"
+    },
+    "shiny-r::RY010::R/reactives.R:542:9": {
+      "package": "shiny-r",
+      "code": "RY010",
+      "path": "R/reactives.R",
+      "line": 542,
+      "column": 9,
+      "severity": "warning",
+      "message": "variable `rLog` is not bound in this scope"
+    },
+    "shiny-r::RY010::R/reactives.R:548:11": {
+      "package": "shiny-r",
+      "code": "RY010",
+      "path": "R/reactives.R",
+      "line": 548,
+      "column": 11,
+      "severity": "warning",
+      "message": "variable `rLog` is not bound in this scope"
+    },
+    "shiny-r::RY010::R/reactives.R:556:11": {
+      "package": "shiny-r",
+      "code": "RY010",
+      "path": "R/reactives.R",
+      "line": 556,
+      "column": 11,
+      "severity": "warning",
+      "message": "variable `rLog` is not bound in this scope"
+    },
+    "shiny-r::RY010::R/reactives.R:574:9": {
+      "package": "shiny-r",
+      "code": "RY010",
+      "path": "R/reactives.R",
+      "line": 574,
+      "column": 9,
+      "severity": "warning",
+      "message": "variable `rLog` is not bound in this scope"
+    },
+    "shiny-r::RY010::R/reactives.R:606:7": {
+      "package": "shiny-r",
+      "code": "RY010",
+      "path": "R/reactives.R",
+      "line": 606,
+      "column": 7,
+      "severity": "warning",
+      "message": "variable `rLog` is not bound in this scope"
+    },
+    "shiny-r::RY010::R/reactives.R:617:7": {
+      "package": "shiny-r",
+      "code": "RY010",
+      "path": "R/reactives.R",
+      "line": 617,
+      "column": 7,
+      "severity": "warning",
+      "message": "variable `rLog` is not bound in this scope"
+    },
+    "shiny-r::RY010::R/reactives.R:633:11": {
+      "package": "shiny-r",
+      "code": "RY010",
+      "path": "R/reactives.R",
+      "line": 633,
+      "column": 11,
+      "severity": "warning",
+      "message": "variable `rLog` is not bound in this scope"
+    },
+    "shiny-r::RY010::R/reactives.R:642:9": {
+      "package": "shiny-r",
+      "code": "RY010",
+      "path": "R/reactives.R",
+      "line": 642,
+      "column": 9,
+      "severity": "warning",
+      "message": "variable `rLog` is not bound in this scope"
+    },
+    "shiny-r::RY010::R/shiny.R:2512:9": {
+      "package": "shiny-r",
+      "code": "RY010",
+      "path": "R/shiny.R",
+      "line": 2512,
+      "column": 9,
+      "severity": "warning",
+      "message": "variable `rLog` is not bound in this scope"
+    },
+    "shiny-r::RY010::R/shiny.R:2522:9": {
+      "package": "shiny-r",
+      "code": "RY010",
+      "path": "R/shiny.R",
+      "line": 2522,
+      "column": 9,
+      "severity": "warning",
+      "message": "variable `rLog` is not bound in this scope"
+    },
+    "shiny-r::RY010::R/utils.R:334:23": {
+      "package": "shiny-r",
+      "code": "RY010",
+      "path": "R/utils.R",
+      "line": 334,
+      "column": 23,
+      "severity": "warning",
+      "message": "variable `utils` is not bound in this scope"
+    },
+    "shiny-r::RY010::inst/examples/03_reactivity/app.R:38:44": {
+      "package": "shiny-r",
+      "code": "RY010",
+      "path": "inst/examples/03_reactivity/app.R",
+      "line": 38,
+      "column": 44,
+      "severity": "warning",
+      "message": "variable `span` is not bound in this scope"
+    },
+    "shiny-r::RY010::inst/examples/09_upload/app.R:23:7": {
+      "package": "shiny-r",
+      "code": "RY010",
+      "path": "inst/examples/09_upload/app.R",
+      "line": 23,
+      "column": 7,
+      "severity": "warning",
+      "message": "variable `tags` is not bound in this scope"
+    },
+    "shiny-r::RY010::inst/examples/09_upload/app.R:43:7": {
+      "package": "shiny-r",
+      "code": "RY010",
+      "path": "inst/examples/09_upload/app.R",
+      "line": 43,
+      "column": 7,
+      "severity": "warning",
+      "message": "variable `tags` is not bound in this scope"
+    },
+    "shiny-r::RY032::R/conditions.R:154:7": {
+      "package": "shiny-r",
+      "code": "RY032",
+      "path": "R/conditions.R",
+      "line": 154,
+      "column": 7,
+      "severity": "warning",
+      "message": "`||` operand depends on a parameter whose length is not known to be 1; current R errors for vectors",
+      "fix": {
+        "start": 4767,
+        "end": 4769,
+        "replacement": "|"
+      }
+    },
+    "shiny-r::RY032::R/runapp.R:375:7": {
+      "package": "shiny-r",
+      "code": "RY032",
+      "path": "R/runapp.R",
+      "line": 375,
+      "column": 7,
+      "severity": "warning",
+      "message": "`||` operand depends on a parameter whose length is not known to be 1; current R errors for vectors",
+      "fix": {
+        "start": 16127,
+        "end": 16129,
+        "replacement": "|"
+      }
+    },
+    "shiny-r::RY033::R/bookmark-state.R:138:18": {
+      "package": "shiny-r",
+      "code": "RY033",
+      "path": "R/bookmark-state.R",
+      "line": 138,
+      "column": 18,
+      "severity": "warning",
+      "message": "comparing `character` with `double`; R coerces the numeric value to character and compares lexicographically, which is rarely intended"
+    },
+    "shiny-r::RY093::R/bookmark-state.R:138:18": {
+      "package": "shiny-r",
+      "code": "RY093",
+      "path": "R/bookmark-state.R",
+      "line": 138,
+      "column": 18,
+      "severity": "warning",
+      "message": "comparison is inside `length()`; compare `length(x)` instead",
+      "fix": {
+        "start": 4288,
+        "end": 4310,
+        "replacement": "length(inputVals) != 0"
+      }
+    },
+    "shiny-r::RY105::tests/testthat/test-non-blocking.R:127:15": {
+      "package": "shiny-r",
+      "code": "RY105",
+      "path": "tests/testthat/test-non-blocking.R",
+      "line": 127,
+      "column": 15,
+      "severity": "warning",
+      "message": "`generations_seen` is a length-1 integer, so `length(...)` is 1 here and this zero-length guard is always TRUE"
+    },
+    "shinydashboard::RY010::R/boxes.R:301:7": {
+      "package": "shinydashboard",
+      "code": "RY010",
+      "path": "R/boxes.R",
+      "line": 301,
+      "column": 7,
+      "severity": "warning",
+      "message": "variable `tags` is not bound in this scope"
+    },
+    "shinydashboard::RY010::R/boxes.R:421:7": {
+      "package": "shinydashboard",
+      "code": "RY010",
+      "path": "R/boxes.R",
+      "line": 421,
+      "column": 7,
+      "severity": "warning",
+      "message": "variable `tags` is not bound in this scope"
+    },
+    "shinydashboard::RY010::R/dashboardBody.R:12:34": {
+      "package": "shinydashboard",
+      "code": "RY010",
+      "path": "R/dashboardBody.R",
+      "line": 12,
+      "column": 34,
+      "severity": "warning",
+      "message": "variable `tags` is not bound in this scope"
+    },
+    "shinydashboard::RY010::R/dashboardHeader.R:109:19": {
+      "package": "shinydashboard",
+      "code": "RY010",
+      "path": "R/dashboardHeader.R",
+      "line": 109,
+      "column": 19,
+      "severity": "warning",
+      "message": "variable `tags` is not bound in this scope"
+    },
+    "shinydashboard::RY010::R/dashboardHeader.R:109:29": {
+      "package": "shinydashboard",
+      "code": "RY010",
+      "path": "R/dashboardHeader.R",
+      "line": 109,
+      "column": 29,
+      "severity": "warning",
+      "message": "variable `tags` is not bound in this scope"
+    },
+    "shinydashboard::RY010::R/dashboardHeader.R:126:3": {
+      "package": "shinydashboard",
+      "code": "RY010",
+      "path": "R/dashboardHeader.R",
+      "line": 126,
+      "column": 3,
+      "severity": "warning",
+      "message": "variable `tags` is not bound in this scope"
+    },
+    "shinydashboard::RY010::R/dashboardHeader.R:131:5": {
+      "package": "shinydashboard",
+      "code": "RY010",
+      "path": "R/dashboardHeader.R",
+      "line": 131,
+      "column": 5,
+      "severity": "warning",
+      "message": "variable `tags` is not bound in this scope"
+    },
+    "shinydashboard::RY010::R/dashboardHeader.R:146:9": {
+      "package": "shinydashboard",
+      "code": "RY010",
+      "path": "R/dashboardHeader.R",
+      "line": 146,
+      "column": 9,
+      "severity": "warning",
+      "message": "variable `tags` is not bound in this scope"
+    },
+    "shinydashboard::RY010::R/dashboardHeader.R:218:3": {
+      "package": "shinydashboard",
+      "code": "RY010",
+      "path": "R/dashboardHeader.R",
+      "line": 218,
+      "column": 3,
+      "severity": "warning",
+      "message": "variable `tags` is not bound in this scope"
+    },
+    "shinydashboard::RY010::R/dashboardHeader.R:227:5": {
+      "package": "shinydashboard",
+      "code": "RY010",
+      "path": "R/dashboardHeader.R",
+      "line": 227,
+      "column": 5,
+      "severity": "warning",
+      "message": "variable `tags` is not bound in this scope"
+    },
+    "shinydashboard::RY010::R/dashboardHeader.R:229:7": {
+      "package": "shinydashboard",
+      "code": "RY010",
+      "path": "R/dashboardHeader.R",
+      "line": 229,
+      "column": 7,
+      "severity": "warning",
+      "message": "variable `tags` is not bound in this scope"
+    },
+    "shinydashboard::RY010::R/dashboardHeader.R:230:7": {
+      "package": "shinydashboard",
+      "code": "RY010",
+      "path": "R/dashboardHeader.R",
+      "line": 230,
+      "column": 7,
+      "severity": "warning",
+      "message": "variable `tags` is not bound in this scope"
+    },
+    "shinydashboard::RY010::R/dashboardHeader.R:231:9": {
+      "package": "shinydashboard",
+      "code": "RY010",
+      "path": "R/dashboardHeader.R",
+      "line": 231,
+      "column": 9,
+      "severity": "warning",
+      "message": "variable `tags` is not bound in this scope"
+    },
+    "shinydashboard::RY010::R/dashboardHeader.R:264:3": {
+      "package": "shinydashboard",
+      "code": "RY010",
+      "path": "R/dashboardHeader.R",
+      "line": 264,
+      "column": 3,
+      "severity": "warning",
+      "message": "variable `tags` is not bound in this scope"
+    },
+    "shinydashboard::RY010::R/dashboardHeader.R:270:29": {
+      "package": "shinydashboard",
+      "code": "RY010",
+      "path": "R/dashboardHeader.R",
+      "line": 270,
+      "column": 29,
+      "severity": "warning",
+      "message": "variable `tags` is not bound in this scope"
+    },
+    "shinydashboard::RY010::R/dashboardHeader.R:302:3": {
+      "package": "shinydashboard",
+      "code": "RY010",
+      "path": "R/dashboardHeader.R",
+      "line": 302,
+      "column": 3,
+      "severity": "warning",
+      "message": "variable `tags` is not bound in this scope"
+    },
+    "shinydashboard::RY010::R/dashboardHeader.R:323:3": {
+      "package": "shinydashboard",
+      "code": "RY010",
+      "path": "R/dashboardHeader.R",
+      "line": 323,
+      "column": 3,
+      "severity": "warning",
+      "message": "variable `tags` is not bound in this scope"
+    },
+    "shinydashboard::RY010::R/dashboardHeader.R:326:16": {
+      "package": "shinydashboard",
+      "code": "RY010",
+      "path": "R/dashboardHeader.R",
+      "line": 326,
+      "column": 16,
+      "severity": "warning",
+      "message": "variable `tags` is not bound in this scope"
+    },
+    "shinydashboard::RY010::R/dashboardPage.R:66:5": {
+      "package": "shinydashboard",
+      "code": "RY010",
+      "path": "R/dashboardPage.R",
+      "line": 66,
+      "column": 5,
+      "severity": "warning",
+      "message": "variable `tags` is not bound in this scope"
+    },
+    "shinydashboard::RY010::R/dashboardSidebar.R:142:3": {
+      "package": "shinydashboard",
+      "code": "RY010",
+      "path": "R/dashboardSidebar.R",
+      "line": 142,
+      "column": 3,
+      "severity": "warning",
+      "message": "variable `tags` is not bound in this scope"
+    },
+    "shinydashboard::RY010::R/dashboardSidebar.R:147:5": {
+      "package": "shinydashboard",
+      "code": "RY010",
+      "path": "R/dashboardSidebar.R",
+      "line": 147,
+      "column": 5,
+      "severity": "warning",
+      "message": "variable `tags` is not bound in this scope"
+    },
+    "shinydashboard::RY010::R/dashboardSidebar.R:209:3": {
+      "package": "shinydashboard",
+      "code": "RY010",
+      "path": "R/dashboardSidebar.R",
+      "line": 209,
+      "column": 3,
+      "severity": "warning",
+      "message": "variable `tags` is not bound in this scope"
+    },
+    "shinydashboard::RY010::R/dashboardSidebar.R:213:7": {
+      "package": "shinydashboard",
+      "code": "RY010",
+      "path": "R/dashboardSidebar.R",
+      "line": 213,
+      "column": 7,
+      "severity": "warning",
+      "message": "variable `tags` is not bound in this scope"
+    },
+    "shinydashboard::RY010::R/dashboardSidebar.R:222:9": {
+      "package": "shinydashboard",
+      "code": "RY010",
+      "path": "R/dashboardSidebar.R",
+      "line": 222,
+      "column": 9,
+      "severity": "warning",
+      "message": "variable `tags` is not bound in this scope"
+    },
+    "shinydashboard::RY010::R/dashboardSidebar.R:390:11": {
+      "package": "shinydashboard",
+      "code": "RY010",
+      "path": "R/dashboardSidebar.R",
+      "line": 390,
+      "column": 11,
+      "severity": "warning",
+      "message": "variable `tags` is not bound in this scope"
+    },
+    "shinydashboard::RY010::R/dashboardSidebar.R:436:17": {
+      "package": "shinydashboard",
+      "code": "RY010",
+      "path": "R/dashboardSidebar.R",
+      "line": 436,
+      "column": 17,
+      "severity": "warning",
+      "message": "variable `tags` is not bound in this scope"
+    },
+    "shinydashboard::RY010::R/dashboardSidebar.R:447:7": {
+      "package": "shinydashboard",
+      "code": "RY010",
+      "path": "R/dashboardSidebar.R",
+      "line": 447,
+      "column": 7,
+      "severity": "warning",
+      "message": "variable `tags` is not bound in this scope"
+    },
+    "shinydashboard::RY010::R/dashboardSidebar.R:475:3": {
+      "package": "shinydashboard",
+      "code": "RY010",
+      "path": "R/dashboardSidebar.R",
+      "line": 475,
+      "column": 3,
+      "severity": "warning",
+      "message": "variable `tags` is not bound in this scope"
+    },
+    "shinydashboard::RY010::R/dashboardSidebar.R:487:7": {
+      "package": "shinydashboard",
+      "code": "RY010",
+      "path": "R/dashboardSidebar.R",
+      "line": 487,
+      "column": 7,
+      "severity": "warning",
+      "message": "variable `tags` is not bound in this scope"
+    },
+    "shinydashboard::RY010::R/dashboardSidebar.R:526:3": {
+      "package": "shinydashboard",
+      "code": "RY010",
+      "path": "R/dashboardSidebar.R",
+      "line": 526,
+      "column": 3,
+      "severity": "warning",
+      "message": "variable `tags` is not bound in this scope"
+    },
+    "shinydashboard::RY010::R/dashboardSidebar.R:79:19": {
+      "package": "shinydashboard",
+      "code": "RY010",
+      "path": "R/dashboardSidebar.R",
+      "line": 79,
+      "column": 19,
+      "severity": "warning",
+      "message": "variable `tags` is not bound in this scope"
+    },
+    "shinydashboard::RY010::R/dashboardSidebar.R:79:29": {
+      "package": "shinydashboard",
+      "code": "RY010",
+      "path": "R/dashboardSidebar.R",
+      "line": 79,
+      "column": 29,
+      "severity": "warning",
+      "message": "variable `tags` is not bound in this scope"
+    },
+    "shinydashboard::RY010::R/menuOutput.R:17:40": {
+      "package": "shinydashboard",
+      "code": "RY010",
+      "path": "R/menuOutput.R",
+      "line": 17,
+      "column": 40,
+      "severity": "warning",
+      "message": "variable `tags` is not bound in this scope"
+    },
+    "shinydashboard::RY010::R/menuOutput.R:33:41": {
+      "package": "shinydashboard",
+      "code": "RY010",
+      "path": "R/menuOutput.R",
+      "line": 33,
+      "column": 41,
+      "severity": "warning",
+      "message": "variable `tags` is not bound in this scope"
+    },
+    "shinydashboard::RY010::R/menuOutput.R:48:41": {
+      "package": "shinydashboard",
+      "code": "RY010",
+      "path": "R/menuOutput.R",
+      "line": 48,
+      "column": 41,
+      "severity": "warning",
+      "message": "variable `tags` is not bound in this scope"
+    },
+    "shinydashboard::RY010::R/menuOutput.R:62:41": {
+      "package": "shinydashboard",
+      "code": "RY010",
+      "path": "R/menuOutput.R",
+      "line": 62,
+      "column": 41,
+      "severity": "warning",
+      "message": "variable `tags` is not bound in this scope"
+    },
+    "sparklyr::RY001::R/config.R:375:9": {
+      "package": "sparklyr",
+      "code": "RY001",
+      "path": "R/config.R",
+      "line": 375,
+      "column": 9,
+      "severity": "warning",
+      "message": "`if` condition is `logical<len=0>`, expected length-1 logical"
+    },
+    "sparklyr::RY001::R/ml_utils.R:181:13": {
+      "package": "sparklyr",
+      "code": "RY001",
+      "path": "R/ml_utils.R",
+      "line": 181,
+      "column": 13,
+      "severity": "warning",
+      "message": "`if` condition is `opaque<len=0>`, expected length-1 logical"
+    },
+    "sparklyr::RY010::R/connection_livy.R:187:28": {
+      "package": "sparklyr",
+      "code": "RY010",
+      "path": "R/connection_livy.R",
+      "line": 187,
+      "column": 28,
+      "severity": "warning",
+      "message": "variable `add_headers` is not bound in this scope"
+    },
+    "sparklyr::RY032::R/connection.R:273:7": {
+      "package": "sparklyr",
+      "code": "RY032",
+      "path": "R/connection.R",
+      "line": 273,
+      "column": 7,
+      "severity": "warning",
+      "message": "`||` operand depends on a parameter whose length is not known to be 1; current R errors for vectors",
+      "fix": {
+        "start": 8762,
+        "end": 8764,
+        "replacement": "|"
+      }
+    },
+    "sparklyr::RY032::R/spark_submit.R:34:7": {
+      "package": "sparklyr",
+      "code": "RY032",
+      "path": "R/spark_submit.R",
+      "line": 34,
+      "column": 7,
+      "severity": "warning",
+      "message": "`||` operand depends on a parameter whose length is not known to be 1; current R errors for vectors",
+      "fix": {
+        "start": 1058,
+        "end": 1060,
+        "replacement": "|"
+      }
+    },
+    "sparklyr::RY033::R/tidiers_utils.R:74:11": {
+      "package": "sparklyr",
+      "code": "RY033",
+      "path": "R/tidiers_utils.R",
+      "line": 74,
+      "column": 11,
+      "severity": "warning",
+      "message": "comparing `character` with `integer`; R coerces the numeric value to character and compares lexicographically, which is rarely intended"
+    },
+    "sparklyr::RY103::R/worker_apply.R:522:40": {
+      "package": "sparklyr",
+      "code": "RY103",
+      "path": "R/worker_apply.R",
+      "line": 522,
+      "column": 40,
+      "severity": "warning",
+      "message": "`class()` returns a character vector, so this comparison is not length-1 for a multi-class object and the enclosing condition errors; use `!inherits(df[[i]], target_type)`",
+      "fix": {
+        "start": 14365,
+        "end": 14394,
+        "replacement": "!inherits(df[[i]], target_type)"
+      }
+    },
+    "sparklyr::RY103::java/embedded_sources.R:2334:40": {
+      "package": "sparklyr",
+      "code": "RY103",
+      "path": "java/embedded_sources.R",
+      "line": 2334,
+      "column": 40,
+      "severity": "warning",
+      "message": "`class()` returns a character vector, so this comparison is not length-1 for a multi-class object and the enclosing condition errors; use `!inherits(df[[i]], target_type)`",
+      "fix": {
+        "start": 57221,
+        "end": 57250,
+        "replacement": "!inherits(df[[i]], target_type)"
+      }
+    },
+    "styler::RY010::tests/testthat/public-api/renvpkg/tests/testthat/test-package-xyz.R:2:18": {
+      "package": "styler",
+      "code": "RY010",
+      "path": "tests/testthat/public-api/renvpkg/tests/testthat/test-package-xyz.R",
+      "line": 2,
+      "column": 18,
+      "severity": "warning",
+      "message": "variable `x` is not bound in this scope"
+    },
+    "styler::RY010::tests/testthat/public-api/xyzpackage-qmd/tests/testthat/test-package-xyz.R:2:18": {
+      "package": "styler",
+      "code": "RY010",
+      "path": "tests/testthat/public-api/xyzpackage-qmd/tests/testthat/test-package-xyz.R",
+      "line": 2,
+      "column": 18,
+      "severity": "warning",
+      "message": "variable `x` is not bound in this scope"
+    },
+    "styler::RY010::tests/testthat/public-api/xyzpackage-rmd/tests/testthat/test-package-xyz.R:2:18": {
+      "package": "styler",
+      "code": "RY010",
+      "path": "tests/testthat/public-api/xyzpackage-rmd/tests/testthat/test-package-xyz.R",
+      "line": 2,
+      "column": 18,
+      "severity": "warning",
+      "message": "variable `x` is not bound in this scope"
+    },
+    "styler::RY010::tests/testthat/public-api/xyzpackage-rnw/tests/testthat/test-package-xyz.R:2:18": {
+      "package": "styler",
+      "code": "RY010",
+      "path": "tests/testthat/public-api/xyzpackage-rnw/tests/testthat/test-package-xyz.R",
+      "line": 2,
+      "column": 18,
+      "severity": "warning",
+      "message": "variable `x` is not bound in this scope"
+    },
+    "styler::RY010::tests/testthat/public-api/xyzpackage/tests/testthat/test-package-xyz.R:2:18": {
+      "package": "styler",
+      "code": "RY010",
+      "path": "tests/testthat/public-api/xyzpackage/tests/testthat/test-package-xyz.R",
+      "line": 2,
+      "column": 18,
+      "severity": "warning",
+      "message": "variable `x` is not bound in this scope"
+    },
+    "styler::RY033::R/roxygen-examples-add-remove.R:57:25": {
+      "package": "styler",
+      "code": "RY033",
+      "path": "R/roxygen-examples-add-remove.R",
+      "line": 57,
+      "column": 25,
+      "severity": "warning",
+      "message": "comparing `integer` with `character`; R coerces the numeric value to character and compares lexicographically, which is rarely intended"
+    },
+    "styler::RY033::R/rules-line-breaks.R:364:9": {
+      "package": "styler",
+      "code": "RY033",
+      "path": "R/rules-line-breaks.R",
+      "line": 364,
+      "column": 9,
+      "severity": "warning",
+      "message": "comparing `logical` with `character`; R coerces the numeric value to character and compares lexicographically, which is rarely intended"
+    },
+    "tensorflow::RY032::R/install.R:428:6": {
+      "package": "tensorflow",
+      "code": "RY032",
+      "path": "R/install.R",
+      "line": 428,
+      "column": 6,
+      "severity": "warning",
+      "message": "`||` operand depends on a parameter whose length is not known to be 1; current R errors for vectors",
+      "fix": {
+        "start": 15557,
+        "end": 15559,
+        "replacement": "|"
+      }
+    },
+    "tensorflow::RY061::R/generics.R:805:34": {
+      "package": "tensorflow",
+      "code": "RY061",
+      "path": "R/generics.R",
+      "line": 805,
+      "column": 34,
+      "severity": "error",
+      "message": "$ operator is invalid for atomic vectors of mode `integer`"
+    },
+    "testthat::RY000::tests/testthat/test-parallel/syntax-error/tests/testthat/test-error-1.R:6:1": {
+      "package": "testthat",
+      "code": "RY000",
+      "path": "tests/testthat/test-parallel/syntax-error/tests/testthat/test-error-1.R",
+      "line": 6,
+      "column": 1,
+      "severity": "error",
+      "message": "syntax error: unparseable region (recovered tree may be unreliable)"
+    },
+    "testthat::RY001::R/parallel-taskq.R:205:13": {
+      "package": "testthat",
+      "code": "RY001",
+      "path": "R/parallel-taskq.R",
+      "line": 205,
+      "column": 13,
+      "severity": "warning",
+      "message": "`if` condition is `logical<len=0>`, expected length-1 logical"
+    },
+    "testthat::RY010::tests/testthat/test-parallel/syntax-error/tests/testthat/test-error-1.R:5:1": {
+      "package": "testthat",
+      "code": "RY010",
+      "path": "tests/testthat/test-parallel/syntax-error/tests/testthat/test-error-1.R",
+      "line": 5,
+      "column": 1,
+      "severity": "warning",
+      "message": "variable `but` is not bound in this scope"
+    },
+    "testthat::RY010::tests/testthat/test-parallel/syntax-error/tests/testthat/test-error-1.R:5:13": {
+      "package": "testthat",
+      "code": "RY010",
+      "path": "tests/testthat/test-parallel/syntax-error/tests/testthat/test-error-1.R",
+      "line": 5,
+      "column": 13,
+      "severity": "warning",
+      "message": "variable `a` is not bound in this scope"
+    },
+    "testthat::RY010::tests/testthat/test-parallel/syntax-error/tests/testthat/test-error-1.R:5:15": {
+      "package": "testthat",
+      "code": "RY010",
+      "path": "tests/testthat/test-parallel/syntax-error/tests/testthat/test-error-1.R",
+      "line": 5,
+      "column": 15,
+      "severity": "warning",
+      "message": "variable `syntax` is not bound in this scope"
+    },
+    "testthat::RY010::tests/testthat/test-parallel/syntax-error/tests/testthat/test-error-1.R:5:22": {
+      "package": "testthat",
+      "code": "RY010",
+      "path": "tests/testthat/test-parallel/syntax-error/tests/testthat/test-error-1.R",
+      "line": 5,
+      "column": 22,
+      "severity": "warning",
+      "message": "variable `error` is not bound in this scope"
+    },
+    "testthat::RY010::tests/testthat/test-parallel/syntax-error/tests/testthat/test-error-1.R:5:5": {
+      "package": "testthat",
+      "code": "RY010",
+      "path": "tests/testthat/test-parallel/syntax-error/tests/testthat/test-error-1.R",
+      "line": 5,
+      "column": 5,
+      "severity": "warning",
+      "message": "variable `this` is not bound in this scope"
+    },
+    "testthat::RY010::tests/testthat/test-parallel/syntax-error/tests/testthat/test-error-1.R:6:1": {
+      "package": "testthat",
+      "code": "RY010",
+      "path": "tests/testthat/test-parallel/syntax-error/tests/testthat/test-error-1.R",
+      "line": 6,
+      "column": 1,
+      "severity": "warning",
+      "message": "variable `` is not bound in this scope"
+    },
+    "tidyr::RY010::R/chop.R:386:27": {
+      "package": "tidyr",
+      "code": "RY010",
+      "path": "R/chop.R",
+      "line": 386,
+      "column": 27,
+      "severity": "warning",
+      "message": "variable `vec_is_list` is not bound in this scope"
+    },
+    "tidyr::RY010::R/chop.R:465:7": {
+      "package": "tidyr",
+      "code": "RY010",
+      "path": "R/chop.R",
+      "line": 465,
+      "column": 7,
+      "severity": "warning",
+      "message": "variable `vec_recycle` is not bound in this scope"
+    },
+    "tidyr::RY010::R/hoist.R:155:37": {
+      "package": "tidyr",
+      "code": "RY010",
+      "path": "R/hoist.R",
+      "line": 155,
+      "column": 37,
+      "severity": "warning",
+      "message": "variable `vec_is_list` is not bound in this scope"
+    },
+    "tidyr::RY010::R/hoist.R:156:55": {
+      "package": "tidyr",
+      "code": "RY010",
+      "path": "R/hoist.R",
+      "line": 156,
+      "column": 55,
+      "severity": "warning",
+      "message": "variable `vec_chop` is not bound in this scope"
+    },
+    "tidyr::RY010::R/unnest-helper.R:88:40": {
+      "package": "tidyr",
+      "code": "RY010",
+      "path": "R/unnest-helper.R",
+      "line": 88,
+      "column": 40,
+      "severity": "warning",
+      "message": "variable `vec_is_list` is not bound in this scope"
+    },
+    "tidyr::RY010::R/unnest-longer.R:268:23": {
+      "package": "tidyr",
+      "code": "RY010",
+      "path": "R/unnest-longer.R",
+      "line": 268,
+      "column": 23,
+      "severity": "warning",
+      "message": "variable `vec_names` is not bound in this scope"
+    },
+    "tidyr::RY010::R/unnest-longer.R:285:45": {
+      "package": "tidyr",
+      "code": "RY010",
+      "path": "R/unnest-longer.R",
+      "line": 285,
+      "column": 45,
+      "severity": "warning",
+      "message": "variable `vec_rep` is not bound in this scope"
+    },
+    "tidyr::RY010::R/unnest-wider.R:232:17": {
+      "package": "tidyr",
+      "code": "RY010",
+      "path": "R/unnest-wider.R",
+      "line": 232,
+      "column": 17,
+      "severity": "warning",
+      "message": "variable `list_of` is not bound in this scope"
+    },
+    "tinytex::RY010::R/install.R:335:31": {
+      "package": "tinytex",
+      "code": "RY010",
+      "path": "R/install.R",
+      "line": 335,
+      "column": 31,
+      "severity": "warning",
+      "message": "variable `tmp` is not bound in this scope"
+    },
+    "tinytex::RY032::R/install.R:195:7": {
+      "package": "tinytex",
+      "code": "RY032",
+      "path": "R/install.R",
+      "line": 195,
+      "column": 7,
+      "severity": "warning",
+      "message": "`||` operand depends on a parameter whose length is not known to be 1; current R errors for vectors",
+      "fix": {
+        "start": 8673,
+        "end": 8675,
+        "replacement": "|"
+      }
+    },
+    "tinytex::RY032::R/install.R:324:9": {
+      "package": "tinytex",
+      "code": "RY032",
+      "path": "R/install.R",
+      "line": 324,
+      "column": 9,
+      "severity": "warning",
+      "message": "`||` operand depends on a parameter whose length is not known to be 1; current R errors for vectors",
+      "fix": {
+        "start": 13472,
+        "end": 13474,
+        "replacement": "|"
+      }
+    },
+    "torch::RY010::R/codegen-utils.R:12:21": {
+      "package": "torch",
+      "code": "RY010",
+      "path": "R/codegen-utils.R",
+      "line": 12,
+      "column": 21,
+      "severity": "warning",
+      "message": "variable `tensors` is not bound in this scope"
+    },
+    "torch::RY010::R/distributions-categorical.R:56:50": {
+      "package": "torch",
+      "code": "RY010",
+      "path": "R/distributions-categorical.R",
+      "line": 56,
+      "column": 50,
+      "severity": "warning",
+      "message": "variable `.instance` is not bound in this scope"
+    },
+    "torch::RY010::R/distributions-constraints.R:220:27": {
+      "package": "torch",
+      "code": "RY010",
+      "path": "R/distributions-constraints.R",
+      "line": 220,
+      "column": 27,
+      "severity": "warning",
+      "message": "variable `lower_bound` is not bound in this scope"
+    },
+    "torch::RY010::R/distributions-constraints.R:272:8": {
+      "package": "torch",
+      "code": "RY010",
+      "path": "R/distributions-constraints.R",
+      "line": 272,
+      "column": 8,
+      "severity": "warning",
+      "message": "variable `self.` is not bound in this scope"
+    },
+    "torch::RY010::tools/torchgen/R/functional.R:47:15": {
+      "package": "torch",
+      "code": "RY010",
+      "path": "tools/torchgen/R/functional.R",
+      "line": 47,
+      "column": 15,
+      "severity": "warning",
+      "message": "variable `transpose` is not bound in this scope"
+    },
+    "torch::RY033::R/install.R:699:4": {
+      "package": "torch",
+      "code": "RY033",
+      "path": "R/install.R",
+      "line": 699,
+      "column": 4,
+      "severity": "warning",
+      "message": "comparing `character` with `logical`; R coerces the numeric value to character and compares lexicographically, which is rarely intended"
+    },
+    "torch::RY033::R/package.R:42:37": {
+      "package": "torch",
+      "code": "RY033",
+      "path": "R/package.R",
+      "line": 42,
+      "column": 37,
+      "severity": "warning",
+      "message": "comparing `character` with `double`; R coerces the numeric value to character and compares lexicographically, which is rarely intended"
+    },
+    "torch::RY033::R/package.R:88:15": {
+      "package": "torch",
+      "code": "RY033",
+      "path": "R/package.R",
+      "line": 88,
+      "column": 15,
+      "severity": "warning",
+      "message": "comparing `character` with `double`; R coerces the numeric value to character and compares lexicographically, which is rarely intended"
+    },
+    "torch::RY033::tests/testthat.R:4:5": {
+      "package": "torch",
+      "code": "RY033",
+      "path": "tests/testthat.R",
+      "line": 4,
+      "column": 5,
+      "severity": "warning",
+      "message": "comparing `character` with `double`; R coerces the numeric value to character and compares lexicographically, which is rarely intended"
+    },
+    "torch::RY061::R/wrapers.R:174:39": {
+      "package": "torch",
+      "code": "RY061",
+      "path": "R/wrapers.R",
+      "line": 174,
+      "column": 39,
+      "severity": "error",
+      "message": "$ operator is invalid for atomic vectors of mode `double`"
+    },
+    "torch::RY061::R/wrapers.R:179:15": {
+      "package": "torch",
+      "code": "RY061",
+      "path": "R/wrapers.R",
+      "line": 179,
+      "column": 15,
+      "severity": "error",
+      "message": "$ operator is invalid for atomic vectors of mode `double`"
+    },
+    "torch::RY061::tests/testthat/test-ignite.R:196:16": {
+      "package": "torch",
+      "code": "RY061",
+      "path": "tests/testthat/test-ignite.R",
+      "line": 196,
+      "column": 16,
+      "severity": "error",
+      "message": "$ operator is invalid for atomic vectors of mode `double`"
+    },
+    "torch::RY061::tests/testthat/test-ignite.R:248:16": {
+      "package": "torch",
+      "code": "RY061",
+      "path": "tests/testthat/test-ignite.R",
+      "line": 248,
+      "column": 16,
+      "severity": "error",
+      "message": "$ operator is invalid for atomic vectors of mode `double`"
+    },
+    "torch::RY061::tests/testthat/test-ignite.R:251:16": {
+      "package": "torch",
+      "code": "RY061",
+      "path": "tests/testthat/test-ignite.R",
+      "line": 251,
+      "column": 16,
+      "severity": "error",
+      "message": "$ operator is invalid for atomic vectors of mode `double`"
+    },
+    "torch::RY061::tests/testthat/test-ignite.R:265:16": {
+      "package": "torch",
+      "code": "RY061",
+      "path": "tests/testthat/test-ignite.R",
+      "line": 265,
+      "column": 16,
+      "severity": "error",
+      "message": "$ operator is invalid for atomic vectors of mode `double`"
+    },
+    "torch::RY061::tests/testthat/test-ignite.R:266:16": {
+      "package": "torch",
+      "code": "RY061",
+      "path": "tests/testthat/test-ignite.R",
+      "line": 266,
+      "column": 16,
+      "severity": "error",
+      "message": "$ operator is invalid for atomic vectors of mode `double`"
+    },
+    "torch::RY061::tests/testthat/test-save.R:415:30": {
+      "package": "torch",
+      "code": "RY061",
+      "path": "tests/testthat/test-save.R",
+      "line": 415,
+      "column": 30,
+      "severity": "error",
+      "message": "$ operator is invalid for atomic vectors of mode `double`"
+    },
+    "torch::RY061::tests/testthat/test-save.R:416:30": {
+      "package": "torch",
+      "code": "RY061",
+      "path": "tests/testthat/test-save.R",
+      "line": 416,
+      "column": 30,
+      "severity": "error",
+      "message": "$ operator is invalid for atomic vectors of mode `double`"
+    },
+    "usethis::RY010::R/course.R:532:5": {
+      "package": "usethis",
+      "code": "RY010",
+      "path": "R/course.R",
+      "line": 532,
+      "column": 5,
+      "severity": "warning",
+      "message": "variable `dir_exists` is not bound in this scope"
+    },
+    "usethis::RY010::R/git-default-branch.R:675:13": {
+      "package": "usethis",
+      "code": "RY010",
+      "path": "R/git-default-branch.R",
+      "line": 675,
+      "column": 13,
+      "severity": "warning",
+      "message": "variable `path` is not bound in this scope"
+    },
+    "usethis::RY010::R/lifecycle.R:37:28": {
+      "package": "usethis",
+      "code": "RY010",
+      "path": "R/lifecycle.R",
+      "line": 37,
+      "column": 28,
+      "severity": "warning",
+      "message": "variable `file_copy` is not bound in this scope"
+    },
+    "usethis::RY010::R/use_standalone.R:79:50": {
+      "package": "usethis",
+      "code": "RY010",
+      "path": "R/use_standalone.R",
+      "line": 79,
+      "column": 50,
+      "severity": "warning",
+      "message": "variable `path` is not bound in this scope"
+    },
+    "usethis::RY010::R/vscode.R:7:44": {
+      "package": "usethis",
+      "code": "RY010",
+      "path": "R/vscode.R",
+      "line": 7,
+      "column": 44,
+      "severity": "warning",
+      "message": "variable `path_package` is not bound in this scope"
+    },
+    "usethis::RY032::R/use_standalone.R:171:22": {
+      "package": "usethis",
+      "code": "RY032",
+      "path": "R/use_standalone.R",
+      "line": 171,
+      "column": 22,
+      "severity": "warning",
+      "message": "`||` operand depends on a parameter whose length is not known to be 1; current R errors for vectors",
+      "fix": {
+        "start": 4799,
+        "end": 4801,
+        "replacement": "|"
+      }
+    },
+    "usethis::RY032::R/utils.R:64:3": {
+      "package": "usethis",
+      "code": "RY032",
+      "path": "R/utils.R",
+      "line": 64,
+      "column": 3,
+      "severity": "warning",
+      "message": "`&&` operand depends on a parameter whose length is not known to be 1; current R errors for vectors",
+      "fix": {
+        "start": 1341,
+        "end": 1343,
+        "replacement": "&"
+      }
+    },
+    "usethis::RY092::R/utils-github.R:131:20": {
+      "package": "usethis",
+      "code": "RY092",
+      "path": "R/utils-github.R",
+      "line": 131,
+      "column": 20,
+      "severity": "error",
+      "message": "argument `x` to `check_data_frame` is `opaque<len=?>`, expected list"
+    }
+  }
+}

--- a/docs/corpus/posit-messages-0.9.json
+++ b/docs/corpus/posit-messages-0.9.json
@@ -35,12 +35,7 @@
       "line": 618,
       "column": 7,
       "severity": "warning",
-      "message": "`||` operand depends on a parameter whose length is not known to be 1; current R errors for vectors",
-      "fix": {
-        "start": 23664,
-        "end": 23666,
-        "replacement": "|"
-      }
+      "message": "`||` operand depends on a parameter whose length is not known to be 1; current R errors for vectors"
     },
     "blogdown::RY105::R/hugo.R:380:9": {
       "package": "blogdown",
@@ -121,12 +116,7 @@
       "line": 459,
       "column": 9,
       "severity": "warning",
-      "message": "`||` operand depends on a parameter whose length is not known to be 1; current R errors for vectors",
-      "fix": {
-        "start": 13165,
-        "end": 13167,
-        "replacement": "|"
-      }
+      "message": "`||` operand depends on a parameter whose length is not known to be 1; current R errors for vectors"
     },
     "broom::RY032::R/utilities.R:485:9": {
       "package": "broom",
@@ -135,12 +125,7 @@
       "line": 485,
       "column": 9,
       "severity": "warning",
-      "message": "`||` operand depends on a parameter whose length is not known to be 1; current R errors for vectors",
-      "fix": {
-        "start": 13958,
-        "end": 13960,
-        "replacement": "|"
-      }
+      "message": "`||` operand depends on a parameter whose length is not known to be 1; current R errors for vectors"
     },
     "broom::RY032::R/utilities.R:501:9": {
       "package": "broom",
@@ -149,12 +134,7 @@
       "line": 501,
       "column": 9,
       "severity": "warning",
-      "message": "`||` operand depends on a parameter whose length is not known to be 1; current R errors for vectors",
-      "fix": {
-        "start": 14402,
-        "end": 14404,
-        "replacement": "|"
-      }
+      "message": "`||` operand depends on a parameter whose length is not known to be 1; current R errors for vectors"
     },
     "broom::RY033::R/deprecated-0-7-0.R:290:11": {
       "package": "broom",
@@ -937,12 +917,7 @@
       "line": 165,
       "column": 7,
       "severity": "warning",
-      "message": "`||` operand depends on a parameter whose length is not known to be 1; current R errors for vectors",
-      "fix": {
-        "start": 6578,
-        "end": 6580,
-        "replacement": "|"
-      }
+      "message": "`||` operand depends on a parameter whose length is not known to be 1; current R errors for vectors"
     },
     "cli::RY032::R/containers.R:45:7": {
       "package": "cli",
@@ -951,12 +926,7 @@
       "line": 45,
       "column": 7,
       "severity": "warning",
-      "message": "`||` operand depends on a parameter whose length is not known to be 1; current R errors for vectors",
-      "fix": {
-        "start": 1149,
-        "end": 1151,
-        "replacement": "|"
-      }
+      "message": "`||` operand depends on a parameter whose length is not known to be 1; current R errors for vectors"
     },
     "cli::RY032::R/rules.R:187:14": {
       "package": "cli",
@@ -965,12 +935,7 @@
       "line": 187,
       "column": 14,
       "severity": "warning",
-      "message": "`&&` operand depends on a parameter whose length is not known to be 1; current R errors for vectors",
-      "fix": {
-        "start": 4887,
-        "end": 4889,
-        "replacement": "&"
-      }
+      "message": "`&&` operand depends on a parameter whose length is not known to be 1; current R errors for vectors"
     },
     "cli::RY032::R/status-bar.R:256:7": {
       "package": "cli",
@@ -979,12 +944,7 @@
       "line": 256,
       "column": 7,
       "severity": "warning",
-      "message": "`&&` operand depends on a parameter whose length is not known to be 1; current R errors for vectors",
-      "fix": {
-        "start": 9323,
-        "end": 9325,
-        "replacement": "&"
-      }
+      "message": "`&&` operand depends on a parameter whose length is not known to be 1; current R errors for vectors"
     },
     "cli::RY032::R/status-bar.R:259:7": {
       "package": "cli",
@@ -993,12 +953,7 @@
       "line": 259,
       "column": 7,
       "severity": "warning",
-      "message": "`&&` operand depends on a parameter whose length is not known to be 1; current R errors for vectors",
-      "fix": {
-        "start": 9428,
-        "end": 9430,
-        "replacement": "&"
-      }
+      "message": "`&&` operand depends on a parameter whose length is not known to be 1; current R errors for vectors"
     },
     "cli::RY032::R/status-bar.R:262:7": {
       "package": "cli",
@@ -1007,12 +962,7 @@
       "line": 262,
       "column": 7,
       "severity": "warning",
-      "message": "`&&` operand depends on a parameter whose length is not known to be 1; current R errors for vectors",
-      "fix": {
-        "start": 9547,
-        "end": 9549,
-        "replacement": "&"
-      }
+      "message": "`&&` operand depends on a parameter whose length is not known to be 1; current R errors for vectors"
     },
     "cli::RY032::R/status-bar.R:364:7": {
       "package": "cli",
@@ -1021,12 +971,7 @@
       "line": 364,
       "column": 7,
       "severity": "warning",
-      "message": "`||` operand depends on a parameter whose length is not known to be 1; current R errors for vectors",
-      "fix": {
-        "start": 12003,
-        "end": 12005,
-        "replacement": "|"
-      }
+      "message": "`||` operand depends on a parameter whose length is not known to be 1; current R errors for vectors"
     },
     "cli::RY032::R/status-bar.R:451:7": {
       "package": "cli",
@@ -1035,12 +980,7 @@
       "line": 451,
       "column": 7,
       "severity": "warning",
-      "message": "`||` operand depends on a parameter whose length is not known to be 1; current R errors for vectors",
-      "fix": {
-        "start": 14653,
-        "end": 14655,
-        "replacement": "|"
-      }
+      "message": "`||` operand depends on a parameter whose length is not known to be 1; current R errors for vectors"
     },
     "cli::RY033::R/onload.R:44:22": {
       "package": "cli",
@@ -1337,12 +1277,7 @@
       "line": 60,
       "column": 25,
       "severity": "warning",
-      "message": "unknown argument `z` to `intersect`; did you mean `x`?",
-      "fix": {
-        "start": 2110,
-        "end": 2115,
-        "replacement": "x = 3"
-      }
+      "message": "unknown argument `z` to `intersect`; did you mean `x`?"
     },
     "dplyr::RY091::R/data-mask.R:112:7": {
       "package": "dplyr",
@@ -1945,12 +1880,7 @@
       "line": 79,
       "column": 7,
       "severity": "warning",
-      "message": "`||` operand depends on a parameter whose length is not known to be 1; current R errors for vectors",
-      "fix": {
-        "start": 3242,
-        "end": 3244,
-        "replacement": "|"
-      }
+      "message": "`||` operand depends on a parameter whose length is not known to be 1; current R errors for vectors"
     },
     "flexdashboard::RY001::R/flex_dashboard.R:381:11": {
       "package": "flexdashboard",
@@ -2418,12 +2348,7 @@
       "line": 36,
       "column": 23,
       "severity": "warning",
-      "message": "comparison directly inside a numeric math function is usually a parenthesization mistake; compare the math result instead",
-      "fix": {
-        "start": 1183,
-        "end": 1245,
-        "replacement": "abs(breaks$major_source - round(breaks$sec.major_source)) <= 1"
-      }
+      "message": "comparison directly inside a numeric math function is usually a parenthesization mistake; compare the math result instead"
     },
     "ggplot2::RY100::tests/testthat/test-axis-secondary.R:37:23": {
       "package": "ggplot2",
@@ -2432,12 +2357,7 @@
       "line": 37,
       "column": 23,
       "severity": "warning",
-      "message": "comparison directly inside a numeric math function is usually a parenthesization mistake; compare the math result instead",
-      "fix": {
-        "start": 1266,
-        "end": 1328,
-        "replacement": "abs(breaks$minor_source - round(breaks$sec.minor_source)) <= 1"
-      }
+      "message": "comparison directly inside a numeric math function is usually a parenthesization mistake; compare the math result instead"
     },
     "ggplot2::RY100::tests/testthat/test-axis-secondary.R:56:23": {
       "package": "ggplot2",
@@ -2446,12 +2366,7 @@
       "line": 56,
       "column": 23,
       "severity": "warning",
-      "message": "comparison directly inside a numeric math function is usually a parenthesization mistake; compare the math result instead",
-      "fix": {
-        "start": 1994,
-        "end": 2056,
-        "replacement": "abs(breaks$major_source - round(breaks$sec.major_source)) <= 1"
-      }
+      "message": "comparison directly inside a numeric math function is usually a parenthesization mistake; compare the math result instead"
     },
     "ggplot2::RY100::tests/testthat/test-axis-secondary.R:57:23": {
       "package": "ggplot2",
@@ -2460,12 +2375,7 @@
       "line": 57,
       "column": 23,
       "severity": "warning",
-      "message": "comparison directly inside a numeric math function is usually a parenthesization mistake; compare the math result instead",
-      "fix": {
-        "start": 2077,
-        "end": 2139,
-        "replacement": "abs(breaks$minor_source - round(breaks$sec.minor_source)) <= 1"
-      }
+      "message": "comparison directly inside a numeric math function is usually a parenthesization mistake; compare the math result instead"
     },
     "glue::RY040::tests/testthat/test-glue.R:595:20": {
       "package": "glue",
@@ -3383,12 +3293,7 @@
       "line": 117,
       "column": 9,
       "severity": "warning",
-      "message": "`&&` operand depends on a parameter whose length is not known to be 1; current R errors for vectors",
-      "fix": {
-        "start": 3448,
-        "end": 3450,
-        "replacement": "&"
-      }
+      "message": "`&&` operand depends on a parameter whose length is not known to be 1; current R errors for vectors"
     },
     "gt::RY032::R/opts.R:121:9": {
       "package": "gt",
@@ -3397,12 +3302,7 @@
       "line": 121,
       "column": 9,
       "severity": "warning",
-      "message": "`&&` operand depends on a parameter whose length is not known to be 1; current R errors for vectors",
-      "fix": {
-        "start": 3583,
-        "end": 3585,
-        "replacement": "&"
-      }
+      "message": "`&&` operand depends on a parameter whose length is not known to be 1; current R errors for vectors"
     },
     "gt::RY032::R/render_as_i_html.R:922:7": {
       "package": "gt",
@@ -3411,12 +3311,7 @@
       "line": 922,
       "column": 7,
       "severity": "warning",
-      "message": "`||` operand depends on a parameter whose length is not known to be 1; current R errors for vectors",
-      "fix": {
-        "start": 28717,
-        "end": 28719,
-        "replacement": "|"
-      }
+      "message": "`||` operand depends on a parameter whose length is not known to be 1; current R errors for vectors"
     },
     "gt::RY032::R/utils_render_latex.R:44:7": {
       "package": "gt",
@@ -3425,12 +3320,7 @@
       "line": 44,
       "column": 7,
       "severity": "warning",
-      "message": "`&&` operand depends on a parameter whose length is not known to be 1; current R errors for vectors",
-      "fix": {
-        "start": 1073,
-        "end": 1075,
-        "replacement": "&"
-      }
+      "message": "`&&` operand depends on a parameter whose length is not known to be 1; current R errors for vectors"
     },
     "gt::RY032::R/utils_render_rtf.R:795:7": {
       "package": "gt",
@@ -3439,12 +3329,7 @@
       "line": 795,
       "column": 7,
       "severity": "warning",
-      "message": "`&&` operand depends on a parameter whose length is not known to be 1; current R errors for vectors",
-      "fix": {
-        "start": 19659,
-        "end": 19661,
-        "replacement": "&"
-      }
+      "message": "`&&` operand depends on a parameter whose length is not known to be 1; current R errors for vectors"
     },
     "gt::RY032::R/utils_render_xml.R:744:7": {
       "package": "gt",
@@ -3453,12 +3338,7 @@
       "line": 744,
       "column": 7,
       "severity": "warning",
-      "message": "`&&` operand depends on a parameter whose length is not known to be 1; current R errors for vectors",
-      "fix": {
-        "start": 14805,
-        "end": 14807,
-        "replacement": "&"
-      }
+      "message": "`&&` operand depends on a parameter whose length is not known to be 1; current R errors for vectors"
     },
     "gt::RY061::R/utils_render_latex.R:2149:47": {
       "package": "gt",
@@ -3503,12 +3383,7 @@
       "line": 57,
       "column": 7,
       "severity": "warning",
-      "message": "`||` operand depends on a parameter whose length is not known to be 1; current R errors for vectors",
-      "fix": {
-        "start": 1335,
-        "end": 1337,
-        "replacement": "|"
-      }
+      "message": "`||` operand depends on a parameter whose length is not known to be 1; current R errors for vectors"
     },
     "httr::RY070::R/callback.R:100:5": {
       "package": "httr",
@@ -3652,12 +3527,7 @@
       "line": 315,
       "column": 7,
       "severity": "warning",
-      "message": "`||` operand depends on a parameter whose length is not known to be 1; current R errors for vectors",
-      "fix": {
-        "start": 9589,
-        "end": 9591,
-        "replacement": "|"
-      }
+      "message": "`||` operand depends on a parameter whose length is not known to be 1; current R errors for vectors"
     },
     "leaflet::RY032::R/colors.R:326:7": {
       "package": "leaflet",
@@ -3666,12 +3536,7 @@
       "line": 326,
       "column": 7,
       "severity": "warning",
-      "message": "`&&` operand depends on a parameter whose length is not known to be 1; current R errors for vectors",
-      "fix": {
-        "start": 12378,
-        "end": 12380,
-        "replacement": "&"
-      }
+      "message": "`&&` operand depends on a parameter whose length is not known to be 1; current R errors for vectors"
     },
     "leaflet::RY032::R/colors.R:333:14": {
       "package": "leaflet",
@@ -3680,12 +3545,7 @@
       "line": 333,
       "column": 14,
       "severity": "warning",
-      "message": "`&&` operand depends on a parameter whose length is not known to be 1; current R errors for vectors",
-      "fix": {
-        "start": 12663,
-        "end": 12665,
-        "replacement": "&"
-      }
+      "message": "`&&` operand depends on a parameter whose length is not known to be 1; current R errors for vectors"
     },
     "leaflet::RY032::R/layers.R:349:13": {
       "package": "leaflet",
@@ -3694,12 +3554,7 @@
       "line": 349,
       "column": 13,
       "severity": "warning",
-      "message": "`&&` operand depends on a parameter whose length is not known to be 1; current R errors for vectors",
-      "fix": {
-        "start": 12330,
-        "end": 12332,
-        "replacement": "&"
-      }
+      "message": "`&&` operand depends on a parameter whose length is not known to be 1; current R errors for vectors"
     },
     "learnr::RY010::R/question_text.R:122:7": {
       "package": "learnr",
@@ -3762,12 +3617,7 @@
       "line": 583,
       "column": 7,
       "severity": "warning",
-      "message": "`||` operand depends on a parameter whose length is not known to be 1; current R errors for vectors",
-      "fix": {
-        "start": 20210,
-        "end": 20212,
-        "replacement": "|"
-      }
+      "message": "`||` operand depends on a parameter whose length is not known to be 1; current R errors for vectors"
     },
     "lintr::RY032::R/utils.R:183:7": {
       "package": "lintr",
@@ -3776,12 +3626,7 @@
       "line": 183,
       "column": 7,
       "severity": "warning",
-      "message": "`||` operand depends on a parameter whose length is not known to be 1; current R errors for vectors",
-      "fix": {
-        "start": 5183,
-        "end": 5185,
-        "replacement": "|"
-      }
+      "message": "`||` operand depends on a parameter whose length is not known to be 1; current R errors for vectors"
     },
     "lintr::RY034::tests/testthat/dummy_packages/package/R/default_linter_testcode.R:25:73": {
       "package": "lintr",
@@ -3790,12 +3635,7 @@
       "line": 25,
       "column": 73,
       "severity": "warning",
-      "message": "comparison with `NA` always produces `NA`; use `is.na()` instead",
-      "fix": {
-        "start": 502,
-        "end": 509,
-        "replacement": "is.na(x)"
-      }
+      "message": "comparison with `NA` always produces `NA`; use `is.na()` instead"
     },
     "lintr::RY034::tests/testthat/dummy_packages/package/data-raw/default_linter_testcode.R:25:73": {
       "package": "lintr",
@@ -3804,12 +3644,7 @@
       "line": 25,
       "column": 73,
       "severity": "warning",
-      "message": "comparison with `NA` always produces `NA`; use `is.na()` instead",
-      "fix": {
-        "start": 502,
-        "end": 509,
-        "replacement": "is.na(x)"
-      }
+      "message": "comparison with `NA` always produces `NA`; use `is.na()` instead"
     },
     "lintr::RY034::tests/testthat/dummy_packages/package/inst/data-raw/default_linter_testcode.R:25:73": {
       "package": "lintr",
@@ -3818,12 +3653,7 @@
       "line": 25,
       "column": 73,
       "severity": "warning",
-      "message": "comparison with `NA` always produces `NA`; use `is.na()` instead",
-      "fix": {
-        "start": 502,
-        "end": 509,
-        "replacement": "is.na(x)"
-      }
+      "message": "comparison with `NA` always produces `NA`; use `is.na()` instead"
     },
     "lintr::RY060::tests/testthat/test-linter_tags.R:172:24": {
       "package": "lintr",
@@ -4174,12 +4004,7 @@
       "line": 30,
       "column": 20,
       "severity": "warning",
-      "message": "comparison is inside `length()`; compare `length(x)` instead",
-      "fix": {
-        "start": 1073,
-        "end": 1089,
-        "replacement": "length(pkg) == 1"
-      }
+      "message": "comparison is inside `length()`; compare `length(x)` instead"
     },
     "pak::RY093::R/package.R:176:20": {
       "package": "pak",
@@ -4188,12 +4013,7 @@
       "line": 176,
       "column": 20,
       "severity": "warning",
-      "message": "comparison is inside `length()`; compare `length(x)` instead",
-      "fix": {
-        "start": 5510,
-        "end": 5526,
-        "replacement": "length(pkg) == 1"
-      }
+      "message": "comparison is inside `length()`; compare `length(x)` instead"
     },
     "pak::RY093::R/package.R:293:20": {
       "package": "pak",
@@ -4202,12 +4022,7 @@
       "line": 293,
       "column": 20,
       "severity": "warning",
-      "message": "comparison is inside `length()`; compare `length(x)` instead",
-      "fix": {
-        "start": 8526,
-        "end": 8542,
-        "replacement": "length(pkg) == 1"
-      }
+      "message": "comparison is inside `length()`; compare `length(x)` instead"
     },
     "pak::RY102::R/pak-sitrep-data.R:41:5": {
       "package": "pak",
@@ -4216,12 +4031,7 @@
       "line": 41,
       "column": 5,
       "severity": "warning",
-      "message": "`<-` inside `list()` assigns `github-ref` and leaves the element unnamed; write `\"github-ref\" = ...` to name it",
-      "fix": {
-        "start": 1212,
-        "end": 1257,
-        "replacement": "\"github-ref\" = Sys.getenv(\"GITHUB_REF\", \"-\")"
-      }
+      "message": "`<-` inside `list()` assigns `github-ref` and leaves the element unnamed; write `\"github-ref\" = ...` to name it"
     },
     "pak::RY105::R/confirmation.R:42:14": {
       "package": "pak",
@@ -4338,12 +4148,7 @@
       "line": 1360,
       "column": 7,
       "severity": "warning",
-      "message": "`||` operand depends on a parameter whose length is not known to be 1; current R errors for vectors",
-      "fix": {
-        "start": 49164,
-        "end": 49166,
-        "replacement": "|"
-      }
+      "message": "`||` operand depends on a parameter whose length is not known to be 1; current R errors for vectors"
     },
     "plumber::RY033::R/plumber.R:474:82": {
       "package": "plumber",
@@ -4361,12 +4166,7 @@
       "line": 34,
       "column": 7,
       "severity": "warning",
-      "message": "`||` operand depends on a parameter whose length is not known to be 1; current R errors for vectors",
-      "fix": {
-        "start": 1101,
-        "end": 1103,
-        "replacement": "|"
-      }
+      "message": "`||` operand depends on a parameter whose length is not known to be 1; current R errors for vectors"
     },
     "purrr::RY080::tests/testthat/test-map.R:82:20": {
       "package": "purrr",
@@ -5086,12 +4886,7 @@
       "line": 685,
       "column": 7,
       "severity": "warning",
-      "message": "`||` operand depends on a parameter whose length is not known to be 1; current R errors for vectors",
-      "fix": {
-        "start": 18376,
-        "end": 18378,
-        "replacement": "|"
-      }
+      "message": "`||` operand depends on a parameter whose length is not known to be 1; current R errors for vectors"
     },
     "renv::RY032::R/bootstrap.R:981:7": {
       "package": "renv",
@@ -5100,12 +4895,7 @@
       "line": 981,
       "column": 7,
       "severity": "warning",
-      "message": "`||` operand depends on a parameter whose length is not known to be 1; current R errors for vectors",
-      "fix": {
-        "start": 25658,
-        "end": 25660,
-        "replacement": "|"
-      }
+      "message": "`||` operand depends on a parameter whose length is not known to be 1; current R errors for vectors"
     },
     "renv::RY032::R/json-write.R:60:12": {
       "package": "renv",
@@ -5114,12 +4904,7 @@
       "line": 60,
       "column": 12,
       "severity": "warning",
-      "message": "`||` operand depends on a parameter whose length is not known to be 1; current R errors for vectors",
-      "fix": {
-        "start": 1973,
-        "end": 1975,
-        "replacement": "|"
-      }
+      "message": "`||` operand depends on a parameter whose length is not known to be 1; current R errors for vectors"
     },
     "renv::RY032::R/type.R:5:7": {
       "package": "renv",
@@ -5128,12 +4913,7 @@
       "line": 5,
       "column": 7,
       "severity": "warning",
-      "message": "`||` operand depends on a parameter whose length is not known to be 1; current R errors for vectors",
-      "fix": {
-        "start": 108,
-        "end": 110,
-        "replacement": "|"
-      }
+      "message": "`||` operand depends on a parameter whose length is not known to be 1; current R errors for vectors"
     },
     "renv::RY032::R/utils.R:24:7": {
       "package": "renv",
@@ -5142,12 +4922,7 @@
       "line": 24,
       "column": 7,
       "severity": "warning",
-      "message": "`&&` operand depends on a parameter whose length is not known to be 1; current R errors for vectors",
-      "fix": {
-        "start": 495,
-        "end": 497,
-        "replacement": "&"
-      }
+      "message": "`&&` operand depends on a parameter whose length is not known to be 1; current R errors for vectors"
     },
     "renv::RY032::inst/resources/activate.R:1141:9": {
       "package": "renv",
@@ -5156,12 +4931,7 @@
       "line": 1141,
       "column": 9,
       "severity": "warning",
-      "message": "`||` operand depends on a parameter whose length is not known to be 1; current R errors for vectors",
-      "fix": {
-        "start": 32046,
-        "end": 32048,
-        "replacement": "|"
-      }
+      "message": "`||` operand depends on a parameter whose length is not known to be 1; current R errors for vectors"
     },
     "renv::RY070::R/package.R:367:12": {
       "package": "renv",
@@ -5215,12 +4985,7 @@
       "line": 36,
       "column": 5,
       "severity": "warning",
-      "message": "`||` operand depends on a parameter whose length is not known to be 1; current R errors for vectors",
-      "fix": {
-        "start": 1329,
-        "end": 1331,
-        "replacement": "|"
-      }
+      "message": "`||` operand depends on a parameter whose length is not known to be 1; current R errors for vectors"
     },
     "reticulate::RY032::R/py_require.R:591:9": {
       "package": "reticulate",
@@ -5229,12 +4994,7 @@
       "line": 591,
       "column": 9,
       "severity": "warning",
-      "message": "`||` operand depends on a parameter whose length is not known to be 1; current R errors for vectors",
-      "fix": {
-        "start": 21213,
-        "end": 21215,
-        "replacement": "|"
-      }
+      "message": "`||` operand depends on a parameter whose length is not known to be 1; current R errors for vectors"
     },
     "reticulate::RY032::tests/testthat/test-python-pandas.R:382:27": {
       "package": "reticulate",
@@ -5243,12 +5003,7 @@
       "line": 382,
       "column": 27,
       "severity": "warning",
-      "message": "`||` operand depends on a parameter whose length is not known to be 1; current R errors for vectors",
-      "fix": {
-        "start": 9686,
-        "end": 9688,
-        "replacement": "|"
-      }
+      "message": "`||` operand depends on a parameter whose length is not known to be 1; current R errors for vectors"
     },
     "rlang::RY001::R/cnd-abort.R:548:7": {
       "package": "rlang",
@@ -5428,12 +5183,7 @@
       "line": 210,
       "column": 38,
       "severity": "warning",
-      "message": "`||` operand depends on a parameter whose length is not known to be 1; current R errors for vectors",
-      "fix": {
-        "start": 6658,
-        "end": 6660,
-        "replacement": "|"
-      }
+      "message": "`||` operand depends on a parameter whose length is not known to be 1; current R errors for vectors"
     },
     "rmarkdown::RY032::R/pandoc.R:653:33": {
       "package": "rmarkdown",
@@ -5442,12 +5192,7 @@
       "line": 653,
       "column": 33,
       "severity": "warning",
-      "message": "`||` operand depends on a parameter whose length is not known to be 1; current R errors for vectors",
-      "fix": {
-        "start": 21005,
-        "end": 21007,
-        "replacement": "|"
-      }
+      "message": "`||` operand depends on a parameter whose length is not known to be 1; current R errors for vectors"
     },
     "rmarkdown::RY105::R/html_dependencies.R:245:9": {
       "package": "rmarkdown",
@@ -5906,12 +5651,7 @@
       "line": 154,
       "column": 7,
       "severity": "warning",
-      "message": "`||` operand depends on a parameter whose length is not known to be 1; current R errors for vectors",
-      "fix": {
-        "start": 4767,
-        "end": 4769,
-        "replacement": "|"
-      }
+      "message": "`||` operand depends on a parameter whose length is not known to be 1; current R errors for vectors"
     },
     "shiny-r::RY032::R/runapp.R:375:7": {
       "package": "shiny-r",
@@ -5920,12 +5660,7 @@
       "line": 375,
       "column": 7,
       "severity": "warning",
-      "message": "`||` operand depends on a parameter whose length is not known to be 1; current R errors for vectors",
-      "fix": {
-        "start": 16127,
-        "end": 16129,
-        "replacement": "|"
-      }
+      "message": "`||` operand depends on a parameter whose length is not known to be 1; current R errors for vectors"
     },
     "shiny-r::RY033::R/bookmark-state.R:138:18": {
       "package": "shiny-r",
@@ -5943,12 +5678,7 @@
       "line": 138,
       "column": 18,
       "severity": "warning",
-      "message": "comparison is inside `length()`; compare `length(x)` instead",
-      "fix": {
-        "start": 4288,
-        "end": 4310,
-        "replacement": "length(inputVals) != 0"
-      }
+      "message": "comparison is inside `length()`; compare `length(x)` instead"
     },
     "shiny-r::RY105::tests/testthat/test-non-blocking.R:127:15": {
       "package": "shiny-r",
@@ -6317,12 +6047,7 @@
       "line": 273,
       "column": 7,
       "severity": "warning",
-      "message": "`||` operand depends on a parameter whose length is not known to be 1; current R errors for vectors",
-      "fix": {
-        "start": 8762,
-        "end": 8764,
-        "replacement": "|"
-      }
+      "message": "`||` operand depends on a parameter whose length is not known to be 1; current R errors for vectors"
     },
     "sparklyr::RY032::R/spark_submit.R:34:7": {
       "package": "sparklyr",
@@ -6331,12 +6056,7 @@
       "line": 34,
       "column": 7,
       "severity": "warning",
-      "message": "`||` operand depends on a parameter whose length is not known to be 1; current R errors for vectors",
-      "fix": {
-        "start": 1058,
-        "end": 1060,
-        "replacement": "|"
-      }
+      "message": "`||` operand depends on a parameter whose length is not known to be 1; current R errors for vectors"
     },
     "sparklyr::RY033::R/tidiers_utils.R:74:11": {
       "package": "sparklyr",
@@ -6354,12 +6074,7 @@
       "line": 522,
       "column": 40,
       "severity": "warning",
-      "message": "`class()` returns a character vector, so this comparison is not length-1 for a multi-class object and the enclosing condition errors; use `!inherits(df[[i]], target_type)`",
-      "fix": {
-        "start": 14365,
-        "end": 14394,
-        "replacement": "!inherits(df[[i]], target_type)"
-      }
+      "message": "`class()` returns a character vector, so this comparison is not length-1 for a multi-class object and the enclosing condition errors; use `inherits()`"
     },
     "sparklyr::RY103::java/embedded_sources.R:2334:40": {
       "package": "sparklyr",
@@ -6368,12 +6083,7 @@
       "line": 2334,
       "column": 40,
       "severity": "warning",
-      "message": "`class()` returns a character vector, so this comparison is not length-1 for a multi-class object and the enclosing condition errors; use `!inherits(df[[i]], target_type)`",
-      "fix": {
-        "start": 57221,
-        "end": 57250,
-        "replacement": "!inherits(df[[i]], target_type)"
-      }
+      "message": "`class()` returns a character vector, so this comparison is not length-1 for a multi-class object and the enclosing condition errors; use `inherits()`"
     },
     "styler::RY010::tests/testthat/public-api/renvpkg/tests/testthat/test-package-xyz.R:2:18": {
       "package": "styler",
@@ -6445,12 +6155,7 @@
       "line": 428,
       "column": 6,
       "severity": "warning",
-      "message": "`||` operand depends on a parameter whose length is not known to be 1; current R errors for vectors",
-      "fix": {
-        "start": 15557,
-        "end": 15559,
-        "replacement": "|"
-      }
+      "message": "`||` operand depends on a parameter whose length is not known to be 1; current R errors for vectors"
     },
     "tensorflow::RY061::R/generics.R:805:34": {
       "package": "tensorflow",
@@ -6621,12 +6326,7 @@
       "line": 195,
       "column": 7,
       "severity": "warning",
-      "message": "`||` operand depends on a parameter whose length is not known to be 1; current R errors for vectors",
-      "fix": {
-        "start": 8673,
-        "end": 8675,
-        "replacement": "|"
-      }
+      "message": "`||` operand depends on a parameter whose length is not known to be 1; current R errors for vectors"
     },
     "tinytex::RY032::R/install.R:324:9": {
       "package": "tinytex",
@@ -6635,12 +6335,7 @@
       "line": 324,
       "column": 9,
       "severity": "warning",
-      "message": "`||` operand depends on a parameter whose length is not known to be 1; current R errors for vectors",
-      "fix": {
-        "start": 13472,
-        "end": 13474,
-        "replacement": "|"
-      }
+      "message": "`||` operand depends on a parameter whose length is not known to be 1; current R errors for vectors"
     },
     "torch::RY010::R/codegen-utils.R:12:21": {
       "package": "torch",
@@ -6856,12 +6551,7 @@
       "line": 171,
       "column": 22,
       "severity": "warning",
-      "message": "`||` operand depends on a parameter whose length is not known to be 1; current R errors for vectors",
-      "fix": {
-        "start": 4799,
-        "end": 4801,
-        "replacement": "|"
-      }
+      "message": "`||` operand depends on a parameter whose length is not known to be 1; current R errors for vectors"
     },
     "usethis::RY032::R/utils.R:64:3": {
       "package": "usethis",
@@ -6870,12 +6560,7 @@
       "line": 64,
       "column": 3,
       "severity": "warning",
-      "message": "`&&` operand depends on a parameter whose length is not known to be 1; current R errors for vectors",
-      "fix": {
-        "start": 1341,
-        "end": 1343,
-        "replacement": "&"
-      }
+      "message": "`&&` operand depends on a parameter whose length is not known to be 1; current R errors for vectors"
     },
     "usethis::RY092::R/utils-github.R:131:20": {
       "package": "usethis",

--- a/ecosystem/posit_messages.py
+++ b/ecosystem/posit_messages.py
@@ -95,6 +95,12 @@ def main() -> int:
             "findings": {},
         }
     candidate = copy.deepcopy(committed)
+    selected_packages = set(args.packages)
+    candidate["findings"] = {
+        key: value
+        for key, value in committed["findings"].items()
+        if value["package"] not in selected_packages
+    }
     candidate["findings"].update(observed)
     candidate["findings"] = dict(sorted(candidate["findings"].items()))
 
@@ -105,13 +111,14 @@ def main() -> int:
         )
         return 0
 
-    missing = [key for key in observed if key not in committed["findings"]]
-    stale = [
+    committed_findings = committed["findings"]
+    candidate_findings = candidate["findings"]
+    drifted = {
         key
-        for key, value in observed.items()
-        if committed["findings"].get(key) != value
-    ]
-    if not missing and not stale:
+        for key in committed_findings.keys() | candidate_findings.keys()
+        if committed_findings.get(key) != candidate_findings.get(key)
+    }
+    if not drifted:
         print(f"posit messages: {len(observed)} readable identities match")
         return 0
 
@@ -127,7 +134,7 @@ def main() -> int:
         )
     )
     print(
-        f"posit messages: drift in {len(set(missing + stale))} stable identities",
+        f"posit messages: drift in {len(drifted)} stable identities",
         file=sys.stderr,
     )
     return 1

--- a/ecosystem/posit_messages.py
+++ b/ecosystem/posit_messages.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Generate/check readable Posit diagnostic messages keyed by ledger identity."""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import difflib
+import json
+import sys
+from pathlib import Path
+
+
+def identity(finding: dict) -> str:
+    return (
+        f"{finding['package']}::{finding['code']}::{finding['path']}:"
+        f"{finding['line']}:{finding['column']}"
+    )
+
+
+def rendered(document: dict) -> str:
+    return json.dumps(document, ensure_ascii=False, indent=2, sort_keys=False) + "\n"
+
+
+def relative_path_matches(actual: str, expected: str) -> bool:
+    actual = actual.replace("\\", "/").removeprefix("./")
+    expected = expected.replace("\\", "/").removeprefix("./")
+    return actual == expected or actual.endswith("/" + expected)
+
+
+def observed_entries(
+    ledger: dict, json_dir: Path, report_prefix: str, packages: list[str]
+) -> dict[str, dict]:
+    expected = [row for row in ledger["findings"] if row["package"] in packages]
+    by_package: dict[str, list[dict]] = {}
+    for finding in expected:
+        by_package.setdefault(finding["package"], []).append(finding)
+
+    observed: dict[str, dict] = {}
+    for package, findings in by_package.items():
+        report = json_dir / f"{report_prefix}{package}.root.json"
+        diagnostics = json.loads(report.read_text(encoding="utf-8"))
+        for finding in findings:
+            matches = [
+                diagnostic
+                for diagnostic in diagnostics
+                if diagnostic["code"] == finding["code"]
+                and diagnostic["line"] == finding["line"]
+                and diagnostic["column"] == finding["column"]
+                and relative_path_matches(diagnostic["path"], finding["path"])
+            ]
+            if len(matches) != 1:
+                raise SystemExit(
+                    f"posit messages: expected one production diagnostic for "
+                    f"{identity(finding)}, found {len(matches)}"
+                )
+            diagnostic = matches[0]
+            entry = {
+                "package": finding["package"],
+                "code": finding["code"],
+                "path": finding["path"],
+                "line": finding["line"],
+                "column": finding["column"],
+                "severity": diagnostic["severity"],
+                "message": diagnostic["message"],
+            }
+            if "fix" in diagnostic:
+                entry["fix"] = diagnostic["fix"]
+            observed[identity(finding)] = entry
+    return observed
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("mode", choices=("check", "update"))
+    parser.add_argument("--ledger", type=Path, required=True)
+    parser.add_argument("--messages", type=Path, required=True)
+    parser.add_argument("--json-dir", type=Path, required=True)
+    parser.add_argument("--report-prefix", default="")
+    parser.add_argument("packages", nargs="+")
+    args = parser.parse_args()
+
+    ledger = json.loads(args.ledger.read_text(encoding="utf-8"))
+    observed = observed_entries(
+        ledger, args.json_dir, args.report_prefix, args.packages
+    )
+    if args.messages.exists():
+        committed = json.loads(args.messages.read_text(encoding="utf-8"))
+    else:
+        committed = {
+            "schema_version": 1,
+            "corpus": "posit",
+            "ry_version": "0.9.0-dev",
+            "identity_fields": ["package", "code", "path", "line", "column"],
+            "findings": {},
+        }
+    candidate = copy.deepcopy(committed)
+    candidate["findings"].update(observed)
+    candidate["findings"] = dict(sorted(candidate["findings"].items()))
+
+    if args.mode == "update":
+        args.messages.write_text(rendered(candidate), encoding="utf-8")
+        print(
+            f"posit messages: updated {len(observed)} identities in {args.messages}"
+        )
+        return 0
+
+    missing = [key for key in observed if key not in committed["findings"]]
+    stale = [
+        key
+        for key, value in observed.items()
+        if committed["findings"].get(key) != value
+    ]
+    if not missing and not stale:
+        print(f"posit messages: {len(observed)} readable identities match")
+        return 0
+
+    before = rendered(committed).splitlines(keepends=True)
+    after = rendered(candidate).splitlines(keepends=True)
+    sys.stderr.writelines(
+        difflib.unified_diff(
+            before,
+            after,
+            fromfile=str(args.messages),
+            tofile=f"{args.messages} (production)",
+            n=8,
+        )
+    )
+    print(
+        f"posit messages: drift in {len(set(missing + stale))} stable identities",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ecosystem/run.sh
+++ b/ecosystem/run.sh
@@ -443,6 +443,24 @@ if (length(missing) || length(unowned)) {
 RS
 fi
 
+# The identity ledger intentionally omits prose. The companion Posit message
+# ledger is regenerated from the same production JSON diagnostics and keyed by
+# those reviewed identities, making message/fix drift a readable review diff.
+if ! $local_only && [[ "$(basename "$audit_corpus")" == "posit-0.9.0.json" ]]; then
+  command -v python3 >/dev/null 2>&1 || {
+    echo "ecosystem: required command not found: python3" >&2
+    exit 2
+  }
+  message_mode=update
+  $check && message_mode=check
+  python3 "$ecosystem_dir/posit_messages.py" "$message_mode" \
+    --ledger "$audit_corpus" \
+    --messages "$root/docs/corpus/posit-messages-0.9.json" \
+    --json-dir "$work_dir" \
+    --report-prefix "$report_prefix" \
+    "${root_packages[@]}"
+fi
+
 summary_names=("$summary_prefix.md")
 if ! $local_only; then
   summary_names+=("$summary_prefix.root.md")

--- a/ecosystem/run.sh
+++ b/ecosystem/run.sh
@@ -93,12 +93,17 @@ if [[ -z "$audit_corpus" ]]; then
   fi
 fi
 
-for command in cargo git python3 Rscript; do
-  command -v "$command" >/dev/null 2>&1 || {
-    echo "ecosystem: required command not found: $command" >&2
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || {
+    echo "ecosystem: required command not found: $1" >&2
     exit 2
   }
-done
+}
+
+require_command Rscript
+if ! $local_only; then
+  require_command git
+fi
 
 # Snapshots must not depend on which R packages are installed on the
 # machine that generates them: disable ry's installed-library resolution.
@@ -117,6 +122,8 @@ if [[ -n "${RY_BINARY:-}" ]]; then
     exit 2
   fi
 else
+  require_command cargo
+  require_command python3
   # Always ask Cargo for the current release binary. Checking only whether the
   # path exists can silently run an executable built from an older checkout,
   # then regenerate reviewed reports that disagree with clean CI. Resolve the
@@ -492,10 +499,7 @@ if ! $local_only; then
   audit_corpus_path="$(cd "$(dirname "$audit_corpus")" && pwd -P)/$(basename "$audit_corpus")"
   posit_corpus_path="$(cd "$(dirname "$posit_corpus")" && pwd -P)/$(basename "$posit_corpus")"
   if [[ "$audit_corpus_path" == "$posit_corpus_path" ]]; then
-    command -v python3 >/dev/null 2>&1 || {
-      echo "ecosystem: required command not found: python3" >&2
-      exit 2
-    }
+    require_command python3
     message_mode=update
     $check && message_mode=check
     python3 "$ecosystem_dir/posit_messages.py" "$message_mode" \

--- a/ecosystem/run.sh
+++ b/ecosystem/run.sh
@@ -93,7 +93,7 @@ if [[ -z "$audit_corpus" ]]; then
   fi
 fi
 
-for command in cargo git Rscript; do
+for command in cargo git python3 Rscript; do
   command -v "$command" >/dev/null 2>&1 || {
     echo "ecosystem: required command not found: $command" >&2
     exit 2
@@ -119,9 +119,39 @@ if [[ -n "${RY_BINARY:-}" ]]; then
 else
   # Always ask Cargo for the current release binary. Checking only whether the
   # path exists can silently run an executable built from an older checkout,
-  # then regenerate reviewed reports that disagree with clean CI.
-  cargo build --release --locked -p ry-cli --bin ry --manifest-path "$root/Cargo.toml"
-  binary="$root/target/release/ry"
+  # then regenerate reviewed reports that disagree with clean CI. Resolve the
+  # executable from Cargo's artifact stream so CARGO_TARGET_DIR, configured
+  # target directories, and explicit build targets cannot redirect it behind
+  # this script's back.
+  binary="$(
+    cargo build --release --locked -p ry-cli --bin ry \
+      --manifest-path "$root/Cargo.toml" \
+      --message-format=json-render-diagnostics |
+      python3 -c '
+import json
+import sys
+
+executable = None
+for line in sys.stdin:
+    message = json.loads(line)
+    if message.get("reason") == "compiler-message":
+        rendered = message.get("message", {}).get("rendered")
+        if rendered:
+            sys.stderr.write(rendered)
+    target = message.get("target", {})
+    if (
+        message.get("reason") == "compiler-artifact"
+        and target.get("name") == "ry"
+        and "bin" in target.get("kind", [])
+        and message.get("executable")
+    ):
+        executable = message["executable"]
+if executable is None:
+    sys.stderr.write("ecosystem: Cargo did not report the ry executable\n")
+    raise SystemExit(1)
+print(executable)
+'
+  )"
 fi
 
 write_report() {

--- a/ecosystem/run.sh
+++ b/ecosystem/run.sh
@@ -110,9 +110,18 @@ trap 'rm -rf "$work_dir"' EXIT
 generated_dir="$work_dir/reports"
 mkdir -p "$generated_dir"
 
-binary="${RY_BINARY:-$root/target/release/ry}"
-if [[ ! -x "$binary" ]]; then
+if [[ -n "${RY_BINARY:-}" ]]; then
+  binary="$RY_BINARY"
+  if [[ ! -x "$binary" ]]; then
+    echo "ecosystem: RY_BINARY is not executable: $binary" >&2
+    exit 2
+  fi
+else
+  # Always ask Cargo for the current release binary. Checking only whether the
+  # path exists can silently run an executable built from an older checkout,
+  # then regenerate reviewed reports that disagree with clean CI.
   cargo build --release --locked -p ry-cli --bin ry --manifest-path "$root/Cargo.toml"
+  binary="$root/target/release/ry"
 fi
 
 write_report() {

--- a/ecosystem/run.sh
+++ b/ecosystem/run.sh
@@ -446,19 +446,26 @@ fi
 # The identity ledger intentionally omits prose. The companion Posit message
 # ledger is regenerated from the same production JSON diagnostics and keyed by
 # those reviewed identities, making message/fix drift a readable review diff.
-if ! $local_only && [[ "$(basename "$audit_corpus")" == "posit-0.9.0.json" ]]; then
-  command -v python3 >/dev/null 2>&1 || {
-    echo "ecosystem: required command not found: python3" >&2
-    exit 2
-  }
-  message_mode=update
-  $check && message_mode=check
-  python3 "$ecosystem_dir/posit_messages.py" "$message_mode" \
-    --ledger "$audit_corpus" \
-    --messages "$root/docs/corpus/posit-messages-0.9.json" \
-    --json-dir "$work_dir" \
-    --report-prefix "$report_prefix" \
-    "${root_packages[@]}"
+# Compare normalized full paths: a different ledger with the same basename must
+# never update or check the canonical Posit message ledger.
+if ! $local_only; then
+  posit_corpus="$root/docs/corpus/posit-0.9.0.json"
+  audit_corpus_path="$(cd "$(dirname "$audit_corpus")" && pwd -P)/$(basename "$audit_corpus")"
+  posit_corpus_path="$(cd "$(dirname "$posit_corpus")" && pwd -P)/$(basename "$posit_corpus")"
+  if [[ "$audit_corpus_path" == "$posit_corpus_path" ]]; then
+    command -v python3 >/dev/null 2>&1 || {
+      echo "ecosystem: required command not found: python3" >&2
+      exit 2
+    }
+    message_mode=update
+    $check && message_mode=check
+    python3 "$ecosystem_dir/posit_messages.py" "$message_mode" \
+      --ledger "$audit_corpus" \
+      --messages "$root/docs/corpus/posit-messages-0.9.json" \
+      --json-dir "$work_dir" \
+      --report-prefix "$report_prefix" \
+      "${root_packages[@]}"
+  fi
 fi
 
 summary_names=("$summary_prefix.md")

--- a/ecosystem/test_posit_messages.py
+++ b/ecosystem/test_posit_messages.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+import json
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+class PositMessagesGateTest(unittest.TestCase):
+    def test_one_word_message_change_has_readable_unified_diff(self):
+        root = Path(__file__).resolve().parents[1]
+        script = root / "ecosystem/posit_messages.py"
+        with tempfile.TemporaryDirectory() as directory:
+            temp = Path(directory)
+            ledger = temp / "ledger.json"
+            messages = temp / "messages.json"
+            report = temp / "posit.demo.root.json"
+            ledger.write_text(json.dumps({
+                "findings": [{
+                    "package": "demo", "code": "RY010", "path": "R/x.R",
+                    "line": 1, "column": 1,
+                }]
+            }))
+            report.write_text(json.dumps([{
+                "path": "/cache/demo/R/x.R", "code": "RY010",
+                "line": 1, "column": 1, "severity": "warning",
+                "message": "variable `old` is not bound",
+            }]))
+            base = [
+                str(script), "update", "--ledger", str(ledger),
+                "--messages", str(messages), "--json-dir", str(temp),
+                "--report-prefix", "posit.", "demo",
+            ]
+            subprocess.run(base, check=True, capture_output=True, text=True)
+            document = json.loads(messages.read_text())
+            entry = next(iter(document["findings"].values()))
+            entry["message"] = "variable `new` is not bound"
+            messages.write_text(json.dumps(document, indent=2) + "\n")
+
+            result = subprocess.run(
+                [base[0], "check", *base[2:]],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn('-      "message": "variable `new` is not bound"', result.stderr)
+            self.assertIn('+      "message": "variable `old` is not bound"', result.stderr)
+            self.assertIn("demo::RY010::R/x.R:1:1", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ecosystem/test_posit_messages.py
+++ b/ecosystem/test_posit_messages.py
@@ -48,6 +48,61 @@ class PositMessagesGateTest(unittest.TestCase):
             self.assertIn('+      "message": "variable `old` is not bound"', result.stderr)
             self.assertIn("demo::RY010::R/x.R:1:1", result.stderr)
 
+    def test_selected_packages_are_replaced_without_pruning_unselected_packages(self):
+        root = Path(__file__).resolve().parents[1]
+        script = root / "ecosystem/posit_messages.py"
+        with tempfile.TemporaryDirectory() as directory:
+            temp = Path(directory)
+            ledger = temp / "ledger.json"
+            messages = temp / "messages.json"
+            report = temp / "posit.demo.root.json"
+            ledger.write_text(json.dumps({
+                "findings": [{
+                    "package": "demo", "code": "RY010", "path": "R/x.R",
+                    "line": 1, "column": 1,
+                }]
+            }))
+            report.write_text(json.dumps([{
+                "path": "/cache/demo/R/x.R", "code": "RY010",
+                "line": 1, "column": 1, "severity": "warning",
+                "message": "current",
+            }]))
+            base = [
+                str(script), "update", "--ledger", str(ledger),
+                "--messages", str(messages), "--json-dir", str(temp),
+                "--report-prefix", "posit.", "demo",
+            ]
+            subprocess.run(base, check=True, capture_output=True, text=True)
+            document = json.loads(messages.read_text())
+            obsolete_demo = "demo::RY010::R/obsolete.R:2:1"
+            unselected = "other::RY010::R/preserved.R:3:1"
+            document["findings"][obsolete_demo] = {
+                "package": "demo", "code": "RY010", "path": "R/obsolete.R",
+                "line": 2, "column": 1, "severity": "warning",
+                "message": "obsolete",
+            }
+            document["findings"][unselected] = {
+                "package": "other", "code": "RY010", "path": "R/preserved.R",
+                "line": 3, "column": 1, "severity": "warning",
+                "message": "preserved",
+            }
+            messages.write_text(json.dumps(document, indent=2) + "\n")
+
+            check = subprocess.run(
+                [base[0], "check", *base[2:]],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            self.assertNotEqual(check.returncode, 0)
+            self.assertIn(f'-    "{obsolete_demo}"', check.stderr)
+            self.assertNotIn(f'-    "{unselected}"', check.stderr)
+
+            subprocess.run(base, check=True, capture_output=True, text=True)
+            updated = json.loads(messages.read_text())
+            self.assertNotIn(obsolete_demo, updated["findings"])
+            self.assertIn(unselected, updated["findings"])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Continuation of #58 after Plans 34 and P35-W1–W4 merged.

This draft begins with P35-W5 in the mandatory execution order:
- structured source-backed diagnostic fixes
- CLI JSON and LSP parity
- apply/parse/recheck oracle and snapshots
- reviewed Posit message ledger and drift gate

Validation:
- `cargo test --workspace`
- `cargo fmt --all -- --check`
- `python3 ecosystem/test_posit_messages.py`

Plan 35 work remains in progress; Plan 36 will not begin until Plan 35 acceptance is green and committed.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add structured quick-fix edits to diagnostics for RY032, RY034, RY090, RY093, RY100, RY101, RY102, and RY103
> - Introduces a `Fix` struct (span + replacement text) attached optionally to `Diagnostic`, serialized in JSON output under a `fix` key and exposed via LSP `data` payloads when source text is available.
> - Implements fix generation for eight lint rules: `&&`/`||` → `&`/`|` (RY032), `x == NA` → `is.na(x)` (RY034), closest-parameter rename (RY090), move comparison outside `length()`/`nchar()`/math calls (RY093, RY100), `[[]]` extraction rewrite (RY101), `<-` → `=` in element assignment (RY102), and `class(x) ==` → `inherits()` (RY103).
> - Adds scope-aware guards: RY032 fixes are suppressed in scalar `if`/`while` conditions and short-circuit guard patterns; RY103 fixes are suppressed unless the `class` call is unambiguously from base.
> - Adds a `posit_messages.py` ecosystem script and CI step that validates a human-readable message/fix ledger (`docs/corpus/posit-messages-0.9.json`) against production diagnostic output, emitting a unified diff on drift.
> - Extends `SourceFile` and `Checker` to carry source text so fix spans can be sliced and validated at emit time.
> - Risk: `Checker::check()` previously double-emitted parse errors (RY000); this is fixed, so parse error counts will drop by one per error in callers that used `check()`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b49dde7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added structured automatic fixes for common diagnostic issues, including operator, indexing, comparison, argument, and spelling corrections.
  * Published fix ranges and replacement text through JSON and LSP diagnostics.
  * Added source-aware diagnostic details and confidence values.
  * Added validation for Posit diagnostic messages and fixes.

* **Documentation**
  * Documented the diagnostic message and fix validation ledger.

* **Tests**
  * Expanded coverage for fixes, UTF-8/UTF-16 positions, diagnostic validation, and message synchronization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->