### PR TITLE
P36-W5+W7: cache baseline/config outside lock (#45) and bounded discovery (#48)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to ry are documented in this file.
 
 ## [Unreleased]
 
+### Added — Shared, bounded discovery (P36-W7, #48)
+
+- **Shared directory discovery**: CLI (`ry check`) and LSP now use the
+  same `ry-workspace` discovery module so both produce identical file
+  sets over hidden, excluded, oversized, deep, symlink, and test-fixture
+  cases. Gated by `p36_w7_cli_lsp_discovery_set_equality`.
+- **Bounded discovery caps**: `index.max-files` (default 20,000),
+  `index.max-file-bytes` (default 2 MiB), and `index.max-depth`
+  (default 64) limit how many files are discovered. Each accepts a
+  positive integer; zero is a configuration error.
+- **Visible cap reporting**: a cap hit emits a structured tracing event,
+  one user-visible LSP warning per scan generation, a CLI warning, and
+  observable truncated state exposed to tests.
+
 ### Added — Editor extensions
 
 - **VS Code / Positron extension** (`editors/code/`): installable from

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1402,6 +1402,7 @@ version = "0.8.0"
 dependencies = [
  "bzip2",
  "flate2",
+ "glob",
  "rds2rust",
  "ry-checker",
  "ry-config",

--- a/README.md
+++ b/README.md
@@ -211,11 +211,24 @@ exclude = ["renv", "tests/snaps/**"]
 
 # Include R fixture data nested under package tests/ directories.
 check-test-fixtures = false
+
+# Bounded directory discovery. Both CLI (`ry check`) and LSP apply the
+# same limits so the two modes discover exactly the same file set.
+# Each key accepts a positive integer; zero is a configuration error.
+[index]
+max-files      = 20000   # files discovered per root (default: 20,000)
+max-file-bytes = 2097152 # bytes per R file (default: 2 MiB)
+max-depth      = 64      # directory depth (default: 64)
 ```
 
 CLI flags override the config only when passed explicitly.
 When multiple paths are checked, the first path anchors config discovery;
 that one configuration applies to the complete invocation.
+
+In the editor, open documents that are ineligible for analysis (excluded by
+`exclude` patterns, over `max-file-bytes`, or below a pruned `max-depth`)
+may still receive syntax highlighting and editor features, but they do not
+enter project-wide binding or diagnostic state.
 
 ## Custom typesheds
 

--- a/crates/ry-cli/src/main.rs
+++ b/crates/ry-cli/src/main.rs
@@ -1209,7 +1209,7 @@ fn report_truncation(report: &ry_workspace::TruncationReport, root: &std::path::
     }
     if report.max_files_hit {
         eprintln!(
-            "ry: warning: file count cap (index.max-files) reached at {};              additional R files were not discovered",
+            "ry: warning: file count cap (index.max-files) reached at {}; additional R files were not discovered",
             root.display()
         );
     }
@@ -1222,7 +1222,7 @@ fn report_truncation(report: &ry_workspace::TruncationReport, root: &std::path::
     }
     for dir in &report.depth_pruned_dirs {
         eprintln!(
-            "ry: warning: directory depth cap (index.max-depth) reached at {};              files below {} were not discovered",
+            "ry: warning: directory depth cap (index.max-depth) reached at {}; files below {} were not discovered",
             root.display(),
             dir.display()
         );

--- a/crates/ry-cli/src/main.rs
+++ b/crates/ry-cli/src/main.rs
@@ -434,26 +434,6 @@ fn render_diagnostics(
 /// root prefix from the literal path, and finally to the file's full
 /// display string, so exclude matching degrades gracefully rather than
 /// panicking.
-fn relative_path_for_exclude(file: &std::path::Path, root: &std::path::Path) -> String {
-    let canon_file = std::fs::canonicalize(file).ok();
-    let canon_root = std::fs::canonicalize(root).ok();
-    if let (Some(f), Some(r)) = (canon_file, canon_root) {
-        if let Ok(rel) = f.strip_prefix(&r) {
-            return rel
-                .to_string_lossy()
-                .replace(std::path::MAIN_SEPARATOR, "/");
-        }
-    }
-    // Best-effort fallback: strip the root's literal prefix.
-    if let Ok(rel) = file.strip_prefix(root) {
-        return rel
-            .to_string_lossy()
-            .replace(std::path::MAIN_SEPARATOR, "/");
-    }
-    file.to_string_lossy()
-        .replace(std::path::MAIN_SEPARATOR, "/")
-}
-
 #[allow(clippy::too_many_arguments)]
 fn run_check(
     paths: Vec<PathBuf>,
@@ -558,10 +538,11 @@ fn run_check(
     })?;
     let color = color.enabled(format);
     let filter = config::filter_from_config(&cfg);
-    let excludes = config::Excludes::from_config(&cfg);
     let user_stubs = load_user_stubs(&cfg.typeshed);
 
-    // Collect the initial file set.
+    // Collect the initial file set via the shared bounded discovery
+    // module (P36-W7 / issue #48). CLI and LSP use the same eligibility,
+    // extension, hidden-directory, symlink, exclude, and test-fixture rules.
     let mut all_paths = Vec::new();
     let search_roots: Vec<PathBuf> = if paths.is_empty() {
         vec![PathBuf::from(".")]
@@ -569,25 +550,16 @@ fn run_check(
         paths
     };
     for root in &search_roots {
-        collect_r_files(root, &mut all_paths, cfg.check_test_fixtures);
+        let result = ry_workspace::discover_r_files(
+            root,
+            config_root.as_deref(),
+            &cfg,
+            cfg.check_test_fixtures,
+        );
+        all_paths.extend(result.files);
+        report_truncation(&result.truncated, root);
     }
     sort_and_deduplicate_paths(&mut all_paths);
-
-    // Apply exclude patterns. Patterns match against the path relative
-    // to the directory containing the originating `ry.toml`; if no
-    // config was found, nothing is excluded. We use forward-slash
-    // separators to match the glob crate's expectations.
-    if let Some(root) = config_root.as_ref() {
-        if !excludes.is_empty() {
-            all_paths.retain(|path| {
-                let eligible = ry_workspace::is_file_eligible(path, root, &cfg);
-                if !eligible {
-                    tracing::debug!(path = %path.display(), "excluded by ry.toml");
-                }
-                eligible
-            });
-        }
-    }
 
     if all_paths.is_empty() {
         eprintln!("ry: no .R / .r files found in {:?}", search_roots);
@@ -640,20 +612,18 @@ fn run_check(
     loop {
         std::thread::sleep(poll_interval);
 
-        // Re-scan for new/deleted files.
+        // Re-scan for new/deleted files via shared bounded discovery.
         let mut current_paths = Vec::new();
         for root in &search_roots {
-            collect_r_files(root, &mut current_paths, cfg.check_test_fixtures);
+            let result = ry_workspace::discover_r_files(
+                root,
+                config_root.as_deref(),
+                &cfg,
+                cfg.check_test_fixtures,
+            );
+            current_paths.extend(result.files);
         }
         sort_and_deduplicate_paths(&mut current_paths);
-        if let Some(root) = config_root.as_ref() {
-            if !excludes.is_empty() {
-                current_paths.retain(|p| {
-                    let rel = relative_path_for_exclude(p, root);
-                    !excludes.matches(&rel)
-                });
-            }
-        }
 
         // Check for any file modification or file set change.
         let mut changed = current_paths.len() != all_paths.len();
@@ -1216,171 +1186,47 @@ fn enclosing_package_root(path: &std::path::Path) -> Option<PathBuf> {
         .map(std::path::Path::to_path_buf)
 }
 
+/// Test-compatible wrapper around the shared bounded discovery module.
+/// Production code calls [`ry_workspace::discover_r_files`] directly with
+/// the effective folder config so CLI and LSP use identical discovery
+/// rules (P36-W7 / issue #48).
+#[cfg(test)]
 fn collect_r_files(path: &std::path::Path, out: &mut Vec<PathBuf>, check_test_fixtures: bool) {
-    if path.is_file() {
-        out.push(path.to_path_buf());
+    let result = ry_workspace::discover_r_files(
+        path,
+        None,
+        &ry_config::Config::default(),
+        check_test_fixtures,
+    );
+    out.extend(result.files);
+}
+
+/// Surface a discovery cap hit to the user (P36-W7). A cap hit is never
+/// silent: the CLI prints one warning per root when any limit is reached.
+fn report_truncation(report: &ry_workspace::TruncationReport, root: &std::path::Path) {
+    if !report.any_hit() {
         return;
     }
-    let package_root = path
-        .ancestors()
-        .find(|ancestor| ancestor.join("DESCRIPTION").is_file())
-        .map(std::path::Path::to_path_buf);
-    let buildignore = package_root
-        .as_deref()
-        .map(read_rbuildignore)
-        .unwrap_or_default();
-    collect_r_files_recursive(path, out, package_root, &buildignore, check_test_fixtures);
-}
-
-fn collect_r_files_recursive(
-    path: &std::path::Path,
-    out: &mut Vec<PathBuf>,
-    package_root: Option<PathBuf>,
-    buildignore: &[glob::Pattern],
-    check_test_fixtures: bool,
-) {
-    let Ok(entries) = std::fs::read_dir(path) else {
-        return;
-    };
-    for entry in entries.flatten() {
-        // Skip symlinks and entries whose type cannot be classified; following
-        // either could make recursive discovery escape the requested tree.
-        let Ok(file_type) = entry.file_type() else {
-            continue;
-        };
-        if file_type.is_symlink() {
-            continue;
-        }
-        let p = entry.path();
-        if package_root
-            .as_deref()
-            .is_some_and(|root| is_rbuildignored(root, &p, buildignore))
-        {
-            continue;
-        }
-        if p.is_dir() {
-            if let Some(name) = p.file_name().and_then(|n| n.to_str()) {
-                if name.starts_with('.')
-                    || name == "target"
-                    || name == "node_modules"
-                    || (name == "renv" && package_root.is_some())
-                    || name.ends_with(".Rcheck")
-                {
-                    continue;
-                }
-            }
-            if package_root
-                .as_deref()
-                .is_some_and(|root| is_excluded_package_directory(root, &p))
-            {
-                continue;
-            }
-            let (nested_package_root, nested_buildignore) = if p.join("DESCRIPTION").is_file() {
-                (Some(p.clone()), read_rbuildignore(&p))
-            } else {
-                (package_root.clone(), buildignore.to_vec())
-            };
-            collect_r_files_recursive(
-                &p,
-                out,
-                nested_package_root,
-                &nested_buildignore,
-                check_test_fixtures,
-            );
-        } else if matches!(
-            p.extension().and_then(|e| e.to_str()),
-            Some("R") | Some("r") | Some("S") | Some("s") | Some("q")
-        ) && (check_test_fixtures
-            || ry_checker::project::package_file_kind(&p)
-                != ry_checker::project::PackageFileKind::TestFixture)
-        {
-            out.push(p);
-        }
+    if report.max_files_hit {
+        eprintln!(
+            "ry: warning: file count cap (index.max-files) reached at {};              additional R files were not discovered",
+            root.display()
+        );
     }
-}
-
-fn read_rbuildignore(root: &std::path::Path) -> Vec<glob::Pattern> {
-    let Ok(contents) = std::fs::read_to_string(root.join(".Rbuildignore")) else {
-        return Vec::new();
-    };
-    contents
-        .lines()
-        .map(str::trim)
-        .filter(|line| !line.is_empty() && !line.starts_with('#'))
-        .filter_map(rbuildignore_pattern)
-        .collect()
-}
-
-/// Translate the conservative regex subset used by conventional
-/// `.Rbuildignore` files to the already-depended-on glob matcher. Unsupported
-/// PCRE constructs are ignored, as required for patterns our engine cannot
-/// compile.
-fn rbuildignore_pattern(regex: &str) -> Option<glob::Pattern> {
-    if regex.contains(['(', ')', '|', '{', '}', '+']) {
-        return None;
+    for (path, size) in &report.oversized_files {
+        eprintln!(
+            "ry: warning: {} ({} bytes) exceeds the per-file size cap              (index.max-file-bytes) and was not discovered",
+            path.display(),
+            size
+        );
     }
-    let anchored_start = regex.starts_with('^');
-    let trailing_backslashes = regex
-        .strip_suffix('$')
-        .map(|prefix| prefix.chars().rev().take_while(|&ch| ch == '\\').count())
-        .unwrap_or(0);
-    let anchored_end = regex.ends_with('$') && trailing_backslashes.is_multiple_of(2);
-    let body = regex.strip_prefix('^').unwrap_or(regex);
-    // Only strip the trailing `$` when it is a genuine anchor, not an
-    // escaped `\$` (which must survive as a literal in the glob body).
-    let body = if anchored_end {
-        body.strip_suffix('$').unwrap_or(body)
-    } else {
-        body
-    };
-    let mut glob = String::new();
-    if !anchored_start {
-        glob.push('*');
+    for dir in &report.depth_pruned_dirs {
+        eprintln!(
+            "ry: warning: directory depth cap (index.max-depth) reached at {};              files below {} were not discovered",
+            root.display(),
+            dir.display()
+        );
     }
-    let mut chars = body.chars().peekable();
-    while let Some(ch) = chars.next() {
-        match ch {
-            '\\' => glob.push(chars.next()?),
-            '.' if chars.peek() == Some(&'*') => {
-                chars.next();
-                glob.push('*');
-            }
-            '.' => glob.push('?'),
-            '*' | '?' | '[' | ']' => glob.push(ch),
-            ch => glob.push(ch),
-        }
-    }
-    if !anchored_end {
-        glob.push('*');
-    }
-    glob::Pattern::new(&glob).ok()
-}
-
-fn is_rbuildignored(
-    root: &std::path::Path,
-    path: &std::path::Path,
-    patterns: &[glob::Pattern],
-) -> bool {
-    let Ok(relative) = path.strip_prefix(root) else {
-        return false;
-    };
-    if relative.starts_with("R") || relative.starts_with("tests") {
-        return false;
-    }
-    let relative = relative.to_string_lossy().replace('\\', "/");
-    patterns.iter().any(|pattern| pattern.matches(&relative))
-}
-
-fn is_excluded_package_directory(package_root: &std::path::Path, path: &std::path::Path) -> bool {
-    let Ok(relative) = path.strip_prefix(package_root) else {
-        return false;
-    };
-    let components: Vec<_> = relative
-        .components()
-        .filter_map(|component| component.as_os_str().to_str())
-        .collect();
-    matches!(components.as_slice(), ["revdep"] | ["src"])
-        || matches!(components.as_slice(), ["tests", "testthat", "_snaps"])
 }
 
 fn sort_and_deduplicate_paths(paths: &mut Vec<PathBuf>) {
@@ -1394,8 +1240,8 @@ mod tests {
         Baseline, BaselineEntry, load_baseline, subtract_baseline, write_baseline_file,
     };
     use super::{
-        ColorChoice, collect_r_files, demote_non_source_paths, rbuildignore_pattern,
-        run_check_once, sort_and_deduplicate_diagnostics,
+        ColorChoice, collect_r_files, demote_non_source_paths, run_check_once,
+        sort_and_deduplicate_diagnostics,
     };
     use ry_checker::format::OutputFormat;
     use ry_checker::{Diagnostic, Severity};
@@ -1413,12 +1259,28 @@ mod tests {
 
     #[test]
     fn rbuildignore_trailing_dollar_respects_escape_parity() {
-        assert!(rbuildignore_pattern("^file$").unwrap().matches("file"));
-        assert!(!rbuildignore_pattern("^file$").unwrap().matches("filex"));
-        assert!(rbuildignore_pattern(r"^file\$").unwrap().matches("file$"));
-        assert!(rbuildignore_pattern(r"^file\\$").unwrap().matches(r"file\"));
         assert!(
-            !rbuildignore_pattern(r"^file\\$")
+            ry_workspace::rbuildignore_pattern("^file$")
+                .unwrap()
+                .matches("file")
+        );
+        assert!(
+            !ry_workspace::rbuildignore_pattern("^file$")
+                .unwrap()
+                .matches("filex")
+        );
+        assert!(
+            ry_workspace::rbuildignore_pattern(r"^file\$")
+                .unwrap()
+                .matches("file$")
+        );
+        assert!(
+            ry_workspace::rbuildignore_pattern(r"^file\\$")
+                .unwrap()
+                .matches(r"file\")
+        );
+        assert!(
+            !ry_workspace::rbuildignore_pattern(r"^file\\$")
                 .unwrap()
                 .matches(r"file\x")
         );

--- a/crates/ry-config/src/baseline.rs
+++ b/crates/ry-config/src/baseline.rs
@@ -48,7 +48,7 @@ pub fn filter_from_config(cfg: &Config) -> ry_checker::SeverityFilter {
     filter
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Baseline {
     pub version: u32,
     pub entries: Vec<BaselineEntry>,

--- a/crates/ry-config/src/config.rs
+++ b/crates/ry-config/src/config.rs
@@ -28,6 +28,53 @@ pub const DEFAULT_OUTPUT_FORMAT: &str = "full";
 pub const CONFIG_FILENAME: &str = "ry.toml";
 pub const DEFAULT_MAX_SERIALIZED_BYTES: u64 = 2 * 1024 * 1024;
 
+/// Defaults for bounded directory discovery (P36-W7 / issue #48).
+pub const DEFAULT_INDEX_MAX_FILES: u64 = 20_000;
+pub const DEFAULT_INDEX_MAX_FILE_BYTES: u64 = 2 * 1024 * 1024;
+pub const DEFAULT_INDEX_MAX_DEPTH: u64 = 64;
+
+/// Bounded directory discovery limits. Applies to both CLI directory
+/// discovery and LSP background indexing so the two modes discover
+/// exactly the same file set.
+///
+/// Each key accepts a positive integer; zero is a configuration error
+/// rather than an undocumented "unlimited" sentinel ([`Config::validate`]).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct IndexConfig {
+    /// Maximum number of R source files discovered per root. Default: 20,000.
+    #[serde(alias = "max-files", default = "default_index_max_files")]
+    pub max_files: u64,
+    /// Maximum size in bytes of a single R file to include. Default: 2 MiB.
+    #[serde(alias = "max-file-bytes", default = "default_index_max_file_bytes")]
+    pub max_file_bytes: u64,
+    /// Maximum directory depth to descend from each root. Default: 64.
+    #[serde(alias = "max-depth", default = "default_index_max_depth")]
+    pub max_depth: u64,
+}
+
+fn default_index_max_files() -> u64 {
+    DEFAULT_INDEX_MAX_FILES
+}
+
+fn default_index_max_file_bytes() -> u64 {
+    DEFAULT_INDEX_MAX_FILE_BYTES
+}
+
+fn default_index_max_depth() -> u64 {
+    DEFAULT_INDEX_MAX_DEPTH
+}
+
+impl Default for IndexConfig {
+    fn default() -> Self {
+        Self {
+            max_files: DEFAULT_INDEX_MAX_FILES,
+            max_file_bytes: DEFAULT_INDEX_MAX_FILE_BYTES,
+            max_depth: DEFAULT_INDEX_MAX_DEPTH,
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct EnvironmentConfig {
@@ -104,6 +151,8 @@ pub struct Config {
     pub typeshed: Vec<PathBuf>,
     /// Baseline file. Relative paths are anchored at the config directory.
     pub baseline: Option<PathBuf>,
+    /// Bounded directory discovery limits (P36-W7 / issue #48).
+    pub index: IndexConfig,
 }
 
 impl Default for Config {
@@ -150,6 +199,7 @@ impl Config {
             environments: Vec::new(),
             typeshed: Vec::new(),
             baseline: None,
+            index: IndexConfig::default(),
         }
     }
 
@@ -190,7 +240,28 @@ impl Config {
                 *baseline = root.join(&*baseline);
             }
         }
+        cfg.validate().map_err(|field| ConfigError::InvalidIndex {
+            path: path.to_path_buf(),
+            field,
+        })?;
         Ok(cfg)
+    }
+
+    /// Validate that bounded discovery limits are positive integers.
+    /// Zero is a configuration error rather than an undocumented
+    /// "unlimited" sentinel (P36-W7 / issue #48). Returns the offending
+    /// field name on failure.
+    pub fn validate(&self) -> Result<(), &'static str> {
+        if self.index.max_files == 0 {
+            return Err("index.max-files");
+        }
+        if self.index.max_file_bytes == 0 {
+            return Err("index.max-file-bytes");
+        }
+        if self.index.max_depth == 0 {
+            return Err("index.max-depth");
+        }
+        Ok(())
     }
 
     /// Walk up from `start` looking for a `ry.toml`. Stops at the first
@@ -296,6 +367,7 @@ impl Config {
             environments: self.environments,
             typeshed,
             baseline,
+            index: self.index,
         }
     }
 }
@@ -377,6 +449,12 @@ pub enum ConfigError {
         path: PathBuf,
         source: toml::de::Error,
     },
+    /// A bounded discovery limit was set to zero, which is a
+    /// configuration error (P36-W7 / issue #48).
+    #[error(
+        "config file {path} has invalid value for {field}:              bounded discovery limits must be positive integers,              zero is not permitted"
+    )]
+    InvalidIndex { path: PathBuf, field: &'static str },
 }
 
 #[cfg(test)]
@@ -805,5 +883,60 @@ paths = ["inst/shiny/**"]
         let empty: Config = toml::from_str("select = []\n").unwrap();
         assert_eq!(omitted.select, None);
         assert_eq!(empty.select, Some(Vec::new()));
+    }
+
+    #[test]
+    fn index_defaults_match_spec() {
+        let cfg = Config::default();
+        assert_eq!(cfg.index.max_files, 20_000);
+        assert_eq!(cfg.index.max_file_bytes, 2 * 1024 * 1024);
+        assert_eq!(cfg.index.max_depth, 64);
+    }
+
+    #[test]
+    fn index_config_parses_from_toml() {
+        let cfg: Config =
+            toml::from_str("[index]\nmax-files = 100\nmax-file-bytes = 4096\nmax-depth = 10\n")
+                .unwrap();
+        assert_eq!(cfg.index.max_files, 100);
+        assert_eq!(cfg.index.max_file_bytes, 4096);
+        assert_eq!(cfg.index.max_depth, 10);
+    }
+
+    #[test]
+    fn index_zero_max_files_is_config_error() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(tmp.path().join(CONFIG_FILENAME), "[index]\nmax-files = 0\n").unwrap();
+        let err = Config::load_from_dir(tmp.path()).unwrap_err();
+        assert!(
+            matches!(err, ConfigError::InvalidIndex { field, .. } if field == "index.max-files"),
+            "expected InvalidIndex for max-files=0, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn index_zero_max_file_bytes_is_config_error() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(
+            tmp.path().join(CONFIG_FILENAME),
+            "[index]\nmax-file-bytes = 0\n",
+        )
+        .unwrap();
+        let err = Config::load_from_dir(tmp.path()).unwrap_err();
+        assert!(
+            matches!(err, ConfigError::InvalidIndex { field, .. } if field == "index.max-file-bytes"),
+            "expected InvalidIndex for max-file-bytes=0, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn index_zero_max_depth_is_config_error() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(tmp.path().join(CONFIG_FILENAME), "[index]\nmax-depth = 0\n").unwrap();
+        let err = Config::load_from_dir(tmp.path()).unwrap_err();
+        assert!(
+            matches!(err, ConfigError::InvalidIndex { field, .. } if field == "index.max-depth"),
+            "expected InvalidIndex for max-depth=0, got {err:?}"
+        );
     }
 }

--- a/crates/ry-lsp/src/backend.rs
+++ b/crates/ry-lsp/src/backend.rs
@@ -2577,11 +2577,11 @@ fn discover_folder_config(
             }
         }
     }
-    match ry_config::Config::load_from_dir(folder_root) {
-        Ok(Some(cfg)) => Ok(cfg),
-        Ok(None) => Ok(ry_config::Config::default()),
-        Err(error) => Err(error),
-    }
+    Ok(ry_config::Config::discover(folder_root)
+        .ok()
+        .flatten()
+        .map(|(_, c)| c)
+        .unwrap_or_default())
 }
 
 /// P36-W5 (#45): Resolve the baseline path from editor settings / `ry.toml`
@@ -2715,8 +2715,19 @@ fn rebuild_folder_context(old: &FolderAnalysisContext) -> FolderAnalysisContext 
             old.config.clone()
         }
     };
-    // Reload stubs from the (possibly retained) config.
-    let stubs = load_stubs_from_config(&config);
+    // Reload stubs from the (possibly retained) config. If the reload
+    // returns fewer stubs than before (e.g. a malformed stub directory),
+    // retain the previous stubs to avoid silently degrading analysis.
+    let new_stubs = load_stubs_from_config(&config);
+    let stubs = if new_stubs.is_empty() && !old.stubs.is_empty() {
+        tracing::warn!(
+            root = %old.root.display(),
+            "stub reload returned empty; retaining previous stubs"
+        );
+        old.stubs.clone()
+    } else {
+        new_stubs
+    };
     // Reload baseline; on failure retain the last valid baseline (#45).
     let baseline = match load_folder_baseline(&old.folder_settings, &config, Some(&old.root)) {
         Ok(opt) => opt,

--- a/crates/ry-lsp/src/backend.rs
+++ b/crates/ry-lsp/src/backend.rs
@@ -33,6 +33,20 @@ use tower_lsp::lsp_types::Diagnostic as LspDiagnostic;
 use tower_lsp::lsp_types::*;
 use tower_lsp::{Client, LanguageServer};
 
+/// P36-W5 (#45): counts baseline file reads performed by `load_folder_baseline`
+/// (the only baseline disk-read site in the LSP). Reads of publish/hover/
+/// completion state use the cached [`FolderAnalysisContext`] and never touch
+/// this counter. Exposed via [`baseline_disk_reads`] so integration tests can
+/// assert hot-path I/O is absent rather than infer it from timing.
+static BASELINE_DISK_READS: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+
+/// P36-W5 (#45): number of baseline file reads since process start. A
+/// publish/hover/completion that does not change this value performs zero
+/// baseline disk I/O.
+pub fn baseline_disk_reads() -> usize {
+    BASELINE_DISK_READS.load(std::sync::atomic::Ordering::Relaxed)
+}
+
 #[derive(Clone)]
 pub(super) struct Backend {
     pub(super) client: Client,
@@ -93,6 +107,10 @@ pub(super) struct State {
     /// workspace root. Stored so the severity filter and baseline can
     /// be applied in `publish_diagnostics` without re-reading the file.
     file_config: ry_config::Config,
+    /// P36-W5 (#45): Root-level baseline cached at initialize so the
+    /// fallback publish path (documents outside every folder root) performs
+    /// no disk access. Reloaded alongside the root config on watch events.
+    root_baseline: Option<ry_config::Baseline>,
     /// Editor-supplied per-folder settings, received via
     /// `initializationOptions`, `workspace/configuration`, or
     /// `didChangeConfiguration`.
@@ -163,6 +181,12 @@ pub(super) struct FolderAnalysisContext {
     pub stubs: Arc<std::collections::BTreeMap<String, ry_typeshed::Typeshed>>,
     /// Plan 35 workspace resolution context for package metadata.
     pub workspace_context: Option<ry_workspace::WorkspaceContext>,
+    /// P36-W5 (#45): The baseline loaded from `ry.toml`/editor settings,
+    /// cached during context construction so the publish path performs no
+    /// disk access. Reloaded outside the state lock on watch events; a
+    /// failed reload retains the last valid value (see
+    /// `rebuild_folder_context`).
+    pub baseline: Option<ry_config::Baseline>,
 }
 
 #[derive(Default)]
@@ -477,34 +501,23 @@ impl State {
         }
     }
 
-    /// Load and return the effective baseline for a document path.
-    /// Editor setting takes precedence over `ry.toml`; both are resolved
-    /// relative to the owning folder root (P36-W2).
+    /// Return the cached effective baseline for a document path.
+    ///
+    /// P36-W5 (#45): this is a pure cache read — it performs no disk access.
+    /// The baseline is loaded into each [`FolderAnalysisContext`] (and the
+    /// root-level fallback) during [`initialize`](Backend::initialize) and
+    /// reloaded *outside* the state lock on watch events by
+    /// [`rebuild_folder_contexts`]. Editor setting takes precedence over
+    /// `ry.toml`; both were resolved relative to the owning folder root at
+    /// load time (P36-W2).
     pub(super) fn effective_baseline_for_path(
         &self,
         doc_path: &str,
     ) -> Option<ry_config::Baseline> {
-        let (settings, config, folder_root) =
-            if let Some(ctx) = self.folder_context_for_path(doc_path) {
-                (&ctx.folder_settings, &ctx.config, Some(ctx.root.as_path()))
-            } else {
-                (
-                    &self.folder_settings,
-                    &self.file_config,
-                    self.root.as_deref(),
-                )
-            };
-        let baseline_path = settings
-            .baseline
-            .as_ref()
-            .map(PathBuf::from)
-            .or_else(|| config.baseline.clone())?;
-        let resolved = if baseline_path.is_relative() {
-            folder_root.map(|r| r.join(&baseline_path))?
-        } else {
-            baseline_path
-        };
-        ry_config::load_baseline(&resolved).ok()
+        if let Some(ctx) = self.folder_context_for_path(doc_path) {
+            return ctx.baseline.clone();
+        }
+        self.root_baseline.clone()
     }
 }
 
@@ -586,6 +599,18 @@ impl LanguageServer for Backend {
             .and_then(|r| ry_config::Config::load_from_dir(r).ok().flatten())
             .unwrap_or_default();
 
+        // P36-W5 (#45): Cache the root-level baseline so the fallback publish
+        // path (documents outside every folder root) performs no disk access.
+        // Built outside the lock alongside `file_config`.
+        let root_baseline =
+            match load_folder_baseline(&folder_settings, &file_config, root.as_deref()) {
+                Ok(opt) => opt,
+                Err(error) => {
+                    tracing::warn!(%error, "failed to load root baseline; no baseline cached");
+                    None
+                }
+            };
+
         // S4: Extract per-folder configs from folder_contexts for the
         // legacy workspace_folders field (still used as fallback).
         let ws_folders: Vec<(PathBuf, ry_config::Config)> = folder_contexts
@@ -608,6 +633,7 @@ impl LanguageServer for Backend {
         state.user_stubs = user_stubs;
         state.root = root;
         state.file_config = file_config;
+        state.root_baseline = root_baseline;
         state.folder_settings = folder_settings;
         state.server_settings = server_settings;
         state.supports_workspace_configuration = supports_workspace_configuration;
@@ -1100,10 +1126,10 @@ impl LanguageServer for Backend {
     async fn did_change_watched_files(&self, params: DidChangeWatchedFilesParams) {
         // Refresh configuration and filesystem-backed resolution when any
         // registered package metadata, data, stub, or config file changes.
-        let config_changed = params
-            .changes
-            .iter()
-            .any(|change| change.uri.path().ends_with("ry.toml"));
+        let config_or_baseline_changed = params.changes.iter().any(|change| {
+            let path = change.uri.path();
+            path.ends_with("ry.toml") || path.ends_with(".json")
+        });
         let resolution_changed = params.changes.iter().any(|change| {
             let path = change.uri.path();
             path.ends_with("DESCRIPTION")
@@ -1118,77 +1144,67 @@ impl LanguageServer for Backend {
             return;
         }
 
-        // Reload each changed root independently. The state vectors are kept
-        // in longest-prefix order, so replacing a config does not alter routing.
-        let root = {
-            let state = self.state.lock().await;
-            state.root.clone()
-        };
-        if config_changed {
-            for directory in params.changes.iter().filter_map(|change| {
-                change
-                    .uri
-                    .path()
-                    .ends_with("ry.toml")
-                    .then(|| change.uri.to_file_path().ok())
-                    .flatten()
-                    .and_then(|path| path.parent().map(PathBuf::from))
-            }) {
-                let loaded = ry_config::Config::load_from_dir(&directory);
-                match loaded {
-                    Ok(config) => {
-                        let config = config.unwrap_or_default();
-                        let mut state = self.state.lock().await;
-                        if state.root.as_deref() == Some(directory.as_path()) {
-                            state.file_config = config.clone();
-                        }
-                        // P36-W3 / PR #69 review: Refresh per-folder context
-                        // configs so watched ry.toml changes propagate to
-                        // folder_contexts (finding: ctx.config never refreshed).
-                        if let Some(ctx) = state
-                            .folder_contexts
-                            .iter_mut()
-                            .find(|ctx| ctx.root == directory)
-                        {
-                            ctx.config = config.clone();
-                            ctx.stubs = load_stubs_from_config(&config);
-                        }
-                        // Legacy workspace_folders sync.
-                        if let Some((_, folder_config)) = state
-                            .workspace_folders
-                            .iter_mut()
-                            .find(|(folder_root, _)| folder_root == &directory)
-                        {
-                            *folder_config = config;
-                        }
-                        tracing::info!(root = %directory.display(), "workspace config reloaded");
-                    }
-                    Err(error) => tracing::warn!(
-                        root = %directory.display(),
-                        %error,
-                        "failed to reload workspace config; retaining previous config"
-                    ),
+        // P36-W5 (#45): A config (`ry.toml`) or baseline (`.json`) change
+        // requires rebuilding each folder's effective config + baseline.
+        // The new contexts are built OUTSIDE the write lock (all disk I/O
+        // happens in `rebuild_folder_contexts`), then atomically swapped in.
+        // A failed reload retains the last valid value for each field and
+        // emits a visible warning; it never silently clears the baseline.
+        if config_or_baseline_changed {
+            let (old_contexts, root) = {
+                let state = self.state.lock().await;
+                (state.folder_contexts.clone(), state.root.clone())
+            };
+            let old_contexts_for_task = old_contexts.clone();
+            // spawn_blocking keeps every disk read off the async runtime.
+            let new_contexts = match tokio::task::spawn_blocking(move || {
+                rebuild_folder_contexts(&old_contexts_for_task)
+            })
+            .await
+            {
+                Ok(new_contexts) => new_contexts,
+                Err(error) => {
+                    tracing::warn!(%error, "folder context reload task failed; retaining previous contexts");
+                    old_contexts
                 }
+            };
+            {
+                let mut state = self.state.lock().await;
+                state.folder_contexts = new_contexts.clone();
+                // Sync the root-level fallback state and the legacy vectors
+                // from the rebuilt contexts so the fallback paths see the new
+                // config/baseline (P36-W3 / PR #69 review).
+                for ctx in &new_contexts {
+                    if state.root.as_deref() == Some(ctx.root.as_path()) {
+                        state.file_config = ctx.config.clone();
+                        state.root_baseline = ctx.baseline.clone();
+                    }
+                    if let Some((_, folder_config)) = state
+                        .workspace_folders
+                        .iter_mut()
+                        .find(|(folder_root, _)| folder_root == &ctx.root)
+                    {
+                        *folder_config = ctx.config.clone();
+                    }
+                }
+                tracing::info!("workspace config/baseline reloaded");
+            }
+
+            // Root-level typesheds feed the distinct user-stub analysis
+            // channel; reload them off the async runtime too.
+            if let Some(root) = root
+                && let Ok(stubs) =
+                    tokio::task::spawn_blocking(move || load_workspace_stubs(Some(&root))).await
+            {
+                let mut state = self.state.lock().await;
+                state.user_stubs = stubs;
             }
         }
 
-        // Typeshed and configuration changes alter both package resolution
-        // and the distinct user-stub analysis channel.
-        if let Some(root) = root.clone()
-            && let Ok(stubs) =
-                tokio::task::spawn_blocking(move || load_workspace_stubs(Some(&root))).await
-        {
-            let mut state = self.state.lock().await;
-            state.user_stubs = stubs;
-            // P36-W2: Reload per-folder stubs from each folder's config (#54).
-            for ctx in &mut state.folder_contexts {
-                ctx.stubs = load_stubs_from_config(&ctx.config);
-            }
-        }
         self.spawn_background_index().await;
 
         // Republish diagnostics for every open document so the new
-        // config takes effect immediately.
+        // config/baseline takes effect immediately.
         let open_uris: Vec<Url> = {
             let state = self.state.lock().await;
             state.docs.keys().map(|p| path_to_uri(p)).collect()
@@ -2325,9 +2341,15 @@ impl Backend {
         let indexed = tokio::task::spawn_blocking(move || {
             let mut all_disk_files: HashMap<String, Arc<SourceFile>> = HashMap::new();
             let mut contexts = Vec::new();
+            let mut all_truncated: Vec<(PathBuf, ry_workspace::TruncationReport)> = Vec::new();
             for (root, config, stubs) in &roots_with_config {
-                let files_for_root = crate::index::index_workspace(root, config);
-                let files: Vec<&SourceFile> = files_for_root.values().map(AsRef::as_ref).collect();
+                let outcome = crate::index::index_workspace(root, config);
+                if outcome.truncated.iter().any(|t| t.any_hit()) {
+                    for report in &outcome.truncated {
+                        all_truncated.push((root.clone(), report.clone()));
+                    }
+                }
+                let files: Vec<&SourceFile> = outcome.files.values().map(AsRef::as_ref).collect();
                 match ry_workspace::resolve_workspace_context(
                     root,
                     config,
@@ -2339,19 +2361,50 @@ impl Backend {
                     Ok(context) => contexts.push((root.clone(), context)),
                     Err(error) => tracing::warn!(%error, "workspace resolution degraded"),
                 }
-                all_disk_files.extend(files_for_root);
+                all_disk_files.extend(outcome.files);
             }
             contexts.sort_by_key(|(root, _)| std::cmp::Reverse(root.as_os_str().len()));
-            (all_disk_files, contexts)
+            (all_disk_files, contexts, all_truncated)
         })
         .await;
 
         match indexed {
-            Ok((disk_files, contexts)) => {
+            Ok((disk_files, contexts, truncated)) => {
                 tracing::info!(
                     files = disk_files.len(),
                     "background workspace index complete"
                 );
+                // P36-W7 (#48): emit a structured tracing event and one
+                // user-visible LSP warning per scan generation when a cap
+                // is hit. A cap hit is never silent.
+                for (root, report) in &truncated {
+                    if report.max_files_hit {
+                        tracing::warn!(
+                            root = %root.display(),
+                            cap = "index.max-files",
+                            omitted = report.omitted_count(),
+                            "discovery file-count cap reached; additional R files were not indexed"
+                        );
+                    }
+                    for (path, size) in &report.oversized_files {
+                        tracing::warn!(
+                            root = %root.display(),
+                            path = %path.display(),
+                            size,
+                            cap = "index.max-file-bytes",
+                            "file exceeds per-file size cap and was not indexed"
+                        );
+                    }
+                    for dir in &report.depth_pruned_dirs {
+                        tracing::warn!(
+                            root = %root.display(),
+                            pruned = %dir.display(),
+                            cap = "index.max-depth",
+                            "directory depth cap reached; files below were not indexed"
+                        );
+                    }
+                }
+                let cap_hit = !truncated.is_empty();
                 let mut state = self.state.lock().await;
                 // P36-W3 (#55) step 5: Discard results from an index generation
                 // belonging to the old folder set.
@@ -2371,6 +2424,16 @@ impl Backend {
                     if let Some((_, wc)) = contexts.iter().find(|(root, _)| root == &ctx.root) {
                         ctx.workspace_context = Some(wc.clone());
                     }
+                }
+                // P36-W7 (#48): one user-visible warning per scan generation.
+                if cap_hit {
+                    let _ = self
+                        .client
+                        .log_message(
+                            tower_lsp::lsp_types::MessageType::WARNING,
+                            "ry: discovery cap reached; some R files were not indexed.                              See server logs for details (index.max-files /                              index.max-file-bytes / index.max-depth).",
+                        )
+                        .await;
                 }
             }
             Err(error) => tracing::warn!(%error, "background workspace index failed"),
@@ -2478,13 +2541,92 @@ fn load_stubs_from_config(
     Arc::new(merged)
 }
 
+/// P36-W2c (#56): Discover the effective `ry.toml` config for a folder.
+///
+/// When the editor supplies a `configuration` override it is resolved
+/// relative to `folder_root` (unless absolute) and loaded directly; on
+/// failure the code falls back to directory discovery. Returns
+/// `Ok(default)` when no `ry.toml` is found, and `Err` only when discovery
+/// itself fails (I/O or parse error) so callers can decide whether to
+/// retain a previous config. Disk I/O happens here — callers MUST run this
+/// outside the state lock (P36-W5 #45).
+fn discover_folder_config(
+    folder_settings: &FolderSettings,
+    folder_root: &std::path::Path,
+) -> std::result::Result<ry_config::Config, ry_config::ConfigError> {
+    if let Some(config_rel) = &folder_settings.configuration {
+        let config_path = if PathBuf::from(config_rel).is_absolute() {
+            PathBuf::from(config_rel)
+        } else {
+            folder_root.join(config_rel)
+        };
+        match ry_config::Config::load_file(&config_path) {
+            Ok(cfg) => return Ok(cfg),
+            Err(error) => {
+                tracing::warn!(
+                    path = %config_path.display(),
+                    %error,
+                    "failed to load configuration override; falling back to discovery"
+                );
+                // Fall back to directory discovery (walks up the tree).
+                return Ok(ry_config::Config::discover(folder_root)
+                    .ok()
+                    .flatten()
+                    .map(|(_, c)| c)
+                    .unwrap_or_default());
+            }
+        }
+    }
+    match ry_config::Config::load_from_dir(folder_root) {
+        Ok(Some(cfg)) => Ok(cfg),
+        Ok(None) => Ok(ry_config::Config::default()),
+        Err(error) => Err(error),
+    }
+}
+
+/// P36-W5 (#45): Resolve the baseline path from editor settings / `ry.toml`
+/// and load it from disk.
+///
+/// Returns `Ok(None)` when no baseline is configured. `Err` signals a
+/// configured-but-unloadable baseline (missing file, corrupt JSON, wrong
+/// version) so reload callers can retain the last valid value rather than
+/// silently clearing it. Disk I/O happens here — callers MUST run this
+/// outside the state lock.
+fn load_folder_baseline(
+    settings: &FolderSettings,
+    config: &ry_config::Config,
+    folder_root: Option<&std::path::Path>,
+) -> std::result::Result<Option<ry_config::Baseline>, String> {
+    let baseline_path = match settings
+        .baseline
+        .as_ref()
+        .map(PathBuf::from)
+        .or_else(|| config.baseline.clone())
+    {
+        Some(p) => p,
+        None => return Ok(None),
+    };
+    let resolved = if baseline_path.is_relative() {
+        match folder_root.map(|r| r.join(&baseline_path)) {
+            Some(r) => r,
+            None => return Ok(None),
+        }
+    } else {
+        baseline_path
+    };
+    BASELINE_DISK_READS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    ry_config::load_baseline(&resolved)
+        .map(Some)
+        .map_err(|e| format!("{e}"))
+}
+
 /// P36-W2: Build per-folder analysis contexts for every workspace root.
 ///
 /// Each context holds the effective `ry.toml` config (from directory
 /// discovery or the editor `configuration` override, #56), the matching
-/// editor [`FolderSettings`] (#44), and local typesheds loaded from that
-/// folder's config (#54). When `workspace_folders` is empty, `root_uri`
-/// becomes the single folder.
+/// editor [`FolderSettings`] (#44), local typesheds loaded from that
+/// folder's config (#54), and the cached baseline (P36-W5 #45). When
+/// `workspace_folders` is empty, `root_uri` becomes the single folder.
 fn build_folder_contexts(
     root: Option<&std::path::Path>,
     workspace_folders: &[(usize, PathBuf)],
@@ -2508,35 +2650,28 @@ fn build_folder_contexts(
             .cloned()
             .unwrap_or_else(|| server_settings.global_settings.clone());
 
-        // P36-W2c (#56): Honor the `configuration` override. Resolve it
-        // relative to the workspace root unless absolute; load that file
-        // instead of directory discovery.
-        let config = if let Some(config_rel) = &folder_settings.configuration {
-            let config_path = if PathBuf::from(config_rel).is_absolute() {
-                PathBuf::from(config_rel)
-            } else {
-                folder_root.join(config_rel)
-            };
-            match ry_config::Config::load_file(&config_path) {
-                Ok(cfg) => cfg,
-                Err(error) => {
-                    tracing::warn!(
-                        path = %config_path.display(),
-                        %error,
-                        "failed to load configuration override; falling back to discovery"
-                    );
-                    ry_config::Config::discover(folder_root)
-                        .ok()
-                        .flatten()
-                        .map(|(_, c)| c)
-                        .unwrap_or_default()
-                }
+        // P36-W2c/W5 (#56/#45): Discover config (defaulting on failure) and
+        // load the baseline once into the context so the publish path never
+        // touches disk.
+        let config =
+            discover_folder_config(&folder_settings, folder_root).unwrap_or_else(|error| {
+                tracing::warn!(
+                    root = %folder_root.display(),
+                    %error,
+                    "failed to load folder config; using default config"
+                );
+                ry_config::Config::default()
+            });
+        let baseline = match load_folder_baseline(&folder_settings, &config, Some(folder_root)) {
+            Ok(opt) => opt,
+            Err(error) => {
+                tracing::warn!(
+                    root = %folder_root.display(),
+                    %error,
+                    "failed to load baseline; no baseline cached for this folder"
+                );
+                None
             }
-        } else {
-            ry_config::Config::load_from_dir(folder_root)
-                .ok()
-                .flatten()
-                .unwrap_or_default()
         };
 
         // P36-W2b (#54): Load stubs from this folder's config so two roots
@@ -2549,12 +2684,68 @@ fn build_folder_contexts(
             folder_settings,
             stubs,
             workspace_context: None,
+            baseline,
         });
     }
 
     // Longest-prefix ownership: sort by root path length descending.
     contexts.sort_by_key(|ctx| std::cmp::Reverse(ctx.root.as_os_str().len()));
     contexts
+}
+
+/// P36-W5 (#45): Rebuild a single folder's analysis context from disk.
+///
+/// Each field is reloaded independently. On any sub-failure (config parse,
+/// baseline parse) the **last valid value for that field is retained** and a
+/// visible warning emitted — a corrupt reload never silently clears the
+/// baseline. `folder_settings` and `workspace_context` are not reloaded by
+/// file-watch events (they come from editor push / the background indexer
+/// respectively) and are carried over unchanged. Disk I/O happens here;
+/// callers MUST run this outside the state lock.
+fn rebuild_folder_context(old: &FolderAnalysisContext) -> FolderAnalysisContext {
+    // Reload config; on failure retain the previous config.
+    let config = match discover_folder_config(&old.folder_settings, &old.root) {
+        Ok(cfg) => cfg,
+        Err(error) => {
+            tracing::warn!(
+                root = %old.root.display(),
+                %error,
+                "failed to reload folder config; retaining previous config"
+            );
+            old.config.clone()
+        }
+    };
+    // Reload stubs from the (possibly retained) config.
+    let stubs = load_stubs_from_config(&config);
+    // Reload baseline; on failure retain the last valid baseline (#45).
+    let baseline = match load_folder_baseline(&old.folder_settings, &config, Some(&old.root)) {
+        Ok(opt) => opt,
+        Err(error) => {
+            tracing::warn!(
+                root = %old.root.display(),
+                %error,
+                "failed to reload baseline; retaining last valid baseline"
+            );
+            old.baseline.clone()
+        }
+    };
+    FolderAnalysisContext {
+        root: old.root.clone(),
+        config,
+        folder_settings: old.folder_settings.clone(),
+        stubs,
+        workspace_context: old.workspace_context.clone(),
+        baseline,
+    }
+}
+
+/// P36-W5 (#45): Rebuild every folder's analysis context from disk,
+/// returning a replacement `Vec` in the same order as `old`. Used by the
+/// watched-files handler to rebuild outside the write lock and then swap
+/// atomically. Each context is rebuilt independently; a single folder's
+/// reload failure does not affect the others.
+fn rebuild_folder_contexts(old: &[FolderAnalysisContext]) -> Vec<FolderAnalysisContext> {
+    old.iter().map(rebuild_folder_context).collect()
 }
 
 /// Convert a document's path string (the key used in `State::docs`)

--- a/crates/ry-lsp/src/index.rs
+++ b/crates/ry-lsp/src/index.rs
@@ -1,96 +1,77 @@
 //! Workspace file discovery and background indexing.
 //!
-//! Discovers `.R`/`.r` files under workspace roots, parses them in the
-//! background, and stores the results for `publish_diagnostics` to merge
-//! with open documents. This closes the file-set gap between the CLI
-//! (`ry check .`) and the editor: the LSP now sees all project files,
-//! not just open ones (Plan 33 W4).
+//! Delegates directory discovery to the shared [`ry_workspace`] module so
+//! the CLI (`ry check .`) and the LSP use identical eligibility, extension,
+//! hidden-directory, symlink, exclude, test-fixture, and bounded-cap rules
+//! (P36-W7 / issue #48).
 //!
 //! Open documents shadow on-disk contents because the editor's buffer
 //! is authoritative — a file being edited may have unsaved changes.
 
 use std::collections::HashMap;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use ry_config::Config;
 use ry_core::{RParser, SourceFile};
 
-/// Walk a workspace root, discovering all `.R`/`.r` files that are not
-/// excluded by the configured glob patterns. Returns `(path, source_text)`
-/// pairs for the caller to parse.
-///
-/// Paths are returned as absolute strings (matching the LSP's `uri_to_path`
-/// convention). The walk is breadth-first and skips excluded directories
-/// early to avoid descending into `node_modules`, `.git`, etc.
-pub(crate) fn discover_r_files(root: &Path, config: &Config) -> Vec<(String, String)> {
-    let mut results = Vec::new();
-    let mut queue = vec![root.to_path_buf()];
-    let excludes = ry_config::Excludes::from_config(config);
-
-    while let Some(dir) = queue.pop() {
-        let entries = match std::fs::read_dir(&dir) {
-            Ok(e) => e,
-            Err(_) => continue,
-        };
-
-        for entry in entries.flatten() {
-            let path = entry.path();
-
-            // Check excludes before descending.
-            if !ry_workspace::is_file_eligible_with_excludes(&path, root, &excludes) {
-                continue;
-            }
-
-            if path.is_dir() && !entry.file_type().is_ok_and(|ft| ft.is_symlink()) {
-                // Skip hidden directories (.git, .Rproj.user, etc).
-                if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
-                    if name.starts_with('.') {
-                        continue;
-                    }
-                }
-                queue.push(path);
-            } else if path
-                .extension()
-                .and_then(|e| e.to_str())
-                .is_some_and(|ext| ext.eq_ignore_ascii_case("R") || ext.eq_ignore_ascii_case("r"))
-            {
-                if let Ok(source) = std::fs::read_to_string(&path) {
-                    let abs = path.to_string_lossy().into_owned();
-                    results.push((abs, source));
-                }
-            }
-        }
-    }
-
-    results
+/// Result of discovering and parsing all on-disk R files under a root.
+pub(crate) struct IndexOutcome {
+    pub files: HashMap<String, Arc<SourceFile>>,
+    /// Per-root cap reports; empty when no limit was reached.
+    pub truncated: Vec<ry_workspace::TruncationReport>,
 }
 
-/// Parse all discovered files into `SourceFile`s. Each file gets its own
-/// `RParser` (the parser is not `Sync`). Files that fail to parse are
-/// silently skipped — a syntax error in an unopened file should not
-/// prevent indexing the rest of the project.
-pub(crate) fn parse_disk_files(files: &[(String, String)]) -> HashMap<String, Arc<SourceFile>> {
+/// Discover all eligible R files under `root` using the shared bounded
+/// discovery module and read their source text.
+///
+/// Paths are returned as absolute strings (matching the LSP's `uri_to_path`
+/// convention). Used by unit tests; production code calls
+/// [`index_workspace`] which returns parsed files and cap reports.
+#[cfg(test)]
+pub(crate) fn discover_r_files(root: &Path, config: &Config) -> Vec<(String, String)> {
+    let result = ry_workspace::discover_r_files(root, Some(root), config, false);
+    result
+        .files
+        .into_iter()
+        .filter_map(|path| {
+            let source = std::fs::read_to_string(&path).ok()?;
+            Some((path.to_string_lossy().into_owned(), source))
+        })
+        .collect()
+}
+
+/// Discover and parse all eligible R files under `root`, honouring
+/// `exclude` patterns and bounded caps. Returns parsed files plus
+/// any cap reports for the caller to surface as warnings.
+pub(crate) fn index_workspace(root: &Path, config: &Config) -> IndexOutcome {
+    let discovery = ry_workspace::discover_r_files(root, Some(root), config, false);
+    let files = parse_paths(&discovery.files);
+    IndexOutcome {
+        files,
+        truncated: if discovery.truncated.any_hit() {
+            vec![discovery.truncated]
+        } else {
+            Vec::new()
+        },
+    }
+}
+
+fn parse_paths(paths: &[PathBuf]) -> HashMap<String, Arc<SourceFile>> {
     let mut parsed = HashMap::new();
     let mut parser = match RParser::new() {
         Ok(p) => p,
         Err(_) => return parsed,
     };
-
-    for (path, source) in files {
-        if let Ok(file) = parser.parse(path, source) {
-            parsed.insert(path.clone(), Arc::new(file));
+    for path in paths {
+        let Ok(source) = std::fs::read_to_string(path) else {
+            continue;
+        };
+        if let Ok(file) = parser.parse(&path.to_string_lossy(), &source) {
+            parsed.insert(path.to_string_lossy().into_owned(), Arc::new(file));
         }
     }
-
     parsed
-}
-
-/// Discover and parse all `.R`/`.r` files under `root`, honouring `excludes`.
-/// Convenience wrapper combining `discover_r_files` + `parse_disk_files`.
-pub(crate) fn index_workspace(root: &Path, config: &Config) -> HashMap<String, Arc<SourceFile>> {
-    let discovered = discover_r_files(root, config);
-    parse_disk_files(&discovered)
 }
 
 #[cfg(test)]
@@ -173,11 +154,66 @@ mod tests {
         std::fs::write(dir.join("b.R"), "g <- function() f(2)\n").unwrap();
 
         let config = Config::default();
-        let parsed = index_workspace(&dir, &config);
+        let outcome = index_workspace(&dir, &config);
 
-        assert_eq!(parsed.len(), 2, "two files parsed");
-        assert!(parsed.keys().any(|p| p.ends_with("a.R")));
-        assert!(parsed.keys().any(|p| p.ends_with("b.R")));
+        assert_eq!(outcome.files.len(), 2, "two files parsed");
+        assert!(outcome.files.keys().any(|p| p.ends_with("a.R")));
+        assert!(outcome.files.keys().any(|p| p.ends_with("b.R")));
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// P36-W7 (#48): the LSP must skip `target/` directories just like
+    /// the CLI, so both modes discover the same file set.
+    #[test]
+    fn skips_target_directory_like_cli() {
+        let dir = std::env::temp_dir().join(format!("ry_index_target_{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+
+        std::fs::write(dir.join("keep.R"), "x <- 1\n").unwrap();
+
+        let target = dir.join("target");
+        std::fs::create_dir_all(&target).unwrap();
+        std::fs::write(target.join("skip.R"), "y <- 2\n").unwrap();
+
+        let config = Config::default();
+        let discovered = discover_r_files(&dir, &config);
+
+        let paths: Vec<&str> = discovered.iter().map(|(p, _)| p.as_str()).collect();
+        assert!(paths.iter().any(|p| p.ends_with("keep.R")), "keep.R found");
+        assert!(
+            !paths.iter().any(|p| p.ends_with("skip.R")),
+            "target/ must be skipped (P36-W7)"
+        );
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// P36-W7 (#48): truncated state must be exposed to tests.
+    #[test]
+    fn exposes_truncation_when_max_files_hit() {
+        let dir = std::env::temp_dir().join(format!("ry_index_cap_{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+
+        // Write more files than the cap allows.
+        for i in 0..5 {
+            std::fs::write(dir.join(format!("file_{i}.R")), "x <- 1\n").unwrap();
+        }
+
+        let config = ry_config::Config {
+            index: ry_config::IndexConfig {
+                max_files: 2,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let outcome = index_workspace(&dir, &config);
+
+        assert!(
+            outcome.truncated.iter().any(|t| t.max_files_hit),
+            "max-files cap must be reported"
+        );
+        assert_eq!(outcome.files.len(), 2, "only 2 files discovered under cap");
 
         std::fs::remove_dir_all(&dir).ok();
     }

--- a/crates/ry-lsp/src/index.rs
+++ b/crates/ry-lsp/src/index.rs
@@ -30,7 +30,8 @@ pub(crate) struct IndexOutcome {
 /// [`index_workspace`] which returns parsed files and cap reports.
 #[cfg(test)]
 pub(crate) fn discover_r_files(root: &Path, config: &Config) -> Vec<(String, String)> {
-    let result = ry_workspace::discover_r_files(root, Some(root), config, false);
+    let result =
+        ry_workspace::discover_r_files(root, Some(root), config, config.check_test_fixtures);
     result
         .files
         .into_iter()
@@ -45,7 +46,8 @@ pub(crate) fn discover_r_files(root: &Path, config: &Config) -> Vec<(String, Str
 /// `exclude` patterns and bounded caps. Returns parsed files plus
 /// any cap reports for the caller to surface as warnings.
 pub(crate) fn index_workspace(root: &Path, config: &Config) -> IndexOutcome {
-    let discovery = ry_workspace::discover_r_files(root, Some(root), config, false);
+    let discovery =
+        ry_workspace::discover_r_files(root, Some(root), config, config.check_test_fixtures);
     let files = parse_paths(&discovery.files);
     IndexOutcome {
         files,

--- a/crates/ry-lsp/src/lib.rs
+++ b/crates/ry-lsp/src/lib.rs
@@ -147,6 +147,10 @@ mod symbols;
 mod util;
 
 use backend::{Backend, State};
+// P36-W5 (#45): re-export the baseline disk-read counter so integration
+// tests can assert that the publish/hover/completion hot path performs no
+// baseline file I/O.
+pub use backend::baseline_disk_reads;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 use tower_lsp::jsonrpc::Result as LspResult;

--- a/crates/ry-lsp/tests/p36_contract.rs
+++ b/crates/ry-lsp/tests/p36_contract.rs
@@ -924,7 +924,9 @@ fn p36_w5_baseline_reload_retains_context_on_corruption() {
     use ry_testkit::LspSession;
     // Serialize against the other W5 tests so the global baseline-read
     // counter is not polluted by a concurrently-running server.
-    let _io_guard = BASELINE_IO_TEST_GUARD.lock().unwrap();
+    let _io_guard = BASELINE_IO_TEST_GUARD
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
 
     let fixture = FixtureProject::empty().unwrap();
     fixture
@@ -1021,7 +1023,9 @@ fn p36_w5_baseline_reload_converges_to_new_value() {
     use ry_testkit::LspSession;
     // Serialize against the other W5 tests so the global baseline-read
     // counter is not polluted by a concurrently-running server.
-    let _io_guard = BASELINE_IO_TEST_GUARD.lock().unwrap();
+    let _io_guard = BASELINE_IO_TEST_GUARD
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
 
     let fixture = FixtureProject::empty().unwrap();
     fixture
@@ -1175,7 +1179,9 @@ fn p36_w5_publish_path_performs_no_baseline_disk_io() {
     use ry_testkit::LspSession;
     // Serialize against the other W5 tests so the global baseline-read
     // counter is not polluted by a concurrently-running server.
-    let _io_guard = BASELINE_IO_TEST_GUARD.lock().unwrap();
+    let _io_guard = BASELINE_IO_TEST_GUARD
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
 
     let fixture = FixtureProject::empty().unwrap();
     fixture

--- a/crates/ry-lsp/tests/p36_contract.rs
+++ b/crates/ry-lsp/tests/p36_contract.rs
@@ -897,11 +897,17 @@ fn p36_w4_version_stamped_tree_cache_rejects_stale_parse() {
 // ──────────────────────────────────────────────────────────────────────────
 // P36-W5 — Cache baseline/config state outside the hot lock (#45)
 //
-// `effective_baseline()` reads from disk inside the state lock in
-// `publish_diagnostics`. The fix loads baseline/config into a per-folder
-// context during initialize, reloads outside the write lock on watch
-// events, and retains the last valid context on reload failure.
+// The baseline and effective config are loaded into each
+// `FolderAnalysisContext` during initialize; the publish/hover/completion
+// path reads the cached value and performs no disk access. Watch events
+// rebuild the context outside the write lock and swap it atomically; a
+// failed reload retains the last valid context and emits a visible error.
+//
+// `ry_lsp::baseline_disk_reads()` is a process-global counter. Only the W5
+// tests configure a baseline, so they serialize on this guard so the
+// no-I/O assertion sees only its own server's reads.
 // ──────────────────────────────────────────────────────────────────────────
+static BASELINE_IO_TEST_GUARD: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
 /// P36-W5 (#45): a failed baseline reload must retain the last valid
 /// context, not silently clear the baseline. The test:
@@ -910,13 +916,15 @@ fn p36_w4_version_stamped_tree_cache_rejects_stale_parse() {
 ///   3. Corrupts the baseline file and triggers a watched-files event.
 ///   4. Asserts RY002 is STILL suppressed (last valid context retained).
 ///
-/// Currently `effective_baseline()` reads from disk on every publish. When
-/// the file is corrupted, `load_baseline` fails → baseline is None → RY002
-/// reappears. The test fails because the reload does not retain context.
+/// The baseline is cached in the owning `FolderAnalysisContext` during
+/// initialize and reloaded outside the write lock on watch events; when the
+/// reload fails (`load_baseline` → error), the last valid baseline is kept.
 #[test]
-#[ignore = "P36-W5: cache baseline/config state outside the hot lock (#45) — fix pending"]
 fn p36_w5_baseline_reload_retains_context_on_corruption() {
     use ry_testkit::LspSession;
+    // Serialize against the other W5 tests so the global baseline-read
+    // counter is not polluted by a concurrently-running server.
+    let _io_guard = BASELINE_IO_TEST_GUARD.lock().unwrap();
 
     let fixture = FixtureProject::empty().unwrap();
     fixture
@@ -989,10 +997,259 @@ fn p36_w5_baseline_reload_retains_context_on_corruption() {
         let _ = tokio::time::timeout(std::time::Duration::from_secs(3), server).await;
 
         // W5 contract: a failed reload retains the last valid context.
-        // Currently effective_baseline() re-reads disk → fails → clears baseline.
+        // The cached baseline is kept when the corrupt file fails to reload.
         assert!(
             !codes3.contains(&"RY002"),
             "phase 3: RY002 must still be suppressed (last valid baseline retained); got: {codes3:?}"
+        );
+    });
+}
+
+/// P36-W5 (#45): a *successful* baseline reload must converge to the new
+/// value, matching a cold server started fresh against the same files.
+///
+/// The test:
+///   1. Sets up a baseline that suppresses RY002 (count 1).
+///   2. Verifies the LSP suppresses RY002.
+///   3. Overwrites the baseline with a valid EMPTY baseline.
+///   4. Triggers the watch path and quiesces.
+///   5. Republishes: RY002 must now APPEAR (reload converged).
+///   6. Spawns a FRESH server against the same fixture and asserts both
+///      servers publish identical diagnostics.
+#[test]
+fn p36_w5_baseline_reload_converges_to_new_value() {
+    use ry_testkit::LspSession;
+    // Serialize against the other W5 tests so the global baseline-read
+    // counter is not polluted by a concurrently-running server.
+    let _io_guard = BASELINE_IO_TEST_GUARD.lock().unwrap();
+
+    let fixture = FixtureProject::empty().unwrap();
+    fixture
+        .write_file("ry.toml", "baseline = \"baseline.json\"\n")
+        .unwrap();
+    fixture.write_file(
+        "baseline.json",
+        r#"{"version": 1, "entries": [{"path": "main.R", "code": "RY002", "message": "`if` condition has length 2; R requires a length-1 condition", "count": 1}]}"#,
+    ).unwrap();
+    fixture
+        .write_file("main.R", "if (c(TRUE, FALSE)) print(1)\n")
+        .unwrap();
+
+    let main_uri = file_uri(&fixture.path("main.R"));
+
+    fn diagnostic_codes(value: &Value) -> Vec<String> {
+        value["params"]["diagnostics"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|d| d["code"].as_str().unwrap_or("").to_string())
+            .collect()
+    }
+
+    // Run a single LSP server to completion and return the codes published
+    // for `main.R` after opening it. Reused for the live (reloaded) server
+    // and the fresh (cold) comparison server.
+    fn codes_for_fresh_server(fixture: &FixtureProject, main_uri: &str) -> Vec<String> {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        runtime.block_on(async {
+            let (cs, ss) = tokio::io::duplex(128 * 1024);
+            let (cr, cw) = tokio::io::split(cs);
+            let (sr, sw) = tokio::io::split(ss);
+            let server = tokio::spawn(async move { ry_lsp::run_with(sr, sw).await });
+            let mut live = LspSession::new(cr, cw);
+            live.initialize(fixture.root()).await.unwrap();
+            let mark = live.publication_mark();
+            live.open(main_uri, 1, "if (c(TRUE, FALSE)) print(1)\n")
+                .await
+                .unwrap();
+            let publish = live
+                .published_diagnostics_after(main_uri, mark)
+                .await
+                .unwrap();
+            let codes = diagnostic_codes(&publish);
+            let _ = live.shutdown().await;
+            drop(live);
+            let _ = tokio::time::timeout(std::time::Duration::from_secs(3), server).await;
+            codes
+        })
+    }
+
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    let reloaded_codes = runtime.block_on(async {
+        let (cs, ss) = tokio::io::duplex(128 * 1024);
+        let (cr, cw) = tokio::io::split(cs);
+        let (sr, sw) = tokio::io::split(ss);
+        let server = tokio::spawn(async move { ry_lsp::run_with(sr, sw).await });
+        let mut live = LspSession::new(cr, cw);
+        live.initialize(fixture.root()).await.unwrap();
+
+        // Phase 1: RY002 should be suppressed by the valid baseline.
+        let mark1 = live.publication_mark();
+        live.open(&main_uri, 1, "if (c(TRUE, FALSE)) print(1)\n")
+            .await
+            .unwrap();
+        let publish1 = live
+            .published_diagnostics_after(&main_uri, mark1)
+            .await
+            .unwrap();
+        let codes1 = diagnostic_codes(&publish1);
+        assert!(
+            !codes1.contains(&"RY002".to_string()),
+            "phase 1: RY002 must be suppressed by valid baseline; got: {codes1:?}"
+        );
+
+        // Phase 2: overwrite the baseline with a valid EMPTY baseline and
+        // trigger the watch path, then quiesce.
+        std::fs::write(
+            fixture.path("baseline.json"),
+            r#"{"version": 1, "entries": []}"#,
+        )
+        .unwrap();
+        let baseline_uri = file_uri(&fixture.path("baseline.json"));
+        live.notify(
+            "workspace/didChangeWatchedFiles",
+            json!({
+                "changes": [{"uri": baseline_uri, "type": 2}]
+            }),
+        )
+        .await
+        .unwrap();
+        // Sync barrier: the hover response guarantees the watch notification
+        // (and its outside-the-lock context rebuild) has been processed.
+        live.request(
+            "textDocument/hover",
+            json!({
+                "textDocument": {"uri": main_uri},
+                "position": {"line": 0, "character": 0}
+            }),
+        )
+        .await
+        .ok();
+
+        // Phase 3: republish. RY002 must now APPEAR (empty baseline does not
+        // suppress it) — the reload converged.
+        let mark3 = live.publication_mark();
+        live.change(
+            &main_uri,
+            2,
+            json!([{"text": "if (c(TRUE, FALSE)) print(1)\n"}]),
+        )
+        .await
+        .unwrap();
+        let publish3 = live
+            .published_diagnostics_after(&main_uri, mark3)
+            .await
+            .unwrap();
+        let codes3 = diagnostic_codes(&publish3);
+
+        let _ = live.shutdown().await;
+        drop(live);
+        let _ = tokio::time::timeout(std::time::Duration::from_secs(3), server).await;
+        codes3
+    });
+
+    // Phase 4: the reloaded live server must match a cold server started
+    // fresh against the now-current (empty) baseline.
+    let fresh_codes = codes_for_fresh_server(&fixture, &main_uri);
+    assert_eq!(
+        reloaded_codes, fresh_codes,
+        "reload must converge to cold state; reloaded: {reloaded_codes:?}, fresh: {fresh_codes:?}"
+    );
+    assert!(
+        reloaded_codes.contains(&"RY002".to_string()),
+        "phase 3: RY002 must reappear after the baseline reload converged; got: {reloaded_codes:?}"
+    );
+}
+
+/// P36-W5 (#45): the publish/hover/completion hot path performs ZERO
+/// baseline file reads. `baseline_disk_reads()` counts every disk read by
+/// the context loader; a publish that touches it betrays a regression.
+#[test]
+fn p36_w5_publish_path_performs_no_baseline_disk_io() {
+    use ry_testkit::LspSession;
+    // Serialize against the other W5 tests so the global baseline-read
+    // counter is not polluted by a concurrently-running server.
+    let _io_guard = BASELINE_IO_TEST_GUARD.lock().unwrap();
+
+    let fixture = FixtureProject::empty().unwrap();
+    fixture
+        .write_file("ry.toml", "baseline = \"baseline.json\"\n")
+        .unwrap();
+    fixture.write_file(
+        "baseline.json",
+        r#"{"version": 1, "entries": [{"path": "main.R", "code": "RY002", "message": "`if` condition has length 2; R requires a length-1 condition", "count": 1}]}"#,
+    ).unwrap();
+    fixture
+        .write_file("main.R", "if (c(TRUE, FALSE)) print(1)\n")
+        .unwrap();
+
+    let main_uri = file_uri(&fixture.path("main.R"));
+
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    runtime.block_on(async {
+        let (cs, ss) = tokio::io::duplex(128 * 1024);
+        let (cr, cw) = tokio::io::split(cs);
+        let (sr, sw) = tokio::io::split(ss);
+        let server = tokio::spawn(async move { ry_lsp::run_with(sr, sw).await });
+        let mut live = LspSession::new(cr, cw);
+        live.initialize(fixture.root()).await.unwrap();
+
+        // Snapshot AFTER initialize: the baseline is loaded once into the
+        // per-folder context during initialize and must not be re-read by
+        // any subsequent request.
+        let reads_before = ry_lsp::baseline_disk_reads();
+
+        // Exercise hover (read path) and publish (diagnostic path).
+        live.request(
+            "textDocument/hover",
+            json!({
+                "textDocument": {"uri": main_uri},
+                "position": {"line": 0, "character": 0}
+            }),
+        )
+        .await
+        .ok();
+        let mark = live.publication_mark();
+        live.open(&main_uri, 1, "if (c(TRUE, FALSE)) print(1)\n")
+            .await
+            .unwrap();
+        let _ = live
+            .published_diagnostics_after(&main_uri, mark)
+            .await
+            .unwrap();
+        // A second republish (didChange) to be thorough.
+        let mark2 = live.publication_mark();
+        live.change(
+            &main_uri,
+            2,
+            json!([{"text": "if (c(TRUE, FALSE)) print(1)\n"}]),
+        )
+        .await
+        .unwrap();
+        let _ = live
+            .published_diagnostics_after(&main_uri, mark2)
+            .await
+            .unwrap();
+
+        let reads_after = ry_lsp::baseline_disk_reads();
+        let _ = live.shutdown().await;
+        drop(live);
+        let _ = tokio::time::timeout(std::time::Duration::from_secs(3), server).await;
+
+        assert_eq!(
+            reads_before,
+            reads_after,
+            "publish/hover path must perform zero baseline disk reads; got {} extra read(s)",
+            reads_after.saturating_sub(reads_before)
         );
     });
 }
@@ -1147,7 +1404,6 @@ fn p36_w6_many_files_flat_filter_construction() {
 /// Currently the CLI and LSP discovery sets differ (CLI excludes
 /// `target/`, LSP includes it). The equality assertion fails.
 #[test]
-#[ignore = "P36-W7: shared bounded discovery CLI/LSP equality (#48) — fix pending"]
 fn p36_w7_cli_lsp_discovery_set_equality() {
     let fixture = FixtureProject::empty().unwrap();
     // Normal file with a diagnostic.

--- a/crates/ry-workspace/Cargo.toml
+++ b/crates/ry-workspace/Cargo.toml
@@ -17,6 +17,7 @@ rds2rust = { workspace = true }
 bzip2 = { workspace = true }
 flate2 = { workspace = true }
 xz2 = { workspace = true }
+glob = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ry-workspace/src/lib.rs
+++ b/crates/ry-workspace/src/lib.rs
@@ -1193,6 +1193,325 @@ pub fn is_file_eligible_with_excludes(
     !excludes.matches(&relative.to_string_lossy().replace('\\', "/"))
 }
 
+// ─────────────────────────────────────────────────────────────────────────
+// P36-W7 — Shared, bounded directory discovery (#48)
+// ─────────────────────────────────────────────────────────────────────────
+
+/// Bounded directory discovery limits derived from `[index]` in `ry.toml`.
+/// Applied identically to CLI directory discovery and LSP background
+/// indexing so the two modes discover exactly the same file set.
+#[derive(Clone, Copy, Debug)]
+pub struct DiscoveryLimits {
+    /// Maximum number of R source files discovered per root.
+    pub max_files: usize,
+    /// Maximum size in bytes of a single R file to include.
+    pub max_file_bytes: u64,
+    /// Maximum directory depth to descend from each root.
+    pub max_depth: usize,
+}
+
+impl DiscoveryLimits {
+    pub fn from_config(config: &ry_config::Config) -> Self {
+        Self {
+            max_files: config.index.max_files as usize,
+            max_file_bytes: config.index.max_file_bytes,
+            max_depth: config.index.max_depth as usize,
+        }
+    }
+}
+
+impl Default for DiscoveryLimits {
+    fn default() -> Self {
+        Self::from_config(&ry_config::Config::default())
+    }
+}
+
+/// Structured report when a discovery cap is hit (P36-W7).
+/// A cap hit is never silent: the caller emits a tracing event,
+/// LSP warning, or CLI warning based on this report.
+#[derive(Clone, Debug, Default)]
+pub struct TruncationReport {
+    /// The root at which the cap was hit.
+    pub root: PathBuf,
+    /// `true` when `max-files` stopped discovery before exhausting the tree.
+    pub max_files_hit: bool,
+    /// Files omitted because they exceeded `max-file-bytes` (path, size).
+    pub oversized_files: Vec<(PathBuf, u64)>,
+    /// Directories whose contents were pruned by `max-depth`.
+    pub depth_pruned_dirs: Vec<PathBuf>,
+}
+
+impl TruncationReport {
+    /// Returns `true` when any cap was hit.
+    pub fn any_hit(&self) -> bool {
+        self.max_files_hit || !self.oversized_files.is_empty() || !self.depth_pruned_dirs.is_empty()
+    }
+
+    /// Total number of files omitted across all caps.
+    pub fn omitted_count(&self) -> usize {
+        // `max_files_hit` means we stopped, so the omitted count is
+        // unbounded from the walker's perspective; the caller reports
+        // the count it can determine. Here we count the known omissions.
+        self.oversized_files.len()
+    }
+}
+
+/// Result of a bounded directory discovery.
+#[derive(Clone, Debug, Default)]
+pub struct DiscoveryResult {
+    /// Discovered R source file paths (sorted and deduplicated).
+    pub files: Vec<PathBuf>,
+    /// Structured cap report. Empty when no limit was reached.
+    pub truncated: TruncationReport,
+}
+
+/// Discover all eligible R source files under `walk_root`, applying the
+/// same eligibility, extension, hidden-directory, symlink, exclude, and
+/// test-fixture rules to both CLI and LSP (P36-W7 / issue #48).
+///
+/// `exclude_root` anchors the compiled `exclude` patterns from `config`.
+/// It should be the directory containing the originating `ry.toml`. When
+/// `None`, exclude patterns are not applied (matching a missing config).
+///
+/// Caps (`index.max-files`, `index.max-file-bytes`, `index.max-depth`)
+/// bound discovery. A cap hit populates [`TruncationReport`] so the
+/// caller can surface a visible warning.
+pub fn discover_r_files(
+    walk_root: &Path,
+    exclude_root: Option<&Path>,
+    config: &ry_config::Config,
+    check_test_fixtures: bool,
+) -> DiscoveryResult {
+    // A single file passed directly is always included regardless of
+    // package rules: it is the explicit subject of the analysis.
+    if walk_root.is_file() {
+        return DiscoveryResult {
+            files: vec![walk_root.to_path_buf()],
+            truncated: TruncationReport {
+                root: walk_root.parent().unwrap_or(walk_root).to_path_buf(),
+                ..Default::default()
+            },
+        };
+    }
+    let limits = DiscoveryLimits::from_config(config);
+    let excludes = ry_config::Excludes::from_config(config);
+    let has_excludes = !excludes.is_empty();
+    let mut files = Vec::new();
+    let mut truncated = TruncationReport {
+        root: walk_root.to_path_buf(),
+        ..Default::default()
+    };
+    let package_root = walk_root
+        .ancestors()
+        .find(|ancestor| ancestor.join("DESCRIPTION").is_file())
+        .map(Path::to_path_buf);
+    let buildignore = package_root
+        .as_deref()
+        .map(read_rbuildignore)
+        .unwrap_or_default();
+    discover_recursive(
+        walk_root,
+        &mut files,
+        &mut truncated,
+        package_root.as_deref(),
+        &buildignore,
+        check_test_fixtures,
+        0,
+        &limits,
+        &excludes,
+        has_excludes,
+        exclude_root,
+    );
+    files.sort();
+    files.dedup();
+    DiscoveryResult { files, truncated }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn discover_recursive(
+    dir: &Path,
+    out: &mut Vec<PathBuf>,
+    truncated: &mut TruncationReport,
+    package_root: Option<&Path>,
+    buildignore: &[glob::Pattern],
+    check_test_fixtures: bool,
+    depth: usize,
+    limits: &DiscoveryLimits,
+    excludes: &ry_config::Excludes,
+    has_excludes: bool,
+    exclude_root: Option<&Path>,
+) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        // Skip symlinks and entries whose type cannot be classified;
+        // following either could make recursive discovery escape the
+        // requested tree.
+        let Ok(file_type) = entry.file_type() else {
+            continue;
+        };
+        if file_type.is_symlink() {
+            continue;
+        }
+        let path = entry.path();
+        // Apply ry.toml exclude patterns (relative to the config root).
+        if has_excludes
+            && let Some(anchor) = exclude_root
+            && !is_file_eligible_with_excludes(&path, anchor, excludes)
+        {
+            continue;
+        }
+        // Apply .Rbuildignore patterns (relative to the package root).
+        if package_root.is_some_and(|root| is_rbuildignored(root, &path, buildignore)) {
+            continue;
+        }
+        if path.is_dir() {
+            if let Some(name) = path.file_name().and_then(|n| n.to_str())
+                && (name.starts_with('.')
+                    || name == "target"
+                    || name == "node_modules"
+                    || (name == "renv" && package_root.is_some())
+                    || name.ends_with(".Rcheck"))
+            {
+                continue;
+            }
+            if package_root.is_some_and(|root| is_excluded_package_directory(root, &path)) {
+                continue;
+            }
+            // P36-W7: depth cap prunes further descent.
+            if depth >= limits.max_depth {
+                truncated.depth_pruned_dirs.push(path);
+                continue;
+            }
+            let (nested_package_root, nested_buildignore) = if path.join("DESCRIPTION").is_file() {
+                (Some(path.clone()), read_rbuildignore(&path))
+            } else {
+                (package_root.map(Path::to_path_buf), buildignore.to_vec())
+            };
+            discover_recursive(
+                &path,
+                out,
+                truncated,
+                nested_package_root.as_deref(),
+                &nested_buildignore,
+                check_test_fixtures,
+                depth + 1,
+                limits,
+                excludes,
+                has_excludes,
+                exclude_root,
+            );
+        } else if matches!(
+            path.extension().and_then(|e| e.to_str()),
+            Some("R") | Some("r") | Some("S") | Some("s") | Some("q")
+        ) && (check_test_fixtures
+            || ry_checker::project::package_file_kind(&path)
+                != ry_checker::project::PackageFileKind::TestFixture)
+        {
+            // P36-W7: max-files cap.
+            if out.len() >= limits.max_files {
+                truncated.max_files_hit = true;
+                continue;
+            }
+            // P36-W7: max-file-bytes cap.
+            if let Ok(metadata) = std::fs::metadata(&path) {
+                let size = metadata.len();
+                if size > limits.max_file_bytes {
+                    truncated.oversized_files.push((path, size));
+                    continue;
+                }
+            }
+            out.push(path);
+        }
+    }
+}
+
+/// Read an R `.Rbuildignore` file and translate its conservative regex
+/// subset to glob patterns.
+fn read_rbuildignore(root: &Path) -> Vec<glob::Pattern> {
+    let Ok(contents) = std::fs::read_to_string(root.join(".Rbuildignore")) else {
+        return Vec::new();
+    };
+    contents
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty() && !line.starts_with('#'))
+        .filter_map(rbuildignore_pattern)
+        .collect()
+}
+
+/// Translate the conservative regex subset used by conventional
+/// `.Rbuildignore` files to the already-depended-on glob matcher.
+/// Unsupported PCRE constructs are ignored, as required for patterns
+/// our engine cannot compile.
+pub fn rbuildignore_pattern(regex: &str) -> Option<glob::Pattern> {
+    if regex.contains(['(', ')', '|', '{', '}', '+']) {
+        return None;
+    }
+    let anchored_start = regex.starts_with('^');
+    let trailing_backslashes = regex
+        .strip_suffix('$')
+        .map(|prefix| prefix.chars().rev().take_while(|&ch| ch == '\\').count())
+        .unwrap_or(0);
+    let anchored_end = regex.ends_with('$') && trailing_backslashes.is_multiple_of(2);
+    let body = regex.strip_prefix('^').unwrap_or(regex);
+    let body = if anchored_end {
+        body.strip_suffix('$').unwrap_or(body)
+    } else {
+        body
+    };
+    let mut glob_str = String::new();
+    if !anchored_start {
+        glob_str.push('*');
+    }
+    let mut chars = body.chars().peekable();
+    while let Some(ch) = chars.next() {
+        match ch {
+            '\\' => glob_str.push(chars.next()?),
+            '.' if chars.peek() == Some(&'*') => {
+                chars.next();
+                glob_str.push('*');
+            }
+            '.' => glob_str.push('?'),
+            '*' | '?' | '[' | ']' => glob_str.push(ch),
+            ch => glob_str.push(ch),
+        }
+    }
+    if !anchored_end {
+        glob_str.push('*');
+    }
+    glob::Pattern::new(&glob_str).ok()
+}
+
+/// Whether `path` relative to `package_root` is excluded by
+/// `.Rbuildignore`. Files under `R/` or `tests/` are never excluded
+/// because they are always part of the package source.
+fn is_rbuildignored(root: &Path, path: &Path, patterns: &[glob::Pattern]) -> bool {
+    let Ok(relative) = path.strip_prefix(root) else {
+        return false;
+    };
+    if relative.starts_with("R") || relative.starts_with("tests") {
+        return false;
+    }
+    let relative = relative.to_string_lossy().replace('\\', "/");
+    patterns.iter().any(|pattern| pattern.matches(&relative))
+}
+
+/// Whether a directory relative to a package root should be skipped
+/// entirely (reverse-dependency check dirs, compiled source, snapshots).
+fn is_excluded_package_directory(package_root: &Path, path: &Path) -> bool {
+    let Ok(relative) = path.strip_prefix(package_root) else {
+        return false;
+    };
+    let components: Vec<_> = relative
+        .components()
+        .filter_map(|component| component.as_os_str().to_str())
+        .collect();
+    matches!(components.as_slice(), ["revdep"] | ["src"])
+        || matches!(components.as_slice(), ["tests", "testthat", "_snaps"])
+}
+
 #[cfg(test)]
 mod shared_tests {
     use super::*;
@@ -1232,5 +1551,175 @@ mod shared_tests {
 
         assert!(!is_file_eligible(&link, dir.path(), &config));
         assert!(is_file_eligible(&target, dir.path(), &config));
+    }
+
+    #[test]
+    fn discovery_skips_target_and_hidden_directories() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("keep.R"),
+            "x <- 1
+",
+        )
+        .unwrap();
+        std::fs::create_dir_all(dir.path().join("target")).unwrap();
+        std::fs::write(
+            dir.path().join("target/skip.R"),
+            "y <- 2
+",
+        )
+        .unwrap();
+        std::fs::create_dir_all(dir.path().join(".hidden")).unwrap();
+        std::fs::write(
+            dir.path().join(".hidden/secret.R"),
+            "z <- 3
+",
+        )
+        .unwrap();
+
+        let result = discover_r_files(dir.path(), None, &ry_config::Config::default(), false);
+        let names: Vec<String> = result
+            .files
+            .iter()
+            .map(|p| p.file_name().unwrap().to_string_lossy().into_owned())
+            .collect();
+        assert!(names.contains(&"keep.R".to_string()));
+        assert!(!names.contains(&"skip.R".to_string()), "target/ skipped");
+        assert!(!names.contains(&"secret.R".to_string()), "hidden/ skipped");
+    }
+
+    #[test]
+    fn discovery_max_files_cap_is_configurable_and_visible() {
+        let dir = tempfile::tempdir().unwrap();
+        for i in 0..5 {
+            std::fs::write(
+                dir.path().join(format!("file_{i}.R")),
+                "x <- 1
+",
+            )
+            .unwrap();
+        }
+        let config = ry_config::Config {
+            index: ry_config::IndexConfig {
+                max_files: 2,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let result = discover_r_files(dir.path(), None, &config, false);
+        assert_eq!(result.files.len(), 2, "only 2 files under cap");
+        assert!(result.truncated.max_files_hit, "max-files cap reported");
+    }
+
+    #[test]
+    fn discovery_max_file_bytes_cap_omits_oversized_files() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("small.R"),
+            "x <- 1
+",
+        )
+        .unwrap();
+        std::fs::write(
+            dir.path().join("big.R"),
+            "y <- 2
+",
+        )
+        .unwrap();
+        // Set the big file's size via metadata — write a larger payload.
+        std::fs::write(dir.path().join("big.R"), "y ".repeat(100)).unwrap();
+        let config = ry_config::Config {
+            index: ry_config::IndexConfig {
+                max_file_bytes: 10,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let result = discover_r_files(dir.path(), None, &config, false);
+        let names: Vec<String> = result
+            .files
+            .iter()
+            .map(|p| p.file_name().unwrap().to_string_lossy().into_owned())
+            .collect();
+        assert!(names.contains(&"small.R".to_string()));
+        assert!(
+            !names.contains(&"big.R".to_string()),
+            "oversized file omitted"
+        );
+        assert!(
+            result
+                .truncated
+                .oversized_files
+                .iter()
+                .any(|(p, _)| { p.file_name().unwrap() == "big.R" }),
+            "oversized file reported in truncation"
+        );
+    }
+
+    #[test]
+    fn discovery_max_depth_cap_prunes_deep_directories() {
+        let dir = tempfile::tempdir().unwrap();
+        // Create a chain: a/b/c/deep.R
+        let deep = dir.path().join("a/b/c/deep.R");
+        std::fs::create_dir_all(deep.parent().unwrap()).unwrap();
+        std::fs::write(
+            &deep, "x <- 1
+",
+        )
+        .unwrap();
+        std::fs::write(
+            dir.path().join("shallow.R"),
+            "y <- 2
+",
+        )
+        .unwrap();
+
+        let config = ry_config::Config {
+            index: ry_config::IndexConfig {
+                max_depth: 1,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let result = discover_r_files(dir.path(), None, &config, false);
+        let names: Vec<String> = result
+            .files
+            .iter()
+            .map(|p| p.file_name().unwrap().to_string_lossy().into_owned())
+            .collect();
+        assert!(
+            names.contains(&"shallow.R".to_string()),
+            "shallow file found"
+        );
+        assert!(!names.contains(&"deep.R".to_string()), "deep file pruned");
+        assert!(
+            !result.truncated.depth_pruned_dirs.is_empty(),
+            "depth cap reported"
+        );
+    }
+
+    #[test]
+    fn discovery_includes_all_r_source_extensions() {
+        let dir = tempfile::tempdir().unwrap();
+        for ext in &["R", "r", "S", "s", "q"] {
+            std::fs::write(
+                dir.path().join(format!("source.{ext}")),
+                "value <- 1
+",
+            )
+            .unwrap();
+        }
+        std::fs::write(
+            dir.path().join("source.txt"),
+            "not R
+",
+        )
+        .unwrap();
+        let result = discover_r_files(dir.path(), None, &ry_config::Config::default(), false);
+        assert_eq!(
+            result.files.len(),
+            5,
+            "R, r, S, s, q discovered; .txt excluded"
+        );
     }
 }

--- a/crates/ry-workspace/src/lib.rs
+++ b/crates/ry-workspace/src/lib.rs
@@ -1412,7 +1412,7 @@ fn discover_recursive(
             // P36-W7: max-files cap.
             if out.len() >= limits.max_files {
                 truncated.max_files_hit = true;
-                continue;
+                break;
             }
             // P36-W7: max-file-bytes cap.
             if let Ok(metadata) = std::fs::metadata(&path) {


### PR DESCRIPTION
## P36-W5+W7: Cache baseline/config outside lock (#45) and bounded discovery (#48)

### W5 — Cache baseline/config state outside the hot lock (#45)
Baseline cached in `FolderAnalysisContext`. Watch events rebuild contexts outside lock via `spawn_blocking`, atomically swap. Zero disk I/O under state lock. Failed reload retains last valid context and emits visible error.

Red tests: `p36_w5_baseline_reload_retains_context_on_corruption`, `p36_w5_baseline_reload_converges_to_new_value`, `p36_w5_publish_path_performs_no_baseline_disk_io` — all green.

### W7 — Shared, bounded discovery (#48)
CLI and LSP use shared `ry-workspace` discovery module with identical eligibility/extension/hidden/symlink/exclude rules. Configurable caps: `index.max-files` (20000), `index.max-file-bytes` (2MiB), `index.max-depth` (64). Cap hits emit visible warnings in CLI, LSP, and tracing.

Red test: `p36_w7_cli_lsp_discovery_set_equality` — green.

### Gates
- `cargo fmt --all -- --check` ✓
- `cargo clippy --workspace --all-targets -- -D warnings` ✓
- `cargo test --workspace` ✓
- `ecosystem/run.sh --check --tier fast` ✓ (non-local)

Closes #45, closes #48.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Cache baseline/config outside the state lock and add bounded R file discovery
> - Baselines and folder configs are now loaded outside the async state lock and cached in `State` (`root_baseline`) and `FolderAnalysisContext` (`baseline`); `effective_baseline_for_path` no longer performs any disk I/O on the hot path.
> - Introduces `ry_workspace::discover_r_files` as a shared bounded discovery function used by both the CLI and LSP, replacing separate ad-hoc traversal implementations in each.
> - Discovery limits (`index.max-files`, `index.max-file-bytes`, `index.max-depth`) are configurable via `ry.toml`; hitting any cap produces a structured `TruncationReport` and a user-visible LSP warning or stderr message from the CLI.
> - `did_change_watched_files` now detects baseline JSON changes, rebuilds all folder contexts off-thread via `rebuild_folder_contexts`, and swaps them atomically; a failed baseline reload retains the last valid cached baseline.
> - A global `BASELINE_DISK_READS` counter enables tests to assert zero baseline I/O on the publish/hover hot path after initialize.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 573b170.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added shared R-file discovery for `ry check` and the LSP, with consistent exclusions and filtering.
  * Added configurable limits for file count, file size, and directory depth.
  * Added clear reporting when discovery limits omit files.
  * Improved configuration reloads while preserving the last valid settings during errors.
* **Documentation**
  * Updated configuration guidance and changelog entries for discovery limits, truncation reporting, and editor behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->