### PR TITLE
Resolve #81: w10 convergence race is a harness artifact; delete force_full_recollection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -166,6 +166,15 @@ All notable changes to ry are documented in this file.
   (functions, known-vars) from a previous file into the current check. This
   accumulated-diagnostics defect is gated by the P35-W9 reset/non-interference
   property tests.
+- The w10 session convergence failure (#81) was a race in the test harness,
+  not the checker: the close's clearing `[]` publication can be written after
+  a subsequent request's response, so the harness matched the stale `[]` as
+  the reopened document's publication. `Close` in the model now consumes its
+  own clearing publication, and a deterministic close/reopen regression test
+  pins the behaviour.
+- Deleted `Project::force_full_recollection` and its call in the LSP check
+  cycle. The workaround forced a full project re-collection on every
+  keystroke and did not prevent the failure it was added for.
 
 ## [0.8.0] - 2026-08-04
 

--- a/crates/ry-checker/src/project.rs
+++ b/crates/ry-checker/src/project.rs
@@ -238,22 +238,6 @@ impl Project {
         }
     }
 
-    /// Force a full re-collection of all files on the next check.
-    ///
-    /// This is the nuclear option for incremental convergence: it clears
-    /// all cached collection state so the next `check_incremental()` call
-    /// re-collects every file from scratch. Used when files are removed
-    /// and re-added (close/reopen) to prevent stale cross-file state.
-    pub fn force_full_recollection(&mut self) {
-        self.collected_files.clear();
-        self.file_known_vars.clear();
-        self.dirty_paths.clear();
-        let paths: Vec<String> = self.files.iter().map(|(p, _)| p.clone()).collect();
-        for p in paths {
-            self.dirty_paths.insert(p);
-        }
-    }
-
     /// Install runtime package stubs. User packages, including `base`,
     /// replace same-named embedded packages wholesale for this project.
     /// Mark every file as dirty so the next incremental check re-emits all.

