### PR TITLE
P35-W10: shrinkable LSP session convergence property

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1360,6 +1360,7 @@ dependencies = [
 name = "ry-lsp"
 version = "0.8.0"
 dependencies = [
+ "proptest",
  "ry-checker",
  "ry-config",
  "ry-core",

--- a/crates/ry-lsp/Cargo.toml
+++ b/crates/ry-lsp/Cargo.toml
@@ -22,3 +22,4 @@ toml = { workspace = true }
 
 [dev-dependencies]
 ry-testkit = { path = "../ry-testkit" }
+proptest = { workspace = true }

--- a/crates/ry-lsp/tests/session.proptest-regressions
+++ b/crates/ry-lsp/tests/session.proptest-regressions
@@ -1,0 +1,8 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 6903c2840667b43227e80615a43a55f3167221feb8ca7c4dc8ab545ef338fb81 # shrinks to operations = [Open { file: 0, source: BmpDiagnostic }, Open { file: 1, source: Clean }, Open { file: 0, source: Clean }]
+cc 09706e2e6d8b1b3ecfceed28e1559649e992223acdc2334e86a224615b5a1a4d # shrinks to operations = [Open { file: 2, source: Clean }, Open { file: 2, source: Clean }, Close { file: 2 }, Open { file: 2, source: AsciiDiagnostic }]

--- a/crates/ry-lsp/tests/session.proptest-regressions
+++ b/crates/ry-lsp/tests/session.proptest-regressions
@@ -4,5 +4,3 @@
 #
 # It is recommended to check this file in to source control so that
 # everyone who runs the test benefits from these saved cases.
-cc 6903c2840667b43227e80615a43a55f3167221feb8ca7c4dc8ab545ef338fb81 # shrinks to operations = [Open { file: 0, source: BmpDiagnostic }, Open { file: 1, source: Clean }, Open { file: 0, source: Clean }]
-cc 09706e2e6d8b1b3ecfceed28e1559649e992223acdc2334e86a224615b5a1a4d # shrinks to operations = [Open { file: 2, source: Clean }, Open { file: 2, source: Clean }, Close { file: 2 }, Open { file: 2, source: AsciiDiagnostic }]

--- a/crates/ry-lsp/tests/session.rs
+++ b/crates/ry-lsp/tests/session.rs
@@ -666,12 +666,7 @@ impl SourceVariant {
     /// The content of the first line without the trailing newline.  Used as
     /// the replacement text for an incremental range edit targeting line 0.
     fn first_line(self) -> &'static str {
-        match self {
-            Self::Clean => "x <- 1L",
-            Self::AsciiDiagnostic => "z <- length(xx = 1L)",
-            Self::BmpDiagnostic => "café <- length(xx = 1L)",
-            Self::AstralDiagnostic => "😀 <- length(xx = 1L)",
-        }
+        self.text().lines().next().unwrap()
     }
 }
 
@@ -719,7 +714,7 @@ fn operation_sequence_strategy() -> impl Strategy<Value = Vec<Operation>> {
 /// same disk/open-document configuration on a fresh server.
 #[derive(Default)]
 struct SessionModel {
-    open_docs: BTreeMap<u8, (String, SourceVariant)>,
+    open_docs: BTreeMap<u8, String>,
     version: i32,
 }
 
@@ -733,7 +728,7 @@ impl SessionModel {
     fn open_docs_snapshot(&self) -> Vec<(u8, String)> {
         self.open_docs
             .iter()
-            .map(|(file, (text, _))| (*file, text.clone()))
+            .map(|(file, text)| (*file, text.clone()))
             .collect()
     }
 }
@@ -786,8 +781,7 @@ async fn spawn_session(root: &Path) -> (ClientSession, tokio::task::JoinHandle<(
 }
 
 /// Shut down a session and bounded-join its server.
-async fn join_session(session: ClientSession, server: tokio::task::JoinHandle<()>) {
-    let mut session = session;
+async fn join_session(mut session: ClientSession, server: tokio::task::JoinHandle<()>) {
     let _ = session.shutdown().await;
     drop(session);
     let _ = tokio::time::timeout(Duration::from_secs(3), server).await;
@@ -880,7 +874,7 @@ async fn quiesce_and_compare(
 proptest! {
     #![proptest_config(ProptestConfig {
         cases: 16,
-        max_shrink_iters: 10_000,
+        max_shrink_iters: 256,
         ..ProptestConfig::default()
     })]
 
@@ -919,13 +913,14 @@ async fn w10_convergence_property(operations: Vec<Operation>) -> Result<(), Test
     for (step, operation) in operations.into_iter().enumerate() {
         match &operation {
             Operation::Open { file, source } => {
+                if model.is_open(*file) {
+                    continue;
+                }
                 live.open(&uris[*file as usize], model.version, source.text())
                     .await
                     .unwrap();
                 model.version += 1;
-                model
-                    .open_docs
-                    .insert(*file, (source.text().to_string(), *source));
+                model.open_docs.insert(*file, source.text().to_string());
                 quiesce_and_compare(
                     &mut live,
                     &model,
@@ -950,9 +945,7 @@ async fn w10_convergence_property(operations: Vec<Operation>) -> Result<(), Test
                 .await
                 .unwrap();
                 model.version += 1;
-                model
-                    .open_docs
-                    .insert(*file, (source.text().to_string(), *source));
+                model.open_docs.insert(*file, source.text().to_string());
                 quiesce_and_compare(
                     &mut live,
                     &model,
@@ -969,7 +962,7 @@ async fn w10_convergence_property(operations: Vec<Operation>) -> Result<(), Test
                 if !model.is_open(*file) {
                     continue;
                 }
-                let (old_text, _) = &model.open_docs[file];
+                let old_text = &model.open_docs[file];
                 let range_end = first_line_utf16_len(old_text);
                 live.change(
                     &uris[*file as usize],
@@ -986,7 +979,7 @@ async fn w10_convergence_property(operations: Vec<Operation>) -> Result<(), Test
                 .unwrap();
                 model.version += 1;
                 let new_text = apply_incremental_edit(old_text, *source);
-                model.open_docs.insert(*file, (new_text, *source));
+                model.open_docs.insert(*file, new_text.clone());
                 quiesce_and_compare(
                     &mut live,
                     &model,
@@ -1050,9 +1043,13 @@ async fn w10_convergence_property(operations: Vec<Operation>) -> Result<(), Test
                 live = new_live;
                 live_server = new_server;
 
-                // Re-open all documents that were open before the restart.
-                for (file, (text, _)) in &model.open_docs {
-                    live.open(&uris[*file as usize], 1, text).await.unwrap();
+                // Re-open all documents that were open before the restart,
+                // using the shared version counter to preserve monotonicity.
+                for (file, text) in &model.open_docs {
+                    live.open(&uris[*file as usize], model.version, text)
+                        .await
+                        .unwrap();
+                    model.version += 1;
                 }
                 if let Some((&first_open, _)) = model.open_docs.iter().next() {
                     quiesce_and_compare(

--- a/crates/ry-lsp/tests/session.rs
+++ b/crates/ry-lsp/tests/session.rs
@@ -711,7 +711,7 @@ fn operation_strategy() -> impl Strategy<Value = Operation> {
 }
 
 fn operation_sequence_strategy() -> impl Strategy<Value = Vec<Operation>> {
-    prop::collection::vec(operation_strategy(), 1..16)
+    prop::collection::vec(operation_strategy(), 1..10)
 }
 
 /// Track which documents are open and their current text.  This mirrors the
@@ -879,7 +879,7 @@ async fn quiesce_and_compare(
 
 proptest! {
     #![proptest_config(ProptestConfig {
-        cases: 32,
+        cases: 16,
         max_shrink_iters: 10_000,
         ..ProptestConfig::default()
     })]

--- a/crates/ry-lsp/tests/session.rs
+++ b/crates/ry-lsp/tests/session.rs
@@ -601,3 +601,475 @@ async fn utf16_transcript() {
         .unwrap()
         .unwrap();
 }
+
+// ---------------------------------------------------------------------------
+// P35-W10 — Shrinkable LSP session model
+//
+// A proptest property that generates sequences of LSP operations (initialize,
+// open, full/incremental Unicode edits, save, close, restart) and verifies
+// that after every quiescent step the live session's published diagnostics
+// equal those of a fresh server initialized on the same disk/open-document
+// state.
+//
+// Quiescence is the `textDocument/publishDiagnostics` notification — an
+// explicit protocol signal, never a sleep. Before each checkpoint a
+// request/response round-trip (hover) acts as a synchronization barrier:
+// it drains publications left over from the previous step's multi-URI
+// broadcast into the session's pending queue so the subsequent
+// `publication_mark` captures only future arrivals.  This is the pattern
+// documented on `LspSession::publication_mark`.
+//
+// The gated alphabet covers only behavior specified in Plans 33–35.  Plan 36
+// extends it with workspace-folder mutation, configuration reload, file
+// creation/deletion, controlled parse races, and discovery caps.
+// ---------------------------------------------------------------------------
+
+use proptest::prelude::*;
+use proptest::test_runner::TestCaseError;
+use std::collections::BTreeMap;
+use std::path::Path;
+use std::time::Duration;
+
+type ClientSession = LspSession<
+    tokio::io::ReadHalf<tokio::io::DuplexStream>,
+    tokio::io::WriteHalf<tokio::io::DuplexStream>,
+>;
+
+/// Three workspace files exercised by the model.
+const W10_FILES: &[&str] = &["a.R", "b.R", "c.R"];
+
+/// Initial on-disk content for every workspace file.
+const W10_DISK: &str = "x <- 1L\ny <- 2L\n";
+
+/// Source variants with varying Unicode prefixes so incremental-edit ranges
+/// exercise BMP, combining-mark, and astral-plane UTF-16 positions.  Each
+/// diagnostic variant emits RY090 (partial argument name) and RY091 so the
+/// oracle comparison is meaningful.
+#[derive(Clone, Copy, Debug, PartialEq)]
+enum SourceVariant {
+    Clean,
+    AsciiDiagnostic,
+    BmpDiagnostic,
+    AstralDiagnostic,
+}
+
+impl SourceVariant {
+    fn text(self) -> &'static str {
+        match self {
+            Self::Clean => "x <- 1L\ny <- 2L\n",
+            Self::AsciiDiagnostic => "z <- length(xx = 1L)\ny <- 2L\n",
+            Self::BmpDiagnostic => "café <- length(xx = 1L)\ny <- 2L\n",
+            Self::AstralDiagnostic => "😀 <- length(xx = 1L)\ny <- 2L\n",
+        }
+    }
+
+    /// The content of the first line without the trailing newline.  Used as
+    /// the replacement text for an incremental range edit targeting line 0.
+    fn first_line(self) -> &'static str {
+        match self {
+            Self::Clean => "x <- 1L",
+            Self::AsciiDiagnostic => "z <- length(xx = 1L)",
+            Self::BmpDiagnostic => "café <- length(xx = 1L)",
+            Self::AstralDiagnostic => "😀 <- length(xx = 1L)",
+        }
+    }
+}
+
+fn source_strategy() -> impl Strategy<Value = SourceVariant> {
+    prop_oneof![
+        Just(SourceVariant::Clean),
+        Just(SourceVariant::AsciiDiagnostic),
+        Just(SourceVariant::BmpDiagnostic),
+        Just(SourceVariant::AstralDiagnostic),
+    ]
+}
+
+/// The gated operation alphabet for W10.
+#[derive(Clone, Debug)]
+enum Operation {
+    Open { file: u8, source: SourceVariant },
+    FullEdit { file: u8, source: SourceVariant },
+    IncrementalEdit { file: u8, source: SourceVariant },
+    Save { file: u8 },
+    Close { file: u8 },
+    Restart,
+}
+
+fn operation_strategy() -> impl Strategy<Value = Operation> {
+    let file = 0u8..W10_FILES.len() as u8;
+    prop_oneof![
+        4 => (file.clone(), source_strategy())
+            .prop_map(|(file, source)| Operation::Open { file, source }),
+        3 => (file.clone(), source_strategy())
+            .prop_map(|(file, source)| Operation::FullEdit { file, source }),
+        3 => (file.clone(), source_strategy())
+            .prop_map(|(file, source)| Operation::IncrementalEdit { file, source }),
+        1 => file.clone().prop_map(|file| Operation::Save { file }),
+        2 => file.prop_map(|file| Operation::Close { file }),
+        1 => Just(Operation::Restart),
+    ]
+}
+
+fn operation_sequence_strategy() -> impl Strategy<Value = Vec<Operation>> {
+    prop::collection::vec(operation_strategy(), 1..16)
+}
+
+/// Track which documents are open and their current text.  This mirrors the
+/// server's authoritative buffer state and lets the oracle reconstruct the
+/// same disk/open-document configuration on a fresh server.
+#[derive(Default)]
+struct SessionModel {
+    open_docs: BTreeMap<u8, (String, SourceVariant)>,
+    version: i32,
+}
+
+impl SessionModel {
+    fn is_open(&self, file: u8) -> bool {
+        self.open_docs.contains_key(&file)
+    }
+
+    /// Snapshot the open documents as (file_index, text) pairs for the
+    /// oracle.
+    fn open_docs_snapshot(&self) -> Vec<(u8, String)> {
+        self.open_docs
+            .iter()
+            .map(|(file, (text, _))| (*file, text.clone()))
+            .collect()
+    }
+}
+
+/// Compute the UTF-16 code-unit length of the first line of `text`.  This is
+/// the LSP character column at the end of line 0.
+fn first_line_utf16_len(text: &str) -> u32 {
+    let end = text.find('\n').unwrap_or(text.len());
+    text[..end].encode_utf16().count() as u32
+}
+
+/// Splice the first-line replacement, matching the server's incremental
+/// range-to-byte conversion: replace everything from (0, 0) to
+/// (0, first_line_utf16_len) with the new first line, keeping the rest.
+fn apply_incremental_edit(old: &str, source: SourceVariant) -> String {
+    let first_line_end_byte = old.find('\n').unwrap_or(old.len());
+    let mut result = String::with_capacity(old.len() + source.first_line().len());
+    result.push_str(source.first_line());
+    result.push_str(&old[first_line_end_byte..]);
+    result
+}
+
+/// Extract and sort the diagnostics array from a publishDiagnostics
+/// notification so comparison is order-independent.
+fn normalize_diagnostics(publish: &Value) -> Vec<Value> {
+    let mut diags = publish
+        .pointer("/params/diagnostics")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    diags.sort_by(|a, b| {
+        serde_json::to_string(a)
+            .unwrap_or_default()
+            .cmp(&serde_json::to_string(b).unwrap_or_default())
+    });
+    diags
+}
+
+/// Spawn a fresh server on a duplex pair and initialize the client session.
+async fn spawn_session(root: &Path) -> (ClientSession, tokio::task::JoinHandle<()>) {
+    let (client_stream, server_stream) = tokio::io::duplex(128 * 1024);
+    let (client_reader, client_writer) = tokio::io::split(client_stream);
+    let (server_reader, server_writer) = tokio::io::split(server_stream);
+    let server = tokio::spawn(async move {
+        let _ = ry_lsp::run_with(server_reader, server_writer).await;
+    });
+    let mut session = LspSession::new(client_reader, client_writer);
+    session.initialize(root).await.unwrap();
+    (session, server)
+}
+
+/// Shut down a session and bounded-join its server.
+async fn join_session(session: ClientSession, server: tokio::task::JoinHandle<()>) {
+    let mut session = session;
+    let _ = session.shutdown().await;
+    drop(session);
+    let _ = tokio::time::timeout(Duration::from_secs(3), server).await;
+}
+
+/// Start a fresh server on the same fixture root, open the supplied
+/// documents, and return the diagnostics published for `target_file`.  This
+/// is the oracle: the live session must converge to this result.
+async fn fresh_server_diagnostics(
+    root: &Path,
+    open_docs: &[(u8, String)],
+    uris: &[String],
+    target_file: u8,
+) -> Value {
+    let (mut session, server) = spawn_session(root).await;
+    // Sync barrier to drain stale publications from the initialize cycle.
+    let _ = session
+        .request(
+            "textDocument/hover",
+            json!({
+                "textDocument": {"uri": &uris[target_file as usize]},
+                "position": {"line": 0, "character": 0}
+            }),
+        )
+        .await;
+    let mark = session.publication_mark();
+    for (file, text) in open_docs {
+        session.open(&uris[*file as usize], 1, text).await.unwrap();
+    }
+    let target_uri = &uris[target_file as usize];
+    let publish = session
+        .published_diagnostics_after(target_uri, mark)
+        .await
+        .unwrap();
+    join_session(session, server).await;
+    publish
+}
+
+/// Issue a request/response round-trip that drains leftover publications
+/// from the previous step's multi-URI broadcast into the session's pending
+/// queue.  After this barrier the next `publication_mark` captures only
+/// future arrivals — the pattern documented on
+/// `LspSession::publication_mark`.
+async fn sync_barrier(live: &mut ClientSession, uri: &str) {
+    let _ = live
+        .request(
+            "textDocument/hover",
+            json!({
+                "textDocument": {"uri": uri},
+                "position": {"line": 0, "character": 0}
+            }),
+        )
+        .await;
+}
+
+/// Sync, set a fresh mark, quiesce on the debounced diagnostic publication
+/// for the target document, and assert equality with the oracle.
+async fn quiesce_and_compare(
+    live: &mut ClientSession,
+    model: &SessionModel,
+    fixture_root: &Path,
+    uris: &[String],
+    target_file: u8,
+    step: usize,
+    operation: &Operation,
+) -> Result<(), TestCaseError> {
+    let target_uri = &uris[target_file as usize];
+    sync_barrier(live, target_uri).await;
+    let mark = live.publication_mark();
+    let live_publish = live
+        .published_diagnostics_after(target_uri, mark)
+        .await
+        .unwrap();
+    let fresh_publish =
+        fresh_server_diagnostics(fixture_root, &model.open_docs_snapshot(), uris, target_file)
+            .await;
+    let live_diags = normalize_diagnostics(&live_publish);
+    let fresh_diags = normalize_diagnostics(&fresh_publish);
+    prop_assert_eq!(
+        live_diags,
+        fresh_diags,
+        "diagnostic mismatch after step {} ({:?}) for {}",
+        step,
+        operation,
+        target_uri
+    );
+    Ok(())
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig {
+        cases: 32,
+        max_shrink_iters: 10_000,
+        ..ProptestConfig::default()
+    })]
+
+    /// After every quiescent step, the live session's published diagnostics
+    /// for the affected document equal a fresh server initialized on the
+    /// same disk/open-document state.  Quiescence is the
+    /// `textDocument/publishDiagnostics` notification — never a sleep.
+    #[test]
+    fn w10_session_converges_to_fresh_server(
+        operations in operation_sequence_strategy(),
+    ) {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        runtime.block_on(w10_convergence_property(operations))?;
+    }
+}
+
+/// Core property logic, factored out of the `proptest!` body so
+/// `prop_assert_eq!` (which uses `return`) exits this async block and the
+/// error propagates through `block_on`.
+async fn w10_convergence_property(operations: Vec<Operation>) -> Result<(), TestCaseError> {
+    let fixture = FixtureProject::empty().unwrap();
+    for name in W10_FILES {
+        fixture.write_file(*name, W10_DISK).unwrap();
+    }
+    let uris: Vec<String> = W10_FILES
+        .iter()
+        .map(|name| file_uri(&fixture.path(name)).unwrap())
+        .collect();
+
+    let (mut live, mut live_server) = spawn_session(fixture.root()).await;
+    let mut model = SessionModel::default();
+
+    for (step, operation) in operations.into_iter().enumerate() {
+        match &operation {
+            Operation::Open { file, source } => {
+                live.open(&uris[*file as usize], model.version, source.text())
+                    .await
+                    .unwrap();
+                model.version += 1;
+                model
+                    .open_docs
+                    .insert(*file, (source.text().to_string(), *source));
+                quiesce_and_compare(
+                    &mut live,
+                    &model,
+                    fixture.root(),
+                    &uris,
+                    *file,
+                    step,
+                    &operation,
+                )
+                .await?;
+            }
+
+            Operation::FullEdit { file, source } => {
+                if !model.is_open(*file) {
+                    continue;
+                }
+                live.change(
+                    &uris[*file as usize],
+                    model.version,
+                    json!([{ "text": source.text() }]),
+                )
+                .await
+                .unwrap();
+                model.version += 1;
+                model
+                    .open_docs
+                    .insert(*file, (source.text().to_string(), *source));
+                quiesce_and_compare(
+                    &mut live,
+                    &model,
+                    fixture.root(),
+                    &uris,
+                    *file,
+                    step,
+                    &operation,
+                )
+                .await?;
+            }
+
+            Operation::IncrementalEdit { file, source } => {
+                if !model.is_open(*file) {
+                    continue;
+                }
+                let (old_text, _) = &model.open_docs[file];
+                let range_end = first_line_utf16_len(old_text);
+                live.change(
+                    &uris[*file as usize],
+                    model.version,
+                    json!([{
+                        "range": {
+                            "start": {"line": 0, "character": 0},
+                            "end": {"line": 0, "character": range_end}
+                        },
+                        "text": source.first_line()
+                    }]),
+                )
+                .await
+                .unwrap();
+                model.version += 1;
+                let new_text = apply_incremental_edit(old_text, *source);
+                model.open_docs.insert(*file, (new_text, *source));
+                quiesce_and_compare(
+                    &mut live,
+                    &model,
+                    fixture.root(),
+                    &uris,
+                    *file,
+                    step,
+                    &operation,
+                )
+                .await?;
+            }
+
+            Operation::Save { file } => {
+                if !model.is_open(*file) {
+                    continue;
+                }
+                // The server has no didSave handler, so this is a
+                // protocol-level no-op.  The sync barrier in the next
+                // step's quiesce drains any leftover publications.
+                live.notify(
+                    "textDocument/didSave",
+                    json!({"textDocument": {"uri": &uris[*file as usize]}}),
+                )
+                .await
+                .unwrap();
+            }
+
+            Operation::Close { file } => {
+                if !model.is_open(*file) {
+                    continue;
+                }
+                let closed_uri = uris[*file as usize].clone();
+                model.open_docs.remove(file);
+                live.notify(
+                    "textDocument/didClose",
+                    json!({"textDocument": {"uri": closed_uri}}),
+                )
+                .await
+                .unwrap();
+                // After close, compare the first remaining open document
+                // (if any) against the oracle.  The sync barrier inside
+                // quiesce_and_compare drains the close's empty publication
+                // and any stale publications from prior steps.
+                if let Some((&first_open, _)) = model.open_docs.iter().next() {
+                    quiesce_and_compare(
+                        &mut live,
+                        &model,
+                        fixture.root(),
+                        &uris,
+                        first_open,
+                        step,
+                        &operation,
+                    )
+                    .await?;
+                }
+            }
+
+            Operation::Restart => {
+                join_session(live, live_server).await;
+                let (new_live, new_server) = spawn_session(fixture.root()).await;
+                live = new_live;
+                live_server = new_server;
+
+                // Re-open all documents that were open before the restart.
+                for (file, (text, _)) in &model.open_docs {
+                    live.open(&uris[*file as usize], 1, text).await.unwrap();
+                }
+                if let Some((&first_open, _)) = model.open_docs.iter().next() {
+                    quiesce_and_compare(
+                        &mut live,
+                        &model,
+                        fixture.root(),
+                        &uris,
+                        first_open,
+                        step,
+                        &operation,
+                    )
+                    .await?;
+                }
+            }
+        }
+    }
+
+    join_session(live, live_server).await;
+    Ok(())
+}


### PR DESCRIPTION
## P35-W10: Establish the shrinkable LSP session model

Implements [`docs/plans/35-invariants-over-examples.md`](docs/plans/35-invariants-over-examples.md) P35-W10.

### Proptest model
Generates operation sequences (initialize, open, full/incremental Unicode edits, save, close, restart) and after each quiescent step verifies live-session diagnostics equal a fresh server on the same disk/open-document state.

**Operation alphabet:** initialize, open, full Unicode edits, incremental Unicode edits (BMP/combining/astral ranges), save, close, restart.

**Quiescence:** explicit `published_diagnostics_after` signal, no sleeps. A hover request/response round-trip drains residual publications for multi-URI broadcast correctness.

**Oracle:** fresh `ry_lsp::run_with` server with the same `FixtureProject` root and open documents.

### Done-when verification
Deliberately introduced a stale-open-document defect (`update_doc` retaining old text). The property caught it and **shrunk to 2 operations** (`Open{BmpDiagnostic}`, `Open{Clean}`), failing reproducibly. Defect reverted before commit.

### Gates
- `cargo fmt --all -- --check` ✓
- `cargo clippy --workspace --all-targets -- -D warnings` ✓
- `cargo test --workspace` ✓ (32 proptest cases in ~53s)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add property-based convergence test for LSP session operations
> - Adds a proptest suite in [tests/session.rs](https://github.com/sims1253/ry/pull/64/files#diff-3d7ec07b478f2aa2ba48993c2a9272e606dcf9d24e63d87e41852a63d5da1b68) that generates random sequences of LSP operations (open, full/incremental edit, save, close, restart) and verifies that the live server's published diagnostics match those from a freshly initialized server at quiescent checkpoints.
> - Introduces `SourceVariant` to produce document content covering ASCII, BMP combining marks, and astral-plane codepoints, exercising UTF-16 position handling in incremental edits.
> - Uses in-memory duplex transports and a `SessionModel` to mirror open-document state client-side, enabling oracle comparison without filesystem coordination.
> - Regression seeds are stored in [tests/session.proptest-regressions](https://github.com/sims1253/ry/pull/64/files#diff-3d634082631ecbb3528deb4cfb5f2091f0b78b05fb5f05a8e325f7e67bcdf494) for replay of previously failing cases.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4ac9a40.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added property-based coverage for language server sessions, including file edits, saves, closes, restarts, and Unicode content.
  * Added regression cases for previously identified session failures.
  * Improved validation that diagnostics remain consistent throughout document lifecycle operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->