### PR TITLE
P36-W4+W6: version-stamped tree cache (#53) and precompute filters (#46)

### DIFF
--- a/crates/ry-lsp/src/backend.rs
+++ b/crates/ry-lsp/src/backend.rs
@@ -133,8 +133,14 @@ pub(super) struct State {
     /// these — when a path exists in both `docs` and `disk_files`,
     /// the open document's content is authoritative.
     disk_files: HashMap<String, Arc<SourceFile>>,
-    /// Tree-sitter trees for incremental parsing (Plan 33 W6).
-    trees: HashMap<String, ry_core::Tree>,
+    /// P36-W4 (#53): Version-stamped tree-sitter trees for incremental
+    /// parsing (Plan 33 W6). Each entry stores the document version
+    /// (generation) the tree was produced from. A parse result may
+    /// replace the cache only if its version still matches the current
+    /// document version; a cache read returns the tree only under the
+    /// same invariant, so no cached tree can ever be served for a
+    /// different document generation.
+    trees: HashMap<String, (i32, ry_core::Tree)>,
 }
 
 /// P36-W2: One per-folder analysis context (#44/#54/#56).
@@ -293,6 +299,33 @@ impl State {
     #[cfg(test)]
     pub(super) fn parse_count(&self) -> usize {
         self.parse_count.load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    /// P36-W4 (#53): Return the cached tree-sitter `Tree` for `path`
+    /// only when its recorded generation matches the current document
+    /// version. A stale tree from a superseded generation is never
+    /// served — the cache read enforces the same invariant as the
+    /// write (`store_tree`).
+    fn tree_for(&self, path: &str) -> Option<ry_core::Tree> {
+        let current_version = self.versions.get(path).copied()?;
+        let (tree_version, tree) = self.trees.get(path)?;
+        if *tree_version == current_version {
+            Some(tree.clone())
+        } else {
+            None
+        }
+    }
+
+    /// P36-W4 (#53): Store a tree-sitter `Tree` for `path`, tagged with
+    /// `version`. The tree replaces the cache entry only if `version`
+    /// still matches the current document version. A stale parse whose
+    /// version was superseded by a concurrent edit is dropped rather
+    /// than overwriting the current tree, so no cached tree can ever
+    /// be served for a different document generation.
+    fn store_tree(&mut self, path: &str, version: i32, tree: ry_core::Tree) {
+        if self.versions.get(path).copied() == Some(version) {
+            self.trees.insert(path.to_string(), (version, tree));
+        }
     }
 
     /// Drop the cached parse and scope for `path`, mirroring the
@@ -831,6 +864,12 @@ impl LanguageServer for Backend {
         // Debounced: a burst of keystrokes coalesces into a single
         // diagnostic publish.
         self.schedule_diagnostics(uri).await;
+        // P36-W4 (#53): test-only scheduling seam. Signals that the
+        // document version has been bumped and diagnostics re-scheduled,
+        // so a waiting test can release the parse barrier knowing the
+        // version-stamped cache will reject the stale parse. When no test
+        // is waiting this is a single atomic swap — effectively free.
+        crate::test_seam::note_did_change();
     }
 
     async fn did_change_configuration(&self, params: DidChangeConfigurationParams) {
@@ -1819,7 +1858,7 @@ impl Backend {
             let (old_text, old_tree) = {
                 let state = self.state.lock().await;
                 let old = state.docs.get(path).cloned();
-                (old, state.trees.get(path).cloned())
+                (old, state.tree_for(path))
             };
 
             if let Some(old_text) = old_text {
@@ -1853,7 +1892,7 @@ impl Backend {
                 // Store the tree for next time so the next parse is incremental.
                 let mut state = self.state.lock().await;
                 if let Some(tree) = tree_mut {
-                    state.trees.insert(path.to_string(), tree);
+                    state.store_tree(path, version, tree);
                 } else {
                     state.trees.remove(path);
                 }
@@ -1928,17 +1967,33 @@ impl Backend {
                 _ => return None,
             };
             // W6: Use incremental parse when we have an old tree.
+            // P36-W4 (#53): tree_for returns the cached tree only when its
+            // recorded generation matches the current document version.
             let old_tree = {
                 let state = self.state.lock().await;
-                state.trees.get(path).cloned()
+                state.tree_for(path)
             };
+            // P36-W4 (#53): test-only scheduling barrier. When armed, the
+            // parse pauses here — after reading the document text, version,
+            // and old tree, but before the expensive parse — so the test can
+            // force the interleaving:
+            //   1. parse version N starts (we are here)
+            //   2. didChange installs N+1
+            //   3. parse N finishes (test releases the barrier)
+            //   4. stale result is rejected by store_tree / record_parse
+            //   5. the retry loop parses the current version N+1 fresh
+            // The seam controls scheduling only; cache policy is production
+            // code. When not armed this is a single relaxed atomic load.
+            crate::test_seam::maybe_pause().await;
             let mut parser = RParser::new().ok()?;
             let file = if let Some(tree) = old_tree {
                 let (parsed, new_tree) = parser.parse_with_tree(path, &text, Some(&tree)).ok()?;
-                // Store the new tree for the next incremental parse.
+                // P36-W4 (#53): Store the tree only if the version still
+                // matches. A parse whose version was superseded by a
+                // concurrent edit must not overwrite the current tree.
                 {
                     let mut state = self.state.lock().await;
-                    state.trees.insert(path.to_string(), new_tree);
+                    state.store_tree(path, version, new_tree);
                 }
                 Arc::new(parsed)
             } else {
@@ -1946,7 +2001,7 @@ impl Backend {
                 let (parsed, new_tree) = parser.parse_with_tree(path, &text, None).ok()?;
                 {
                     let mut state = self.state.lock().await;
-                    state.trees.insert(path.to_string(), new_tree);
+                    state.store_tree(path, version, new_tree);
                 }
                 Arc::new(parsed)
             };

--- a/crates/ry-lsp/src/lib.rs
+++ b/crates/ry-lsp/src/lib.rs
@@ -31,6 +31,109 @@
 //! and crash the client. All `tracing` output is routed to stderr via
 //! the CLI's `tracing_subscriber` initialization before `run()` is called.
 
+/// P36-W4 (#53): Test-only scheduler/barrier seam for forcing
+/// parse/didChange interleaving. The seam controls scheduling only; cache
+/// policy (version-stamped tree rejection) is production code in
+/// `backend::parsed_file` and `State::store_tree`/`State::tree_for`.
+///
+/// The barrier is **thread-local**: each test creates a single-threaded
+/// (`new_current_thread`) tokio runtime, so the server and its spawned
+/// tasks share the barrier with the test, while other tests running in
+/// parallel on different threads are completely isolated. No test sleeps;
+/// the barrier uses `tokio::sync::Notify` for deterministic rendezvous.
+pub mod test_seam {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use tokio::sync::Notify;
+
+    /// Per-thread coordination state. Stored behind an `Arc` so it can be
+    /// cloned out of the `thread_local` accessor and used in async code.
+    struct ParseBarrier {
+        armed: AtomicBool,
+        did_change_waiting: AtomicBool,
+        arrived: Notify,
+        release: Notify,
+        did_change_fired: Notify,
+    }
+
+    impl ParseBarrier {
+        fn new() -> Self {
+            Self {
+                armed: AtomicBool::new(false),
+                did_change_waiting: AtomicBool::new(false),
+                arrived: Notify::new(),
+                release: Notify::new(),
+                did_change_fired: Notify::new(),
+            }
+        }
+    }
+
+    thread_local! {
+        static PARSE_BARRIER: Arc<ParseBarrier> = Arc::new(ParseBarrier::new());
+    }
+
+    /// Clone the thread-local barrier out for async use.
+    fn barrier() -> Arc<ParseBarrier> {
+        PARSE_BARRIER.with(|b| b.clone())
+    }
+
+    /// Arm the barrier so the next `parsed_file` cache miss pauses after
+    /// reading the document text/version/tree but before parsing. Also
+    /// arms the `didChange` notification so the test can confirm the new
+    /// version is installed before releasing the paused parse. Both flags
+    /// are consumed atomically (once each); subsequent calls proceed
+    /// normally.
+    pub fn arm() {
+        let b = barrier();
+        b.armed.store(true, Ordering::Release);
+        b.did_change_waiting.store(true, Ordering::Release);
+    }
+
+    /// Wait for `parsed_file` to arrive at the barrier. Returns once the
+    /// server-side parse has read the document but has not yet parsed it,
+    /// so the test can install a new version before the parse completes.
+    pub async fn wait_arrived() {
+        barrier().arrived.notified().await;
+    }
+
+    /// Wait for a `didChange` to be fully processed: document updated,
+    /// version bumped, and diagnostics re-scheduled. The test calls this
+    /// after sending `didChange` and before releasing the barrier, so the
+    /// version-stamped cache rejection is exercised deterministically.
+    pub async fn wait_did_change() {
+        barrier().did_change_fired.notified().await;
+    }
+
+    /// Release the paused parse so it can finish. The stale result is
+    /// rejected by the version-stamped tree cache; the retry loop in
+    /// `parsed_file` then parses the current version fresh.
+    pub fn release_barrier() {
+        barrier().release.notify_one();
+    }
+
+    /// Called by `parsed_file` (production code). If armed, atomically
+    /// disarms and pauses: signals arrival, then waits for the test to
+    /// release. When not armed, this is a no-op (single relaxed load).
+    pub(crate) async fn maybe_pause() {
+        let b = barrier();
+        if b.armed.swap(false, Ordering::AcqRel) {
+            b.arrived.notify_one();
+            b.release.notified().await;
+        }
+    }
+
+    /// Called by `did_change` after the document is updated and diagnostics
+    /// are re-scheduled. Only fires when a test has armed the notification
+    /// (via `arm`). The flag is consumed atomically so only the first
+    /// `didChange` after arming signals.
+    pub(crate) fn note_did_change() {
+        let b = barrier();
+        if b.did_change_waiting.swap(false, Ordering::AcqRel) {
+            b.did_change_fired.notify_one();
+        }
+    }
+}
+
 mod backend;
 mod diagnostics;
 mod folding;

--- a/crates/ry-lsp/tests/p36_contract.rs
+++ b/crates/ry-lsp/tests/p36_contract.rs
@@ -800,11 +800,11 @@ fn p36_w3_workspace_folder_add_remove_convergence() {
 ///   4. stale result is rejected;
 ///   5. diagnostics equal a fresh parse of N+1.
 ///
-/// The scheduler/barrier seam to force this ordering does not exist yet
-/// (P36-W4 adds it). The test compiles and documents the contract; the
-/// forced-interleaving assertions will be completed in P36-W4.
+/// The test-only scheduler/barrier seam (`ry_lsp::test_seam`) forces this
+/// ordering without any sleeps. The seam controls scheduling only; cache
+/// policy (version-stamped tree rejection) is production code in
+/// `backend::parsed_file` and `State::store_tree`/`State::tree_for`.
 #[test]
-#[ignore = "P36-W4: version-stamped tree cache with forced interleaving (#53) — seam pending"]
 fn p36_w4_version_stamped_tree_cache_rejects_stale_parse() {
     use ry_testkit::LspSession;
 
@@ -827,36 +827,55 @@ fn p36_w4_version_stamped_tree_cache_rejects_stale_parse() {
         let mut live = LspSession::new(cr, cw);
         live.initialize(fixture.root()).await.unwrap();
 
-        // Open version 1.
-        let mark1 = live.publication_mark();
-        live.open(&main_uri, 1, source_v1).await.unwrap();
-        let publish_v1 = live
-            .published_diagnostics_after(&main_uri, mark1)
-            .await
-            .unwrap();
-        let v1_codes: Vec<&str> = publish_v1["params"]["diagnostics"]
-            .as_array()
-            .unwrap()
-            .iter()
-            .map(|d| d["code"].as_str().unwrap())
-            .collect();
-        assert!(v1_codes.is_empty(), "source v1 should be clean");
+        // ── Force the interleaving (#53): ──
+        //   1. parse version N=1 starts
+        //   2. didChange installs N+1=2
+        //   3. parse N=1 finishes
+        //   4. stale result is rejected by the version-stamped tree cache
+        //   5. diagnostics equal a fresh parse of N+1=2
 
-        // Edit to version 2 (introduces RY090).
-        let mark2 = live.publication_mark();
+        // Arm the test-only scheduler barrier. The next `parsed_file` cache
+        // miss pauses after reading the document text/version/tree but before
+        // parsing. The barrier also arms a didChange-processed notification
+        // so the test can confirm the new version is installed before
+        // releasing the paused parse.
+        ry_lsp::test_seam::arm();
+
+        // Open version 1. `schedule_diagnostics` debounces 180 ms, then
+        // `publish_diagnostics` calls `parsed_file` → barrier pauses.
+        live.open(&main_uri, 1, source_v1).await.unwrap();
+
+        // Wait for the parse of version 1 to start (step 1): `parsed_file`
+        // has read the v1 text/version/tree and is now paused.
+        ry_lsp::test_seam::wait_arrived().await;
+
+        // Install version 2 while the version-1 parse is paused (step 2).
         live.change(&main_uri, 2, json!([{"text": source_v2}]))
             .await
             .unwrap();
+
+        // Wait for didChange to be fully processed: document updated,
+        // version bumped, diagnostics re-scheduled. This sync point is
+        // necessary because tower-lsp dispatches handlers concurrently —
+        // without it the barrier release could race ahead of the document
+        // update and the stale parse would not be detected.
+        ry_lsp::test_seam::wait_did_change().await;
+
+        // Release the barrier: the version-1 parse finishes (step 3). Its
+        // tree is rejected by `store_tree` (version 1 ≠ current version 2)
+        // and its `SourceFile` is rejected by `record_parse` (step 4). The
+        // retry loop then parses version 2 fresh.
+        ry_lsp::test_seam::release_barrier();
+
+        // Collect diagnostics for version 2 (step 5). The didChange
+        // triggered `schedule_diagnostics(gen=2)`, which publishes after
+        // the debounce.
+        let mark = live.publication_mark();
         let publish_v2 = live
-            .published_diagnostics_after(&main_uri, mark2)
+            .published_diagnostics_after(&main_uri, mark)
             .await
             .unwrap();
 
-        // P36-W4 adds the scheduler seam to force:
-        //   parse(v1) start → didChange(v2) → parse(v1) finish → stale rejected.
-        // Without the seam, this best-effort check confirms that v2's
-        // diagnostics reflect the new source. The seam makes the rejection
-        // assertion deterministic.
         let v2_codes: Vec<&str> = publish_v2["params"]["diagnostics"]
             .as_array()
             .unwrap()
@@ -865,22 +884,13 @@ fn p36_w4_version_stamped_tree_cache_rejects_stale_parse() {
             .collect();
         assert!(
             v2_codes.contains(&"RY090"),
-            "version 2 must produce RY090; got: {v2_codes:?}"
+            "version 2 must produce RY090 after the stale parse is rejected; got: {v2_codes:?}"
         );
 
-        // P36-W4 adds a test-only scheduler barrier seam to force:
-        //   parse(v1) start → didChange(v2) → parse(v1) finish → stale rejected.
-        // Until the seam exists the stale-cache race cannot be triggered
-        // deterministically without sleeps (which the plan forbids).
-        // This sentinel marks the test RED; P36-W4 replaces it with the
-        // forced-interleaving sequence.
+        // Cleanup.
         let _ = live.shutdown().await;
         drop(live);
         let _ = tokio::time::timeout(std::time::Duration::from_secs(3), server).await;
-        panic!(
-            "P36-W4: scheduler barrier seam required for deterministic \
-             interleaving; this sentinel is removed when W4 provides the seam"
-        );
     });
 }
 


### PR DESCRIPTION
## P36-W4+W6: Version-stamped tree cache (#53) and precompute filters (#46)

Implements [`docs/plans/36-lsp-contract.md`](docs/plans/36-lsp-contract.md) P36-W4 and P36-W6.

### W4 — Version-stamped tree cache (#53)
`State::trees` → `HashMap<String, (i32, Tree)>` with `store_tree`/`tree_for` enforcing generation invariant. Thread-local test seam forces 5-step interleaving (parse N starts → didChange N+1 → parse N finishes → stale rejected → fresh N+1). No sleeps.

### W6 — Precompute filters once per folder (#46)
`(SeverityFilter, min_confidence, Excludes)` compiled once per `FolderAnalysisContext`. Publish loop borrows precompiled values — no config clone or glob recompilation per file. Thread-local construction-count hook asserts flat growth as file count increases.

### Red tests turned green
- `p36_w4_version_stamped_tree_cache_rejects_stale_parse` ✓
- `p36_w6_many_files_flat_filter_construction` ✓

### Gates
- `cargo fmt --all -- --check` ✓
- `cargo clippy --workspace --all-targets -- -D warnings` ✓
- `cargo test --workspace` ✓
- `ecosystem/run.sh --check --tier fast` ✓ (non-local)

Closes #53, closes #46.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add version-stamped tree cache and deterministic test seam for stale parse rejection in LSP backend
> - The incremental parse tree cache in [backend.rs](https://github.com/sims1253/ry/pull/71/files#diff-6fe792d8d98d8cc3b53addc7bfb8e79c6bd08b1383372fe5f7340be58ecf8d36) now stores `(version, tree)` pairs and exposes `tree_for`/`store_tree` helpers that reject reads and writes when the cached version does not match the current document version.
> - A new `test_seam` module in [lib.rs](https://github.com/sims1253/ry/pull/71/files#diff-51dc21440dbe6ca89d0a7d0a702964c49fc0915f2c141b8d98ed8c0c375eb367) provides a thread-local barrier and notification channel so tests can deterministically interleave parse tasks with `didChange` events; it is a no-op in production.
> - The previously ignored test `p36_w4_version_stamped_tree_cache_rejects_stale_parse` in [p36_contract.rs](https://github.com/sims1253/ry/pull/71/files#diff-582eb44cd676fa74addaa6105bda4d8502899de7542457496088d62db5b6576d) now runs and asserts that a stale v1 parse result is discarded when a v2 edit arrives mid-parse, and that diagnostics reflect the newer version.
> - Behavioral Change: incremental parse results that arrive after a subsequent edit is applied are silently dropped rather than overwriting the current cache entry.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a6409ec.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->