### PR TITLE
refactor(checker): deduplicate operator S3-generic list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,15 @@ All notable changes to ry are documented in this file.
 
 ### Changed
 
+- **Deduplicated the operator S3-generic list (#42)**: `is_operator_generic`
+  now answers from `semantic_lists::OPERATORS` instead of restating the same
+  13 Arith + Compare symbols as match arms, so the S3 method-name splitter
+  and the method-registration predicate share one registered constant. The
+  recognized operator set is unchanged; a new test iterates the list against
+  the predicate, with negative samples for the operator symbols that must
+  stay unrecognized, so the two representations cannot silently drift.
+  `is_operator_symbol` remains a separate, documented set covering all
+  plain operator tokens for RY010 suppression.
 - `Project`'s six environment setters (`set_loaded`, `set_bare_loaded`,
   `set_external_bindings`, `set_imported_from`, `set_external_s3_methods`,
   `set_load_bindings`) and `set_user_stubs` are equality-aware: reinstalling

--- a/crates/ry-checker/src/infer/index.rs
+++ b/crates/ry-checker/src/infer/index.rs
@@ -445,6 +445,15 @@ pub(crate) fn is_return_call(e: &Expr) -> bool {
 /// These are commonly user-defined or package-imported operators that
 /// the checker cannot resolve against any scope, typeshed, or FnTable.
 /// Used to suppress spurious RY010 (unbound variable) on such names.
+///
+/// This list deliberately covers a different set than
+/// [`crate::semantic_lists::OPERATORS`]: RY010 suppression wants every
+/// plain operator token (Logic, assignment, sequence, and access
+/// operators included), while operator S3 dispatch is modeled only for
+/// the Arith + Compare members (see [`is_operator_generic`]). The
+/// `%`-wrapped operators (`%%`, `%/%`, user-defined `%foo%`) are absent
+/// because the call site tests `contains('%')` before consulting this
+/// predicate, so the two lists must not be unified.
 pub(crate) fn is_operator_symbol(s: &str) -> bool {
     matches!(
         s,
@@ -620,11 +629,18 @@ pub(crate) fn is_dplyr_control_arg(name: &str) -> bool {
     )
 }
 
+/// Whether `name` is an operator that ry models as an S3 generic, e.g. the
+/// `+` in `` `+.widget` ``. This is exactly the Arith + Compare operator
+/// set registered as [`crate::semantic_lists::OPERATORS`] and already used
+/// by the S3 method-name splitter, so the predicate reads that constant
+/// rather than restating the symbols; the two users cannot drift apart.
+///
+/// Membership is pinned to R's own Arith and Compare group definitions by
+/// the oracle test in `tests/semantic_lists.rs`. Logic and other operator
+/// tokens are deliberately outside the set: they are RY010-suppression
+/// operator symbols (see [`is_operator_symbol`]), not modeled generics.
 pub(crate) fn is_operator_generic(name: &str) -> bool {
-    matches!(
-        name,
-        "+" | "-" | "*" | "/" | "^" | "%%" | "%/%" | "==" | "!=" | "<" | "<=" | ">" | ">="
-    )
+    crate::semantic_lists::OPERATORS.contains(&name)
 }
 
 pub(crate) fn insert_s3_dispatch_context(method_name: &str, scope: &mut Scope, globals: &Globals) {
@@ -720,4 +736,38 @@ pub(crate) fn assigned_names_in_body(body: &[Stmt]) -> HashSet<String> {
         visit(statement, &mut names);
     }
     names
+}
+
+#[cfg(test)]
+mod operator_generic_tests {
+    use super::is_operator_generic;
+    use crate::semantic_lists::OPERATORS;
+
+    /// `is_operator_generic` must recognize exactly the members of
+    /// `semantic_lists::OPERATORS`: the same constant backs the S3
+    /// method-name splitter in `lib.rs`, so any divergence between the two
+    /// representations is an inconsistency (issue #42). The negative
+    /// samples pin the set to the Arith + Compare members -- Logic,
+    /// assignment, sequence, and access operators are operator symbols
+    /// for RY010 suppression but never operator generics, `%in%` is a
+    /// function-backed infix operator outside both dispatch groups, and a
+    /// full method name like `+.foo` is split before this predicate runs.
+    /// Reinstating a separate hardcoded symbol set here fails this test.
+    #[test]
+    fn operator_generic_recognizes_exactly_the_operators_list() {
+        for operator in OPERATORS {
+            assert!(
+                is_operator_generic(operator),
+                "OPERATORS member {operator:?} must be recognized as an operator generic"
+            );
+        }
+        for non_generic in [
+            "&", "|", "&&", "||", "!", ":", "<-", "<<-", "=", "~", "$", "@", "?", "%in%", "+.foo",
+        ] {
+            assert!(
+                !is_operator_generic(non_generic),
+                "{non_generic:?} is not an Arith/Compare operator and must not be recognized"
+            );
+        }
+    }
 }


### PR DESCRIPTION
## Summary

The 13 Arith + Compare operator symbols were encoded twice in ry-checker: as the `OPERATORS` const in `semantic_lists.rs` (consumed by the S3 method-name splitter) and as match arms in `is_operator_generic` (`infer/index.rs`). Adding an operator to one without the other would silently create an inconsistency, and nothing asserted the two agreed.

`is_operator_generic` now reads `crate::semantic_lists::OPERATORS`, matching how the `infer` tree already consumes registry constants (`DEFUSING_CALLS.contains(&..)` in `infer/misc.rs`, `NAME_CARRYING_CONTAINERS` in `infer/recall.rs`). Both users share one representation.

Note: issue #42's line numbers had drifted - `OPERATORS` was since promoted out of `lib.rs` into `semantic_lists.rs` (the crate's single-source-of-truth registry, oracle-checked against R's `Arith` + `Compare` groups), and `index.rs` became `infer/index.rs`. The duplication itself was still real.

Closes #42.

## Test added

`operator_generic_recognizes_exactly_the_operators_list` in `infer/index.rs`:
- positive loop: every `OPERATORS` member is recognized by `is_operator_generic`
- negative loop: Logic (`&`, `|`, `&&`, `||`, `!`), sequence (`:`), assignment (`<-`, `<<-`, `=`), access (`$`, `@`, `?`), formula (`~`), `%in%`, and unsplit method names (`+.foo`) must stay unrecognized

The two lists can no longer silently drift.

## Behavior unchanged

Removed match arms: `"+" | "-" | "*" | "/" | "^" | "%%" | "%/%" | "==" | "!=" | "<" | "<=" | ">" | ">="` - the identical 13 strings as the `OPERATORS` const, so the recognized set is bit-for-bit the same. The existing `operators_match_r_oracle` test still pins membership to `getGroupMembers("Arith") U getGroupMembers("Compare")` and ran green against the installed R 4.6.1.

## `is_operator_symbol` deliberately not unified

It is not actually a strict superset of `OPERATORS` (it lacks `%%`/`%/%` because its call site in `infer/mod.rs` tests `contains('%')` first) and serves a different purpose (RY010 suppression over plain operator tokens). Its doc comment now records that relationship explicitly.

Also verified against R 4.6.1: R dispatches `&.foo`/`!.foo` as individual methods, so the 13-element Arith + Compare set is ry's modeling choice, not an R restriction - the new doc comment is worded accordingly. Widening the set is out of scope for a zero-behavior-change dedup.

## Gates

- `cargo test --workspace` - ok, 0 failures (includes the R oracle gate)
- `cargo clippy --workspace --all-targets -- -D warnings` - clean
- `cargo fmt --all -- --check` - clean
