### PR TITLE
P35-W6: focused UTF-16 protocol contracts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1382,6 +1382,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "tokio",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ tokio = "1"
 toml = "1.1.2"
 glob = "0.3"
 tempfile = "3"
+url = "2"
 insta = { version = "1.48.0", features = ["yaml"] }
 proptest = "1.7"
 # parallelism (Project::check pass 3 + CLI parsing)

--- a/crates/ry-lsp/src/backend.rs
+++ b/crates/ry-lsp/src/backend.rs
@@ -120,7 +120,17 @@ pub(super) struct State {
 #[derive(Default)]
 pub(super) struct ProjectCache {
     project: Project,
-    versions: HashMap<String, i32>,
+    /// Snapshot identity for every file currently installed in `project`.
+    /// The LSP version is sufficient for open documents, but indexed files
+    /// use version zero, so `Arc` identity also participates in freshness.
+    files: HashMap<String, (i32, Arc<SourceFile>)>,
+}
+
+pub(super) struct ProjectCheckResult {
+    diagnostics: Vec<(String, Vec<ry_checker::Diagnostic>)>,
+    /// The exact parsed snapshots supplied to this check. Publication uses
+    /// their owned source and comments, never a separately-read document.
+    files: HashMap<String, Arc<SourceFile>>,
 }
 
 impl ProjectCache {
@@ -131,6 +141,7 @@ impl ProjectCache {
         user_stubs: Arc<std::collections::BTreeMap<String, ry_typeshed::Typeshed>>,
     ) -> Vec<(String, Vec<ry_checker::Diagnostic>)> {
         self.check_with_workspace(files, user_stubs, None)
+            .diagnostics
     }
 
     pub(super) fn check_with_workspace(
@@ -138,18 +149,22 @@ impl ProjectCache {
         files: Vec<(String, i32, Arc<SourceFile>)>,
         user_stubs: Arc<std::collections::BTreeMap<String, ry_typeshed::Typeshed>>,
         workspace: Option<&ry_workspace::WorkspaceContext>,
-    ) -> Vec<(String, Vec<ry_checker::Diagnostic>)> {
+    ) -> ProjectCheckResult {
+        let checked_files = files
+            .iter()
+            .map(|(path, _, file)| (path.clone(), Arc::clone(file)))
+            .collect();
         let current_paths: std::collections::HashSet<&str> =
             files.iter().map(|(path, _, _)| path.as_str()).collect();
         let removed: Vec<String> = self
-            .versions
+            .files
             .keys()
             .filter(|path| !current_paths.contains(path.as_str()))
             .cloned()
             .collect();
         for path in removed {
             self.project.remove_file(&path);
-            self.versions.remove(&path);
+            self.files.remove(&path);
         }
 
         self.project.set_user_stubs(user_stubs);
@@ -167,12 +182,21 @@ impl ProjectCache {
         self.project
             .set_load_bindings(workspace.load_bindings.clone());
         for (path, version, file) in files {
-            if self.versions.get(&path).copied() != Some(version) {
+            let changed = self
+                .files
+                .get(&path)
+                .is_none_or(|(cached_version, cached)| {
+                    *cached_version != version || !Arc::ptr_eq(cached, &file)
+                });
+            if changed {
                 self.project.update_file(path.clone(), Arc::clone(&file));
-                self.versions.insert(path, version);
+                self.files.insert(path, (version, file));
             }
         }
-        self.project.check_incremental()
+        ProjectCheckResult {
+            diagnostics: self.project.check_incremental(),
+            files: checked_files,
+        }
     }
 }
 
@@ -445,6 +469,9 @@ impl LanguageServer for Backend {
         state.workspace_folders = ws_folders;
         Ok(InitializeResult {
             capabilities: ServerCapabilities {
+                // All position conversion in this server is UTF-16. Advertise
+                // it explicitly instead of relying on the protocol default.
+                position_encoding: Some(PositionEncodingKind::UTF16),
                 text_document_sync: Some(TextDocumentSyncCapability::Kind(
                     // Incremental sync (Plan 33 W6): the client sends
                     // only the edited range, which we use to build a
@@ -879,7 +906,7 @@ impl LanguageServer for Backend {
             };
             let mut project = project.lock().await;
             project.project.remove_file(&path);
-            project.versions.remove(&path);
+            project.files.remove(&path);
         }
         // Clear diagnostics for the closed document so stale squiggles
         // don't linger after the user closes the file.
@@ -1505,11 +1532,19 @@ impl Backend {
             };
 
             if let Some(old_text) = old_text {
-                let new_text = apply_range_edit(&old_text, range, &change.text);
+                // Invalid UTF-16 endpoints (including a position inside an
+                // astral surrogate pair) cannot describe a byte splice.
+                // Ignore the malformed event rather than clamping it and
+                // corrupting the document.
+                let Some(new_text) = apply_range_edit(&old_text, range, &change.text) else {
+                    tracing::warn!(?range, "ignoring document change with invalid UTF-16 range");
+                    return;
+                };
+                let edit = build_input_edit(&old_text, range, &change.text)
+                    .expect("validated document-change range");
                 self.update_doc(path.to_string(), new_text, version).await;
 
                 // Build InputEdit and do incremental parse.
-                let edit = build_input_edit(&old_text, range, &change.text);
                 let mut tree_mut = old_tree;
                 if let Some(ref mut tree) = tree_mut {
                     tree.edit(&edit);
@@ -1711,10 +1746,8 @@ impl Backend {
         // Update the persistent multi-file Project from every open document
         // so cross-file calls resolve. Cached parses avoid re-parsing
         // unchanged documents, and ProjectCache forwards only changed
-        // versions to Project::update_file so pass-1 collection is reused.
+        // snapshots to Project::update_file so pass-1 collection is reused.
         let mut project_files = Vec::with_capacity(doc_paths.len());
-        let mut per_file_comments: HashMap<String, Vec<ry_core::ast::Comment>> = HashMap::new();
-        let mut per_file_source: HashMap<String, String> = HashMap::new();
         // Cached parses: `parsed_file` reuses the
         // per-document `SourceFile` cached in `State` and only re-parses
         // documents whose version changed since the last request.
@@ -1722,17 +1755,6 @@ impl Backend {
             let Some((file, _)) = self.parsed_file(doc_path).await else {
                 continue;
             };
-            per_file_comments.insert(doc_path.clone(), file.comments.clone());
-            // Snapshot source text for this document only (used later for
-            // comment-based suppression filtering and source-aware LSP
-            // diagnostic formatting). This avoids cloning the entire docs
-            // map up front.
-            {
-                let state = self.state.lock().await;
-                if let Some(text) = state.docs.get(doc_path) {
-                    per_file_source.insert(doc_path.clone(), text.clone());
-                }
-            }
             let Some(version) = versions.get(doc_path).copied() else {
                 continue;
             };
@@ -1763,7 +1785,7 @@ impl Backend {
             state.workspace_context_for_path(&path).cloned()
         };
         let mut project = project.lock().await;
-        let per_file =
+        let checked =
             project.check_with_workspace(project_files, user_stubs, workspace_context.as_ref());
         // An edit that arrived while parsing/checking invalidates this whole
         // project result because every open document is republished below.
@@ -1773,6 +1795,10 @@ impl Backend {
                 return;
             }
         }
+        let ProjectCheckResult {
+            diagnostics: per_file,
+            files: checked_files,
+        } = checked;
         for (diagnostic_path, mut diagnostics) in per_file {
             // `Project::check` emits every rule, including the ones the
             // default rule set leaves off (RY003). The CLI drops those in
@@ -1822,15 +1848,16 @@ impl Backend {
                 ry_config::subtract_baseline(&mut diagnostics, baseline, config_root.as_deref());
             }
 
-            let source_text = per_file_source.get(&diagnostic_path).map(String::as_str);
-            let file_comments = per_file_comments.get(&diagnostic_path);
-            let (file_level, suppressions) = match file_comments {
-                Some(comments) => (
-                    ry_checker::has_file_suppression_from_comments(comments),
-                    ry_checker::parse_suppressions_from_comments(
-                        comments,
-                        source_text.unwrap_or(""),
-                    ),
+            // Source, comments, spans, and fixes all come from the same
+            // `SourceFile` snapshot passed through `ProjectCache` for this
+            // check. This includes unopened indexed files and avoids both a
+            // disk reread race and an open-buffer/check snapshot mismatch.
+            let checked_file = checked_files.get(&diagnostic_path);
+            let source_text = checked_file.map(|file| file.source.as_str());
+            let (file_level, suppressions) = match checked_file {
+                Some(file) => (
+                    ry_checker::has_file_suppression_from_comments(&file.comments),
+                    ry_checker::parse_suppressions_from_comments(&file.comments, &file.source),
                 ),
                 None => (false, Vec::new()),
             };
@@ -2015,69 +2042,46 @@ pub(crate) fn uri_to_path(uri: &Url) -> String {
 /// Apply an LSP range-based edit to the old source text, producing the
 /// new text. LSP positions are 0-based line/character (UTF-16 code units).
 /// We convert to byte offsets for the splice.
-fn apply_range_edit(old_text: &str, range: Range, new_text: &str) -> String {
-    let start_byte = position_to_byte(old_text, range.start);
-    let end_byte = position_to_byte(old_text, range.end);
+fn apply_range_edit(old_text: &str, range: Range, new_text: &str) -> Option<String> {
+    let start_byte = position_to_byte_offset_pos(old_text, range.start)?;
+    let end_byte = position_to_byte_offset_pos(old_text, range.end)?;
+    if start_byte > end_byte {
+        return None;
+    }
     let mut result = String::with_capacity(old_text.len() + new_text.len());
     result.push_str(&old_text[..start_byte]);
     result.push_str(new_text);
     result.push_str(&old_text[end_byte..]);
-    result
+    Some(result)
 }
 
 /// Build a tree-sitter `InputEdit` from an LSP range and replacement text.
 /// The InputEdit tells tree-sitter which byte range changed and the new
 /// positions, so it can reuse unchanged subtrees.
-pub(crate) fn build_input_edit(old_text: &str, range: Range, new_text: &str) -> ry_core::InputEdit {
-    let start_byte = position_to_byte(old_text, range.start);
-    let old_end_byte = position_to_byte(old_text, range.end);
+pub(crate) fn build_input_edit(
+    old_text: &str,
+    range: Range,
+    new_text: &str,
+) -> Option<ry_core::InputEdit> {
+    let start_byte = position_to_byte_offset_pos(old_text, range.start)?;
+    let old_end_byte = position_to_byte_offset_pos(old_text, range.end)?;
+    if start_byte > old_end_byte {
+        return None;
+    }
     let new_end_byte = start_byte + new_text.len();
 
     let start_position = byte_offset_to_point(old_text, start_byte);
     let old_end_position = byte_offset_to_point(old_text, old_end_byte);
     let new_end_position = byte_offset_to_point_relative(start_byte, start_position, new_text);
 
-    ry_core::InputEdit {
+    Some(ry_core::InputEdit {
         start_byte,
         old_end_byte,
         new_end_byte,
         start_position,
         old_end_position,
         new_end_position,
-    }
-}
-
-/// Convert an LSP Position (0-based line, UTF-16 code unit column) to a
-/// byte offset in the source text.
-fn position_to_byte(text: &str, pos: Position) -> usize {
-    let mut line_start = 0;
-    let mut current_line = 0;
-
-    // Find the start of the target line.
-    while current_line < pos.line {
-        if let Some(nl) = text[line_start..].find('\n') {
-            line_start += nl + 1;
-            current_line += 1;
-        } else {
-            return text.len();
-        }
-    }
-
-    // Find the byte offset within the line corresponding to the UTF-16 column.
-    let line = &text[line_start..];
-    let line_end = line.find('\n').unwrap_or(line.len());
-    let line = &line[..line_end];
-
-    let mut utf16_col = 0u32;
-    for (byte_off, ch) in line.char_indices() {
-        if utf16_col >= pos.character {
-            return line_start + byte_off;
-        }
-        utf16_col += ch.len_utf16() as u32;
-    }
-
-    // Position at or beyond end of line.
-    line_start + line.len()
+    })
 }
 
 /// Convert a byte offset to a tree-sitter Point (row, byte column).

--- a/crates/ry-lsp/src/backend.rs
+++ b/crates/ry-lsp/src/backend.rs
@@ -695,8 +695,18 @@ impl LanguageServer for Backend {
         // Incremental sync (W6): process each change event, applying
         // range-based edits to the old text and building a tree-sitter
         // InputEdit for incremental reparse.
+        //
+        // If any change has an invalid UTF-16 range, abort the remaining
+        // batch: subsequent changes' ranges are relative to the client
+        // text after the dropped edit, so applying them to the server's
+        // (pre-dropped-edit) text would splice wrong bytes.
         for change in params.content_changes {
-            self.apply_incremental_change(&path, change, version).await;
+            if !self.apply_incremental_change(&path, change, version).await {
+                tracing::error!(
+                    "aborting remaining changes in didChange batch for {path};                      server and client text will desynchronize until a full sync is received"
+                );
+                break;
+            }
         }
         // Debounced: a burst of keystrokes coalesces into a single
         // diagnostic publish.
@@ -1522,7 +1532,7 @@ impl Backend {
         path: &str,
         change: TextDocumentContentChangeEvent,
         version: i32,
-    ) {
+    ) -> bool {
         if let Some(range) = change.range {
             // Incremental: apply the range edit to the old text.
             let (old_text, old_tree) = {
@@ -1539,9 +1549,9 @@ impl Backend {
                 let Some((start_byte, end_byte)) = range_byte_span(&old_text, range) else {
                     tracing::error!(
                         ?range,
-                        "dropping document change with invalid UTF-16 range; server and client text will desynchronize until a full sync is received"
+                        "invalid UTF-16 range in document change; server and client text will desynchronize until a full sync is received"
                     );
-                    return;
+                    return false;
                 };
                 let new_text = {
                     let mut result = String::with_capacity(old_text.len() + change.text.len());
@@ -1575,6 +1585,7 @@ impl Backend {
                 self.update_doc(path.to_string(), change.text, version)
                     .await;
             }
+            true
         } else {
             // Full text change (no range). Clear stale tree.
             {
@@ -1583,6 +1594,7 @@ impl Backend {
             }
             self.update_doc(path.to_string(), change.text, version)
                 .await;
+            true
         }
     }
 
@@ -2057,8 +2069,6 @@ fn range_byte_span(old_text: &str, range: Range) -> Option<(usize, usize)> {
     let end_byte = position_to_byte_offset_pos(old_text, range.end)?;
     (start_byte <= end_byte).then_some((start_byte, end_byte))
 }
-
-
 
 /// Build a tree-sitter `InputEdit` from an LSP range and replacement text.
 /// The InputEdit tells tree-sitter which byte range changed and the new

--- a/crates/ry-lsp/src/backend.rs
+++ b/crates/ry-lsp/src/backend.rs
@@ -1536,12 +1536,22 @@ impl Backend {
                 // astral surrogate pair) cannot describe a byte splice.
                 // Ignore the malformed event rather than clamping it and
                 // corrupting the document.
-                let Some(new_text) = apply_range_edit(&old_text, range, &change.text) else {
-                    tracing::warn!(?range, "ignoring document change with invalid UTF-16 range");
+                let Some((start_byte, end_byte)) = range_byte_span(&old_text, range) else {
+                    tracing::error!(
+                        ?range,
+                        "dropping document change with invalid UTF-16 range; server and client text will desynchronize until a full sync is received"
+                    );
                     return;
                 };
-                let edit = build_input_edit(&old_text, range, &change.text)
-                    .expect("validated document-change range");
+                let new_text = {
+                    let mut result = String::with_capacity(old_text.len() + change.text.len());
+                    result.push_str(&old_text[..start_byte]);
+                    result.push_str(&change.text);
+                    result.push_str(&old_text[end_byte..]);
+                    result
+                };
+                let edit =
+                    build_input_edit_from_span(&old_text, start_byte, end_byte, &change.text);
                 self.update_doc(path.to_string(), new_text, version).await;
 
                 // Build InputEdit and do incremental parse.
@@ -2042,46 +2052,52 @@ pub(crate) fn uri_to_path(uri: &Url) -> String {
 /// Apply an LSP range-based edit to the old source text, producing the
 /// new text. LSP positions are 0-based line/character (UTF-16 code units).
 /// We convert to byte offsets for the splice.
-fn apply_range_edit(old_text: &str, range: Range, new_text: &str) -> Option<String> {
+fn range_byte_span(old_text: &str, range: Range) -> Option<(usize, usize)> {
     let start_byte = position_to_byte_offset_pos(old_text, range.start)?;
     let end_byte = position_to_byte_offset_pos(old_text, range.end)?;
-    if start_byte > end_byte {
-        return None;
-    }
-    let mut result = String::with_capacity(old_text.len() + new_text.len());
-    result.push_str(&old_text[..start_byte]);
-    result.push_str(new_text);
-    result.push_str(&old_text[end_byte..]);
-    Some(result)
+    (start_byte <= end_byte).then_some((start_byte, end_byte))
 }
+
+
 
 /// Build a tree-sitter `InputEdit` from an LSP range and replacement text.
 /// The InputEdit tells tree-sitter which byte range changed and the new
 /// positions, so it can reuse unchanged subtrees.
+#[cfg(test)]
 pub(crate) fn build_input_edit(
     old_text: &str,
     range: Range,
     new_text: &str,
 ) -> Option<ry_core::InputEdit> {
-    let start_byte = position_to_byte_offset_pos(old_text, range.start)?;
-    let old_end_byte = position_to_byte_offset_pos(old_text, range.end)?;
-    if start_byte > old_end_byte {
-        return None;
-    }
+    let (start_byte, old_end_byte) = range_byte_span(old_text, range)?;
+    Some(build_input_edit_from_span(
+        old_text,
+        start_byte,
+        old_end_byte,
+        new_text,
+    ))
+}
+
+fn build_input_edit_from_span(
+    old_text: &str,
+    start_byte: usize,
+    old_end_byte: usize,
+    new_text: &str,
+) -> ry_core::InputEdit {
     let new_end_byte = start_byte + new_text.len();
 
     let start_position = byte_offset_to_point(old_text, start_byte);
     let old_end_position = byte_offset_to_point(old_text, old_end_byte);
     let new_end_position = byte_offset_to_point_relative(start_byte, start_position, new_text);
 
-    Some(ry_core::InputEdit {
+    ry_core::InputEdit {
         start_byte,
         old_end_byte,
         new_end_byte,
         start_position,
         old_end_position,
         new_end_position,
-    })
+    }
 }
 
 /// Convert a byte offset to a tree-sitter Point (row, byte column).

--- a/crates/ry-lsp/src/hints.rs
+++ b/crates/ry-lsp/src/hints.rs
@@ -146,7 +146,9 @@ pub(super) fn collect_completions(
             // index; resolve it to a byte offset before slicing so a
             // line with a non-ASCII character before the cursor cannot
             // panic (or truncate) the slice.
-            let until = utf16_col_to_byte(line, position.character).unwrap_or(line.len());
+            let Some(until) = utf16_col_to_byte(line, position.character) else {
+                return Vec::new();
+            };
             let before_cursor = &line[..until];
             // Strip the trailing `$` (and any whitespace between the
             // identifier and it) so `extract_last_identifier` lands
@@ -338,9 +340,9 @@ pub(super) fn find_enclosing_call(text: &str, line: usize, col: usize) -> Option
     // `col` is a UTF-16 code-unit column from the LSP request.
     // Resolve it to a byte offset before slicing, so a line with a
     // non-ASCII character before the cursor cannot panic the slice.
-    // A cursor past the last character (a common transient state
-    // right after typing `(`) is clamped to the line end.
-    let until = utf16_col_to_byte(line_str, col as u32).unwrap_or(line_str.len());
+    // Positions past the line or inside an astral surrogate pair are invalid
+    // LSP positions and must not alias the end of the line.
+    let until = utf16_col_to_byte(line_str, col as u32)?;
     let before_cursor = &line_str[..until];
 
     // Walk backward to find the last unmatched `(`. We track depth so

--- a/crates/ry-lsp/src/tests.rs
+++ b/crates/ry-lsp/src/tests.rs
@@ -2559,7 +2559,7 @@ fn build_input_edit_uses_byte_offsets_for_non_ascii() {
     };
     let new_text = "X";
 
-    let edit = crate::backend::build_input_edit(text, range, new_text);
+    let edit = crate::backend::build_input_edit(text, range, new_text).unwrap();
 
     // start_byte should be 2 (ASCII bytes), not 2 UTF-16 units.
     assert_eq!(edit.start_byte, 2);
@@ -2589,7 +2589,7 @@ fn build_input_edit_multiline_replacement() {
     };
     let new_text = "00\nextra";
 
-    let edit = crate::backend::build_input_edit(text, range, new_text);
+    let edit = crate::backend::build_input_edit(text, range, new_text).unwrap();
 
     // start_byte: "x <- " = 5 bytes, so position (0,5) = byte 5.
     assert_eq!(edit.start_byte, 5);

--- a/crates/ry-lsp/src/util.rs
+++ b/crates/ry-lsp/src/util.rs
@@ -57,8 +57,16 @@ pub(crate) fn position_to_byte_offset(text: &str, line: u32, utf16_col: u32) -> 
     let mut cur_line = 0u32;
     let mut cur_col = 0u32;
     for (b, ch) in text.char_indices() {
-        if cur_line == line && cur_col >= utf16_col {
-            return Some(b);
+        if cur_line == line {
+            if cur_col == utf16_col {
+                return Some(b);
+            }
+            // No byte boundary exists inside an astral scalar's UTF-16
+            // surrogate pair. Reject that position instead of snapping it
+            // forward to the next scalar.
+            if cur_col > utf16_col {
+                return None;
+            }
         }
         match ch {
             '\r' if text.as_bytes().get(b + 1) == Some(&b'\n') => {
@@ -72,7 +80,7 @@ pub(crate) fn position_to_byte_offset(text: &str, line: u32, utf16_col: u32) -> 
             _ => cur_col += utf16_len(ch) as u32,
         }
     }
-    if cur_line == line && cur_col >= utf16_col {
+    if cur_line == line && cur_col == utf16_col {
         Some(text.len())
     } else {
         None

--- a/crates/ry-lsp/tests/protocol.rs
+++ b/crates/ry-lsp/tests/protocol.rs
@@ -379,6 +379,125 @@ list(ok = 1L, "wi\"dget" <- 2L)
 }
 
 #[test]
+fn indexed_unopened_diagnostics_use_the_checked_source_for_utf16_ranges_and_fixes() {
+    let fixture = FixtureProject::empty().unwrap();
+    fixture
+        .write_file("disk.R", "emoji <- \"😀\"; length(xx = 1L)\r\n")
+        .unwrap();
+    fixture.write_file("trigger.R", "ok <- 1L\n").unwrap();
+
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    runtime.block_on(async {
+        let (client_stream, server_stream) = tokio::io::duplex(128 * 1024);
+        let (client_reader, client_writer) = tokio::io::split(client_stream);
+        let (server_reader, server_writer) = tokio::io::split(server_stream);
+        let server =
+            tokio::spawn(async move { ry_lsp::run_with(server_reader, server_writer).await });
+        let mut client = AsyncJsonRpcClient::new(client_reader, client_writer);
+        let root_uri = file_uri(fixture.root());
+        let initialize_id = client
+            .request(
+                "initialize",
+                json!({
+                    "processId": null,
+                    "rootUri": root_uri,
+                    "capabilities": {},
+                    "workspaceFolders": [{"uri": root_uri, "name": "fixture"}]
+                }),
+            )
+            .await
+            .unwrap();
+        client
+            .receive_until(
+                |message| message.get("id") == Some(&json!(initialize_id)),
+                16,
+            )
+            .await
+            .unwrap();
+        client.notify("initialized", json!({})).await.unwrap();
+
+        let trigger_path = fixture.path("trigger.R");
+        let trigger_uri = file_uri(&trigger_path);
+        let trigger_text = std::fs::read_to_string(&trigger_path).unwrap();
+        client
+            .notify(
+                "textDocument/didOpen",
+                json!({"textDocument": {
+                    "uri": trigger_uri,
+                    "languageId": "r",
+                    "version": 1,
+                    "text": trigger_text
+                }}),
+            )
+            .await
+            .unwrap();
+
+        let disk_uri = file_uri(&fixture.path("disk.R"));
+        let publication = client
+            .receive_until(
+                |message| {
+                    message.get("method") == Some(&json!("textDocument/publishDiagnostics"))
+                        && message.pointer("/params/uri") == Some(&json!(disk_uri))
+                },
+                64,
+            )
+            .await
+            .unwrap();
+        let diagnostics = publication["params"]["diagnostics"].as_array().unwrap();
+        let diagnostic = |code: &str| {
+            diagnostics
+                .iter()
+                .find(|diagnostic| diagnostic["code"] == code)
+                .unwrap_or_else(|| panic!("missing {code} in {diagnostics:?}"))
+        };
+
+        let unknown_argument = diagnostic("RY090");
+        assert_eq!(
+            unknown_argument["range"],
+            json!({
+                "start": {"line": 0, "character": 22},
+                "end": {"line": 0, "character": 29}
+            })
+        );
+        assert_eq!(
+            unknown_argument["data"]["fix"],
+            json!({
+                "range": {
+                    "start": {"line": 0, "character": 22},
+                    "end": {"line": 0, "character": 24}
+                },
+                "replacement": "x"
+            })
+        );
+
+        let missing_argument = diagnostic("RY091");
+        assert_eq!(
+            missing_argument["range"],
+            json!({
+                "start": {"line": 0, "character": 15},
+                "end": {"line": 0, "character": 30}
+            })
+        );
+
+        let shutdown_id = client.request("shutdown", Value::Null).await.unwrap();
+        client
+            .receive_until(|message| message.get("id") == Some(&json!(shutdown_id)), 16)
+            .await
+            .unwrap();
+        client.notify("exit", Value::Null).await.unwrap();
+        drop(client);
+        tokio::time::timeout(std::time::Duration::from_secs(3), server)
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+    });
+}
+
+#[test]
 fn default_disabled_rules_are_absent_in_both_modes() {
     let fixture = FixtureProject::empty().unwrap();
     fixture

--- a/crates/ry-lsp/tests/session.rs
+++ b/crates/ry-lsp/tests/session.rs
@@ -1,0 +1,603 @@
+use ry_testkit::{FixtureProject, LspSession, file_uri};
+use serde_json::{Value, json};
+
+const SOURCE: &str = concat!(
+    "ascii <- 1L\r\n",
+    "frame <- data.frame(column = 1L)\r\n",
+    "marker <- \"é e\u{301} 😀\"; target <- 1L\r\n",
+    "marker; target\r\n",
+    "marker <- \"😀\"; frame$\r\n",
+    "marker <- \"é😀\"; round(1L, 2L)\r\n",
+    "marker <- \"😀\"; length(xx = 1L)\r\n",
+    "`😀` <- 4L\r\n",
+    "`😀`\r\n",
+);
+const OTHER_SOURCE: &str = "\"😀\"; target\r\n";
+const DISK_SOURCE: &str = "marker <- \"😀\"; length(xx = 1L)\r\n";
+
+#[derive(Clone, Copy, Debug)]
+struct Anchor {
+    name: &'static str,
+    byte: usize,
+    line: u32,
+    scalar: u32,
+    character: u32,
+    following: &'static str,
+}
+
+// Hand-declared from the literal above. These values intentionally do not use
+// ry-lsp or ry-testkit conversion helpers: byte offsets count UTF-8 bytes and
+// character columns count UTF-16 code units.
+const ANCHORS: &[Anchor] = &[
+    Anchor {
+        name: "ascii",
+        byte: 0,
+        line: 0,
+        scalar: 0,
+        character: 0,
+        following: "ascii",
+    },
+    Anchor {
+        name: "line after CRLF",
+        byte: 13,
+        line: 1,
+        scalar: 0,
+        character: 0,
+        following: "frame",
+    },
+    Anchor {
+        name: "BMP start",
+        byte: 58,
+        line: 2,
+        scalar: 11,
+        character: 11,
+        following: "é",
+    },
+    Anchor {
+        name: "BMP end",
+        byte: 60,
+        line: 2,
+        scalar: 12,
+        character: 12,
+        following: " ",
+    },
+    Anchor {
+        name: "combining base",
+        byte: 61,
+        line: 2,
+        scalar: 13,
+        character: 13,
+        following: "e",
+    },
+    Anchor {
+        name: "combining mark",
+        byte: 62,
+        line: 2,
+        scalar: 14,
+        character: 14,
+        following: "\u{301}",
+    },
+    Anchor {
+        name: "combining end",
+        byte: 64,
+        line: 2,
+        scalar: 15,
+        character: 15,
+        following: " ",
+    },
+    Anchor {
+        name: "astral start",
+        byte: 65,
+        line: 2,
+        scalar: 16,
+        character: 16,
+        following: "😀",
+    },
+    Anchor {
+        name: "astral end",
+        byte: 69,
+        line: 2,
+        scalar: 17,
+        character: 18,
+        following: "\"",
+    },
+    Anchor {
+        name: "target declaration",
+        byte: 72,
+        line: 2,
+        scalar: 20,
+        character: 21,
+        following: "target",
+    },
+    Anchor {
+        name: "target declaration end",
+        byte: 78,
+        line: 2,
+        scalar: 26,
+        character: 27,
+        following: " ",
+    },
+    Anchor {
+        name: "target read",
+        byte: 94,
+        line: 3,
+        scalar: 8,
+        character: 8,
+        following: "target",
+    },
+    Anchor {
+        name: "target read end",
+        byte: 100,
+        line: 3,
+        scalar: 14,
+        character: 14,
+        following: "\r\n",
+    },
+    Anchor {
+        name: "completion cursor",
+        byte: 126,
+        line: 4,
+        scalar: 21,
+        character: 22,
+        following: "\r\n",
+    },
+    Anchor {
+        name: "signature astral",
+        byte: 141,
+        line: 5,
+        scalar: 12,
+        character: 12,
+        following: "😀",
+    },
+    Anchor {
+        name: "signature cursor",
+        byte: 158,
+        line: 5,
+        scalar: 26,
+        character: 27,
+        following: "2L",
+    },
+    Anchor {
+        name: "diagnostic name",
+        byte: 188,
+        line: 6,
+        scalar: 22,
+        character: 23,
+        following: "xx",
+    },
+    Anchor {
+        name: "diagnostic name end",
+        byte: 190,
+        line: 6,
+        scalar: 24,
+        character: 25,
+        following: " =",
+    },
+    Anchor {
+        name: "diagnostic end",
+        byte: 195,
+        line: 6,
+        scalar: 29,
+        character: 30,
+        following: ")",
+    },
+    Anchor {
+        name: "backtick astral",
+        byte: 199,
+        line: 7,
+        scalar: 1,
+        character: 1,
+        following: "😀",
+    },
+    Anchor {
+        name: "backtick astral end",
+        byte: 203,
+        line: 7,
+        scalar: 2,
+        character: 3,
+        following: "`",
+    },
+    Anchor {
+        name: "multiline backtick read",
+        byte: 213,
+        line: 8,
+        scalar: 1,
+        character: 1,
+        following: "😀",
+    },
+];
+
+fn anchor(name: &str) -> Anchor {
+    *ANCHORS.iter().find(|anchor| anchor.name == name).unwrap()
+}
+
+fn position(name: &str) -> Value {
+    let anchor = anchor(name);
+    json!({"line": anchor.line, "character": anchor.character})
+}
+
+fn assert_position(actual: &Value, name: &str) {
+    assert_eq!(actual, &position(name), "wrong LSP position for {name}");
+}
+
+#[test]
+fn utf16_contract_holds_across_one_real_lsp_transcript() {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    runtime.block_on(utf16_transcript());
+}
+
+async fn utf16_transcript() {
+    for anchor in ANCHORS {
+        assert!(
+            SOURCE.as_bytes()[anchor.byte..].starts_with(anchor.following.as_bytes()),
+            "bad independent byte offset for {}",
+            anchor.name
+        );
+        let prefix = &SOURCE[..anchor.byte];
+        let line = prefix.bytes().filter(|byte| *byte == b'\n').count() as u32;
+        let line_start = prefix.rfind('\n').map_or(0, |byte| byte + 1);
+        let line_prefix = &SOURCE[line_start..anchor.byte];
+        assert_eq!(line, anchor.line, "bad line for {}", anchor.name);
+        assert_eq!(
+            line_prefix.chars().count() as u32,
+            anchor.scalar,
+            "bad Unicode-scalar column for {}",
+            anchor.name
+        );
+        assert_eq!(
+            line_prefix.encode_utf16().count() as u32,
+            anchor.character,
+            "bad UTF-16 column for {}",
+            anchor.name
+        );
+    }
+
+    let fixture = FixtureProject::empty().unwrap();
+    fixture.write_file("main.R", SOURCE).unwrap();
+    fixture.write_file("other.R", OTHER_SOURCE).unwrap();
+    fixture.write_file("disk.R", DISK_SOURCE).unwrap();
+    let main_uri = file_uri(&fixture.path("main.R")).unwrap();
+    let other_uri = file_uri(&fixture.path("other.R")).unwrap();
+    let disk_uri = file_uri(&fixture.path("disk.R")).unwrap();
+    let (client_stream, server_stream) = tokio::io::duplex(128 * 1024);
+    let (client_reader, client_writer) = tokio::io::split(client_stream);
+    let (server_reader, server_writer) = tokio::io::split(server_stream);
+    let server = tokio::spawn(async move { ry_lsp::run_with(server_reader, server_writer).await });
+    let mut session = LspSession::new(client_reader, client_writer);
+    let initialize = session.initialize(fixture.root()).await.unwrap();
+    assert_eq!(
+        initialize.pointer("/capabilities/positionEncoding"),
+        Some(&json!("utf-16"))
+    );
+    let open_mark = session.publication_mark();
+    session.open(&main_uri, 1, SOURCE).await.unwrap();
+    session.open(&other_uri, 1, OTHER_SOURCE).await.unwrap();
+
+    // Byte -> UTF-16: diagnostics and their structured fix both publish the
+    // exact range after BMP, combining, astral, and CRLF prefixes.
+    let publish = session
+        .published_diagnostics_after(&main_uri, open_mark)
+        .await
+        .unwrap();
+    let diagnostic = publish["params"]["diagnostics"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|diagnostic| diagnostic["code"] == "RY090")
+        .expect("length's partial argument name should emit RY090");
+    assert_position(&diagnostic["range"]["start"], "diagnostic name");
+    assert_position(&diagnostic["range"]["end"], "diagnostic end");
+    let fix = diagnostic
+        .pointer("/data/fix")
+        .expect("RY090 structured fix");
+    assert_position(&fix["range"]["start"], "diagnostic name");
+    assert_position(&fix["range"]["end"], "diagnostic name end");
+    assert_eq!(fix["replacement"], "x");
+
+    // Unopened indexed files must retain their source text too; otherwise
+    // byte columns leak into LSP and structured fixes disappear.
+    let disk_publish = session
+        .published_diagnostics_after(&disk_uri, open_mark)
+        .await
+        .unwrap();
+    let disk_diagnostic = disk_publish["params"]["diagnostics"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|diagnostic| diagnostic["code"] == "RY090")
+        .expect("indexed file should publish RY090");
+    assert_eq!(
+        disk_diagnostic["range"],
+        json!({
+            "start": {"line": 0, "character": 23},
+            "end": {"line": 0, "character": 30}
+        })
+    );
+    assert_eq!(
+        disk_diagnostic["data"]["fix"],
+        json!({
+            "range": {
+                "start": {"line": 0, "character": 23},
+                "end": {"line": 0, "character": 25}
+            },
+            "replacement": "x"
+        })
+    );
+
+    // UTF-16 -> byte: hover lands on target despite every Unicode class on
+    // the preceding part of the line.
+    let hover = session
+        .request(
+            "textDocument/hover",
+            json!({
+                "textDocument": {"uri": main_uri}, "position": position("target declaration")
+            }),
+        )
+        .await
+        .unwrap();
+    assert!(
+        hover
+            .pointer("/contents/value")
+            .and_then(Value::as_str)
+            .is_some_and(|value| value.contains("target"))
+    );
+    assert!(hover.get("range").is_none());
+
+    // Completion consumes the UTF-16 cursor following an astral scalar.
+    let completion = session
+        .request(
+            "textDocument/completion",
+            json!({
+                "textDocument": {"uri": main_uri},
+                "position": position("completion cursor"),
+                "context": {"triggerKind": 2, "triggerCharacter": "$"}
+            }),
+        )
+        .await
+        .unwrap();
+    assert!(
+        completion
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|item| item["label"] == "column")
+    );
+
+    let column_completion = completion
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|item| item["label"] == "column")
+        .unwrap();
+    // CompletionItem currently relies on the client's default insertion at
+    // the consumed cursor; it emits no position-bearing edit of its own.
+    assert!(column_completion.get("textEdit").is_none());
+    assert!(column_completion.get("additionalTextEdits").is_none());
+
+    let surrogate_interior_completion = session
+        .request(
+            "textDocument/completion",
+            json!({
+                "textDocument": {"uri": main_uri},
+                "position": {"line": 4, "character": 12},
+                "context": {"triggerKind": 2, "triggerCharacter": "$"}
+            }),
+        )
+        .await
+        .unwrap();
+    assert_eq!(surrogate_interior_completion, Value::Null);
+
+    // Signature help consumes a cursor following BMP and astral scalars and
+    // selects the second parameter at the hand-declared UTF-16 column.
+    let signature = session
+        .request(
+            "textDocument/signatureHelp",
+            json!({
+                "textDocument": {"uri": main_uri}, "position": position("signature cursor")
+            }),
+        )
+        .await
+        .unwrap();
+    assert_eq!(signature["signatures"][0]["label"], "round(x, digits, ...)");
+    assert_eq!(signature["activeParameter"], 1);
+    assert!(signature.get("range").is_none());
+    let surrogate_interior_signature = session
+        .request(
+            "textDocument/signatureHelp",
+            json!({
+                "textDocument": {"uri": main_uri},
+                "position": {"line": 5, "character": 13}
+            }),
+        )
+        .await
+        .unwrap();
+    assert_eq!(surrogate_interior_signature, Value::Null);
+
+    // Rename consumes one UTF-16 position and emits workspace-edit ranges in
+    // both the mixed-Unicode CRLF document and another astral document.
+    let rename = session
+        .request(
+            "textDocument/rename",
+            json!({
+                "textDocument": {"uri": main_uri},
+                "position": position("target declaration"),
+                "newName": "renamed"
+            }),
+        )
+        .await
+        .unwrap();
+    let main_edits = rename["changes"][&main_uri].as_array().unwrap();
+    assert_eq!(main_edits.len(), 2);
+    assert_position(&main_edits[0]["range"]["start"], "target declaration");
+    assert_position(&main_edits[0]["range"]["end"], "target declaration end");
+    assert_position(&main_edits[1]["range"]["start"], "target read");
+    assert_position(&main_edits[1]["range"]["end"], "target read end");
+    assert_eq!(
+        rename["changes"][&other_uri][0]["range"],
+        json!({
+            "start": {"line": 0, "character": 6},
+            "end": {"line": 0, "character": 12}
+        })
+    );
+
+    // A cursor inside the surrogate pair is not a legal LSP position. The
+    // valid boundary resolves the backtick identifier; the interior must not
+    // silently snap forward and resolve the same identifier.
+    let valid_astral_hover = session
+        .request(
+            "textDocument/hover",
+            json!({
+                "textDocument": {"uri": main_uri}, "position": position("multiline backtick read")
+            }),
+        )
+        .await
+        .unwrap();
+    assert_ne!(valid_astral_hover, Value::Null);
+    let surrogate_interior_hover = session
+        .request(
+            "textDocument/hover",
+            json!({
+                "textDocument": {"uri": main_uri}, "position": {"line": 8, "character": 2}
+            }),
+        )
+        .await
+        .unwrap();
+    assert_eq!(surrogate_interior_hover, Value::Null);
+
+    // The document-change path must reject the same invalid position rather
+    // than corrupting the document by snapping into the backtick identifier.
+    let invalid_change_mark = session.publication_mark();
+    session
+        .change(
+            &main_uri,
+            2,
+            json!([{
+                "range": {
+                    "start": {"line": 8, "character": 2},
+                    "end": {"line": 8, "character": 3}
+                },
+                "text": "BROKEN"
+            }]),
+        )
+        .await
+        .unwrap();
+    session
+        .published_diagnostics_after(&main_uri, invalid_change_mark)
+        .await
+        .unwrap();
+    let hover_after_invalid_change = session
+        .request(
+            "textDocument/hover",
+            json!({
+                "textDocument": {"uri": main_uri}, "position": position("multiline backtick read")
+            }),
+        )
+        .await
+        .unwrap();
+    assert_ne!(hover_after_invalid_change, Value::Null);
+
+    let out_of_range_change_mark = session.publication_mark();
+    session
+        .change(
+            &main_uri,
+            3,
+            json!([{
+                "range": {
+                    "start": {"line": 8, "character": 99},
+                    "end": {"line": 8, "character": 99}
+                },
+                "text": "BROKEN"
+            }]),
+        )
+        .await
+        .unwrap();
+    session
+        .published_diagnostics_after(&main_uri, out_of_range_change_mark)
+        .await
+        .unwrap();
+    let hover_after_out_of_range_change = session
+        .request(
+            "textDocument/hover",
+            json!({
+                "textDocument": {"uri": main_uri}, "position": position("multiline backtick read")
+            }),
+        )
+        .await
+        .unwrap();
+    assert_ne!(hover_after_out_of_range_change, Value::Null);
+
+    // A valid incremental edit after BMP, decomposed combining, and astral
+    // scalars must use UTF-16 columns in both endpoints.
+    let valid_change_mark = session.publication_mark();
+    session
+        .change(
+            &main_uri,
+            4,
+            json!([{
+                "range": {
+                    "start": {"line": 2, "character": 21},
+                    "end": {"line": 2, "character": 27}
+                },
+                "text": "changed"
+            }]),
+        )
+        .await
+        .unwrap();
+    let changed_publish = session
+        .published_diagnostics_after(&main_uri, valid_change_mark)
+        .await
+        .unwrap();
+    assert!(
+        changed_publish["params"]["diagnostics"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|diagnostic| diagnostic["code"] == "RY090")
+    );
+    let completion_after_change = session
+        .request(
+            "textDocument/completion",
+            json!({
+                "textDocument": {"uri": main_uri},
+                "position": {"line": 4, "character": 22},
+                "context": {"triggerKind": 2, "triggerCharacter": "$"}
+            }),
+        )
+        .await
+        .unwrap();
+    assert!(
+        completion_after_change
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|item| item["label"] == "column")
+    );
+
+    let hover_after_valid_change = session
+        .request(
+            "textDocument/hover",
+            json!({
+                "textDocument": {"uri": main_uri},
+                "position": {"line": 2, "character": 21}
+            }),
+        )
+        .await
+        .unwrap();
+    assert!(
+        hover_after_valid_change
+            .pointer("/contents/value")
+            .and_then(Value::as_str)
+            .is_some_and(|value| value.contains("changed"))
+    );
+
+    session.shutdown().await.unwrap();
+    drop(session);
+    tokio::time::timeout(std::time::Duration::from_secs(3), server)
+        .await
+        .unwrap()
+        .unwrap()
+        .unwrap();
+}

--- a/crates/ry-testkit/Cargo.toml
+++ b/crates/ry-testkit/Cargo.toml
@@ -12,4 +12,5 @@ authors.workspace = true
 serde = { workspace = true }
 serde_json = { workspace = true }
 tempfile = { workspace = true }
-tokio = { workspace = true, features = ["io-util"] }
+tokio = { workspace = true, features = ["io-util", "time"] }
+url = "2"

--- a/crates/ry-testkit/Cargo.toml
+++ b/crates/ry-testkit/Cargo.toml
@@ -13,4 +13,4 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["io-util", "time"] }
-url = "2"
+url = { workspace = true }

--- a/crates/ry-testkit/src/json_rpc.rs
+++ b/crates/ry-testkit/src/json_rpc.rs
@@ -144,6 +144,18 @@ where
         Ok(id)
     }
 
+    pub async fn request_without_params(&mut self, method: &str) -> io::Result<u64> {
+        let id = self.next_id;
+        self.next_id += 1;
+        self.send(&json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "method": method,
+        }))
+        .await?;
+        Ok(id)
+    }
+
     pub async fn notify(&mut self, method: &str, params: Value) -> io::Result<()> {
         self.send(&json!({
             "jsonrpc": "2.0",

--- a/crates/ry-testkit/src/lib.rs
+++ b/crates/ry-testkit/src/lib.rs
@@ -5,11 +5,13 @@
 
 mod fixture;
 mod json_rpc;
+mod lsp_session;
 mod observed;
 mod process;
 
 pub use fixture::FixtureProject;
 pub use json_rpc::{AsyncJsonRpcClient, JsonRpcProcess};
+pub use lsp_session::{LspSession, file_uri};
 pub use observed::{
     Driver, DriverError, ObservedDiagnostic, ObservedFix, ObservedPosition, ObservedRange,
     PositionEncoding, normalize_path, normalize_position,

--- a/crates/ry-testkit/src/lsp_session.rs
+++ b/crates/ry-testkit/src/lsp_session.rs
@@ -1,0 +1,151 @@
+use crate::AsyncJsonRpcClient;
+use serde_json::{Value, json};
+use std::collections::VecDeque;
+use std::io;
+use std::path::Path;
+use tokio::io::{AsyncRead, AsyncWrite};
+
+struct RoutedMessage {
+    sequence: u64,
+    value: Value,
+}
+
+/// Stateful, protocol-only LSP client for production-path integration tests.
+///
+/// Unlike `AsyncJsonRpcClient::receive_until`, this router retains messages
+/// interleaved before the sought response/publication. Crate-specific tests
+/// own the server launcher so this testkit never depends on a production LSP.
+pub struct LspSession<R, W> {
+    client: AsyncJsonRpcClient<R, W>,
+    pending: VecDeque<RoutedMessage>,
+    sequence: u64,
+}
+
+impl<R, W> LspSession<R, W>
+where
+    R: AsyncRead + Unpin,
+    W: AsyncWrite + Unpin,
+{
+    pub fn new(reader: R, writer: W) -> Self {
+        Self {
+            client: AsyncJsonRpcClient::new(reader, writer),
+            pending: VecDeque::new(),
+            sequence: 0,
+        }
+    }
+
+    pub async fn initialize(&mut self, root: &Path) -> io::Result<Value> {
+        let root_uri = file_uri(root)?;
+        let result = self
+            .request(
+                "initialize",
+                json!({
+                    "processId": null,
+                    "rootUri": root_uri,
+                    "capabilities": {},
+                    "workspaceFolders": [{"uri": root_uri, "name": "fixture"}]
+                }),
+            )
+            .await?;
+        self.notify("initialized", json!({})).await?;
+        Ok(result)
+    }
+
+    pub async fn request(&mut self, method: &str, params: Value) -> io::Result<Value> {
+        let id = self.client.request(method, params).await?;
+        self.response(method, id).await
+    }
+
+    async fn response(&mut self, method: &str, id: u64) -> io::Result<Value> {
+        let response = self
+            .receive_matching(0, |message| message.get("id") == Some(&json!(id)))
+            .await?;
+        if let Some(error) = response.get("error") {
+            return Err(io::Error::other(format!("{method} failed: {error}")));
+        }
+        Ok(response.get("result").cloned().unwrap_or(Value::Null))
+    }
+
+    pub async fn notify(&mut self, method: &str, params: Value) -> io::Result<()> {
+        self.client.notify(method, params).await
+    }
+
+    pub async fn open(&mut self, uri: &str, version: i32, text: &str) -> io::Result<()> {
+        self.notify(
+            "textDocument/didOpen",
+            json!({"textDocument": {
+                "uri": uri, "languageId": "r", "version": version, "text": text
+            }}),
+        )
+        .await
+    }
+
+    pub async fn change(&mut self, uri: &str, version: i32, changes: Value) -> io::Result<()> {
+        self.notify(
+            "textDocument/didChange",
+            json!({
+                "textDocument": {"uri": uri, "version": version},
+                "contentChanges": changes
+            }),
+        )
+        .await
+    }
+
+    /// Mark the currently routed transcript. Pair with
+    /// `published_diagnostics_after` to require a publication caused by a
+    /// later action rather than reusing an already-routed one.
+    pub fn publication_mark(&self) -> u64 {
+        self.sequence
+    }
+
+    pub async fn published_diagnostics_after(&mut self, uri: &str, mark: u64) -> io::Result<Value> {
+        self.receive_matching(mark.saturating_add(1), |message| {
+            message.get("method") == Some(&json!("textDocument/publishDiagnostics"))
+                && message.pointer("/params/uri") == Some(&json!(uri))
+        })
+        .await
+    }
+
+    /// Complete the protocol shutdown. The owning adapter remains
+    /// responsible for dropping this session and bounded-joining its server.
+    pub async fn shutdown(&mut self) -> io::Result<()> {
+        let id = self.client.request_without_params("shutdown").await?;
+        let _ = self.response("shutdown", id).await?;
+        self.notify("exit", Value::Null).await
+    }
+
+    async fn receive_matching(
+        &mut self,
+        minimum_sequence: u64,
+        predicate: impl Fn(&Value) -> bool,
+    ) -> io::Result<Value> {
+        if let Some(index) = self
+            .pending
+            .iter()
+            .position(|message| message.sequence >= minimum_sequence && predicate(&message.value))
+        {
+            return Ok(self.pending.remove(index).unwrap().value);
+        }
+        loop {
+            let value =
+                tokio::time::timeout(std::time::Duration::from_secs(5), self.client.receive())
+                    .await
+                    .map_err(|_| {
+                        io::Error::new(io::ErrorKind::TimedOut, "JSON-RPC receive timed out")
+                    })??;
+            self.sequence = self.sequence.wrapping_add(1);
+            let sequence = self.sequence;
+            if sequence >= minimum_sequence && predicate(&value) {
+                return Ok(value);
+            }
+            self.pending.push_back(RoutedMessage { sequence, value });
+        }
+    }
+}
+
+pub fn file_uri(path: &Path) -> io::Result<String> {
+    let path = path.canonicalize()?;
+    url::Url::from_file_path(&path)
+        .map(String::from)
+        .map_err(|()| io::Error::new(io::ErrorKind::InvalidInput, "path cannot form a file URI"))
+}

--- a/crates/ry-testkit/src/lsp_session.rs
+++ b/crates/ry-testkit/src/lsp_session.rs
@@ -58,7 +58,9 @@ where
 
     async fn response(&mut self, method: &str, id: u64) -> io::Result<Value> {
         let response = self
-            .receive_matching(0, |message| message.get("id") == Some(&json!(id)))
+            .receive_matching(0, |message| {
+                message.get("id") == Some(&json!(id)) && message.get("method").is_none()
+            })
             .await?;
         if let Some(error) = response.get("error") {
             return Err(io::Error::other(format!("{method} failed: {error}")));
@@ -94,6 +96,15 @@ where
     /// Mark the currently routed transcript. Pair with
     /// `published_diagnostics_after` to require a publication caused by a
     /// later action rather than reusing an already-routed one.
+    /// Mark the currently routed transcript. Pair with
+    /// `published_diagnostics_after` to require a publication caused by a
+    /// later action rather than reusing an already-routed one.
+    ///
+    /// This counts read order, not server-side arrival order. A message
+    /// already written by the server but not yet read receives a sequence
+    /// after this mark. Callers that need a hard barrier should issue a
+    /// request/response round-trip between the mark and the action, or
+    /// ensure prior publications have already been consumed.
     pub fn publication_mark(&self) -> u64 {
         self.sequence
     }
@@ -126,13 +137,13 @@ where
         {
             return Ok(self.pending.remove(index).unwrap().value);
         }
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
         loop {
-            let value =
-                tokio::time::timeout(std::time::Duration::from_secs(5), self.client.receive())
-                    .await
-                    .map_err(|_| {
-                        io::Error::new(io::ErrorKind::TimedOut, "JSON-RPC receive timed out")
-                    })??;
+            let value = tokio::time::timeout_at(deadline, self.client.receive())
+                .await
+                .map_err(|_| {
+                    io::Error::new(io::ErrorKind::TimedOut, "JSON-RPC receive timed out")
+                })??;
             self.sequence = self.sequence.wrapping_add(1);
             let sequence = self.sequence;
             if sequence >= minimum_sequence && predicate(&value) {


### PR DESCRIPTION
## P35-W6: Focused UTF-16 protocol contracts

Implements [`docs/plans/35-invariants-over-examples.md`](docs/plans/35-invariants-over-examples.md) P35-W6.

### Production harness
- **`ry_testkit::LspSession`**: a reusable, protocol-only JSON-RPC client that routes interleaved responses and publications instead of discarding unmatched messages, with publication marks for explicit quiescence (no sleeps) and proper encoded file URIs. The owning `ry-lsp` test supplies the real `ry_lsp::run_with` launcher, keeping testkit acyclic.
- **`tests/session.rs`**: one focused production transcript through real `ry_lsp::run_with` with a hand-declared table of UTF-8 byte offsets, Unicode-scalar columns, and UTF-16 LSP positions covering ASCII, BMP, decomposed combining (`e\u{301}`), astral, CRLF, and multiline cases. The transcript exercises diagnostic + structured-fix ranges, hover cursor, completion cursor (plus explicit assertion of current edit-shape absence), rename input and workspace edits across two files, signature-help cursor, and incremental document changes with publication barriers after every `didChange`.

### Production fixes
- Advertise UTF-16 position encoding explicitly.
- Strictly reject surrogate-interior and out-of-line reverse positions in `position_to_byte_offset` instead of snapping forward.
- Remove the clamping `position_to_byte` duplicate; `apply_range_edit` and `build_input_edit` use the canonical strict converter and return `Option`, rejecting invalid ranges without document corruption.
- Reject invalid completion/signature cursors rather than aliasing EOL.
- Source-back every diagnostic publication (including unopened indexed files) via `ProjectCheckResult` carrying the exact `Arc<SourceFile>` snapshots supplied to the check, eliminating byte-columns-as-UTF-16, collapsed ranges, and missing fix data for indexed files.
- `ProjectCache` freshness now keys on version plus Arc identity so refreshed indexed snapshots are installed before checking.

### Red findings before fixes
1. Hover at the interior half of a backtick astral identifier returned that identifier's hover.
2. Completion and signature-help surrogate-interior positions aliased EOL because `None` was clamped to `line.len()`.
3. The separate backend didChange converter snapped surrogate halves/out-of-range columns and could mutate/delete the whole scalar.
4. Unopened indexed diagnostics lacked source, leaked byte columns as UTF-16, collapsed ranges, and omitted structured fix data.

### Gates
- `cargo fmt --all -- --check` ✓
- `cargo clippy --workspace --all-targets -- -D warnings` ✓
- `cargo test --workspace` ✓ (all green including protocol, session, testkit)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Enforce strict UTF-16 protocol contracts in LSP position handling and diagnostics
> - `position_to_byte_offset` in [util.rs](https://github.com/sims1253/ry/pull/60/files#diff-76824e3b4e87e65a3e99445b2fde130d50d31b8048c17bbc1fb1f63b4f446ecb) now returns `None` for positions inside surrogate pairs or past line end, instead of snapping to a nearby byte offset.
> - `apply_incremental_change` in [backend.rs](https://github.com/sims1253/ry/pull/60/files#diff-6fe792d8d98d8cc3b53addc7bfb8e79c6bd08b1383372fe5f7340be58ecf8d36) rejects ranged edits with invalid UTF-16 positions and aborts the remainder of a `didChange` batch on failure to avoid text desynchronization.
> - Server now explicitly advertises `positionEncoding: UTF16` in the `initialize` response.
> - Diagnostics, suppressions, and fixes now use the exact `SourceFile` snapshot from `check_with_workspace` via the new `ProjectCheckResult` struct, ensuring consistency for unopened indexed files.
> - Adds integration tests in [session.rs](https://github.com/sims1253/ry/pull/60/files#diff-3d7ec07b478f2aa2ba48993c2a9272e606dcf9d24e63d87e41852a63d5da1b68) and [protocol.rs](https://github.com/sims1253/ry/pull/60/files#diff-e20d84254230b6fd6ec26c6f35bc4a53d4bd3e1fc670750f7fac3f7a85724142) covering UTF-16 position contracts across hover, completion, rename, and incremental edits with mixed Unicode.
> - Behavioral Change: invalid UTF-16 positions in completions and signature help now return empty/`None` instead of falling back to end-of-line.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9145840.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved LSP diagnostics and fixes for indexed or unopened files, including CRLF line endings and astral Unicode characters.
  * Invalid UTF-16 positions and edits are now rejected instead of being clamped or corrupting text.
  * Document closing and incremental updates now keep diagnostics synchronized with the latest file contents.
  * LSP initialization explicitly supports UTF-16 position encoding.

* **Tests**
  * Added comprehensive coverage for diagnostics, edits, hover, completion, signature help, rename, Unicode handling, and session shutdown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->