### PR TITLE
docs: Orwell/STE writing pass plus stale-record corrections

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,7 +99,7 @@ bunx @vscode/vsce package --no-dependencies
 
 This is required because `vsce`'s dependency walker cannot read
 `bun.lock`, so a non-bundled extension mis-resolves `node_modules`.
-Bundling with esbuild sidesteps this.
+Bundling with esbuild avoids this.
 
 ### Zed extension
 

--- a/README.md
+++ b/README.md
@@ -77,8 +77,8 @@ ry check demo.R
 ```
 
 Diagnostics use the `full` format by default – the offending line with
-the span underlined – and messages carry the context you need to act,
-e.g. a column miss lists what IS there:
+the span underlined – and messages carry the context you need to act;
+for example, an undefined-column diagnostic lists the available columns.
 
 ``` bash
 ry check /tmp/ry-readme/analysis.R
@@ -90,8 +90,8 @@ ry check /tmp/ry-readme/analysis.R
 
 Exit codes are CI-friendly: non-zero when any error-level diagnostic
 fires (`--exit-zero` overrides; `--error-on-warning` promotes warnings).
-Human-readable diagnostics use ANSI color on terminals; select the policy
-explicitly with `--color auto|always|never`. Automatic color respects
+Human-readable diagnostics use ANSI color on terminals; select the
+color policy with `--color auto|always|never`. Automatic color respects
 `NO_COLOR`, and machine-readable formats never contain ANSI escapes.
 
 ## Package awareness
@@ -120,10 +120,10 @@ recipes, mirai, and others. Packages attached outside the checked
 sources can be declared in `ry.toml`.
 
 When checking a package source tree, files are checked in their
-evaluation context: executable `tests/testthat/` and `inst/tinytest/` files see
+evaluation context. Executable `tests/testthat/` and `inst/tinytest/` files see
 the package’s own namespace, the test framework, DESCRIPTION
 `Depends` / `Suggests`, and bindings plus `library()` calls from
-`helper*` / `setup*` files; `data-raw/`, `demo/`, and `vignettes/`
+`helper*` / `setup*` files. `data-raw/`, `demo/`, and `vignettes/`
 attach `Depends`. `revdep/`, `src/`, snapshot data, and
 `.Rbuildignore` matches (never `R/` or `tests/`) are skipped. R files nested
 under `tests/` are treated as fixture data unless they are runners at
@@ -175,8 +175,8 @@ rlang’s `{{ }}` embrace, the `.data` / `.env` pronouns, `!!` / `!!!`,
 and functions that defuse their own arguments (a parameter whose first
 use is `enquo()` / `substitute()` / …) are recognized, so wrapper
 functions do not produce false unbound-variable reports. When the
-masked data’s schema is unknown, column candidates stay silent rather
-than guessed at.
+masked data’s schema is unknown, ry stays silent rather than guessing
+at column candidates.
 
 ## Configuration (`ry.toml`)
 

--- a/docs/architecture/analysis-query-engine.md
+++ b/docs/architecture/analysis-query-engine.md
@@ -37,8 +37,10 @@ The `ry-analysis` crate currently implements manual revisioned storage:
 - The `Project` in ry-checker already has hand-maintained incremental state
   (`collected_files`, `file_known_vars`) that duplicates what a query engine
   would provide automatically