--- a/crates/ry-lsp/src/backend.rs
+++ b/crates/ry-lsp/src/backend.rs
@@ -393,19 +393,6 @@ impl ProjectCache {
             .set_external_s3_methods(workspace.s3_methods.clone());
         self.project
             .set_load_bindings(workspace.load_bindings.clone());
-        // Workaround for the close/reopen convergence defect (issue #81):
-        // re-collect the whole project whenever any file changed. This is
-        // expensive — it defeats pass-1 reuse on every keystroke — but
-        // removing it makes a reopened document publish no diagnostics.
-        // Remove only together with a fix for the underlying stale state.
-        let any_changed = files.iter().any(|(path, version, file)| {
-            self.files.get(path).is_none_or(|(cached_version, cached)| {
-                *cached_version != *version || !Arc::ptr_eq(cached, file)
-            })
-        });
-        if any_changed {
-            self.project.force_full_recollection();
-        }
         for (path, version, file) in files {
             let changed = self
                 .files

--- a/crates/ry-lsp/tests/session.proptest-regressions
+++ b/crates/ry-lsp/tests/session.proptest-regressions
@@ -5,3 +5,4 @@
 # It is recommended to check this file in to source control so that
 # everyone who runs the test benefits from these saved cases.
 cc 3f6889a6ce7bbafd22ae59e2c5a9b91c1f5aa6592d60ffa56a69d063a816dc87 # shrinks to operations = [Open { file: 2, source: Clean }, FullEdit { file: 2, source: Clean }, Close { file: 2 }, Open { file: 2, source: AsciiDiagnostic }]
+cc 726404ecbb55b606c718e583e3980e670593ba009a56679dea99df1bf6c2eb15 # shrinks to operations = [Open { file: 2, source: Clean }, Open { file: 0, source: Clean }, Close { file: 0 }, Close { file: 2 }, Open { file: 2, source: AsciiDiagnostic }]

--- a/crates/ry-lsp/tests/session.rs
+++ b/crates/ry-lsp/tests/session.rs
@@ -969,6 +969,20 @@ async fn w10_convergence_property(operations: Vec<Operation>) -> Result<(), Test
                     continue;
                 }
                 let closed_uri = uris[*file as usize].clone();
+                // Consume the close's clearing publication here instead of
+                // relying on a later step's barrier (#81).  `did_close`
+                // publishes `[]` from the notification lane while requests
+                // are answered on a concurrent lane, so the clearing
+                // notification can be written after a subsequent hover
+                // response; a read-order mark taken after that response
+                // then matches the stale `[]` instead of the reopened
+                // document's real publication.  The barrier drains
+                // in-flight publications for the URI before the mark, and
+                // the loop absorbs any populated one written so late that
+                // it still sequences after it — only the close's `[]` can
+                // terminate the wait.
+                sync_barrier(&mut live, &closed_uri).await;
+                let clear_mark = live.publication_mark();
                 model.open_docs.remove(file);
                 live.notify(
                     "textDocument/didClose",
@@ -976,10 +990,17 @@ async fn w10_convergence_property(operations: Vec<Operation>) -> Result<(), Test
                 )
                 .await
                 .unwrap();
+                loop {
+                    let publish = live
+                        .published_diagnostics_after(&closed_uri, clear_mark)
+                        .await
+                        .unwrap();
+                    if normalize_diagnostics(&publish).is_empty() {
+                        break;
+                    }
+                }
                 // After close, compare the first remaining open document
-                // (if any) against the oracle.  The sync barrier inside
-                // quiesce_and_compare drains the close's empty publication
-                // and any stale publications from prior steps.
+                // (if any) against the oracle.
                 if let Some((&first_open, _)) = model.open_docs.iter().next() {
                     quiesce_and_compare(
                         &mut live,
@@ -1026,4 +1047,75 @@ async fn w10_convergence_property(operations: Vec<Operation>) -> Result<(), Test
 
     join_session(live, live_server).await;
     Ok(())
+}
+
+/// Regression for #81: after a close/reopen the server must publish the
+/// reopened document's diagnostics, and the close's clearing `[]` must not
+/// be mistakable for that publication.  Deterministic companion to the
+/// convergence property, which samples this path randomly.
+#[test]
+fn close_reopen_publishes_diagnostics_again() {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    runtime.block_on(close_reopen_republishes());
+}
+
+async fn close_reopen_republishes() {
+    let fixture = FixtureProject::empty().unwrap();
+    fixture.write_file("a.R", W10_DISK).unwrap();
+    let uri = file_uri(&fixture.path("a.R")).unwrap();
+    let (mut session, server) = spawn_session(fixture.root()).await;
+
+    // Barrier + mark before the open, the same pattern
+    // `fresh_server_diagnostics` uses to drain the initialize cycle's
+    // background-index publications.
+    sync_barrier(&mut session, &uri).await;
+    let open_mark = session.publication_mark();
+    session
+        .open(&uri, 1, SourceVariant::AsciiDiagnostic.text())
+        .await
+        .unwrap();
+    let first = session
+        .published_diagnostics_after(&uri, open_mark)
+        .await
+        .unwrap();
+    assert!(
+        !normalize_diagnostics(&first).is_empty(),
+        "initial open must publish diagnostics"
+    );
+
+    let close_mark = session.publication_mark();
+    session
+        .notify(
+            "textDocument/didClose",
+            json!({"textDocument": {"uri": uri}}),
+        )
+        .await
+        .unwrap();
+    let cleared = session
+        .published_diagnostics_after(&uri, close_mark)
+        .await
+        .unwrap();
+    assert!(
+        normalize_diagnostics(&cleared).is_empty(),
+        "close must clear diagnostics"
+    );
+
+    let reopen_mark = session.publication_mark();
+    session
+        .open(&uri, 2, SourceVariant::AstralDiagnostic.text())
+        .await
+        .unwrap();
+    let republish = session
+        .published_diagnostics_after(&uri, reopen_mark)
+        .await
+        .unwrap();
+    assert!(
+        !normalize_diagnostics(&republish).is_empty(),
+        "reopen must publish diagnostics again, not the close's clearing []"
+    );
+
+    join_session(session, server).await;
 }

--- a/docs/architecture/p38-w12-acceptance.md
+++ b/docs/architecture/p38-w12-acceptance.md
@@ -30,6 +30,10 @@ The LSP handler migration (routing every feature through `AnalysisSnapshot`)
 remains future work. The foundation is in place.
 
 ## Gates
-- 963 workspace tests pass (1 pre-existing convergence failure)
+- 963 workspace tests pass. The one convergence failure recorded here as a
+  known baseline was later diagnosed as a race in the w10 test harness
+  (the close's clearing publication matched as the reopened document's
+  publication), not a checker defect; it is fixed and regression-gated —
+  see #81.
 - 0 clippy warnings
 - Dependency edges enforced


### PR DESCRIPTION
Closes #81. Also moots the `force_full_recollection` bullet in #90 and unblocks #86.

## Diagnosis

#81's convergence failure is a race in the test harness, not the checker. Reproduced on `main` with a 40-run loop of `cargo test -p ry-lsp --test session w10_session_converges`: 12 passes, then 8 consecutive failures once the machine came under load. Every failure shows `left: []` (live) against the fresh oracle's populated set, always at the `Open` step immediately following a `Close` of the same file. The loop's failing runs recorded a second, independently shrunk seed (`726404ec…`, committed here alongside the existing one) with the same shape: closes, then a reopen that "publishes nothing".

Mechanism:

- `did_close` publishes a clearing `[]` for the closed URI (`backend.rs`), while the reopened document's real publication only arrives after the 180 ms debounce.
- tower-lsp answers requests and notifications on concurrent lanes, so a hover response can be written before the close's `[]`.
- `quiesce_and_compare` takes its `publication_mark` after the hover barrier, and the mark counts **read order**. When the `[]` is written after the hover response, it sequences after the mark and `published_diagnostics_after` matches the stale `[]` as if it were the reopen's publication. The real publication arrives later and is never read.

The production behaviour is correct: the reopened document does get its diagnostics, 180 ms later.

## Changes

- **`session.rs` — `Close` consumes its own clearing publication.** Barrier on the closed URI (drains in-flight publications), mark, `didClose`, then wait until an empty publication for the URI arrives. The loop absorbs the corner case of a populated publication written so late that it still sequences after the mark; only the close's `[]` can terminate the wait. The comment that wrongly claimed the next step's barrier drains the close's publication is gone — that false assumption is how the race survived review.
- **`session.rs` — deterministic regression test.** `close_reopen_publishes_diagnostics_again`: open (populated publication) → close (`[]`) → reopen (populated again). Pins the user-visible property without sampling.
- **`force_full_recollection` deleted** (`ry-checker/src/project.rs`, call site in `backend.rs`). It forced a full project re-collection on every keystroke and demonstrably did not prevent this failure — it reproduced with the call in place and with it removed. Its unconditional-clearing shape was also flagged as a correctness risk in #90 (names not moved into `invalidated_fns` before clearing); deleting it closes that item as moot.
- **`p38-w12-acceptance.md`** no longer records the red gate as an accepted baseline; CHANGELOG entry added.

## Verification

- New regression test passes deterministically (~0.4 s).
- 40 stress runs of the property under artificial CPU load (8 burners on a 24-core box — the same conditions that produced the 8-failure burst on `main`): zero failures, with both recorded seeds replayed on every run.
- `cargo test --workspace`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt --all -- --check`.

## Deliberately not in this PR

- #86 (equality-aware environment setters) lands separately on top, gated by this fix.
- `p36_contract.rs`'s drain loop (#90 flags it as the same harness-timing family) is its own small change.
- Stamping document `version` into `publishDiagnostics` would make publication attribution structural (the issue's third option). If any attribution race survives this fix, that is the escalation path, not more harness logic.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a race that could show stale diagnostics when files were closed and reopened.
  * Diagnostics now clear reliably on close and refresh correctly when reopened with updated content.
  * Improved incremental checking behavior to avoid unnecessary full-project recollection.

* **Tests**
  * Added regression coverage for close-and-reopen diagnostic scenarios, including Unicode content.

* **Documentation**
  * Clarified the documented cause and resolution of the session-convergence issue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->