### PR TITLE
Test theater sweep (#82): fix or delete assertions that could not fail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -161,6 +161,16 @@ All notable changes to ry are documented in this file.
 
 ### Fixed
 
+- Tests that could not fail were fixed or deleted (#82): the ry-analysis
+  workspace-context test now asserts the rlang/RY070 flip in both
+  directions (check.rs), the same-name symbol test asserts reference
+  indexing instead of an unobservable resolution claim (symbols.rs), the
+  property tests write distinct per-apply content and claim only
+  final-contents equivalence (tests/property.rs), and the w8 session
+  model rotates corrected-operation targets across candidate slots with
+  the stale coverage eprintln (which miscounted invalid ops as
+  corrections and claimed it should stay zero) removed
+  (ry-lsp/tests/w8_session.rs).
 - `Checker::check` now resets the function table and return slots before each
   run, so a reused single-file `Checker` no longer leaks inference state
   (functions, known-vars) from a previous file into the current check. This

--- a/crates/ry-analysis/src/check.rs
+++ b/crates/ry-analysis/src/check.rs
@@ -87,18 +87,42 @@ mod tests {
 
     #[test]
     fn check_project_with_workspace_context() {
-        let mut parser = ry_core::RParser::new().unwrap();
-        let file = parser.parse("test.R", "dplyr_function(1)\n").unwrap();
-        let mut workspace = ry_workspace::WorkspaceContext::default();
-        workspace.attached_packages.insert("dplyr".to_string());
-        let input = CheckInput {
-            files: vec![("test.R".to_string(), 0, Arc::new(file))],
-            user_stubs: Arc::new(BTreeMap::new()),
-            workspace: Some(workspace),
+        // `is_null(x)` narrows `x` away from NULL only when its defining
+        // package is attached, so the trailing `x()` is an RY070
+        // (calling a non-function) exactly when rlang is absent. Running
+        // the same source with and without the workspace context proves
+        // check_project actually feeds attached_packages into the checker
+        // instead of ignoring it.
+        let src = "x <- NULL\nif (is_null(x)) stop(\"missing\")\nx()\n";
+        let run = |workspace: Option<ry_workspace::WorkspaceContext>| -> usize {
+            let mut parser = ry_core::RParser::new().unwrap();
+            let file = parser.parse("test.R", src).unwrap();
+            let output = check_project(CheckInput {
+                files: vec![("test.R".to_string(), 0, Arc::new(file))],
+                user_stubs: Arc::new(BTreeMap::new()),
+                workspace,
+            });
+            output
+                .diagnostics
+                .iter()
+                .flat_map(|(_, diags)| diags.iter())
+                .filter(|d| d.code == "RY070")
+                .count()
         };
-        let output = check_project(input);
-        // Should complete without error even with workspace context.
-        assert!(!output.diagnostics.is_empty());
+
+        let without = run(None);
+        assert!(
+            without > 0,
+            "without rlang the predicate cannot narrow x; RY070 must fire for x()"
+        );
+
+        let mut with = ry_workspace::WorkspaceContext::default();
+        with.attached_packages.insert("rlang".to_string());
+        assert_eq!(
+            run(Some(with)),
+            0,
+            "with rlang attached the predicate narrows x; no RY070 may survive"
+        );
     }
 
     #[test]

--- a/crates/ry-analysis/src/symbols.rs
+++ b/crates/ry-analysis/src/symbols.rs
@@ -419,7 +419,9 @@ mod tests {
 
     #[test]
     fn same_name_different_files() {
-        // Two files defining the same name - both are valid definitions
+        // Two files defining the same name: the merge must keep both
+        // definitions (one per file) without corrupting the reference
+        // side — b.R's call to its local helper stays indexed.
         let file_a = parse("helper <- function() 1\n");
         let file_b = parse("helper <- function() 2\nhelper()\n");
         let idx_a = build_index_from_file("a.R", &file_a);
@@ -428,9 +430,16 @@ mod tests {
 
         let defs = merged.find_definitions("helper");
         assert_eq!(defs.len(), 2, "both files define helper");
+        for file in ["a.R", "b.R"] {
+            assert_eq!(
+                defs.iter().filter(|d| d.symbol.file == file).count(),
+                1,
+                "{file} must contribute exactly one helper definition"
+            );
+        }
 
-        // The reference in b.R should resolve to b.R's local definition
-        let b_def = defs.iter().find(|d| d.symbol.file == "b.R").unwrap();
-        assert_eq!(b_def.start, 0);
+        let refs = merged.find_references("helper");
+        assert_eq!(refs.len(), 1, "b.R's call to helper must stay a reference");
+        assert_eq!(refs[0].file, "b.R");
     }
 }

--- a/crates/ry-analysis/tests/property.rs
+++ b/crates/ry-analysis/tests/property.rs
@@ -1,8 +1,11 @@
 //! P38-W5 property tests: live vs fresh equivalence after arbitrary change batches.
 //!
 //! The core invariant: after applying a batch of changes to the host,
-//! a snapshot taken from the live host must equal a snapshot taken from
-//! a fresh host constructed with the same final inputs.
+//! a snapshot taken from the live host must match, file for file, a
+//! snapshot taken from a fresh host fed the same final *contents*. The
+//! host exposes no open-file queries, so the fresh host cannot replay
+//! open/closed state or document versions — every file is installed as
+//! a disk file and only content equivalence is asserted.
 
 use proptest::prelude::*;
 use ry_analysis::*;
@@ -53,7 +56,9 @@ fn arb_change() -> impl Strategy<Value = Change> {
 
 proptest! {
     /// Property: a live host after N changes produces the same file set
-    /// and content as a fresh host built from the final state.
+    /// and content as a fresh host fed the same final contents (as disk
+    /// files — open state and versions are not reconstructable through
+    /// the host's public API).
     #[test]
     fn live_equals_fresh_file_contents(changes in proptest::collection::vec(arb_change(), 1..20)) {
         // Apply all changes to a live host.
@@ -62,7 +67,7 @@ proptest! {
             live.apply([change.clone()]);
         }
 
-        // Build a fresh host from the live host's final state.
+        // Build a fresh host from the live host's final contents.
         let mut fresh = AnalysisHost::new();
         let live_files: Vec<_> = live.all_files().map(|p| p.to_path_buf()).collect();
         for path in &live_files {
@@ -122,10 +127,13 @@ proptest! {
     fn revision_monotonically_increases(n in 1u32..50) {
         let mut host = AnalysisHost::new();
         let initial = host.revision();
-        for _ in 0..n {
+        for i in 0..n {
+            // Index, not the loop bound: reusing the bound wrote the same
+            // bytes every iteration, so the sequence never exercised
+            // successive different writes to one path.
             host.apply([Change::SetDiskFile {
                 path: PathBuf::from("R/a.R"),
-                content: format!("v{}", n),
+                content: format!("v{i}"),
             }]);
         }
         let final_rev = host.revision();

--- a/crates/ry-lsp/tests/w8_session.rs
+++ b/crates/ry-lsp/tests/w8_session.rs
@@ -233,6 +233,10 @@ struct SessionModel {
     max_files: u64,
     /// Monotonic version counter.
     version: i32,
+    /// Rotation counter for corrected operations: always correcting to
+    /// the lowest open doc / first free slot collapses every correction
+    /// onto one file, hollowing out seed coverage.
+    correction_step: usize,
 }
 
 impl Default for SessionModel {
@@ -248,6 +252,7 @@ impl Default for SessionModel {
             second_folder: false,
             max_files: 20_000,
             version: 1,
+            correction_step: 0,
         }
     }
 }
@@ -292,39 +297,54 @@ impl SessionModel {
     }
 
     /// P37-W7c: Generate a valid alternative for an invalid operation.
-    fn valid_alternative(&self, original: &Operation) -> Option<Operation> {
+    /// Each correction advances `correction_step` and picks the
+    /// `step % len`-th candidate slot, so consecutive corrections
+    /// rotate across open docs / free slots instead of all funneling
+    /// onto the first one. Deterministic: the step is model state, and
+    /// every seed lane replays the same sequence.
+    fn valid_alternative(&mut self, original: &Operation) -> Option<Operation> {
+        let step = self.correction_step;
+        self.correction_step = self.correction_step.wrapping_add(1);
+        let nth = |slots: &[u8]| -> Option<u8> {
+            if slots.is_empty() {
+                None
+            } else {
+                Some(slots[step % slots.len()])
+            }
+        };
         match original {
             Operation::Open { source, .. } => {
                 let closed_on_disk: Vec<u8> = (0..FILES.len() as u8)
                     .filter(|&f| !self.is_open(f) && self.has_disk(f))
                     .collect();
-                closed_on_disk.first().map(|&f| Operation::Open {
+                nth(&closed_on_disk).map(|f| Operation::Open {
                     file: f,
                     source: *source,
                 })
             }
             Operation::FullEdit { source, .. } | Operation::IncrementalEdit { source, .. } => {
-                self.open_docs.keys().next().map(|&f| Operation::FullEdit {
+                let open: Vec<u8> = self.open_docs.keys().copied().collect();
+                nth(&open).map(|f| Operation::FullEdit {
                     file: f,
                     source: *source,
                 })
             }
             Operation::RapidEdit { source, .. } => {
-                self.open_docs.keys().next().map(|&f| Operation::RapidEdit {
+                let open: Vec<u8> = self.open_docs.keys().copied().collect();
+                nth(&open).map(|f| Operation::RapidEdit {
                     file: f,
                     source: *source,
                 })
             }
-            Operation::Close { .. } => self
-                .open_docs
-                .keys()
-                .next()
-                .map(|&f| Operation::Close { file: f }),
+            Operation::Close { .. } => {
+                let open: Vec<u8> = self.open_docs.keys().copied().collect();
+                nth(&open).map(|f| Operation::Close { file: f })
+            }
             Operation::CreateFile { source, .. } => {
                 let empty: Vec<u8> = (0..FILES.len() as u8)
                     .filter(|&f| !self.has_disk(f))
                     .collect();
-                empty.first().map(|&f| Operation::CreateFile {
+                nth(&empty).map(|f| Operation::CreateFile {
                     file: f,
                     source: *source,
                 })
@@ -333,9 +353,7 @@ impl SessionModel {
                 let deletable: Vec<u8> = (0..FILES.len() as u8)
                     .filter(|&f| self.has_disk(f) && !self.is_open(f))
                     .collect();
-                deletable
-                    .first()
-                    .map(|&f| Operation::DeleteFile { file: f })
+                nth(&deletable).map(|f| Operation::DeleteFile { file: f })
             }
             _ => None,
         }
@@ -577,13 +595,11 @@ async fn w8_convergence_property(operations: Vec<Operation>) -> Result<(), TestC
     let (mut live, mut live_server) = spawn_session(&roots).await;
     let mut model = SessionModel::default();
 
-    let mut skipped_count: u32 = 0;
     for (step, operation) in operations.into_iter().enumerate() {
-        // P37-W7c: Track operations skipped due to invalid state.
-        // After precomputation, the generator should only produce
-        // valid operations, so this should remain zero.
+        // P37-W7c: Correct invalid operations to valid alternatives so
+        // every generated op contributes coverage instead of being
+        // silently skipped by the executor.
         let operation = if !model.is_valid(&operation) {
-            skipped_count += 1;
             match model.valid_alternative(&operation) {
                 Some(valid) => valid,
                 None => continue,
@@ -942,13 +958,6 @@ async fn w8_convergence_property(operations: Vec<Operation>) -> Result<(), TestC
                 target_uri
             );
         }
-    }
-
-    // P37-W7c: Record corrected operations for coverage analysis.
-    if skipped_count > 0 {
-        eprintln!(
-            "P37-W7c: {skipped_count} operations were corrected to valid              alternatives (coverage could be improved with state-aware generation)"
-        );
     }
 
     join_session(live, live_server).await;

--- a/crates/ry-lsp/tests/w8_session.rs
+++ b/crates/ry-lsp/tests/w8_session.rs
@@ -322,9 +322,16 @@ impl SessionModel {
                     source: *source,
                 })
             }
-            Operation::FullEdit { source, .. } | Operation::IncrementalEdit { source, .. } => {
+            Operation::FullEdit { source, .. } => {
                 let open: Vec<u8> = self.open_docs.keys().copied().collect();
                 nth(&open).map(|f| Operation::FullEdit {
+                    file: f,
+                    source: *source,
+                })
+            }
+            Operation::IncrementalEdit { source, .. } => {
+                let open: Vec<u8> = self.open_docs.keys().copied().collect();
+                nth(&open).map(|f| Operation::IncrementalEdit {
                     file: f,
                     source: *source,
                 })
@@ -596,9 +603,12 @@ async fn w8_convergence_property(operations: Vec<Operation>) -> Result<(), TestC
     let mut model = SessionModel::default();
 
     for (step, operation) in operations.into_iter().enumerate() {
-        // P37-W7c: Correct invalid operations to valid alternatives so
-        // every generated op contributes coverage instead of being
-        // silently skipped by the executor.
+        // Correct an invalid operation by retargeting it within the same
+        // operation kind (a different open doc, a different free slot).
+        // Ops with no valid same-kind target — RenameFile without a free
+        // destination slot, AddFolder when the second folder already
+        // exists, RemoveFolder when it does not — have no semantic
+        // replacement, so they are deliberately skipped.
         let operation = if !model.is_valid(&operation) {
             match model.valid_alternative(&operation) {
                 Some(valid) => valid,


### PR DESCRIPTION
Closes #82.

Every [verified]/[reported] item was checked against current `main`; each was either fixed to an assertion that provably fails, deleted, or documented down to what it actually checks — per the issue's acceptance criterion, demonstrated by mutating production code and observing failures, not inspection.

## Disposition per item

1. **[verified] `ry-analysis/src/check.rs` — workspace-context test.** Was: attach dplyr, assert diagnostics non-empty (passes with the context ignored entirely). Now: same `rlang`-narrowing source run with and without the context, asserting the RY070 flip in both directions. *Mutation: forcing `check_project` onto an empty workspace fails the with-rlang run (RY070 1 != 0).*
2. **[verified] `p38_feature_diff.rs:187` — vacuous assertion.** Stale: the file was deleted in #79. Pruned from the issue.
3. **[reported] `ry-analysis/src/symbols.rs` — resolution claim.** Verified real: `SymbolIndex` has no position-resolution API, so the comment described behavior the API cannot express while the assertion checked a start offset any merge produces. Now asserts both per-file definitions survive the merge and b.R's call stays indexed as a reference. *Mutation: disabling `add_reference` fails the references assertion (0 != 1).*
4. **[verified] `ry-analysis/tests/property.rs` — loop bound as content.** `format!("v{}", n)` → `format!("v{i}")`, so successive applies actually change content. *Mutation: a host that skips the revision bump when a write changes existing content fails the fixed test (shrinks to n=2); the old body passes under the same mutation — the old test could not see that behavior.*
5. **[reported] `property.rs` — live-vs-fresh inputs.** The host's public API (`apply`, `revision`, `file_content`, `all_files`, `roots`, `snapshot`, `config`) exposes no open-file queries, so the fresh side cannot reconstruct open/closed state or versions. Per the no-new-API rule, the doc comment and property description now claim only final-contents equivalence — which is what the property always compared. No mutation applies to a documentation change.
6. **[reported] `p38_feature_diff.rs:44` — fixed sleep.** Stale: file deleted in #79. Pruned.
7. **[reported] `w8_session.rs` — validity funnel.** Verified real: edits-require-open plus free-slot conjunctions invalidate ~9/22 of the alphabet at sequence start, and corrections always retargeted the lowest slot. The validity rules themselves are protocol correctness and stay; corrections now rotate across candidate slots via model state (deterministic — the seed lanes replay identically). **Honest numbers:** on the 16-seed PR lane, distinct edit-target slots are 3 vs 3 — the lane is underpowered for this metric (only 3 seeds produce any corrected edit op, exactly one each); across all corrected op types, rotation does move targets (e.g. seed `0x0fed…` hits slots [1,2] rotated vs [0,1] always-first). No coverage regressed; no convergence failures surfaced.
8. **[reported] `w8_session.rs` — counter/message mismatch.** Verified real: counted ops failing `is_valid` (a superset of both "corrected" and "skipped") while reporting them as "corrected", with a comment claiming it "should remain zero" (it almost never was). Deleted — counter, increment, comment, and eprintln. Not replaced.

The issue's Related note (`cases: 8` in the w10 config) was resolved in #81/#93: the failure it hid was a harness race, the seeds are committed and replay every run, and a deterministic regression test plus a one-off 256-case run during #94 gate the property.

## Gates

`cargo test --workspace`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt --all -- --check` — all green. Mutation artifacts (a proptest regressions entry pinned to the deliberately broken case) were removed; the tree contains only the reviewed changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved type-narrowing diagnostics when the required package is available or missing.
  - Improved language server session recovery by rotating through eligible file targets, helping sessions converge more reliably.
  - Corrected revision tracking behavior across repeated file updates.
  - Improved duplicate-symbol indexing validation for definitions and references.

- **Tests**
  - Strengthened analysis and language server coverage.
  - Removed misleading stale-coverage and skipped-operation reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->