### PR TITLE
Make Project environment setters equality-aware (#86)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,14 @@ All notable changes to ry are documented in this file.
 
 ### Changed
 
+- `Project`'s six environment setters (`set_loaded`, `set_bare_loaded`,
+  `set_external_bindings`, `set_imported_from`, `set_external_s3_methods`,
+  `set_load_bindings`) and `set_user_stubs` are equality-aware: reinstalling
+  the value already in place no longer marks every file dirty (#86). The LSP
+  reinstalls the whole workspace environment on every check cycle, so this
+  previously defeated `check_incremental`'s emit scoping on every publish.
+  A no-op reinstall now re-emits nothing; a real change still invalidates
+  everything (gated by an `emit_count` test and the convergence property).
 - **Suggested fixes removed from published diagnostics**: the `fix` payload is
   gone from `ry check --output-format json` and from the `data` field of
   published LSP diagnostics, along with the internal `Fix` machinery that

--- a/crates/ry-checker/src/project.rs
+++ b/crates/ry-checker/src/project.rs
@@ -218,15 +218,25 @@ impl Project {
     /// packages attached via `library`/`require` in
     /// any file, and the union is seeded into every pass-3 emitter so
     /// the dplyr NSE gating sees a project-wide view.
+    ///
+    /// Equality-aware: reinstalling the declared set already in place is a
+    /// no-op. The comparison is against `declared_loaded` (the input), not
+    /// `loaded`, which is recomputed from it on every check pass.
     pub fn set_loaded(&mut self, loaded: std::collections::HashSet<String>) {
+        if self.declared_loaded == loaded {
+            return;
+        }
         self.declared_loaded = loaded.clone();
         self.loaded = loaded;
         self.mark_all_dirty();
     }
 
+    /// Equality-aware: reinstalling the value already in place is a no-op.
     pub fn set_bare_loaded(&mut self, loaded: HashMap<String, HashSet<String>>) {
+        if self.bare_loaded == loaded {
+            return;
+        }
         self.bare_loaded = loaded;
-
         self.mark_all_dirty();
     }
 
@@ -240,11 +250,13 @@ impl Project {
 
     /// Install runtime package stubs. User packages, including `base`,
     /// replace same-named embedded packages wholesale for this project.
-    /// Mark every file as dirty so the next incremental check re-emits all.
+    /// Equality-aware: installing the same `Arc` again is a no-op; a
+    /// different stub set clears all cached collection and re-emits.
     pub fn set_user_stubs(&mut self, stubs: Arc<BTreeMap<String, Typeshed>>) {
-        if !Arc::ptr_eq(&self.user_stubs, &stubs) {
-            self.collected_files.clear();
+        if Arc::ptr_eq(&self.user_stubs, &stubs) {
+            return;
         }
+        self.collected_files.clear();
         self.user_stubs = stubs;
         self.mark_all_dirty();
     }
@@ -252,30 +264,42 @@ impl Project {
     /// Declare per-file names provided by project metadata, such as
     /// `NAMESPACE`'s `importFrom()` directives. Per-file scoping prevents an
     /// import in one checked package from leaking into an unrelated package.
+    /// Equality-aware: reinstalling the value already in place is a no-op.
     pub fn set_external_bindings(&mut self, bindings: HashMap<String, HashSet<String>>) {
+        if self.external_bindings == bindings {
+            return;
+        }
         self.external_bindings = bindings;
-
         self.mark_all_dirty();
     }
 
+    /// Equality-aware: reinstalling the value already in place is a no-op.
     pub fn set_imported_from(&mut self, imports: HashMap<String, HashMap<String, String>>) {
+        if self.imported_from == imports {
+            return;
+        }
         self.imported_from = imports;
-
         self.mark_all_dirty();
     }
 
+    /// Equality-aware: reinstalling the value already in place is a no-op.
     pub fn set_external_s3_methods(&mut self, methods: HashMap<String, HashSet<(String, String)>>) {
+        if self.external_s3_methods == methods {
+            return;
+        }
         self.external_s3_methods = methods;
-
         self.mark_all_dirty();
     }
 
+    /// Equality-aware: reinstalling the value already in place is a no-op.
     pub fn set_load_bindings(
         &mut self,
         bindings: HashMap<String, HashMap<usize, HashSet<String>>>,
     ) {
+        if self.load_bindings == bindings {
+            return;
+        }
         self.load_bindings = bindings;
-
         self.mark_all_dirty();
     }
 

--- a/crates/ry-checker/tests/project.rs
+++ b/crates/ry-checker/tests/project.rs
@@ -287,6 +287,86 @@ fn load_bindings_activate_at_the_load_statement() {
     );
 }
 
+/// A no-op environment reinstall must not re-emit any file (#86). The LSP
+/// reinstalls all six environment setters on every check cycle; before the
+/// setters were equality-aware that marked every file dirty on every
+/// publish, defeating `check_incremental`'s emit scoping entirely.
+#[test]
+fn no_op_environment_reinstall_does_not_re_emit() {
+    let mut project = Project::new();
+    project.add_file("a.R".to_string(), parse("a.R", "f <- function(x) x + 1L\n"));
+    project.add_file("b.R".to_string(), parse("b.R", "g <- function() f(1L)\n"));
+
+    let loaded = HashSet::from(["dplyr".to_string()]);
+    let bare_loaded =
+        HashMap::from([("a.R".to_string(), HashSet::from(["bare_name".to_string()]))]);
+    let external_bindings = HashMap::from([(
+        "b.R".to_string(),
+        HashSet::from(["external_name".to_string()]),
+    )]);
+    let imported_from = HashMap::from([(
+        "a.R".to_string(),
+        HashMap::from([("imported_helper".to_string(), "fixture".to_string())]),
+    )]);
+    let external_s3_methods = HashMap::from([(
+        "a.R".to_string(),
+        HashSet::from([("Ops".to_string(), "external_class".to_string())]),
+    )]);
+    let load_bindings = HashMap::from([(
+        "b.R".to_string(),
+        HashMap::from([(0, HashSet::from(["loaded_name".to_string()]))]),
+    )]);
+    let install = |project: &mut Project| {
+        project.set_loaded(loaded.clone());
+        project.set_bare_loaded(bare_loaded.clone());
+        project.set_external_bindings(external_bindings.clone());
+        project.set_imported_from(imported_from.clone());
+        project.set_external_s3_methods(external_s3_methods.clone());
+        project.set_load_bindings(load_bindings.clone());
+    };
+
+    install(&mut project);
+    let first = project.check_incremental();
+    assert_eq!(
+        project.emit_count, 2,
+        "first check must emit both files, got {}",
+        project.emit_count
+    );
+
+    // Reinstalling the identical environment is a no-op: nothing is
+    // re-emitted and the cached diagnostics are served unchanged.
+    install(&mut project);
+    let second = project.check_incremental();
+    assert_eq!(
+        project.emit_count, 0,
+        "no-op reinstall must not re-emit any file"
+    );
+    assert_eq!(
+        second, first,
+        "no-op reinstall must serve the cached diagnostics unchanged"
+    );
+
+    // The same holds for stubs installed as the identical Arc.
+    let stubs = generated_user_stubs(true);
+    project.set_user_stubs(Arc::clone(&stubs));
+    let _ = project.check_incremental();
+    assert!(project.emit_count >= 1, "installing new stubs must re-emit");
+    project.set_user_stubs(Arc::clone(&stubs));
+    let _ = project.check_incremental();
+    assert_eq!(
+        project.emit_count, 0,
+        "reinstalling the same stub Arc must not re-emit"
+    );
+
+    // A real change must still invalidate.
+    project.set_loaded(HashSet::from(["dplyr".to_string(), "rlang".to_string()]));
+    let _ = project.check_incremental();
+    assert_eq!(
+        project.emit_count, 2,
+        "a changed environment must re-emit every file"
+    );
+}
+
 #[test]
 fn redefinition_in_different_files_shadows() {
     // If utils.R defines f and other.R also defines f, the later


### PR DESCRIPTION
Closes #86.

## What changed

All six `Project` environment setters (`set_loaded`, `set_bare_loaded`, `set_external_bindings`, `set_imported_from`, `set_external_s3_methods`, `set_load_bindings`) now early-return when the incoming value equals the stored one, and `set_user_stubs` early-returns on the identical `Arc` instead of only guarding the collection clear.

Two details worth review attention:

- `set_loaded` compares against `declared_loaded` (its actual input). `self.loaded` is the union with `library()`/`require()` attachments and is recomputed from `declared_loaded` on every check pass (`project.rs:327`, `:396`), so the early return cannot leave a stale union behind.
- `set_user_stubs` keeps `Arc::ptr_eq` semantics: two different `Arc`s with equal content still invalidate. The LSP passes the same `Arc` every cycle, which is the case that matters.

## Why now

The LSP reinstalls the whole workspace environment on every check cycle, so the unconditional `mark_all_dirty` meant every file was re-emitted on every publish — `check_incremental`'s pass-3 emit scoping has never actually scoped anything. This was held back only by #81: the unconditional dirtying papered over the convergence failure, which #93 resolved as a harness race. With that landed (workaround deleted, property deterministic about publication attribution), the guards can go in with the property as the gate.

## Verification

- New `no_op_environment_reinstall_does_not_re_emit` test in `ry-checker`: first check emits both files; an identical reinstall re-emits **nothing** (`emit_count == 0`) and serves the cached diagnostics byte-identical; reinstalling the same stub `Arc` is a no-op; a genuinely different value re-emits everything.
- `incremental_matches_cold_property` (64 cases, drives all setters statefully against cold rebuilds) passes.
- The w10 convergence property — the acceptance gate named in #86 — passed **once at 256 cases** (~3 min; that also confirms why the committed default stays at 8) and **30/30 runs under artificial CPU load**, with both recorded seeds replayed on every run.
- 1004 workspace tests, clippy `-D warnings`, fmt clean.

## Note

`invalidated_fns` is drained at the end of every `refine_and_emit` cycle, so stale invalidations cannot accumulate and force re-emission on later no-op cycles — the settling behavior the new test asserts on is structural, not incidental.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reapplying unchanged project environment settings no longer marks files as modified or produces duplicate diagnostics.
  * Genuine environment changes continue to invalidate and refresh affected files.
  * Updated user stubs now correctly clear cached results when changes occur.

* **Tests**
  * Added coverage confirming stable behavior for repeated and changed project configuration updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->