### PR TITLE
P35-W8: complexity scaling rather than only wall-clock budgets

### DIFF
--- a/crates/ry-checker/tests/perf.rs
+++ b/crates/ry-checker/tests/perf.rs
@@ -15,7 +15,7 @@
 
 use std::io::Write;
 use std::sync::Arc;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use ry_checker::Checker;
 use ry_checker::Project;
@@ -132,4 +132,331 @@ fn warm_edit_checks_quickly() {
         "warm incremental check took {:.3}s (budget 1.0s)",
         elapsed.as_secs_f64()
     );
+}
+
+// ===========================================================================
+// P35-W8 — Complexity scaling rather than only wall-clock budgets
+//
+// The three budget tests above guard absolute latency. They are
+// timing-sensitive: a single `< 4` ratio on a 2× size step sits exactly
+// on the quadratic boundary and flips with CI noise. These scaling
+// tests instead measure the **fitted log-log slope** across multiple
+// geometric sizes. A linear algorithm has slope ≈ 1; quadratic ≈ 2;
+// exponential ≫ 2. The slope is a *rate-of-growth* measurement, far
+// less sensitive to absolute machine speed than a wall-clock budget.
+//
+// The acceptance oracle is historical falsification. Each of the three
+// regression classes below was once a real defect; temporarily
+// restoring any one makes its corresponding scaling test fail because
+// the fitted slope blows past the sub-quadratic budget:
+//
+//   1. **Parser rescanning** (commit 89eddd2): `char_col` rescanned the
+//      entire source from byte 0 for every AST node — O(n²) parsing.
+//      Restoring it makes `scaling_file_length` report slope ≈ 2.
+//
+//   2. **Pipe exponential** (commit e8d7408): pipe desugaring re-inferred
+//      the entire LHS at every stage — O(2ⁿ) inference. Restoring it
+//      makes `scaling_pipe_length` report slope ≫ 2.
+//
+//   3. **Force-flow double walk** (commit e8d7408): `statement_force_flow`
+//      walked each if-branch twice (once for force, once for
+//      fall-through) — O(2ᵈ) collection. Restoring it makes
+//      `scaling_branch_depth` report slope ≫ 2.
+//
+// All tests are `#[ignore]`'d like the budget tests; CI runs them via
+// `cargo test -p ry-checker --test perf --release -- --ignored`.
+// ===========================================================================
+
+/// Fitted log-log slope above this value is treated as a complexity
+/// regression. 1.5 is the midpoint between linear (1.0) and quadratic
+/// (2.0). Every dimension in the fixed code is linear-time, so 1.5
+/// leaves wide margin against timing jitter while still catching both
+/// quadratic (slope → 2) and exponential (slope ≫ 2) blow-ups.
+const SLOPE_BUDGET: f64 = 1.5;
+
+/// For a 2× size step, the time ratio of a quadratic algorithm is 4.0.
+/// This cross-check catches a localised cliff (e.g. the very largest
+/// size spiking) that a global least-squares fit might smooth over.
+/// 3.5 sits between linear (2.0) and quadratic (4.0).
+const RATIO_BUDGET: f64 = 3.5;
+
+/// Minimum number of geometric data points for a reliable slope fit.
+/// Four points give three consecutive ratios.
+const MIN_SIZES: usize = 4;
+
+/// Measure the median per-call wall-clock time of `body`.
+///
+/// Fast operations (sub-millisecond) are **batched**: `body` runs in a
+/// tight loop sized so each sample is ~5 ms, then the total is divided by
+/// the batch count. Batching amortises timer-granularity and scheduling
+/// jitter, giving a stable median even when a single call is only a few
+/// tens of microseconds. Expensive operations (≥ 200 ms) are never
+/// batched and get only 3 samples so the test cannot stall CI.
+fn timed_median(mut body: impl FnMut()) -> Duration {
+    // Warm up: caches, branch predictors, page faults.
+    body();
+    let probe = Instant::now();
+    body();
+    let single = probe.elapsed();
+    if single >= Duration::from_millis(200) {
+        // Expensive: three individual runs, median.
+        let mut samples: Vec<Duration> = (0..3)
+            .map(|_| {
+                let start = Instant::now();
+                body();
+                start.elapsed()
+            })
+            .collect();
+        samples.sort();
+        return samples[1];
+    }
+    // Fast: batch to ~5 ms per sample so the timer has signal to work
+    // with, then take the median of 11 batched samples.
+    // Size the batch so each sample takes ~5 ms. Guard against a
+    // zero-duration probe (instant return) by defaulting to 10 000.
+    let batch = (5_000_000 / single.as_nanos().max(1) as u64).clamp(1, 10_000) as usize;
+    let mut samples: Vec<Duration> = (0..11)
+        .map(|_| {
+            let start = Instant::now();
+            for _ in 0..batch {
+                body();
+            }
+            start.elapsed() / batch as u32
+        })
+        .collect();
+    samples.sort();
+    samples[5]
+}
+
+/// Least-squares log-log slope: `time ∝ size^slope`.
+///
+/// Computed from `(size, time_seconds)` pairs. Uses **all** geometric
+/// points (multi-ratio evidence), unlike a single consecutive ratio
+/// which the plan calls out as unreliable on the quadratic boundary.
+fn log_log_slope(points: &[(f64, f64)]) -> f64 {
+    let n = points.len() as f64;
+    let (sx, sy, sxx, sxy) =
+        points
+            .iter()
+            .fold((0.0_f64, 0.0_f64, 0.0_f64, 0.0_f64), |acc, &(s, t)| {
+                let lx = s.ln();
+                let ly = t.max(1e-12).ln();
+                (acc.0 + lx, acc.1 + ly, acc.2 + lx * lx, acc.3 + lx * ly)
+            });
+    let denom = n * sxx - sx * sx;
+    if denom.abs() < 1e-30 {
+        f64::INFINITY
+    } else {
+        (n * sxy - sx * sy) / denom
+    }
+}
+
+/// Assert that growth across `sizes` / `times` is comfortably
+/// sub-quadratic. Reports the fitted slope, all data points, and each
+/// consecutive ratio on failure so a regression is easy to diagnose.
+fn assert_subquadratic_scaling(label: &str, sizes: &[usize], times: &[Duration]) {
+    assert!(
+        sizes.len() >= MIN_SIZES,
+        "{label}: need >= {MIN_SIZES} sizes for a stable slope, got {}",
+        sizes.len(),
+    );
+    let points: Vec<(f64, f64)> = sizes
+        .iter()
+        .zip(times)
+        .map(|(&s, t)| (s as f64, t.as_secs_f64()))
+        .collect();
+
+    let slope = log_log_slope(&points);
+    assert!(
+        slope < SLOPE_BUDGET,
+        "{label}: fitted log-log slope {slope:.3} >= {SLOPE_BUDGET} (sub-quadratic budget)\n\
+         {label}: points (size, seconds): {points:?}",
+    );
+
+    // Multi-ratio cross-check: every consecutive pair must stay below
+    // the quadratic prediction.
+    for w in points.windows(2) {
+        let ratio = w[1].1 / w[0].1.max(1e-12);
+        assert!(
+            ratio < RATIO_BUDGET,
+            "{label}: time ratio {ratio:.2} >= {RATIO_BUDGET} between sizes {:.0}→{:.0}\n\
+             {label}: points (size, seconds): {points:?}",
+            w[0].0,
+            w[1].0,
+        );
+    }
+
+    eprintln!("[{label}] slope {slope:.3}  points {points:?}");
+}
+
+// ---- input generators ----------------------------------------------------
+
+/// `n` assignment lines, each producing ~3 AST nodes so the parser's
+/// per-node `span` call (once O(n²)) is exercised.
+fn gen_file_source(n: usize) -> String {
+    (0..n)
+        .map(|i| format!("v{i} <- c({i}, {}) * 2", i + 1))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// A left-associative pipe chain of `n` stages. The historical defect
+/// re-inferred the entire LHS at every stage (O(2ⁿ)); the fix caches
+/// the inferred type.
+fn gen_pipe_chain(n: usize) -> String {
+    let stages = vec!["f"; n].join(" |> ");
+    format!("f <- function(x) x\nresult <- 1L |> {stages}\n")
+}
+
+/// A function whose body is a left-nested `if` chain of depth `d`,
+/// each branch referencing parameter `x`. The historical force-flow
+/// defect walked each branch twice → O(2ᵈ); the fix fuses both facts
+/// into one pass → O(d).
+fn gen_nested_branches(d: usize) -> String {
+    let mut body = String::from("x");
+    for i in (0..d).rev() {
+        body = format!("if (x > {i}) {{ {body} }} else {{ x }}");
+    }
+    format!("g <- function(x) {body}\n")
+}
+
+/// `k` files, each defining one function. `Project::check` is rayon-
+/// parallel per file, so growth should be linear in `k`.
+fn gen_project_files(k: usize) -> Vec<(String, String)> {
+    (0..k)
+        .map(|i| {
+            (
+                format!("file{i}.R"),
+                format!("f{i} <- function(x) x * {i}\n"),
+            )
+        })
+        .collect()
+}
+
+/// A single expression with `n` nested function-call layers:
+/// `f(f(f(…f(1L)…)))`. Call inference recurses to depth `n`.
+fn gen_call_depth(n: usize) -> String {
+    let inner = "f(".repeat(n);
+    let close = ")".repeat(n);
+    format!("f <- function(x) x\nresult <- {inner}1L{close}\n")
+}
+
+// ---- scaling tests -------------------------------------------------------
+
+/// **File length / parser rescanning.** The parser once computed each
+/// node's column by rescanning the source from byte 0 (O(n²) total,
+/// 47 s on 20 k lines). The fix uses tree-sitter's column directly.
+/// Restoring the rescan makes the slope approach 2.0.
+#[test]
+#[ignore]
+fn scaling_file_length() {
+    let sizes = [1_000usize, 2_000, 4_000, 8_000];
+    let mut parser = RParser::new().expect("parser init");
+    let times: Vec<Duration> = sizes
+        .iter()
+        .map(|&n| {
+            let src = gen_file_source(n);
+            timed_median(|| {
+                parser.parse("file.R", &src).expect("parse");
+            })
+        })
+        .collect();
+    assert_subquadratic_scaling("file_length", &sizes, &times);
+}
+
+/// **Pipe length / pipe exponential.** A pipe chain of `n` stages once
+/// re-inferred the entire LHS at every stage (O(2ⁿ)). The fix reuses
+/// the already-inferred LHS type. Restoring the re-inference makes the
+/// slope blow far past 2.0.
+#[test]
+#[ignore]
+fn scaling_pipe_length() {
+    let sizes = [8usize, 12, 16, 20];
+    let mut parser = RParser::new().expect("parser init");
+    let times: Vec<Duration> = sizes
+        .iter()
+        .map(|&n| {
+            let src = gen_pipe_chain(n);
+            timed_median(|| {
+                let file = parser.parse("pipe.R", &src).expect("parse");
+                let mut c = Checker::new("pipe.R");
+                c.check(&file);
+                let _ = c.take_diagnostics();
+            })
+        })
+        .collect();
+    assert_subquadratic_scaling("pipe_length", &sizes, &times);
+}
+
+/// **Branch depth / force-flow double walk.** The required-parameter
+/// force-flow analysis once walked each if-branch twice (O(2ᵈ)). The
+/// fix fuses force and fall-through into a single walk (O(d)).
+/// Restoring the double walk makes the slope blow past 2.0.
+#[test]
+#[ignore]
+fn scaling_branch_depth() {
+    let sizes = [10usize, 14, 18, 22];
+    let mut parser = RParser::new().expect("parser init");
+    let times: Vec<Duration> = sizes
+        .iter()
+        .map(|&d| {
+            let src = gen_nested_branches(d);
+            timed_median(|| {
+                let file = parser.parse("branch.R", &src).expect("parse");
+                let mut c = Checker::new("branch.R");
+                c.check(&file);
+                let _ = c.take_diagnostics();
+            })
+        })
+        .collect();
+    assert_subquadratic_scaling("branch_depth", &sizes, &times);
+}
+
+/// **Project size.** `Project::check` runs each file through the
+/// checker (rayon-parallel). Growth should be linear in file count.
+#[test]
+#[ignore]
+fn scaling_project_size() {
+    let sizes = [50usize, 100, 200, 400];
+    let mut parser = RParser::new().expect("parser init");
+    let times: Vec<Duration> = sizes
+        .iter()
+        .map(|&k| {
+            let files = gen_project_files(k);
+            let parsed: Vec<(String, ry_core::SourceFile)> = files
+                .iter()
+                .map(|(path, src)| (path.clone(), parser.parse(path, src).expect("parse")))
+                .collect();
+            timed_median(|| {
+                let mut project = Project::new();
+                for (path, file) in &parsed {
+                    project.add_file(path.clone(), file.clone());
+                }
+                let _ = project.check();
+            })
+        })
+        .collect();
+    assert_subquadratic_scaling("project_size", &sizes, &times);
+}
+
+/// **Call depth.** A single expression with `n` nested calls. Inference
+/// recurses to depth `n`. Growth should be linear.
+#[test]
+#[ignore]
+fn scaling_call_depth() {
+    let sizes = [8usize, 12, 16, 20];
+    let mut parser = RParser::new().expect("parser init");
+    let times: Vec<Duration> = sizes
+        .iter()
+        .map(|&n| {
+            let src = gen_call_depth(n);
+            timed_median(|| {
+                let file = parser.parse("call.R", &src).expect("parse");
+                let mut c = Checker::new("call.R");
+                c.check(&file);
+                let _ = c.take_diagnostics();
+            })
+        })
+        .collect();
+    assert_subquadratic_scaling("call_depth", &sizes, &times);
 }


### PR DESCRIPTION
## P35-W8: Complexity scaling rather than only wall-clock budgets

Implements [`docs/plans/35-invariants-over-examples.md`](docs/plans/35-invariants-over-examples.md) P35-W8.

### Scaling tests
Five geometric scaling dimensions with multi-ratio evidence:
- **File length** (1k–8k lines)
- **Pipe length** (8–20 stages)
- **Branch depth** (10–22 nested ifs)
- **Project size** (50–400 files)
- **Call depth** (8–20 nested calls)

Each uses `timed_median` (adaptive batched timing) and `log_log_slope` (least-squares fit). Primary gate: fitted slope < 1.5. Secondary cross-check: every consecutive 2×-size ratio < 3.5.

### Historical falsification acceptance
Three historical regressions were temporarily restored and confirmed to FAIL:
1. **Parser rescanning** (`89eddd2`): char_col rescanned source from byte 0 per AST node → file_length slope ≈ 2.0
2. **Pipe exponential** (`e8d7408`): pipe desugaring re-inferred entire LHS at every stage → pipe_length slope ≈ 9
3. **Force-flow double walk** (`e8d7408`): statement_force_flow walked each if-branch twice → branch_depth slope ≈ 9

### Stability
10 consecutive release-mode runs, all 5 scaling tests pass. Highest clean slope: 1.10 (branch_depth). No flakes.

### Gates
- `cargo fmt --all -- --check` ✓
- `cargo clippy --workspace --all-targets -- -D warnings` ✓
- `cargo test --workspace` ✓
- `cargo test -p ry-checker --test perf --release -- --ignored` ✓ (8/8)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add complexity scaling tests using log-log slope fitting instead of wall-clock budgets
> - Replaces wall-clock time budgets with log-log slope fitting: tests now measure how time scales with input size and assert the fitted slope stays below 1.5 (sub-quadratic).
> - Adds a `timed_median` utility in [perf.rs](https://github.com/sims1253/ry/pull/62/files#diff-71eac516786f7cb23e114fa3de13fb8dc944df367960de7780a0582e3797b664) that uses batched sampling for fast operations and median-of-three for slow ones (≥200ms), reducing timing noise.
> - Adds `assert_subquadratic_scaling`, which checks both the global fitted slope and each adjacent step ratio (must be <3.5 for 2× size steps).
> - Adds five ignored scaling tests covering file length, pipe chain length, branch nesting depth, project file count, and call nesting depth.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e963148.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->