-- The pre-existing convergence bug (`w10_session_converges_to_fresh_server`)
-  is exactly the kind of incremental invalidation error that Salsa prevents
+- The `w10_session_converges_to_fresh_server` failure (#81) was recorded here as
+  the kind of incremental invalidation error Salsa prevents. #93 later
+  diagnosed it as a race in the w10 test harness, not the checker; it is fixed
+  and no longer counts against manual invalidation.
 
 ### Salsa evaluation
 
@@ -77,8 +79,8 @@ Rationale:
 3. Migrating to Salsa requires restructuring `Project::check()` which has
    interior mutation, multi-pass collection, and fixpoint iteration — none of
    which fit Salsa's pure-function model without significant refactoring.
-4. The pre-existing convergence bug should be fixed by improving the manual
-   invalidation in the LSP's `ProjectCache`, not by adopting Salsa.
+4. The convergence failure (#81) was resolved without Salsa: it was a race in
+   the w10 test harness, fixed in #93, not a defect in manual invalidation.
 
 **Rollback trigger:** If more than 3 incremental invalidation bugs are found
 in the LSP session convergence tests, re-evaluate Salsa adoption.

--- a/docs/architecture/plans-37-39-acceptance.md
+++ b/docs/architecture/plans-37-39-acceptance.md
@@ -49,7 +49,8 @@ All 12 workstreams merged:
 
 ## Test summary
 - **970 workspace tests pass**
-- **1 pre-existing convergence failure** (w10_session_converges, tracked)
+- **1 pre-existing convergence failure** (w10_session_converges, tracked;
+  later diagnosed as a race in the w10 test harness and fixed, see #81)
 - **0 clippy warnings**
 - **Dependency edges enforced** by CI gate
 

--- a/docs/corpus/0.9-release-evidence.md
+++ b/docs/corpus/0.9-release-evidence.md
@@ -145,10 +145,11 @@ shrunk by proptest to 3 operations — well under the 10-operation bound.
 
 ## Remaining known gaps
 
-1. **Warm-start cache** (`cache::lookup`/`cache::store`): explicitly deferred.
-   The current format round-trips only `known_vars`, `callable_vars`, and
-   `RType::Unknown`. A future plan must specify a complete `CollectedFile`
-   round trip before wiring.
+1. **Warm-start cache**: explicitly deferred. The unwired draft
+   (`crates/ry-checker/src/cache.rs`) round-tripped only `known_vars`,
+   `callable_vars`, and `RType::Unknown`; it has since been deleted (see
+   `docs/architecture/cache-decision.md`). A future plan must specify a
+   complete `CollectedFile` round trip before wiring a cache.
 
 2. **Precision**: 5.08% overall (4.20% `R/`). The dominant FP source is RY010
    (476 FP — imported/generated/data bindings that exist at runtime). This

--- a/docs/corpus/README.md
+++ b/docs/corpus/README.md
@@ -49,14 +49,14 @@ field selects how a delta is treated:
   missing/unowned delta is printed for visibility but does **not** gate the
   build; re-audit and regenerate the ledger to update it.
 
-In both modes, findings labelled `true_positive` are checked explicitly so a
+In both modes, findings labeled `true_positive` are checked explicitly so a
 real bug disappearing is always surfaced.
 
 ## Regenerating the posit ledger
 
 The posit ledger is generated — never hand-written — from the audit working
 directory, so the 1,142 identities and the 34/1108 classification are re-derived
-from the audited artefacts every time. The generator lives with the audit data
+from the audited artifacts every time. The generator lives with the audit data
 (`ry-audits/posit-corpus/transcribe-corpus.R`) and is deliberately not vendored
 here: it reads a private audit checkout, and this repo carries only the
 resulting ledger.

--- a/docs/editor-defaults.md
+++ b/docs/editor-defaults.md
@@ -38,7 +38,7 @@ The default-enabled rules use the ordinary ry configuration/filter seam
 ## Precision implications
 
 At `minConfidence: "low"` with the default rule set, the editor shows all
-rules with at least low confidence. This means some false positives appear,
+rules with at least low confidence. Some false positives still appear,
 particularly for RY010 in packages with dynamic bindings. Users who want
 fewer false positives can:
 

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -1,7 +1,7 @@
 # Release Runbook
 
-This document covers the release process for ry core binary, VS Code
-extension, and Zed extension. Follow these steps in order.
+This document covers the release process for the ry core binary, the
+VS Code extension, and the Zed extension. Follow these steps in order.
 
 ## Pre-release checklist
 
@@ -83,6 +83,7 @@ v{version}  (e.g. v0.9.0)
 
 3. Post-publish smoke test:
    - Install the extension from the marketplace in a clean VS Code
+     installation
    - Open an R file
    - Verify diagnostics fire
    - Check the status bar shows the correct version
@@ -125,5 +126,5 @@ After all artifacts are published:
 - VS Code extension uses its own SemVer (e.g. `0.1.0`).
 - Zed extension uses its own SemVer (e.g. `0.1.0`).
 - Each extension release records the exact core tag it packages.
-- The CHANGELOG records core version changes; extension releases are
-  recorded in their respective marketplace listings.
+- The CHANGELOG records core version changes; extension releases appear
+  in their marketplace listings.


### PR DESCRIPTION
## What this is

A writing-quality pass over the living documentation, using Orwell's rules from "Politics and the English Language" and the ASD-STE100 baseline for technical prose: short sentences, named actors, one term per concept, American spelling. The author's voice is already direct and specific, so this is a polish, not a rewrite. Meaning, tables, code blocks, commands, and links are preserved; tables and code are byte-identical.

## Classification

| File | Classification | Treatment |
| :-- | :-- | :-- |
| `README.md` | Living (user-facing) | Full pass |
| `CONTRIBUTING.md` | Living (dev-facing) | Full pass |
| `docs/release-runbook.md` | Living (ops-facing) | Full pass |
| `docs/editor-defaults.md` | Living (dev-facing) | Full pass; evidence tables untouched |
| `docs/corpus/README.md` | Living | Full pass |
| `docs/architecture/analysis-query-engine.md` | Decision record (ADR) | No style pass; factual correction only |
| `docs/architecture/cache-decision.md` | Decision record (ADR) | Left as-is (verified accurate: `cache.rs` is gone) |
| `docs/architecture/p38-progress.md` | Progress record | Left as-is |
| `docs/architecture/p38-w12-acceptance.md` | Acceptance record | Left as-is (already carries the #93 note) |
| `docs/architecture/p39-acceptance.md` | Acceptance record | Left as-is |
| `docs/architecture/p39-w1-catalog-design.md` | Design record | Left as-is |
| `docs/architecture/plans-37-39-acceptance.md` | Acceptance record | Factual correction only |
| `docs/architecture/project-remediation-plan.md` | Plan record (dated 2026-08-12) | Left as-is; predates #93 |
| `docs/corpus/0.9-release-evidence.md` | Evidence record | Factual correction only |
| `docs/corpus/parser-option-audit-0.9.md` | Audit record | Left as-is |
| `docs/corpus/plan34-measurement.md` | Measurement record | Left as-is |
| `docs/corpus/rule-evidence-0.9.md` | Evidence record | Left as-is |
| `CHANGELOG.md` | Historical record | Left as-is (entries for #93/#94/#95 present) |
| `comms.md` | Not present in the repo | n/a |

Out of scope per task (not touched): `ecosystem/*.md` (generated reports and analysis notes), `editors/code/*.md` (extension marketplace README and CHANGELOG).

## Kinds of changes

1. **Plain English for a compressed aside** (README):
   - Before: "messages carry the context you need to act, e.g. a column miss lists what IS there:"
   - After: "messages carry the context you need to act; for example, an undefined-column diagnostic lists the available columns."
   - Uses the rule's registered name (`undefined-column`), replacing the ad-hoc "column miss".
2. **Shorter sentences, one statement each** (README): the 60-word package evaluation-context sentence is now three sentences; nothing added or dropped.
3. **Active voice with a named actor** (README): "column candidates stay silent rather than guessed at" -> "ry stays silent rather than guessing at column candidates."
4. **Cut words that did no work** (README): "select the policy explicitly with" -> "select the color policy with". (runbook) "extension releases are recorded in their respective marketplace listings" -> "extension releases appear in their marketplace listings". (editor-defaults) "This means some false positives appear" -> "Some false positives still appear".
5. **Stale figure of speech** (CONTRIBUTING): "Bundling with esbuild sidesteps this" -> "avoids this".
6. **Grammar and spelling** (runbook): "for ry core binary, VS Code extension" -> "for the ry core binary, the VS Code extension"; "in a clean VS Code" -> "in a clean VS Code installation". (corpus README) "labelled" -> "labeled", "artefacts" -> "artifacts" (American English throughout).

Net effect on the living docs is roughly word-neutral to slightly negative; the overall diff is +30/-25 because the three record corrections below state what actually happened.

## Stale-record corrections (vs merged code)

- `docs/architecture/analysis-query-engine.md` claimed the `w10_session_converges_to_fresh_server` failure "is exactly the kind of incremental invalidation error that Salsa prevents" and "should be fixed by improving the manual invalidation in the LSP's `ProjectCache`". #93 resolved #81 as a race in the w10 test harness (not a checker defect) and deleted `force_full_recollection`; both statements now say so.
- `docs/architecture/plans-37-39-acceptance.md` still listed "1 pre-existing convergence failure (w10_session_converges, tracked)" as open; now mirrors the #93 note already recorded in `p38-w12-acceptance.md`.
- `docs/corpus/0.9-release-evidence.md` described `cache::lookup`/`cache::store` as current code whose "current format round-trips only `known_vars`, `callable_vars`, and `RType::Unknown`". `crates/ry-checker/src/cache.rs` was deleted in P38-W10; the entry now says the unwired draft was deleted and points at `cache-decision.md`.

## Flagged for #83

Doc-vs-code contradictions where I could not tell which side is right. I did not rewrite any of them.

1. **README.md:295-297 vs README.md:317-320** — "Diagnostics cover the whole project, exactly as `ry check` does" sits eleven paragraphs above a Note saying "Diagnostics cover only files you have open in the editor. `ry check .` may report additional findings in files you haven't opened." The code supports both halves of the apparent contradiction: the check is project-wide (`crates/ry-lsp/src/backend.rs:2574` "Diagnostics are project-wide"), but `publish_diagnostics` publishes "for every open document" (`backend.rs:2198-2200`; it iterates `state.docs.keys()`), so unopened files never get a publish. Which sentence should win needs a decision, not a rewrite.
2. **docs/editor-defaults.md:30-34** — the policy table mislabels rules against the registry in `crates/ry-checker/src/rules.rs`: "RY020 (type mismatch)" is `unary-minus-type`, "RY030 (scope error)" is `invalid-comparison`, "RY040 (invalid operation)" is `invalid-arithmetic`, "RY090 (partial argument name)" is `unknown-argument`.
3. **docs/editor-defaults.md:35 vs docs/corpus/rule-evidence-0.9.md:84** — editor-defaults says RY032 is "Disabled / Default-off" with "70/70 false positives in test fixtures"; the 0.9 verdict table says RY032 is "keep" (1 TP / 47 FP in the hermetic ledger), and `crates/ry-checker/tests/rule_evidence.rs` gates `enabled_by_default` as true for every rule except RY003.
4. **docs/editor-defaults.md:36** — "minConfidence ... Filters zero-confidence heuristics while retaining all corpus TP", but `Confidence` has only `Low`/`Medium`/`High` (`crates/ry-core/src/diagnostic.rs:30-34`); no zero-confidence tier exists.
5. **CONTRIBUTING.md:69-72** — references `scripts/audit_typeshed.R` ("runs in CI") and `scripts/gen_typeshed.R <pkg>`; neither file exists in the repo (`scripts/` contains only `oracle.sh`, `oracle_driver.R`, `sync_typeshed.sh`). They may live in the r-typeshed repo, but the path as written is wrong.

## Deliberately left as-is

- README's opening voice ("R will happily coerce, recycle, and partially match its way past most of these mistakes ... hand you a statistically wrong answer instead of an error") and "not a surprise halfway through your simulation study": vivid, precise, and the author's own. Sanding it flat would lose information about *why* the mistakes are dangerous.
- "configuration/filter seam", "ground truth", "oracle", "provenance", "hermetic": established project terms with exact meanings here; each keeps one spelling across the docs.
- Parenthetical "(e.g. `0.9.0`)" in the runbook and the README settings table: compact standard usage; converting prose but not tables (which must stay byte-identical) would create an inconsistency, so both keep "e.g.".
- The VS Code Note in README (see flag 1) was left untouched because its content is under #83 review.