### PR TITLE
feat(cli): add ry dump-types subcommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to ry are documented in this file.
 
 ## [Unreleased]
 
+### Added — `ry dump-types` CLI
+
+- **Non-interactive type dump**: `ry dump-types <FILE>...` runs one
+  analysis pass (identical pipeline and environment to `ry check`) and
+  prints every lexical scope of the requested files as JSON on stdout:
+  scope kind/name/extent plus each binding's name, kind
+  (`param`/`local`/`closed-over`/`imported`), type string (the same
+  `Display` rendering the LSP hover returns; `unknown` when inference
+  has nothing), and definition site. `--position LINE:COL` (repeatable)
+  restricts output to the innermost scope containing each position and
+  drops locals assigned after it. `--project-root <DIR>` overrides the
+  analysis root for non-package files; the default mirrors `ry check`'s
+  per-package (DESCRIPTION) grouping. Exit code stays 0 even when the
+  analyzed code has diagnostics; non-zero only for usage, IO, or
+  internal failure.
+- **Opt-in scope capture in the checker**: `Checker` and `Project` can
+  snapshot every completed lexical scope during the pass-3 diagnostic
+  walk (`ry_checker::ScopeRecord`); recording is suppressed in
+  discarding mode so fixpoint and signature-building re-walks never
+  double-capture. `ry_analysis::check_project_with_scope_capture`
+  exposes it through the shared check pipeline. Existing commands and
+  checker behavior are unchanged.
+
 ### Plan 37: Release truth and editor hardening
 
 #### P37-W1: Parser UTF-8 boundary panic fix

--- a/README.md
+++ b/README.md
@@ -245,17 +245,21 @@ ry dump-types R/analysis.R --position 4:5
 ```
 
 A directory argument expands to every discoverable R file under it,
-using `ry check`’s discovery rules. `--project-root <DIR>` overrides the
-analysis root for non-package files; by default each file is analyzed in
-the context of its nearest enclosing package (the ancestor directory
-with a `DESCRIPTION`), else the working directory — mirroring `ry check`’s
-per-package grouping. The exit code is 0 even when the analyzed code has
+using `ry check`’s discovery rules, including the discovered `ry.toml`’s
+`exclude` patterns. `--project-root <DIR>` overrides the analysis root
+for non-package files; by default each file is analyzed in the context
+of its nearest enclosing package (the ancestor directory with a
+`DESCRIPTION`), else the directory owning the discovered `ry.toml`, else
+the working directory — mirroring `ry check`’s per-package grouping. The
+exit code is 0 even when the analyzed code has
 diagnostics; it is non-zero only for usage, IO, or internal failure.
 Scopes reflect the checker’s snapshot semantics: each table is the
 scope’s state at the end of its body, and a nested function captures the
 enclosing scope as of its definition point (ry’s documented closure
 approximation). Anonymous function literals used as call arguments are
-inferred in discarding mode and are therefore not recorded as scopes.
+inferred in discarding mode and are therefore not recorded as scopes —
+but named functions defined *inside* such a callback do complete and are
+recorded, so a dump can contain a scope whose enclosing scope is absent.
 
 ## Configuration (`ry.toml`)
 

--- a/README.md
+++ b/README.md
@@ -178,6 +178,85 @@ functions do not produce false unbound-variable reports. When the
 masked data’s schema is unknown, ry stays silent rather than guessing
 at column candidates.
 
+## Dumping inferred types
+
+`ry dump-types` is the non-interactive counterpart of the LSP hover: it
+runs one analysis pass (the same pass `ry check` runs, over the same
+package-aware environment) and prints every lexical scope of the
+requested files as JSON on stdout. Downstream tooling can query which
+bindings a scope holds and with what inferred types, without re-running
+the checker per position.
+
+``` bash
+ry dump-types R/analysis.R
+#> {
+#>   "files": [
+#>     {
+#>       "path": "R/analysis.R",
+#>       "scopes": [
+#>         {
+#>           "kind": "function",
+#>           "name": "moving_average",
+#>           "start": [3, 19],
+#>           "end": [8, 2],
+#>           "bindings": [
+#>             { "name": "n", "kind": "param", "type": "integer<len=1>", "start": [3, 31] },
+#>             { "name": "threshold", "kind": "closed-over", "type": "integer<len=1>", "start": [1, 1] },
+#>             { "name": "window", "kind": "local", "type": "function<len=1>", "start": [4, 3] },
+#>             { "name": "x", "kind": "param", "type": "unknown", "start": [3, 28] }
+#>           ]
+#>         }
+#>       ]
+#>     }
+#>   ]
+#> }
+```
+
+Positions are 1-based `[row, column]` pairs; columns count characters,
+not bytes. Scopes are ordered by start position, bindings by name.
+`type` is the same string the LSP hover shows; `unknown` marks bindings
+ry could not infer, and never fails the run.
+
+Binding kinds:
+
+- `param` — a formal of this scope that the body never reassigns. A
+  reassigned formal degrades to `local` at its reassignment site
+  (R rebinds rather than narrows).
+- `local` — first assigned inside this scope’s own body (assignments in
+  `if` / `for` / `while` bodies and braced value blocks count; they bind
+  in the enclosing function in R).
+- `closed-over` — function scopes only: present because the body’s
+  scope is cloned from the enclosing one at the point of definition.
+- `imported` — top-level bindings the file never assigns, supplied by
+  the host environment (for example Shiny server fragments, where
+  `input` / `output` / `session` are ambient).
+
+Each binding’s `start` points at its definition site — the formal, the
+first assignment, or, for `closed-over`, the site in the nearest
+enclosing scope that defines the name (`null` when none is recorded).
+
+`--position LINE:COL` (repeatable) restricts output to the innermost
+scope containing each position and drops locals assigned after it,
+answering "which bindings are in scope at line N":
+
+``` bash
+ry dump-types R/analysis.R --position 4:5
+#> (only moving_average’s scope; window is still assigned at 4:3, x and n are visible)
+```
+
+A directory argument expands to every discoverable R file under it,
+using `ry check`’s discovery rules. `--project-root <DIR>` overrides the
+analysis root for non-package files; by default each file is analyzed in
+the context of its nearest enclosing package (the ancestor directory
+with a `DESCRIPTION`), else the working directory — mirroring `ry check`’s
+per-package grouping. The exit code is 0 even when the analyzed code has
+diagnostics; it is non-zero only for usage, IO, or internal failure.
+Scopes reflect the checker’s snapshot semantics: each table is the
+scope’s state at the end of its body, and a nested function captures the
+enclosing scope as of its definition point (ry’s documented closure
+approximation). Anonymous function literals used as call arguments are
+inferred in discarding mode and are therefore not recorded as scopes.
+
 ## Configuration (`ry.toml`)
 
 Discovered by walking up from the checked path. All keys optional:

--- a/crates/ry-analysis/src/check.rs
+++ b/crates/ry-analysis/src/check.rs
@@ -30,7 +30,11 @@ pub struct CheckOutput {
 /// This is the single entry point for diagnostics computation.
 /// ry-cli calls this instead of coordinating Project setters.
 pub fn check_project(input: CheckInput) -> CheckOutput {
-    let mut project = apply_workspace(ry_checker::Project::new(), input.workspace.as_ref(), &input.user_stubs);
+    let mut project = apply_workspace(
+        ry_checker::Project::new(),
+        input.workspace.as_ref(),
+        &input.user_stubs,
+    );
 
     // Add all files.
     for (path, _, file) in &input.files {
@@ -55,8 +59,11 @@ pub fn check_project(input: CheckInput) -> CheckOutput {
 pub fn check_project_with_scope_capture(
     input: CheckInput,
 ) -> Vec<(String, Vec<ry_checker::ScopeRecord>)> {
-    let mut project =
-        apply_workspace(ry_checker::Project::new(), input.workspace.as_ref(), &input.user_stubs);
+    let mut project = apply_workspace(
+        ry_checker::Project::new(),
+        input.workspace.as_ref(),
+        &input.user_stubs,
+    );
     for (path, _, file) in &input.files {
         project.add_file(path.clone(), (**file).clone());
     }

--- a/crates/ry-analysis/src/check.rs
+++ b/crates/ry-analysis/src/check.rs
@@ -30,18 +30,7 @@ pub struct CheckOutput {
 /// This is the single entry point for diagnostics computation.
 /// ry-cli calls this instead of coordinating Project setters.
 pub fn check_project(input: CheckInput) -> CheckOutput {
-    let mut project = ry_checker::Project::new();
-
-    // Apply workspace metadata.
-    let empty_workspace = ry_workspace::WorkspaceContext::default();
-    let workspace = input.workspace.as_ref().unwrap_or(&empty_workspace);
-    project.set_loaded(workspace.attached_packages.clone());
-    project.set_bare_loaded(workspace.bare_bindings.clone());
-    project.set_user_stubs(Arc::clone(&input.user_stubs));
-    project.set_external_bindings(workspace.external_bindings.clone());
-    project.set_imported_from(workspace.imported_bindings.clone());
-    project.set_external_s3_methods(workspace.s3_methods.clone());
-    project.set_load_bindings(workspace.load_bindings.clone());
+    let mut project = apply_workspace(ry_checker::Project::new(), input.workspace.as_ref(), &input.user_stubs);
 
     // Add all files.
     for (path, _, file) in &input.files {
@@ -52,6 +41,48 @@ pub fn check_project(input: CheckInput) -> CheckOutput {
     let diagnostics = project.check();
 
     CheckOutput { diagnostics }
+}
+
+/// Run the same one-shot check, additionally snapshotting every file's
+/// lexical scopes (top level plus each walked function body).
+///
+/// The pipeline is identical to [`check_project`] -- same workspace
+/// metadata, shared fixpoint, one pass -- so captured types match what a
+/// `check` run infers. Returns one `(path, records)` entry per file, in
+/// input order. Diagnostics are computed as usual but discarded: the
+/// dump consumer (`ry dump-types`) treats diagnostics as irrelevant to
+/// its exit code and output.
+pub fn check_project_with_scope_capture(
+    input: CheckInput,
+) -> Vec<(String, Vec<ry_checker::ScopeRecord>)> {
+    let mut project =
+        apply_workspace(ry_checker::Project::new(), input.workspace.as_ref(), &input.user_stubs);
+    for (path, _, file) in &input.files {
+        project.add_file(path.clone(), (**file).clone());
+    }
+    project.enable_scope_capture();
+    project.check();
+    project.take_scope_records()
+}
+
+/// Install the workspace metadata onto a fresh project. Shared by
+/// [`check_project`] and [`check_project_with_scope_capture`] so the two
+/// entry points can never drift in what environment they model.
+fn apply_workspace(
+    mut project: ry_checker::Project,
+    workspace: Option<&ry_workspace::WorkspaceContext>,
+    user_stubs: &Arc<BTreeMap<String, ry_typeshed::Typeshed>>,
+) -> ry_checker::Project {
+    let empty_workspace = ry_workspace::WorkspaceContext::default();
+    let workspace = workspace.unwrap_or(&empty_workspace);
+    project.set_loaded(workspace.attached_packages.clone());
+    project.set_bare_loaded(workspace.bare_bindings.clone());
+    project.set_user_stubs(Arc::clone(user_stubs));
+    project.set_external_bindings(workspace.external_bindings.clone());
+    project.set_imported_from(workspace.imported_bindings.clone());
+    project.set_external_s3_methods(workspace.s3_methods.clone());
+    project.set_load_bindings(workspace.load_bindings.clone());
+    project
 }
 
 #[cfg(test)]
@@ -149,5 +180,29 @@ mod tests {
             .map(|(_, d)| d.len())
             .unwrap_or(0);
         assert_eq!(b_diags, 0, "cross-file function call should resolve");
+    }
+
+    #[test]
+    fn check_project_with_scope_capture_returns_records_per_file() {
+        let mut parser = ry_core::RParser::new().unwrap();
+        let file = parser
+            .parse("a.R", "f <- function(x = 1L) { y <- x\n y }\n")
+            .unwrap();
+        let records = check_project_with_scope_capture(CheckInput {
+            files: vec![("a.R".to_string(), 0, Arc::new(file))],
+            user_stubs: Arc::new(BTreeMap::new()),
+            workspace: None,
+        });
+        assert_eq!(records.len(), 1);
+        let (path, file_records) = &records[0];
+        assert_eq!(path, "a.R");
+        // Exactly the top scope and the one function scope.
+        assert_eq!(file_records.len(), 2, "{file_records:?}");
+        let function = file_records
+            .iter()
+            .find(|r| r.kind == ry_checker::ScopeRecordKind::Function)
+            .expect("function scope recorded");
+        assert_eq!(function.name.as_deref(), Some("f"));
+        assert_eq!(function.params.len(), 1);
     }
 }

--- a/crates/ry-analysis/src/lib.rs
+++ b/crates/ry-analysis/src/lib.rs
@@ -8,4 +8,4 @@
 
 pub mod check;
 
-pub use check::{CheckInput, CheckOutput, check_project};
+pub use check::{CheckInput, CheckOutput, check_project, check_project_with_scope_capture};

--- a/crates/ry-checker/src/infer/mod.rs
+++ b/crates/ry-checker/src/infer/mod.rs
@@ -261,7 +261,7 @@ impl Checker {
                 // runs in discarding mode and emits nothing on its own, so
                 // without this walk almost all real R code would go
                 // unchecked.
-                if let Expr::Function { params, body, .. } = value {
+                if let Expr::Function { params, body, span } = value {
                     let mut fn_scope = scope.clone();
                     if let Some(captures) = self.deferred_captures.last() {
                         for capture in captures {
@@ -308,6 +308,7 @@ impl Checker {
                     for s in body {
                         self.walk_stmt(s, &mut fn_scope, None);
                     }
+                    self.record_scope(binding_name(target), *span, params, &fn_scope);
                     self.vector_intent_parameters.pop();
                     self.enclosing_formals.pop();
                     self.deferred_captures.pop();
@@ -516,7 +517,10 @@ impl Checker {
                 }
             }
             Stmt::FunctionDef {
-                name, params, body, ..
+                name,
+                params,
+                body,
+                span,
             } => {
                 let vt = self.function_value_from_literal(params, body, scope, 0);
                 if let Some(n) = name {
@@ -565,6 +569,10 @@ impl Checker {
                 for s in body {
                     self.walk_stmt(s, &mut fn_scope, None);
                 }
+                // Statement-position literals are anonymous (`name` is
+                // always `None` today, but honor it if the parser ever
+                // names them).
+                self.record_scope(name.as_deref(), *span, params, &fn_scope);
                 self.vector_intent_parameters.pop();
                 self.enclosing_formals.pop();
                 self.deferred_captures.pop();

--- a/crates/ry-checker/src/lib.rs
+++ b/crates/ry-checker/src/lib.rs
@@ -379,6 +379,45 @@ impl Scope {
     }
 }
 
+/// Which lexical scope a [`ScopeRecord`] snapshot came from.
+///
+/// R has exactly two lexical scope kinds: the top level of a source file
+/// and function bodies. Braced blocks, `if` branches, and loop bodies all
+/// assign into the enclosing function's environment, so no other kinds
+/// exist to record.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ScopeRecordKind {
+    Top,
+    Function,
+}
+
+/// One lexical scope's binding table, snapshotted when the checker's
+/// diagnostic walk finishes that scope's body.
+///
+/// The snapshot is the FINAL state of the table (after the body's last
+/// statement), matching what a reader at the closing brace would observe;
+/// consumers that need "in scope at line N" semantics can use each
+/// binding's definition position, which the dump layer derives from the
+/// AST. Only the pass-3 (diagnostic-emitting) walk records scopes: the
+/// fixpoint and signature-building walks reuse the same walker but run
+/// in discarding mode, so no scope is captured twice.
+#[derive(Debug, Clone)]
+pub struct ScopeRecord {
+    pub kind: ScopeRecordKind,
+    /// The bound name for `f <- function(...)` definitions; `None` for
+    /// anonymous statement-position literals and the top level.
+    pub name: Option<String>,
+    /// Span of the function literal; the whole file for the top level.
+    pub span: Span,
+    /// `(name, span)` for every formal parameter. Parameters are also
+    /// present in `scope.bindings` (marked in `parameter_bindings`), but
+    /// the source spans live only here because `Scope` is a plain
+    /// name-to-type table.
+    pub params: Vec<(String, Span)>,
+    /// The final binding table of the scope.
+    pub scope: Scope,
+}
+
 /// A user-defined function recorded for interprocedural inference.
 /// We store the AST nodes by index into a side-table the checker owns,
 /// avoiding lifetime entanglement with the SourceFile.
@@ -678,6 +717,14 @@ pub struct Checker {
     // cache is populated only for the duration of that rewritten call, so it
     // never crosses a scope-changing inference boundary.
     pipe_argument_types: HashMap<Span, RType>,
+    // When true, the pass-3 walk snapshots every completed lexical scope
+    // into `scope_records`. Off by default so ordinary checks (and the
+    // LSP) pay nothing; `dump-types` opts in. Recording is additionally
+    // suppressed while `discarding`, which keeps the fixpoint and
+    // signature-building walks (the same walker in discarding mode) from
+    // double-capturing a body.
+    capture_scopes: bool,
+    scope_records: Vec<ScopeRecord>,
 }
 
 impl Checker {
@@ -803,6 +850,8 @@ impl Checker {
             enclosing_formals: Vec::new(),
             vector_intent_parameters: Vec::new(),
             pipe_argument_types: HashMap::new(),
+            capture_scopes: false,
+            scope_records: Vec::new(),
         }
     }
 
@@ -1189,6 +1238,52 @@ impl Checker {
         for s in &file.stmts {
             self.check_stmt(s, &mut scope);
         }
+        // The top level is itself a lexical scope in R; record it after
+        // the walk so the snapshot reflects every top-level assignment.
+        if self.capture_scopes {
+            let record = ScopeRecord {
+                kind: ScopeRecordKind::Top,
+                name: None,
+                span: whole_file_span(&self.source),
+                params: Vec::new(),
+                scope,
+            };
+            self.scope_records.push(record);
+        }
+    }
+
+    /// Opt this checker into snapshotting every completed lexical scope
+    /// during the diagnostic walk. See [`ScopeRecord`].
+    pub fn enable_scope_capture(&mut self) {
+        self.capture_scopes = true;
+    }
+
+    /// Take the scopes recorded since the last call. Empty unless
+    /// [`enable_scope_capture`](Self::enable_scope_capture) was called.
+    pub fn take_scope_records(&mut self) -> Vec<ScopeRecord> {
+        std::mem::take(&mut self.scope_records)
+    }
+
+    // Snapshot one completed function-body scope. Called at the end of
+    // `walk_stmt`'s two function-definition arms; `discarding` guards the
+    // fixpoint / signature-building re-walks of the same body.
+    pub(crate) fn record_scope(
+        &mut self,
+        name: Option<&str>,
+        span: Span,
+        params: &[Param],
+        scope: &Scope,
+    ) {
+        if !self.capture_scopes || self.discarding {
+            return;
+        }
+        self.scope_records.push(ScopeRecord {
+            kind: ScopeRecordKind::Function,
+            name: name.map(str::to_string),
+            span,
+            params: params.iter().map(|p| (p.name.clone(), p.span)).collect(),
+            scope: scope.clone(),
+        });
     }
 
     pub fn take_diagnostics(&mut self) -> Vec<Diagnostic> {
@@ -1314,6 +1409,17 @@ fn embedded_base() -> Arc<Typeshed> {
     Arc::clone(
         BASE.get_or_init(|| Arc::new(load_base_cached().expect("typeshed must load").clone())),
     )
+}
+
+/// Span covering the entire file, used as the top-level scope record's
+/// extent so position queries anywhere in the file resolve to it.
+fn whole_file_span(source: &str) -> Span {
+    let line = source.matches('\n').count();
+    let col = source
+        .rsplit_once('\n')
+        .map(|(_, last)| last.len())
+        .unwrap_or(source.len());
+    Span::new(0, source.len(), line, col)
 }
 
 #[cfg(test)]

--- a/crates/ry-checker/src/project.rs
+++ b/crates/ry-checker/src/project.rs
@@ -107,6 +107,14 @@ pub struct Project {
     /// Previous pooled known_vars set, used to detect when non-function
     /// bindings changed across files (affects RY010 diagnostics).
     prev_known_vars: HashSet<String>,
+    /// When true, pass-3 emitters snapshot each file's lexical scopes.
+    /// Off by default; see [`Checker::enable_scope_capture`].
+    capture_scopes: bool,
+    /// Scope records from the most recent emission, one entry per
+    /// re-emitted file. Files served from the incremental cache keep no
+    /// records, so a cold `check()` (which emits every file) is the
+    /// complete view.
+    scope_records: Vec<(String, Vec<crate::ScopeRecord>)>,
     /// Test-visible counter: how many files were actually emitted (not
     /// served from cache) in the most recent `refine_and_emit` call.
     /// Asserted on in unit tests the same way `parse_count` is in backend.rs.
@@ -153,6 +161,8 @@ impl Project {
             prev_fn_returns: HashMap::new(),
             prev_fn_signatures: HashMap::new(),
             prev_known_vars: HashSet::new(),
+            capture_scopes: false,
+            scope_records: Vec::new(),
             emit_count: 0,
         }
     }
@@ -246,6 +256,22 @@ impl Project {
         for p in paths {
             self.dirty_paths.insert(p);
         }
+    }
+
+    /// Opt this project into snapshotting every file's lexical scopes
+    /// during the next check. The records replace those of the previous
+    /// emission and are read back with
+    /// [`take_scope_records`](Self::take_scope_records).
+    pub fn enable_scope_capture(&mut self) {
+        self.capture_scopes = true;
+        self.scope_records.clear();
+    }
+
+    /// Take the scope records captured by the most recent check. Empty
+    /// unless [`enable_scope_capture`](Self::enable_scope_capture) was
+    /// called before it.
+    pub fn take_scope_records(&mut self) -> Vec<(String, Vec<crate::ScopeRecord>)> {
+        std::mem::take(&mut self.scope_records)
     }
 
     /// Install runtime package stubs. User packages, including `base`,
@@ -676,8 +702,9 @@ impl Project {
             .map(|(i, _)| i)
             .collect();
         self.emit_count = emit_indices.len();
+        let capture_scopes = self.capture_scopes;
 
-        let per_file: Vec<(usize, String, Vec<Diagnostic>)> = emit_indices
+        let per_file: Vec<(usize, String, Vec<Diagnostic>, Vec<crate::ScopeRecord>)> = emit_indices
             .par_iter()
             .map(|&i| {
                 let (path, file) = &self.files[i];
@@ -706,8 +733,12 @@ impl Project {
                     external_s3_methods.get(path).cloned().unwrap_or_default(),
                 );
                 emitter.set_load_bindings(load_bindings.get(path).cloned().unwrap_or_default());
+                if capture_scopes {
+                    emitter.enable_scope_capture();
+                }
                 emitter.emit_diagnostics(file);
-                (i, path.clone(), emitter.take_diagnostics())
+                let records = emitter.take_scope_records();
+                (i, path.clone(), emitter.take_diagnostics(), records)
             })
             .collect();
 
@@ -727,9 +758,21 @@ impl Project {
         // files that were not in the dirty set.
         let mut result: Vec<(String, Vec<Diagnostic>)> = Vec::with_capacity(self.files.len());
 
+        // Scope records replace the previous emission's; files served
+        // from cache contribute none (see `scope_records` on the struct).
+        let mut per_file = per_file;
+        if capture_scopes {
+            self.scope_records = per_file
+                .iter_mut()
+                .map(|(_, path, _, records)| (path.clone(), std::mem::take(records)))
+                .collect();
+        }
+
         // Build a lookup from emitted results.
-        let mut emitted_map: HashMap<usize, (String, Vec<Diagnostic>)> =
-            per_file.into_iter().map(|(i, p, d)| (i, (p, d))).collect();
+        let mut emitted_map: HashMap<usize, (String, Vec<Diagnostic>)> = per_file
+            .into_iter()
+            .map(|(i, p, d, _)| (i, (p, d)))
+            .collect();
 
         for (i, (path, _)) in self.files.iter().enumerate() {
             if let Some((p, d)) = emitted_map.remove(&i) {
@@ -881,5 +924,83 @@ mod tests {
                 .all(|diagnostic| diagnostic.code != "RY010"),
             "project calls should honor loaded stub eval metadata: {diagnostics:?}"
         );
+    }
+
+    #[test]
+    fn scope_capture_records_top_and_function_scopes_once() {
+        use crate::{Scope, ScopeRecordKind};
+
+        // A nested closure: the inner body references `base`, which only
+        // the outer scope binds, so the inner snapshot must still contain
+        // it (R's lexical capture) while the outer records it as a local.
+        // The trailing `outer()` omits both formals, which is the call
+        // evidence that lets ry commit to `x`'s default type; without a
+        // call site a defaulted formal stays opaque by design.
+        let src = "base <- 2L\nouter <- function(x = 1L, y) {\n  local <- x + base\n  inner <- function(z) z + base\n  inner(y)\n}\nouter()\n";
+        let mut project = Project::new();
+        project.add_file("a.R".to_string(), parse("a.R", src));
+        project.enable_scope_capture();
+        project.check();
+        let records = project.take_scope_records();
+        assert_eq!(records.len(), 1, "one file: {records:?}");
+        let (path, records) = &records[0];
+        assert_eq!(path, "a.R");
+
+        let mut sorted = records.clone();
+        sorted.sort_by_key(|record| record.span.start);
+        // top, outer, inner -- exactly one record each (the fixpoint and
+        // signature walks must not double-capture).
+        assert_eq!(sorted.len(), 3, "{sorted:?}");
+        assert_eq!(sorted[0].kind, ScopeRecordKind::Top);
+        assert!(sorted[0].name.is_none());
+        assert_eq!(sorted[1].kind, ScopeRecordKind::Function);
+        assert_eq!(sorted[1].name.as_deref(), Some("outer"));
+        assert_eq!(
+            sorted[1]
+                .params
+                .iter()
+                .map(|(name, _)| name.as_str())
+                .collect::<Vec<_>>(),
+            vec!["x", "y"]
+        );
+        assert_eq!(sorted[2].name.as_deref(), Some("inner"));
+
+        let outer = &sorted[1];
+        // The default-valued parameter carries its literal type; the
+        // default-less one stays opaque.
+        assert_eq!(
+            outer.scope.get("x").map(|t| t.to_string()),
+            Some("integer<len=1>".to_string())
+        );
+        assert!(outer.scope.parameter_bindings.contains("x"));
+        // Captured from the outer scope's cloned table.
+        assert!(sorted[2].scope.get("base").is_some());
+        // Local assignment present in the final snapshot.
+        assert!(outer.scope.get("local").is_some());
+        // No capture without opting in.
+        let mut plain = Project::new();
+        plain.add_file("a.R".to_string(), parse("a.R", src));
+        plain.check();
+        assert!(plain.take_scope_records().is_empty());
+    }
+
+    #[test]
+    fn scope_snapshot_is_a_plain_scope() {
+        // Compile-level guard: the recorded value is the ordinary `Scope`
+        // type, so dump consumers can use the same accessors as the LSP.
+        use crate::{Scope, ScopeRecordKind};
+        let mut project = Project::new();
+        project.add_file(
+            "a.R".to_string(),
+            parse("a.R", "f <- function(x) { y <- x\n y }\n"),
+        );
+        project.enable_scope_capture();
+        project.check();
+        let records = project.take_scope_records();
+        let _: Option<&Scope> = records[0]
+            .1
+            .iter()
+            .find(|r| r.kind == ScopeRecordKind::Function)
+            .map(|r| &r.scope);
     }
 }

--- a/crates/ry-checker/src/project.rs
+++ b/crates/ry-checker/src/project.rs
@@ -928,7 +928,7 @@ mod tests {
 
     #[test]
     fn scope_capture_records_top_and_function_scopes_once() {
-        use crate::{Scope, ScopeRecordKind};
+        use crate::ScopeRecordKind;
 
         // A nested closure: the inner body references `base`, which only
         // the outer scope binds, so the inner snapshot must still contain

--- a/crates/ry-cli/src/main.rs
+++ b/crates/ry-cli/src/main.rs
@@ -1078,10 +1078,9 @@ struct BindingDump {
 /// clap value parser for `--position LINE:COL`. Rows and columns are
 /// 1-based, matching the dump output.
 fn parse_dump_position(value: &str) -> Result<(usize, usize), String> {
-    let (line, col) =
-        value
-            .split_once(':')
-            .ok_or_else(|| format!("expected LINE:COL, got `{value}`"))?;
+    let (line, col) = value
+        .split_once(':')
+        .ok_or_else(|| format!("expected LINE:COL, got `{value}`"))?;
     let line = line
         .trim()
         .parse::<usize>()
@@ -1408,7 +1407,7 @@ fn assemble_file_dump(
                 .scope
                 .bindings
                 .iter()
-                .filter_map(|(name, ty)| {
+                .map(|(name, ty)| {
                     // A formal counts as `param` only in the scope that
                     // declares it: scope snapshots are cloned from the
                     // enclosing function, which also clones the
@@ -1418,11 +1417,13 @@ fn assemble_file_dump(
                     // rebinds rather than narrows), so it degrades to
                     // `local` at its reassignment site.
                     let is_formal_here = info.params.contains_key(name.as_str());
-                    let is_param =
-                        is_formal_here && record.scope.parameter_bindings.contains(name);
+                    let is_param = is_formal_here && record.scope.parameter_bindings.contains(name);
                     let local_span = info.locals.get(name.as_str()).copied();
                     let (kind, definition_span) = if is_param {
-                        ("param", info.params.get(name.as_str()).copied().or(local_span))
+                        (
+                            "param",
+                            info.params.get(name.as_str()).copied().or(local_span),
+                        )
                     } else if let Some(span) = local_span {
                         ("local", Some(span))
                     } else if record.kind == ry_checker::ScopeRecordKind::Function {
@@ -1433,11 +1434,11 @@ fn assemble_file_dump(
                     // A closed-over binding has no site in this scope;
                     // point at the definition in the nearest enclosing
                     // scope that binds the name, when one was recorded.
-                    let definition_span =
-                        definition_span.or_else(|| enclosing_binding_span(&infos, index, name.as_str()));
-                    Some((name, ty, kind, definition_span, is_formal_here))
+                    let definition_span = definition_span
+                        .or_else(|| enclosing_binding_span(&infos, index, name.as_str()));
+                    (name, ty, kind, definition_span, is_formal_here)
                 })
-                .filter(|(name, _, _, definition_span, is_formal_here)| {
+                .filter(|(_, _, _, definition_span, is_formal_here)| {
                     // Visibility at the selecting positions: formals bind
                     // at call entry (always visible); a local assigned
                     // after every selecting position is not yet in scope
@@ -1458,8 +1459,7 @@ fn assemble_file_dump(
                     name: name.clone(),
                     kind,
                     type_: dump_type_string(ty),
-                    start: definition_span
-                        .map(|span| offset_to_line_char_col(source, span.start)),
+                    start: definition_span.map(|span| offset_to_line_char_col(source, span.start)),
                 })
                 .collect();
             bindings.sort_by(|a, b| a.name.cmp(&b.name));
@@ -1486,11 +1486,7 @@ fn assemble_file_dump(
 /// Definition site of `name` in the nearest recorded scope enclosing
 /// `index`, walking outward. Used for closed-over bindings, whose only
 /// site in this file lives in an outer scope.
-fn enclosing_binding_span(
-    infos: &[ScopeInfo],
-    index: usize,
-    name: &str,
-) -> Option<ry_core::Span> {
+fn enclosing_binding_span(infos: &[ScopeInfo], index: usize, name: &str) -> Option<ry_core::Span> {
     let inner = infos[index].record.span;
     let mut candidates: Vec<&ScopeInfo> = infos
         .iter()
@@ -1530,10 +1526,7 @@ fn run_dump_types(
 
     // Config discovery mirrors `ry check`: anchored at the first input,
     // missing config is fine, malformed config aborts.
-    let search_start = files
-        .first()
-        .cloned()
-        .unwrap_or_else(|| PathBuf::from("."));
+    let search_start = files.first().cloned().unwrap_or_else(|| PathBuf::from("."));
     let cfg = match config::Config::discover(&search_start) {
         Ok(Some((_path, cfg))) => cfg,
         Ok(None) => config::Config::defaults(),
@@ -1562,9 +1555,11 @@ fn run_dump_types(
             const { std::cell::RefCell::new(None) };
     }
     use rayon::prelude::*;
-    // Err(row) = unreadable file (fatal); Ok(None) = unparseable file
-    // (warned and skipped; the dump still covers every parseable file).
-    let results: Vec<Result<Option<(String, String, ry_core::SourceFile)>, String>> = all_paths
+    // Ok(Some(..)) = parsed; Ok(None) = unparseable (warned and skipped;
+    // the dump still covers every parseable file); Err(..) = unreadable
+    // (fatal, reported after the join).
+    type ParseOutcome = Result<Option<(String, String, ry_core::SourceFile)>, String>;
+    let results: Vec<ParseOutcome> = all_paths
         .par_iter()
         .map(|path| {
             let src = match read_r_source(path) {
@@ -1574,8 +1569,9 @@ fn run_dump_types(
             let path_str = path.to_string_lossy().to_string();
             let file = DUMP_PARSER.with(|cell| {
                 let mut slot = cell.borrow_mut();
-                let parser = slot
-                    .get_or_insert_with(|| ry_core::RParser::new().expect("parser init (thread-local)"));
+                let parser = slot.get_or_insert_with(|| {
+                    ry_core::RParser::new().expect("parser init (thread-local)")
+                });
                 parser.parse(&path_str, &src)
             });
             match file {
@@ -1623,16 +1619,15 @@ fn run_dump_types(
             .clone()
             .or_else(|| project_root.clone())
             .unwrap_or_else(|| std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")));
-        let package_scope =
-            ry_workspace::resolve_workspace_context(
-                &resolution_root,
-                &cfg,
-                ry_workspace::ResolutionEnvironment {
-                    files: indices.iter().map(|index| &parsed[*index].2).collect(),
-                    user_stubs: &user_stubs,
-                },
-            )
-            .map_err(|error| miette::miette!(error))?;
+        let package_scope = ry_workspace::resolve_workspace_context(
+            &resolution_root,
+            &cfg,
+            ry_workspace::ResolutionEnvironment {
+                files: indices.iter().map(|index| &parsed[*index].2).collect(),
+                user_stubs: &user_stubs,
+            },
+        )
+        .map_err(|error| miette::miette!(error))?;
         let analysis_files: Vec<_> = indices
             .iter()
             .map(|index| {
@@ -1668,10 +1663,7 @@ fn run_dump_types(
             })
             .collect(),
     };
-    println!(
-        "{}",
-        serde_json::to_string_pretty(&dump).into_diagnostic()?
-    );
+    println!("{}", serde_json::to_string_pretty(&dump).into_diagnostic()?);
     // Diagnostics (if any) never affect the dump's exit code.
     Ok(ExitCode::SUCCESS)
 }
@@ -2607,7 +2599,10 @@ mod tests {
         let src = "a <- 1L\n#\u{e9} <- 2L\nlast <- 3L\n";
         assert_eq!(offset_to_line_char_col(src, 0), (1, 1));
         // Start of line 3.
-        assert_eq!(offset_to_line_char_col(src, src.find("last").unwrap()), (3, 1));
+        assert_eq!(
+            offset_to_line_char_col(src, src.find("last").unwrap()),
+            (3, 1)
+        );
         // The identifier on line 2 starts after `#`, a multi-byte char.
         let ident = src.find("<- 2L").unwrap();
         let (row, col) = offset_to_line_char_col(src, ident);
@@ -2630,7 +2625,8 @@ mod tests {
     fn dump_type_string_renders_unknown_and_display_forms() {
         use super::dump_type_string;
         assert_eq!(dump_type_string(&ry_core::RType::unknown()), "unknown");
-        let integer = ry_core::RType::new(ry_core::types::Mode::Integer, ry_core::types::Length::One);
+        let integer =
+            ry_core::RType::new(ry_core::types::Mode::Integer, ry_core::types::Length::One);
         assert_eq!(dump_type_string(&integer), "integer<len=1>");
     }
 

--- a/crates/ry-cli/src/main.rs
+++ b/crates/ry-cli/src/main.rs
@@ -138,6 +138,32 @@ enum Cmd {
         #[arg(long, value_enum, default_value_t = ConfidenceChoice::Low)]
         min_confidence: ConfidenceChoice,
     },
+    /// Dump inferred types for every lexical scope in R files, as JSON on
+    /// stdout. Non-interactive counterpart of the LSP hover: bindings map
+    /// to the same type strings. Downstream tooling (training-data
+    /// builders, IDE backends) can query which names a scope binds and
+    /// with what inferred types, without re-implementing the checker.
+    DumpTypes {
+        /// R files or directories to dump. A directory expands to every
+        /// discoverable R file under it, using `ry check`'s discovery
+        /// rules.
+        #[arg(required = true)]
+        files: Vec<PathBuf>,
+        /// Analysis root for whole-project inference. Defaults, per file,
+        /// to the nearest ancestor directory containing a DESCRIPTION
+        /// (the enclosing package), else the current directory — the same
+        /// grouping `ry check` uses.
+        #[arg(long, value_name = "DIR")]
+        project_root: Option<PathBuf>,
+        /// Output format. Only `json` is supported.
+        #[arg(long, value_name = "FORMAT", default_value = "json")]
+        format: String,
+        /// Restrict output to the innermost scope(s) containing this
+        /// position, as 1-based LINE:COL. Repeatable; every position is
+        /// evaluated against every dumped file.
+        #[arg(long = "position", value_name = "LINE:COL", value_parser = parse_dump_position)]
+        positions: Vec<(usize, usize)>,
+    },
     /// Start the language server. Speaks the Language Server Protocol
     /// (LSP) over stdio, publishing type-check diagnostics for open R
     /// files. Connect to it from any LSP-aware editor (VS Code, Neovim,
@@ -287,6 +313,12 @@ fn main() -> Result<ExitCode> {
             baseline,
             min_confidence,
         ),
+        Cmd::DumpTypes {
+            files,
+            project_root,
+            format,
+            positions,
+        } => run_dump_types(files, project_root, &format, positions),
         Cmd::Server { log_level } => {
             // The LSP server reads JSON-RPC from stdin and writes
             // JSON-RPC to stdout. CRITICAL: any tracing or log output
@@ -1003,6 +1035,645 @@ fn load_user_stubs(
         }
     }
     Arc::new(merged)
+}
+
+// ---------------------------------------------------------------------------
+// dump-types
+//
+// One analysis pass over the requested files, then a JSON dump of every
+// recorded lexical scope (see ry_checker::ScopeRecord). The dump reuses
+// `ry check`'s pipeline end to end — config discovery, file discovery,
+// per-package grouping, workspace resolution — so the emitted types are
+// exactly what a `ry check` run infers.
+
+#[derive(serde::Serialize)]
+struct TypesDump {
+    files: Vec<FileDump>,
+}
+
+#[derive(serde::Serialize)]
+struct FileDump {
+    path: String,
+    scopes: Vec<ScopeDump>,
+}
+
+#[derive(serde::Serialize)]
+struct ScopeDump {
+    kind: &'static str,
+    name: Option<String>,
+    start: (usize, usize),
+    end: (usize, usize),
+    bindings: Vec<BindingDump>,
+}
+
+#[derive(serde::Serialize)]
+struct BindingDump {
+    name: String,
+    kind: &'static str,
+    #[serde(rename = "type")]
+    type_: String,
+    start: Option<(usize, usize)>,
+}
+
+/// clap value parser for `--position LINE:COL`. Rows and columns are
+/// 1-based, matching the dump output.
+fn parse_dump_position(value: &str) -> Result<(usize, usize), String> {
+    let (line, col) =
+        value
+            .split_once(':')
+            .ok_or_else(|| format!("expected LINE:COL, got `{value}`"))?;
+    let line = line
+        .trim()
+        .parse::<usize>()
+        .map_err(|_| format!("invalid line in `{value}`"))?;
+    let col = col
+        .trim()
+        .parse::<usize>()
+        .map_err(|_| format!("invalid column in `{value}`"))?;
+    if line == 0 || col == 0 {
+        return Err(format!("positions are 1-based, got `{value}`"));
+    }
+    Ok((line, col))
+}
+
+/// The type string for one binding. Same `Display` rendering the LSP
+/// hover produces, except the fully-uninformed type is reported as
+/// "unknown" so consumers never mistake `opaque<len=?>:?` for a real
+/// inference result.
+fn dump_type_string(t: &ry_core::RType) -> String {
+    if *t == ry_core::RType::unknown() {
+        "unknown".to_string()
+    } else {
+        t.to_string()
+    }
+}
+
+/// 1-based (row, character-column) of a byte offset. Parser spans use
+/// byte columns; converting to character columns keeps the dump useful
+/// for files with multi-byte identifiers.
+fn offset_to_line_char_col(source: &str, offset: usize) -> (usize, usize) {
+    let offset = offset.min(source.len());
+    let before = &source[..offset];
+    let row = before.matches('\n').count() + 1;
+    let line_start = before.rfind('\n').map(|i| i + 1).unwrap_or(0);
+    let col = source[line_start..offset].chars().count() + 1;
+    (row, col)
+}
+
+/// Inverse of [`offset_to_line_char_col`]: byte offset of the 1-based
+/// (row, character-column) position. `None` when the row is past the
+/// last line; a column past the line end clamps to the line end.
+fn line_char_col_to_offset(source: &str, row: usize, col: usize) -> Option<usize> {
+    let mut offset = 0usize;
+    for (index, line) in source.split('\n').enumerate() {
+        if index + 1 == row {
+            let mut bytes = 0usize;
+            for ch in line.chars().take(col.saturating_sub(1)) {
+                bytes += ch.len_utf8();
+            }
+            return Some((offset + bytes).min(offset + line.len()));
+        }
+        offset += line.len() + 1;
+    }
+    None
+}
+
+/// Record the first plain assignment to each name in a scope's body.
+///
+/// R has no separate block scoping, so assignments inside `if`/`for`/
+/// `while` bodies and braced value blocks bind in the enclosing function
+/// scope. Function-literal bodies are excluded: those are their own
+/// scopes (recorded separately), though the *name* bound to a function
+/// literal (`inner <- function(...)`) is itself a local of this scope.
+fn collect_local_bindings(stmts: &[ry_core::ast::Stmt], out: &mut HashMap<String, ry_core::Span>) {
+    for statement in stmts {
+        match statement {
+            ry_core::ast::Stmt::Assign { target, value, .. } => {
+                match target {
+                    ry_core::ast::Expr::Ident { name, span }
+                    | ry_core::ast::Expr::String(name, span) => {
+                        out.entry(name.clone()).or_insert(*span);
+                    }
+                    // Indexed targets (`d$col <- v`) mutate an existing
+                    // binding rather than creating one; the base name's
+                    // plain assignment (if any) is found elsewhere.
+                    _ => {}
+                }
+                collect_local_bindings_in_expr(value, out);
+            }
+            ry_core::ast::Stmt::Expr(e) => collect_local_bindings_in_expr(e, out),
+            ry_core::ast::Stmt::If { then, else_, .. } => {
+                collect_local_bindings(then, out);
+                if let Some(else_) = else_ {
+                    collect_local_bindings(else_, out);
+                }
+            }
+            ry_core::ast::Stmt::For {
+                name,
+                name_span,
+                iter,
+                body,
+                ..
+            } => {
+                out.entry(name.clone()).or_insert(*name_span);
+                collect_local_bindings_in_expr(iter, out);
+                collect_local_bindings(body, out);
+            }
+            ry_core::ast::Stmt::While { cond, body, .. } => {
+                collect_local_bindings_in_expr(cond, out);
+                collect_local_bindings(body, out);
+            }
+            // `return()` binds nothing; a bare function definition binds
+            // no name in this scope.
+            ry_core::ast::Stmt::Return { .. } | ry_core::ast::Stmt::FunctionDef { .. } => {}
+        }
+    }
+}
+
+/// Statement-level assignment scan through value positions that contain
+/// statement blocks.
+fn collect_local_bindings_in_expr(
+    expr: &ry_core::ast::Expr,
+    out: &mut HashMap<String, ry_core::Span>,
+) {
+    match expr {
+        ry_core::ast::Expr::Block { body, .. } => collect_local_bindings(body, out),
+        ry_core::ast::Expr::If {
+            then, else_, cond, ..
+        } => {
+            collect_local_bindings_in_expr(cond, out);
+            collect_local_bindings_in_expr(then, out);
+            if let Some(else_) = else_ {
+                collect_local_bindings_in_expr(else_, out);
+            }
+        }
+        // Function literals are separate scopes; their bodies are indexed
+        // by index_scope_bodies instead.
+        _ => {}
+    }
+}
+
+/// Map every function body in the file to its start byte, so each
+/// recorded scope can look up its own local bindings. Mirrors the
+/// statement recursion of `collect_local_bindings` to find nested named
+/// functions at any block depth.
+fn index_scope_bodies(
+    stmts: &[ry_core::ast::Stmt],
+    index: &mut HashMap<usize, HashMap<String, ry_core::Span>>,
+) {
+    for statement in stmts {
+        match statement {
+            ry_core::ast::Stmt::Assign { value, .. } => match value {
+                ry_core::ast::Expr::Function { body, span, .. } => {
+                    index_function_body(*span, body, index);
+                }
+                _ => index_scope_bodies_in_expr(value, index),
+            },
+            ry_core::ast::Stmt::FunctionDef { body, span, .. } => {
+                index_function_body(*span, body, index);
+            }
+            ry_core::ast::Stmt::If { then, else_, .. } => {
+                index_scope_bodies(then, index);
+                if let Some(else_) = else_ {
+                    index_scope_bodies(else_, index);
+                }
+            }
+            ry_core::ast::Stmt::For { body, .. } | ry_core::ast::Stmt::While { body, .. } => {
+                index_scope_bodies(body, index);
+            }
+            ry_core::ast::Stmt::Expr(e) => index_scope_bodies_in_expr(e, index),
+            ry_core::ast::Stmt::Return { value, .. } => {
+                if let Some(value) = value {
+                    index_scope_bodies_in_expr(value, index);
+                }
+            }
+        }
+    }
+}
+
+fn index_scope_bodies_in_expr(
+    expr: &ry_core::ast::Expr,
+    index: &mut HashMap<usize, HashMap<String, ry_core::Span>>,
+) {
+    match expr {
+        ry_core::ast::Expr::Block { body, .. } => index_scope_bodies(body, index),
+        ry_core::ast::Expr::If {
+            then, else_, cond, ..
+        } => {
+            index_scope_bodies_in_expr(cond, index);
+            index_scope_bodies_in_expr(then, index);
+            if let Some(else_) = else_ {
+                index_scope_bodies_in_expr(else_, index);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn index_function_body(
+    span: ry_core::Span,
+    body: &[ry_core::ast::Stmt],
+    index: &mut HashMap<usize, HashMap<String, ry_core::Span>>,
+) {
+    let mut locals = HashMap::new();
+    collect_local_bindings(body, &mut locals);
+    index.insert(span.start, locals);
+    index_scope_bodies(body, index);
+}
+
+/// Per-scope classification inputs derived once per file.
+struct ScopeInfo<'a> {
+    record: &'a ry_checker::ScopeRecord,
+    params: HashMap<&'a str, ry_core::Span>,
+    locals: HashMap<&'a str, ry_core::Span>,
+}
+
+/// Turn one file's scope records into the JSON dump shape.
+///
+/// Binding kinds (documented in the README section for `dump-types`):
+/// - `param`: still marked as a formal in the recorded scope (an
+///   overwritten formal degrades to `local`, matching R's rebinding).
+/// - `local`: first assigned inside this scope's own body.
+/// - `closed-over`: function scopes only — present because the body's
+///   scope was cloned from the enclosing one at definition time.
+/// - `imported`: top-level bindings the file never assigns (ambient names
+///   supplied by the host environment, e.g. Shiny server fragments).
+fn assemble_file_dump(
+    path: &str,
+    file: &ry_core::SourceFile,
+    records: Vec<ry_checker::ScopeRecord>,
+    positions: &[(usize, usize)],
+) -> FileDump {
+    // Sort by start position and drop duplicates (an injected-expression
+    // re-walk can complete the same literal twice).
+    let mut records = records;
+    records.sort_by_key(|record| record.span.start);
+    records.dedup_by(|a, b| a.span.start == b.span.start);
+
+    let mut function_locals: HashMap<usize, HashMap<String, ry_core::Span>> = HashMap::new();
+    index_scope_bodies(&file.stmts, &mut function_locals);
+    let mut top_locals = HashMap::new();
+    collect_local_bindings(&file.stmts, &mut top_locals);
+
+    let infos: Vec<ScopeInfo> = records
+        .iter()
+        .map(|record| ScopeInfo {
+            record,
+            params: record
+                .params
+                .iter()
+                .map(|(name, span)| (name.as_str(), *span))
+                .collect(),
+            locals: match record.kind {
+                ry_checker::ScopeRecordKind::Function => function_locals
+                    .get(&record.span.start)
+                    .map(|locals| {
+                        locals
+                            .iter()
+                            .map(|(name, span)| (name.as_str(), *span))
+                            .collect()
+                    })
+                    .unwrap_or_default(),
+                ry_checker::ScopeRecordKind::Top => top_locals
+                    .iter()
+                    .map(|(name, span)| (name.as_str(), *span))
+                    .collect(),
+            },
+        })
+        .collect();
+
+    // Which scopes does --position select? Without positions, all. With
+    // them, the innermost containing scope for each position (the union,
+    // deduplicated). Byte offsets make containment exact regardless of
+    // encoding.
+    let selected: Vec<usize> = if positions.is_empty() {
+        (0..infos.len()).collect()
+    } else {
+        let mut chosen: Vec<usize> = Vec::new();
+        for &(row, col) in positions {
+            let Some(offset) = line_char_col_to_offset(&file.source, row, col) else {
+                continue;
+            };
+            let mut best: Option<(usize, usize)> = None;
+            for (index, info) in infos.iter().enumerate() {
+                let span = info.record.span;
+                if span.start <= offset && offset < span.end {
+                    let extent = span.end - span.start;
+                    if best.is_none_or(|(extent_so_far, _)| extent < extent_so_far) {
+                        best = Some((extent, index));
+                    }
+                }
+            }
+            if let Some((_, index)) = best {
+                chosen.push(index);
+            }
+        }
+        chosen.sort_unstable();
+        chosen.dedup();
+        chosen
+    };
+
+    // The offsets that selected each scope, for binding-visibility
+    // filtering below.
+    let mut selecting_offsets: HashMap<usize, Vec<usize>> = HashMap::new();
+    if !positions.is_empty() {
+        for &(row, col) in positions {
+            let Some(offset) = line_char_col_to_offset(&file.source, row, col) else {
+                continue;
+            };
+            let mut best: Option<(usize, usize)> = None;
+            for (index, info) in infos.iter().enumerate() {
+                let span = info.record.span;
+                if span.start <= offset && offset < span.end {
+                    let extent = span.end - span.start;
+                    if best.is_none_or(|(extent_so_far, _)| extent < extent_so_far) {
+                        best = Some((extent, index));
+                    }
+                }
+            }
+            if let Some((_, index)) = best {
+                selecting_offsets.entry(index).or_default().push(offset);
+            }
+        }
+    }
+
+    let scopes = selected
+        .into_iter()
+        .map(|index| {
+            let info = &infos[index];
+            let record = info.record;
+            let source = &file.source;
+
+            let mut bindings: Vec<BindingDump> = record
+                .scope
+                .bindings
+                .iter()
+                .filter_map(|(name, ty)| {
+                    // A formal counts as `param` only in the scope that
+                    // declares it: scope snapshots are cloned from the
+                    // enclosing function, which also clones the
+                    // parameter-marker set, so a captured outer formal
+                    // must not be reclassified. A declared formal whose
+                    // marker is gone was reassigned in the body (R
+                    // rebinds rather than narrows), so it degrades to
+                    // `local` at its reassignment site.
+                    let is_formal_here = info.params.contains_key(name.as_str());
+                    let is_param =
+                        is_formal_here && record.scope.parameter_bindings.contains(name);
+                    let local_span = info.locals.get(name.as_str()).copied();
+                    let (kind, definition_span) = if is_param {
+                        ("param", info.params.get(name.as_str()).copied().or(local_span))
+                    } else if let Some(span) = local_span {
+                        ("local", Some(span))
+                    } else if record.kind == ry_checker::ScopeRecordKind::Function {
+                        ("closed-over", None)
+                    } else {
+                        ("imported", None)
+                    };
+                    // A closed-over binding has no site in this scope;
+                    // point at the definition in the nearest enclosing
+                    // scope that binds the name, when one was recorded.
+                    let definition_span =
+                        definition_span.or_else(|| enclosing_binding_span(&infos, index, name.as_str()));
+                    Some((name, ty, kind, definition_span, is_formal_here))
+                })
+                .filter(|(name, _, _, definition_span, is_formal_here)| {
+                    // Visibility at the selecting positions: formals bind
+                    // at call entry (always visible); a local assigned
+                    // after every selecting position is not yet in scope
+                    // there; a binding with no resolvable site is kept
+                    // (it predates the body).
+                    let Some(offsets) = selecting_offsets.get(&index) else {
+                        return true;
+                    };
+                    if *is_formal_here {
+                        return true;
+                    }
+                    let Some(span) = definition_span else {
+                        return true;
+                    };
+                    offsets.iter().any(|offset| span.start <= *offset)
+                })
+                .map(|(name, ty, kind, definition_span, _)| BindingDump {
+                    name: name.clone(),
+                    kind,
+                    type_: dump_type_string(ty),
+                    start: definition_span
+                        .map(|span| offset_to_line_char_col(source, span.start)),
+                })
+                .collect();
+            bindings.sort_by(|a, b| a.name.cmp(&b.name));
+
+            ScopeDump {
+                kind: match record.kind {
+                    ry_checker::ScopeRecordKind::Function => "function",
+                    ry_checker::ScopeRecordKind::Top => "top",
+                },
+                name: record.name.clone(),
+                start: offset_to_line_char_col(source, record.span.start),
+                end: offset_to_line_char_col(source, record.span.end),
+                bindings,
+            }
+        })
+        .collect();
+
+    FileDump {
+        path: path.to_string(),
+        scopes,
+    }
+}
+
+/// Definition site of `name` in the nearest recorded scope enclosing
+/// `index`, walking outward. Used for closed-over bindings, whose only
+/// site in this file lives in an outer scope.
+fn enclosing_binding_span(
+    infos: &[ScopeInfo],
+    index: usize,
+    name: &str,
+) -> Option<ry_core::Span> {
+    let inner = infos[index].record.span;
+    let mut candidates: Vec<&ScopeInfo> = infos
+        .iter()
+        .enumerate()
+        .filter(|(other, info)| {
+            *other != index
+                && info.record.span.start <= inner.start
+                && inner.end <= info.record.span.end
+        })
+        .map(|(_, info)| info)
+        .collect();
+    // Nearest first: smallest enclosing extent.
+    candidates.sort_by_key(|info| info.record.span.end - info.record.span.start);
+    for info in candidates {
+        if let Some(span) = info.params.get(name).copied() {
+            return Some(span);
+        }
+        if let Some(span) = info.locals.get(name).copied() {
+            return Some(span);
+        }
+    }
+    None
+}
+
+fn run_dump_types(
+    files: Vec<PathBuf>,
+    project_root: Option<PathBuf>,
+    format: &str,
+    positions: Vec<(usize, usize)>,
+) -> Result<ExitCode> {
+    if format != "json" {
+        return Err(miette::miette!(
+            "unknown --format `{}`; expected one of: json",
+            format
+        ));
+    }
+
+    // Config discovery mirrors `ry check`: anchored at the first input,
+    // missing config is fine, malformed config aborts.
+    let search_start = files
+        .first()
+        .cloned()
+        .unwrap_or_else(|| PathBuf::from("."));
+    let cfg = match config::Config::discover(&search_start) {
+        Ok(Some((_path, cfg))) => cfg,
+        Ok(None) => config::Config::defaults(),
+        Err(e) => {
+            eprintln!("ry: {}", e);
+            return Ok(ExitCode::FAILURE);
+        }
+    };
+
+    let mut all_paths = Vec::new();
+    for root in &files {
+        if !root.exists() {
+            eprintln!("ry: {}: no such file or directory", root.display());
+            return Ok(ExitCode::FAILURE);
+        }
+        let result = ry_workspace::discover_r_files(root, None, &cfg, cfg.check_test_fixtures);
+        all_paths.extend(result.files);
+        report_truncation(&result.truncated, root);
+    }
+    sort_and_deduplicate_paths(&mut all_paths);
+
+    // Parallel parsing with the same thread-local parser pool as
+    // `ry check` (tree-sitter parsers are not Send).
+    thread_local! {
+        static DUMP_PARSER: std::cell::RefCell<Option<ry_core::RParser>> =
+            const { std::cell::RefCell::new(None) };
+    }
+    use rayon::prelude::*;
+    // Err(row) = unreadable file (fatal); Ok(None) = unparseable file
+    // (warned and skipped; the dump still covers every parseable file).
+    let results: Vec<Result<Option<(String, String, ry_core::SourceFile)>, String>> = all_paths
+        .par_iter()
+        .map(|path| {
+            let src = match read_r_source(path) {
+                Ok(src) => src,
+                Err(e) => return Err(format!("{}: {}", path.display(), e)),
+            };
+            let path_str = path.to_string_lossy().to_string();
+            let file = DUMP_PARSER.with(|cell| {
+                let mut slot = cell.borrow_mut();
+                let parser = slot
+                    .get_or_insert_with(|| ry_core::RParser::new().expect("parser init (thread-local)"));
+                parser.parse(&path_str, &src)
+            });
+            match file {
+                Ok(file) => Ok(Some((path_str, src, file))),
+                Err(e) => {
+                    eprintln!(
+                        "ry: {}: parse error: {e}; file omitted from dump",
+                        path.display()
+                    );
+                    Ok(None)
+                }
+            }
+        })
+        .collect();
+
+    let mut parsed: Vec<(String, String, ry_core::SourceFile)> = Vec::new();
+    for result in results {
+        match result {
+            Err(read_error) => {
+                eprintln!("ry: {read_error}");
+                return Ok(ExitCode::FAILURE);
+            }
+            Ok(Some(entry)) => parsed.push(entry),
+            Ok(None) => {}
+        }
+    }
+
+    let user_stubs = load_user_stubs(&cfg.typeshed);
+
+    // Same per-package grouping as `ry check`: each DESCRIPTION root is
+    // its own library namespace. Non-package scripts share one group
+    // rooted at --project-root (or the working directory).
+    let mut groups: std::collections::BTreeMap<Option<PathBuf>, Vec<usize>> =
+        std::collections::BTreeMap::new();
+    for (index, (path, _, _)) in parsed.iter().enumerate() {
+        groups
+            .entry(enclosing_package_root(std::path::Path::new(path)))
+            .or_default()
+            .push(index);
+    }
+
+    let mut records_by_path: HashMap<String, Vec<ry_checker::ScopeRecord>> = HashMap::new();
+    for (group_root, indices) in &groups {
+        let resolution_root = group_root
+            .clone()
+            .or_else(|| project_root.clone())
+            .unwrap_or_else(|| std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")));
+        let package_scope =
+            ry_workspace::resolve_workspace_context(
+                &resolution_root,
+                &cfg,
+                ry_workspace::ResolutionEnvironment {
+                    files: indices.iter().map(|index| &parsed[*index].2).collect(),
+                    user_stubs: &user_stubs,
+                },
+            )
+            .map_err(|error| miette::miette!(error))?;
+        let analysis_files: Vec<_> = indices
+            .iter()
+            .map(|index| {
+                let (path, _, file) = &parsed[*index];
+                (path.clone(), 0, std::sync::Arc::new(file.clone()))
+            })
+            .collect();
+        let check_input = ry_analysis::CheckInput {
+            files: analysis_files,
+            user_stubs: Arc::clone(&user_stubs),
+            workspace: Some(ry_workspace::WorkspaceContext {
+                attached_packages: package_scope.attached_packages,
+                bare_bindings: package_scope.bare_bindings,
+                external_bindings: package_scope.external_bindings,
+                imported_bindings: package_scope.imported_bindings,
+                s3_methods: package_scope.s3_methods,
+                load_bindings: package_scope.load_bindings,
+                native_registrations: package_scope.native_registrations,
+                degraded_scopes: Vec::new(),
+            }),
+        };
+        for (path, records) in ry_analysis::check_project_with_scope_capture(check_input) {
+            records_by_path.insert(path, records);
+        }
+    }
+
+    let dump = TypesDump {
+        files: parsed
+            .iter()
+            .map(|(path, _src, file)| {
+                let records = records_by_path.remove(path).unwrap_or_default();
+                assemble_file_dump(path, file, records, &positions)
+            })
+            .collect(),
+    };
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&dump).into_diagnostic()?
+    );
+    // Diagnostics (if any) never affect the dump's exit code.
+    Ok(ExitCode::SUCCESS)
 }
 
 fn sort_and_deduplicate_diagnostics(diagnostics: &mut Vec<ry_checker::Diagnostic>) {
@@ -1914,5 +2585,76 @@ mod tests {
                 .iter()
                 .all(|diagnostic| diagnostic.code != "RY097")
         );
+    }
+
+    // ---- dump-types helpers ----
+
+    #[test]
+    fn dump_position_parser_accepts_pairs_and_rejects_garbage() {
+        use super::parse_dump_position;
+        assert_eq!(parse_dump_position("3:14").unwrap(), (3, 14));
+        assert_eq!(parse_dump_position(" 12 : 1 ").unwrap(), (12, 1));
+        assert!(parse_dump_position("3").is_err());
+        assert!(parse_dump_position("a:b").is_err());
+        assert!(parse_dump_position("0:1").is_err(), "rows are 1-based");
+        assert!(parse_dump_position("1:0").is_err(), "cols are 1-based");
+    }
+
+    #[test]
+    fn dump_position_offsets_round_trip_and_clamp() {
+        use super::{line_char_col_to_offset, offset_to_line_char_col};
+        // Multi-byte characters: columns must count characters, not bytes.
+        let src = "a <- 1L\n#\u{e9} <- 2L\nlast <- 3L\n";
+        assert_eq!(offset_to_line_char_col(src, 0), (1, 1));
+        // Start of line 3.
+        assert_eq!(offset_to_line_char_col(src, src.find("last").unwrap()), (3, 1));
+        // The identifier on line 2 starts after `#`, a multi-byte char.
+        let ident = src.find("<- 2L").unwrap();
+        let (row, col) = offset_to_line_char_col(src, ident);
+        assert_eq!((row, col), (2, 4));
+        assert_eq!(
+            line_char_col_to_offset(src, row, col),
+            Some(ident),
+            "round trip"
+        );
+        // Row past the end matches nothing; column past the line end
+        // clamps to the line end.
+        assert_eq!(line_char_col_to_offset(src, 99, 1), None);
+        assert_eq!(
+            line_char_col_to_offset(src, 1, 500),
+            Some(src.find('\n').unwrap())
+        );
+    }
+
+    #[test]
+    fn dump_type_string_renders_unknown_and_display_forms() {
+        use super::dump_type_string;
+        assert_eq!(dump_type_string(&ry_core::RType::unknown()), "unknown");
+        let integer = ry_core::RType::new(ry_core::types::Mode::Integer, ry_core::types::Length::One);
+        assert_eq!(dump_type_string(&integer), "integer<len=1>");
+    }
+
+    #[test]
+    fn dump_local_binding_scan_skips_nested_function_bodies() {
+        let mut parser = ry_core::RParser::new().unwrap();
+        let file = parser
+            .parse(
+                "a.R",
+                "outer <- function(x) {\n  keep <- 1L\n  inner <- function(y) { skip <- 2L }\n  if (x) keep2 <- 3L\n  for (i in 1:3) keep3 <- i\n  keep\n}\n",
+            )
+            .unwrap();
+        // The function body's own locals, extracted from the statement
+        // tree: nested `skip` belongs to the inner scope, not this one.
+        let ry_core::ast::Stmt::Assign { value, .. } = &file.stmts[0] else {
+            panic!("expected assignment");
+        };
+        let ry_core::ast::Expr::Function { body, .. } = value else {
+            panic!("expected function literal");
+        };
+        let mut locals = std::collections::HashMap::new();
+        super::collect_local_bindings(body, &mut locals);
+        let mut names: Vec<_> = locals.keys().map(String::as_str).collect();
+        names.sort_unstable();
+        assert_eq!(names, vec!["i", "inner", "keep", "keep2", "keep3"]);
     }
 }

--- a/crates/ry-cli/src/main.rs
+++ b/crates/ry-cli/src/main.rs
@@ -1444,6 +1444,10 @@ fn assemble_file_dump(
         })
         .collect();
 
+    // Enclosing-scope chains are shared by every binding of a scope, so
+    // compute them once per file instead of once per closed-over lookup.
+    let chains = enclosing_scope_chains(&infos);
+
     // Which scopes does --position select? Without positions, all. With
     // them, the innermost containing scope for each position (the union,
     // deduplicated). Byte offsets make containment exact regardless of
@@ -1517,7 +1521,7 @@ fn assemble_file_dump(
                     // point at the definition in the nearest enclosing
                     // scope that binds the name, when one was recorded.
                     let definition_span = definition_span
-                        .or_else(|| enclosing_binding_span(&infos, index, name.as_str()));
+                        .or_else(|| enclosing_binding_span(&infos, &chains[index], name.as_str()));
                     (name, ty, kind, definition_span, is_formal_here)
                 })
                 .filter(|(_, _, _, definition_span, is_formal_here)| {
@@ -1565,24 +1569,40 @@ fn assemble_file_dump(
     }
 }
 
-/// Definition site of `name` in the nearest recorded scope enclosing
-/// `index`, walking outward. Used for closed-over bindings, whose only
-/// site in this file lives in an outer scope.
-fn enclosing_binding_span(infos: &[ScopeInfo], index: usize, name: &str) -> Option<ry_core::Span> {
-    let inner = infos[index].record.span;
-    let mut candidates: Vec<&ScopeInfo> = infos
-        .iter()
-        .enumerate()
-        .filter(|(other, info)| {
-            *other != index
-                && info.record.span.start <= inner.start
-                && inner.end <= info.record.span.end
+/// Sorted (nearest-first) enclosing-scope index chain for every scope:
+/// each entry lists the other scopes whose span contains it, ordered by
+/// smallest extent first. Computed once per file so every binding lookup
+/// in a scope reuses the same chain.
+fn enclosing_scope_chains(infos: &[ScopeInfo]) -> Vec<Vec<usize>> {
+    (0..infos.len())
+        .map(|index| {
+            let inner = infos[index].record.span;
+            let mut chain: Vec<usize> = (0..infos.len())
+                .filter(|other| {
+                    *other != index
+                        && infos[*other].record.span.start <= inner.start
+                        && inner.end <= infos[*other].record.span.end
+                })
+                .collect();
+            // Nearest first: smallest enclosing extent.
+            chain.sort_by_key(|other| {
+                infos[*other].record.span.end - infos[*other].record.span.start
+            });
+            chain
         })
-        .map(|(_, info)| info)
-        .collect();
-    // Nearest first: smallest enclosing extent.
-    candidates.sort_by_key(|info| info.record.span.end - info.record.span.start);
-    for info in candidates {
+        .collect()
+}
+
+/// Definition site of `name` in the nearest recorded scope enclosing the
+/// scope that owns `chain`, walking outward. Used for closed-over
+/// bindings, whose only site in this file lives in an outer scope.
+fn enclosing_binding_span(
+    infos: &[ScopeInfo],
+    chain: &[usize],
+    name: &str,
+) -> Option<ry_core::Span> {
+    for index in chain {
+        let info = &infos[*index];
         if let Some(span) = info.params.get(name).copied() {
             return Some(span);
         }

--- a/crates/ry-cli/src/main.rs
+++ b/crates/ry-cli/src/main.rs
@@ -151,7 +151,8 @@ enum Cmd {
         files: Vec<PathBuf>,
         /// Analysis root for whole-project inference. Defaults, per file,
         /// to the nearest ancestor directory containing a DESCRIPTION
-        /// (the enclosing package), else the current directory — the same
+        /// (the enclosing package), else the directory owning the
+        /// discovered ry.toml, else the current directory — the same
         /// grouping `ry check` uses.
         #[arg(long, value_name = "DIR")]
         project_root: Option<PathBuf>,
@@ -1304,10 +1305,14 @@ fn assemble_file_dump(
     positions: &[(usize, usize)],
 ) -> FileDump {
     // Sort by start position and drop duplicates (an injected-expression
-    // re-walk can complete the same literal twice).
+    // re-walk can complete the same literal twice). The dedup key
+    // includes the kind: a leading function literal's span starts at the
+    // same byte 0 as the whole-file top scope, and keying on the offset
+    // alone would drop that top scope and every top-level binding with
+    // it.
     let mut records = records;
     records.sort_by_key(|record| record.span.start);
-    records.dedup_by(|a, b| a.span.start == b.span.start);
+    records.dedup_by(|a, b| a.kind == b.kind && a.span.start == b.span.start);
 
     let mut function_locals: HashMap<usize, HashMap<String, ry_core::Span>> = HashMap::new();
     index_scope_bodies(&file.stmts, &mut function_locals);
@@ -1344,38 +1349,14 @@ fn assemble_file_dump(
     // Which scopes does --position select? Without positions, all. With
     // them, the innermost containing scope for each position (the union,
     // deduplicated). Byte offsets make containment exact regardless of
-    // encoding.
-    let selected: Vec<usize> = if positions.is_empty() {
-        (0..infos.len()).collect()
-    } else {
-        let mut chosen: Vec<usize> = Vec::new();
-        for &(row, col) in positions {
-            let Some(offset) = line_char_col_to_offset(&file.source, row, col) else {
-                continue;
-            };
-            let mut best: Option<(usize, usize)> = None;
-            for (index, info) in infos.iter().enumerate() {
-                let span = info.record.span;
-                if span.start <= offset && offset < span.end {
-                    let extent = span.end - span.start;
-                    if best.is_none_or(|(extent_so_far, _)| extent < extent_so_far) {
-                        best = Some((extent, index));
-                    }
-                }
-            }
-            if let Some((_, index)) = best {
-                chosen.push(index);
-            }
-        }
-        chosen.sort_unstable();
-        chosen.dedup();
-        chosen
-    };
-
-    // The offsets that selected each scope, for binding-visibility
-    // filtering below.
+    // encoding. One pass records both the selected scopes and, per
+    // scope, the offsets that selected it — the latter drives
+    // binding-visibility filtering below.
+    let mut selected: Vec<usize> = Vec::new();
     let mut selecting_offsets: HashMap<usize, Vec<usize>> = HashMap::new();
-    if !positions.is_empty() {
+    if positions.is_empty() {
+        selected.extend(0..infos.len());
+    } else {
         for &(row, col) in positions {
             let Some(offset) = line_char_col_to_offset(&file.source, row, col) else {
                 continue;
@@ -1394,6 +1375,9 @@ fn assemble_file_dump(
                 selecting_offsets.entry(index).or_default().push(offset);
             }
         }
+        selected.extend(selecting_offsets.keys().copied());
+        selected.sort_unstable();
+        selected.dedup();
     }
 
     let scopes = selected
@@ -1525,11 +1509,14 @@ fn run_dump_types(
     }
 
     // Config discovery mirrors `ry check`: anchored at the first input,
-    // missing config is fine, malformed config aborts.
+    // missing config is fine, malformed config aborts. The config's
+    // directory is kept as `config_root` — it anchors the `exclude`
+    // patterns below and is the resolution-root fallback for non-package
+    // files, exactly as in `run_check`.
     let search_start = files.first().cloned().unwrap_or_else(|| PathBuf::from("."));
-    let cfg = match config::Config::discover(&search_start) {
-        Ok(Some((_path, cfg))) => cfg,
-        Ok(None) => config::Config::defaults(),
+    let (config_root, cfg) = match config::Config::discover(&search_start) {
+        Ok(Some((path, cfg))) => (path.parent().map(PathBuf::from), cfg),
+        Ok(None) => (None, config::Config::defaults()),
         Err(e) => {
             eprintln!("ry: {}", e);
             return Ok(ExitCode::FAILURE);
@@ -1542,7 +1529,12 @@ fn run_dump_types(
             eprintln!("ry: {}: no such file or directory", root.display());
             return Ok(ExitCode::FAILURE);
         }
-        let result = ry_workspace::discover_r_files(root, None, &cfg, cfg.check_test_fixtures);
+        let result = ry_workspace::discover_r_files(
+            root,
+            config_root.as_deref(),
+            &cfg,
+            cfg.check_test_fixtures,
+        );
         all_paths.extend(result.files);
         report_truncation(&result.truncated, root);
     }
@@ -1603,7 +1595,9 @@ fn run_dump_types(
 
     // Same per-package grouping as `ry check`: each DESCRIPTION root is
     // its own library namespace. Non-package scripts share one group
-    // rooted at --project-root (or the working directory).
+    // rooted at --project-root, else the config root (the directory
+    // owning the discovered ry.toml), else the working directory —
+    // `run_check_once`'s fallback chain with --project-root overriding.
     let mut groups: std::collections::BTreeMap<Option<PathBuf>, Vec<usize>> =
         std::collections::BTreeMap::new();
     for (index, (path, _, _)) in parsed.iter().enumerate() {
@@ -1618,6 +1612,7 @@ fn run_dump_types(
         let resolution_root = group_root
             .clone()
             .or_else(|| project_root.clone())
+            .or_else(|| config_root.clone())
             .unwrap_or_else(|| std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")));
         let package_scope = ry_workspace::resolve_workspace_context(
             &resolution_root,
@@ -1649,6 +1644,15 @@ fn run_dump_types(
                 degraded_scopes: Vec::new(),
             }),
         };
+        // `ry check` prints one summary line per degraded scope; keep the
+        // note on stderr here too so a dump over the same project reports
+        // the same precision loss without polluting the JSON on stdout.
+        for (path, reason) in &package_scope.degraded_scopes {
+            eprintln!(
+                "ry: {}: degraded scope ({reason}); serialized data file(s) over the byte cap fell back to file stems",
+                path.display()
+            );
+        }
         for (path, records) in ry_analysis::check_project_with_scope_capture(check_input) {
             records_by_path.insert(path, records);
         }

--- a/crates/ry-cli/src/main.rs
+++ b/crates/ry-cli/src/main.rs
@@ -1156,13 +1156,20 @@ fn collect_local_bindings(stmts: &[ry_core::ast::Stmt], out: &mut HashMap<String
                     }
                     // Indexed targets (`d$col <- v`) mutate an existing
                     // binding rather than creating one; the base name's
-                    // plain assignment (if any) is found elsewhere.
+                    // plain assignment (if any) is found elsewhere. The
+                    // target's index arguments are not walked either: the
+                    // checker does not bind assignments hidden there
+                    // (`m[i <- 1L] <- v` leaves `i` unbound), and the dump
+                    // reports exactly what a `ry check` run infers.
                     _ => {}
                 }
                 collect_local_bindings_in_expr(value, out);
             }
             ry_core::ast::Stmt::Expr(e) => collect_local_bindings_in_expr(e, out),
-            ry_core::ast::Stmt::If { then, else_, .. } => {
+            ry_core::ast::Stmt::If {
+                cond, then, else_, ..
+            } => {
+                collect_local_bindings_in_expr(cond, out);
                 collect_local_bindings(then, out);
                 if let Some(else_) = else_ {
                     collect_local_bindings(else_, out);
@@ -1183,20 +1190,75 @@ fn collect_local_bindings(stmts: &[ry_core::ast::Stmt], out: &mut HashMap<String
                 collect_local_bindings_in_expr(cond, out);
                 collect_local_bindings(body, out);
             }
-            // `return()` binds nothing; a bare function definition binds
-            // no name in this scope.
-            ry_core::ast::Stmt::Return { .. } | ry_core::ast::Stmt::FunctionDef { .. } => {}
+            // `return(e)` still binds any assignment inside `e`; a bare
+            // function definition binds no name in this scope.
+            ry_core::ast::Stmt::Return { value, .. } => {
+                if let Some(value) = value {
+                    collect_local_bindings_in_expr(value, out);
+                }
+            }
+            ry_core::ast::Stmt::FunctionDef { .. } => {}
         }
     }
 }
 
-/// Statement-level assignment scan through value positions that contain
-/// statement blocks.
+/// Statement-level assignment scan through expression positions. R nests
+/// both statements (braced blocks) and side-effecting assignments
+/// (`f(x <- 1L)`, chained `a <- b <- 1L`, `if (flag <- f())`) inside
+/// arbitrary expressions, and all of them bind in the enclosing function
+/// scope. The recursion set mirrors the checker's own expression walker
+/// (`ry_checker::infer`'s `visit_expr`); literal leaves bind nothing.
+/// Function-literal bodies are excluded: those are their own scopes
+/// (recorded separately), though the *name* bound to a function literal
+/// (`inner <- function(...)`) is itself a local of this scope.
 fn collect_local_bindings_in_expr(
     expr: &ry_core::ast::Expr,
     out: &mut HashMap<String, ry_core::Span>,
 ) {
     match expr {
+        ry_core::ast::Expr::Call { func, args, .. } => {
+            collect_local_bindings_in_expr(func, out);
+            for argument in args {
+                collect_local_bindings_in_expr(&argument.value, out);
+            }
+        }
+        // Assignment operators in expression position bind the LHS in
+        // the current scope — the checker's `Expr::BinOp` arm does the
+        // same for `<-`/`<<-` (R's `<-` returns the value invisibly) and
+        // `%<>%` (which rebinds its LHS ident).
+        ry_core::ast::Expr::BinOp {
+            op:
+                ry_core::ast::BinOpKind::Assign
+                | ry_core::ast::BinOpKind::SuperAssign
+                | ry_core::ast::BinOpKind::PipeAssign,
+            lhs,
+            rhs,
+            ..
+        } => {
+            match lhs.as_ref() {
+                ry_core::ast::Expr::Ident { name, span }
+                | ry_core::ast::Expr::String(name, span) => {
+                    out.entry(name.clone()).or_insert(*span);
+                }
+                // Replacement-function targets (`names(d) <- v`) and
+                // indexed targets mutate; the checker's assignment arms
+                // decide those, not this walk.
+                _ => {}
+            }
+            collect_local_bindings_in_expr(lhs, out);
+            collect_local_bindings_in_expr(rhs, out);
+        }
+        ry_core::ast::Expr::BinOp { lhs, rhs, .. } => {
+            collect_local_bindings_in_expr(lhs, out);
+            collect_local_bindings_in_expr(rhs, out);
+        }
+        ry_core::ast::Expr::UnaryOp { expr, .. } => collect_local_bindings_in_expr(expr, out),
+        ry_core::ast::Expr::Index { base, args, .. } => {
+            collect_local_bindings_in_expr(base, out);
+            for argument in args {
+                collect_local_bindings_in_expr(&argument.value, out);
+            }
+        }
         ry_core::ast::Expr::Block { body, .. } => collect_local_bindings(body, out),
         ry_core::ast::Expr::If {
             then, else_, cond, ..
@@ -1208,7 +1270,8 @@ fn collect_local_bindings_in_expr(
             }
         }
         // Function literals are separate scopes; their bodies are indexed
-        // by index_scope_bodies instead.
+        // by index_scope_bodies instead. Literals and `Unknown` bind
+        // nothing.
         _ => {}
     }
 }
@@ -1232,13 +1295,21 @@ fn index_scope_bodies(
             ry_core::ast::Stmt::FunctionDef { body, span, .. } => {
                 index_function_body(*span, body, index);
             }
-            ry_core::ast::Stmt::If { then, else_, .. } => {
+            ry_core::ast::Stmt::If {
+                cond, then, else_, ..
+            } => {
+                index_scope_bodies_in_expr(cond, index);
                 index_scope_bodies(then, index);
                 if let Some(else_) = else_ {
                     index_scope_bodies(else_, index);
                 }
             }
-            ry_core::ast::Stmt::For { body, .. } | ry_core::ast::Stmt::While { body, .. } => {
+            ry_core::ast::Stmt::For { iter, body, .. } => {
+                index_scope_bodies_in_expr(iter, index);
+                index_scope_bodies(body, index);
+            }
+            ry_core::ast::Stmt::While { cond, body, .. } => {
+                index_scope_bodies_in_expr(cond, index);
                 index_scope_bodies(body, index);
             }
             ry_core::ast::Stmt::Expr(e) => index_scope_bodies_in_expr(e, index),
@@ -1251,11 +1322,32 @@ fn index_scope_bodies(
     }
 }
 
+/// Same expression recursion as [`collect_local_bindings_in_expr`]: named
+/// functions are reachable through any expression position (a callback's
+/// body, a call argument, an index argument), and only finding them there
+/// gives their scopes `function_locals` entries.
 fn index_scope_bodies_in_expr(
     expr: &ry_core::ast::Expr,
     index: &mut HashMap<usize, HashMap<String, ry_core::Span>>,
 ) {
     match expr {
+        ry_core::ast::Expr::Call { func, args, .. } => {
+            index_scope_bodies_in_expr(func, index);
+            for argument in args {
+                index_scope_bodies_in_expr(&argument.value, index);
+            }
+        }
+        ry_core::ast::Expr::BinOp { lhs, rhs, .. } => {
+            index_scope_bodies_in_expr(lhs, index);
+            index_scope_bodies_in_expr(rhs, index);
+        }
+        ry_core::ast::Expr::UnaryOp { expr, .. } => index_scope_bodies_in_expr(expr, index),
+        ry_core::ast::Expr::Index { base, args, .. } => {
+            index_scope_bodies_in_expr(base, index);
+            for argument in args {
+                index_scope_bodies_in_expr(&argument.value, index);
+            }
+        }
         ry_core::ast::Expr::Block { body, .. } => index_scope_bodies(body, index),
         ry_core::ast::Expr::If {
             then, else_, cond, ..
@@ -1266,6 +1358,12 @@ fn index_scope_bodies_in_expr(
                 index_scope_bodies_in_expr(else_, index);
             }
         }
+        // An anonymous function literal gets no `ScopeRecord` of its own
+        // (the checker infers it in discarding mode), but named functions
+        // defined inside it complete and are recorded — walk the body so
+        // those nested definitions are indexed. The literal itself needs
+        // no `function_locals` entry: no record will ever look it up.
+        ry_core::ast::Expr::Function { body, .. } => index_scope_bodies(body, index),
         _ => {}
     }
 }

--- a/crates/ry-cli/tests/dump_types_e2e.rs
+++ b/crates/ry-cli/tests/dump_types_e2e.rs
@@ -1,0 +1,259 @@
+//! End-to-end tests for `ry dump-types`: run the real binary against a
+//! fixture package and assert on the JSON contract (shape, binding
+//! kinds, type strings, --position filtering, exit-code semantics).
+
+use std::fs;
+use std::process::{Command, Output};
+
+fn run(args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_ry"))
+        .args(args)
+        .output()
+        .expect("failed to invoke ry")
+}
+
+fn stdout_json(output: &Output) -> serde_json::Value {
+    serde_json::from_slice(&output.stdout).expect("stdout is valid JSON")
+}
+
+/// A small package exercising every dump shape:
+///
+/// ```r
+/// 1  threshold <- 10L
+/// 3  moving_average <- function(x, n = 10L, w = NULL) {
+/// 4    if (is.null(w)) {
+/// 5      w <- rep(1, n)
+/// 7    weighted <- x * w          # omitted below for line-6 brace
+/// 8    window <- function(values, size) {
+/// 9      head(values, size)
+/// 11   window(weighted, n)
+/// 13 result <- moving_average(c(1, 2, 3))
+/// 14 missing_binding               # diagnostics never fail the dump
+/// ```
+fn fixture_package() -> tempfile::TempDir {
+    let temp = tempfile::tempdir().unwrap();
+    fs::create_dir_all(temp.path().join("R")).unwrap();
+    fs::write(
+        temp.path().join("DESCRIPTION"),
+        "Package: dumpfix\nVersion: 0.0.0.9000\n",
+    )
+    .unwrap();
+    fs::write(
+        temp.path().join("R/analysis.R"),
+        concat!(
+            "threshold <- 10L\n",
+            "\n",
+            "moving_average <- function(x, n = 10L, w = NULL) {\n",
+            "  if (is.null(w)) {\n",
+            "    w <- rep(1, n)\n",
+            "  }\n",
+            "  weighted <- x * w\n",
+            "  window <- function(values, size) {\n",
+            "    head(values, size)\n",
+            "  }\n",
+            "  window(weighted, n)\n",
+            "}\n",
+            "\n",
+            "result <- moving_average(c(1, 2, 3))\n",
+            "missing_binding\n",
+        ),
+    )
+    .unwrap();
+    temp
+}
+
+fn bindings_of<'a>(
+    scope: &'a serde_json::Value,
+) -> Vec<(&'a str, &'a str, &'a str)> {
+    scope["bindings"]
+        .as_array()
+        .expect("bindings array")
+        .iter()
+        .map(|binding| {
+            (
+                binding["name"].as_str().expect("name"),
+                binding["kind"].as_str().expect("kind"),
+                binding["type"].as_str().expect("type"),
+            )
+        })
+        .collect()
+}
+
+#[test]
+fn dumps_json_shape_with_param_concrete_and_unknown_types() {
+    let temp = fixture_package();
+    let file = temp.path().join("R/analysis.R");
+    let output = run(&["dump-types", file.to_str().unwrap()]);
+
+    // Diagnostics exist (missing_binding -> RY010) but never fail the dump.
+    assert!(output.status.success(), "{}", output.status);
+    let dump = stdout_json(&output);
+
+    let files = dump["files"].as_array().expect("files array");
+    assert_eq!(files.len(), 1);
+    assert!(files[0]["path"]
+        .as_str()
+        .expect("path")
+        .ends_with("R/analysis.R"));
+
+    let scopes = files[0]["scopes"].as_array().expect("scopes array");
+    // Top level, moving_average, and the nested window function.
+    assert_eq!(scopes.len(), 3, "{scopes:?}");
+    assert_eq!(scopes[0]["kind"], "top");
+    assert_eq!(scopes[0]["name"], serde_json::Value::Null);
+    assert_eq!(scopes[1]["kind"], "function");
+    assert_eq!(scopes[1]["name"], "moving_average");
+    assert_eq!(scopes[2]["kind"], "function");
+    assert_eq!(scopes[2]["name"], "window");
+
+    // Scopes are ordered by start position; positions are 1-based
+    // [row, col] pairs.
+    assert_eq!(scopes[0]["start"], serde_json::json!([1, 1]));
+    assert_eq!(scopes[1]["start"], serde_json::json!([3, 19]));
+    assert_eq!(scopes[2]["start"], serde_json::json!([8, 13]));
+
+    let outer = &scopes[1];
+    let bindings = bindings_of(outer);
+    // Bindings are sorted by name.
+    let names: Vec<_> = bindings.iter().map(|(name, _, _)| *name).collect();
+    let mut sorted = names.clone();
+    sorted.sort_unstable();
+    assert_eq!(names, sorted);
+
+    // A defaulted formal whose argument a call site omits carries its
+    // literal type: the acceptance "param with a concrete type".
+    let n = bindings
+        .iter()
+        .find(|(name, _, _)| *name == "n")
+        .expect("n bound");
+    assert_eq!(n.1, "param");
+    assert_eq!(n.2, "integer<len=1>");
+
+    // A default-less formal is honest about missing inference.
+    let x = bindings
+        .iter()
+        .find(|(name, _, _)| *name == "x")
+        .expect("x bound");
+    assert_eq!(x.1, "param");
+    assert_eq!(x.2, "unknown");
+
+    // Locals assigned in the body.
+    let weighted = bindings
+        .iter()
+        .find(|(name, _, _)| *name == "weighted")
+        .expect("weighted bound");
+    assert_eq!(weighted.1, "local");
+
+    // Top-level bindings: the function object and the scalar.
+    let top_bindings = bindings_of(&scopes[0]);
+    let threshold = top_bindings
+        .iter()
+        .find(|(name, _, _)| *name == "threshold")
+        .expect("threshold bound");
+    assert_eq!(threshold.1, "local");
+    assert_eq!(threshold.2, "integer<len=1>");
+    assert!(top_bindings
+        .iter()
+        .any(|(name, kind, _)| *name == "moving_average" && *kind == "local"));
+
+    // The nested function closes over names its own body never assigns.
+    let inner_bindings = bindings_of(&scopes[2]);
+    let n_capture = inner_bindings
+        .iter()
+        .find(|(name, _, _)| *name == "n")
+        .expect("n captured");
+    assert_eq!(n_capture.1, "closed-over");
+    assert_eq!(n_capture.2, "integer<len=1>");
+    let values = inner_bindings
+        .iter()
+        .find(|(name, _, _)| *name == "values")
+        .expect("values formal");
+    assert_eq!(values.1, "param");
+}
+
+#[test]
+fn position_flag_selects_innermost_scope_and_filters_late_bindings() {
+    let temp = fixture_package();
+    let file = temp.path().join("R/analysis.R").to_string_lossy().into_owned();
+
+    // Line 9 is inside window's body: only the innermost scope is dumped.
+    let output = run(&["dump-types", &file, "--position", "9:5"]);
+    assert!(output.status.success());
+    let dump = stdout_json(&output);
+    let scopes = dump["files"][0]["scopes"].as_array().unwrap();
+    assert_eq!(scopes.len(), 1, "{scopes:?}");
+    assert_eq!(scopes[0]["name"], "window");
+
+    // Line 4 is inside moving_average (an `if` body creates no scope in
+    // R) but before `weighted` is assigned, so that local is not yet in
+    // scope there.
+    let output = run(&["dump-types", &file, "--position", "4:3"]);
+    let dump = stdout_json(&output);
+    let scopes = dump["files"][0]["scopes"].as_array().unwrap();
+    assert_eq!(scopes.len(), 1);
+    assert_eq!(scopes[0]["name"], "moving_average");
+    let names: Vec<_> = bindings_of(&scopes[0])
+        .iter()
+        .map(|(name, _, _)| *name)
+        .collect();
+    assert!(names.contains(&"x"), "formals always visible: {names:?}");
+    assert!(
+        !names.contains(&"weighted"),
+        "assigned after the position: {names:?}"
+    );
+
+    // Line 1 is top-level only.
+    let output = run(&["dump-types", &file, "--position", "1:1"]);
+    let dump = stdout_json(&output);
+    let scopes = dump["files"][0]["scopes"].as_array().unwrap();
+    assert_eq!(scopes.len(), 1);
+    assert_eq!(scopes[0]["kind"], "top");
+
+    // Repeated positions select the union of their innermost scopes.
+    let output = run(&["dump-types", &file, "--position", "9:5", "--position", "1:1"]);
+    let dump = stdout_json(&output);
+    let scopes = dump["files"][0]["scopes"].as_array().unwrap();
+    let selected: Vec<&str> = scopes
+        .iter()
+        .map(|scope| scope["name"].as_str().unwrap_or("top"))
+        .collect();
+    assert_eq!(selected, vec!["top", "window"]);
+}
+
+#[test]
+fn directory_input_dumps_every_discovered_file() {
+    let temp = fixture_package();
+    let root = temp.path().to_str().unwrap();
+    let output = run(&["dump-types", root]);
+    assert!(output.status.success());
+    let dump = stdout_json(&output);
+    let files = dump["files"].as_array().unwrap();
+    assert_eq!(files.len(), 1);
+    assert!(files[0]["path"]
+        .as_str()
+        .unwrap()
+        .ends_with("R/analysis.R"));
+}
+
+#[test]
+fn exit_code_nonzero_only_for_usage_and_io_failures() {
+    let temp = fixture_package();
+    let file = temp.path().join("R/analysis.R").to_string_lossy().into_owned();
+
+    // Unknown format is a usage failure.
+    let output = run(&["dump-types", &file, "--format", "yaml"]);
+    assert!(!output.status.success());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("expected one of: json"));
+
+    // Missing file is an IO failure.
+    let output = run(&["dump-types", &temp.path().join("nope.R").to_string_lossy()]);
+    assert!(!output.status.success());
+
+    // Malformed position is a usage failure (clap rejects the value).
+    let output = run(&["dump-types", &file, "--position", "line:col"]);
+    assert!(!output.status.success());
+
+    // Files are required.
+    let output = run(&["dump-types"]);
+    assert!(!output.status.success());
+}

--- a/crates/ry-cli/tests/dump_types_e2e.rs
+++ b/crates/ry-cli/tests/dump_types_e2e.rs
@@ -62,9 +62,7 @@ fn fixture_package() -> tempfile::TempDir {
     temp
 }
 
-fn bindings_of<'a>(
-    scope: &'a serde_json::Value,
-) -> Vec<(&'a str, &'a str, &'a str)> {
+fn bindings_of(scope: &serde_json::Value) -> Vec<(&str, &str, &str)> {
     scope["bindings"]
         .as_array()
         .expect("bindings array")
@@ -91,10 +89,12 @@ fn dumps_json_shape_with_param_concrete_and_unknown_types() {
 
     let files = dump["files"].as_array().expect("files array");
     assert_eq!(files.len(), 1);
-    assert!(files[0]["path"]
-        .as_str()
-        .expect("path")
-        .ends_with("R/analysis.R"));
+    assert!(
+        files[0]["path"]
+            .as_str()
+            .expect("path")
+            .ends_with("R/analysis.R")
+    );
 
     let scopes = files[0]["scopes"].as_array().expect("scopes array");
     // Top level, moving_average, and the nested window function.
@@ -152,9 +152,11 @@ fn dumps_json_shape_with_param_concrete_and_unknown_types() {
         .expect("threshold bound");
     assert_eq!(threshold.1, "local");
     assert_eq!(threshold.2, "integer<len=1>");
-    assert!(top_bindings
-        .iter()
-        .any(|(name, kind, _)| *name == "moving_average" && *kind == "local"));
+    assert!(
+        top_bindings
+            .iter()
+            .any(|(name, kind, _)| *name == "moving_average" && *kind == "local")
+    );
 
     // The nested function closes over names its own body never assigns.
     let inner_bindings = bindings_of(&scopes[2]);
@@ -174,7 +176,11 @@ fn dumps_json_shape_with_param_concrete_and_unknown_types() {
 #[test]
 fn position_flag_selects_innermost_scope_and_filters_late_bindings() {
     let temp = fixture_package();
-    let file = temp.path().join("R/analysis.R").to_string_lossy().into_owned();
+    let file = temp
+        .path()
+        .join("R/analysis.R")
+        .to_string_lossy()
+        .into_owned();
 
     // Line 9 is inside window's body: only the innermost scope is dumped.
     let output = run(&["dump-types", &file, "--position", "9:5"]);
@@ -210,7 +216,14 @@ fn position_flag_selects_innermost_scope_and_filters_late_bindings() {
     assert_eq!(scopes[0]["kind"], "top");
 
     // Repeated positions select the union of their innermost scopes.
-    let output = run(&["dump-types", &file, "--position", "9:5", "--position", "1:1"]);
+    let output = run(&[
+        "dump-types",
+        &file,
+        "--position",
+        "9:5",
+        "--position",
+        "1:1",
+    ]);
     let dump = stdout_json(&output);
     let scopes = dump["files"][0]["scopes"].as_array().unwrap();
     let selected: Vec<&str> = scopes
@@ -229,16 +242,17 @@ fn directory_input_dumps_every_discovered_file() {
     let dump = stdout_json(&output);
     let files = dump["files"].as_array().unwrap();
     assert_eq!(files.len(), 1);
-    assert!(files[0]["path"]
-        .as_str()
-        .unwrap()
-        .ends_with("R/analysis.R"));
+    assert!(files[0]["path"].as_str().unwrap().ends_with("R/analysis.R"));
 }
 
 #[test]
 fn exit_code_nonzero_only_for_usage_and_io_failures() {
     let temp = fixture_package();
-    let file = temp.path().join("R/analysis.R").to_string_lossy().into_owned();
+    let file = temp
+        .path()
+        .join("R/analysis.R")
+        .to_string_lossy()
+        .into_owned();
 
     // Unknown format is a usage failure.
     let output = run(&["dump-types", &file, "--format", "yaml"]);

--- a/crates/ry-cli/tests/dump_types_e2e.rs
+++ b/crates/ry-cli/tests/dump_types_e2e.rs
@@ -377,6 +377,70 @@ fn named_function_inside_loop_body_callback_gets_locals() {
     );
 }
 
+/// `--project-root` anchors workspace resolution for non-package files,
+/// overriding the config-root fallback (the directory owning the
+/// discovered `ry.toml`). With two sibling script directories under one
+/// parent, the shared parent's `ry.toml` is discovered from the first
+/// input; `--project-root` must win over that config root, which the
+/// not-a-directory error proves (the config root alone would succeed).
+#[test]
+fn project_root_overrides_config_root_for_non_package_files() {
+    let outer = tempfile::tempdir().unwrap();
+    let parent = outer.path().join("proj");
+    fs::create_dir_all(parent.join("one")).unwrap();
+    fs::create_dir_all(parent.join("two")).unwrap();
+    fs::write(parent.join("ry.toml"), "").unwrap();
+    fs::write(parent.join("one/a.R"), "a_val <- 1L\n").unwrap();
+    fs::write(parent.join("two/b.R"), "b_val <- a_val + 1L\n").unwrap();
+    let a = parent.join("one/a.R").to_string_lossy().into_owned();
+    let b = parent.join("two/b.R").to_string_lossy().into_owned();
+    let parent_str = parent.to_string_lossy().into_owned();
+
+    let run_from_outer = |args: &[&str]| {
+        Command::new(env!("CARGO_BIN_EXE_ry"))
+            .args(args)
+            .current_dir(outer.path())
+            .output()
+            .expect("failed to invoke ry")
+    };
+
+    // Without the flag, the ry.toml's directory (the shared parent) is
+    // the resolution-root fallback and the dump succeeds.
+    let output = run_from_outer(&["dump-types", &a, &b]);
+    assert!(output.status.success(), "{}", output.status);
+    let dump = stdout_json(&output);
+    let files = dump["files"].as_array().unwrap();
+    assert_eq!(files.len(), 2, "{files:?}");
+    assert!(
+        bindings_of(&files[1]["scopes"][0])
+            .iter()
+            .any(|(name, kind, _)| *name == "b_val" && *kind == "local"),
+        "sibling binding missing: {}",
+        files[1]["scopes"][0]
+    );
+
+    // An explicit --project-root at the same parent behaves identically.
+    let output = run_from_outer(&["dump-types", &a, &b, "--project-root", &parent_str]);
+    assert!(output.status.success(), "{}", output.status);
+    assert_eq!(stdout_json(&output)["files"].as_array().unwrap().len(), 2);
+
+    // Pointing the flag at a non-directory fails resolution: the flag
+    // takes precedence over the (valid) config root.
+    let output = run_from_outer(&[
+        "dump-types",
+        &a,
+        &b,
+        "--project-root",
+        &parent.join("one/a.R").to_string_lossy(),
+    ]);
+    assert!(!output.status.success(), "{}", output.status);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("workspace root is not a directory"),
+        "missing InvalidRoot note: {stderr}"
+    );
+}
+
 /// A directory dump must apply the discovered `ry.toml`'s `exclude`
 /// patterns with the same anchoring as `ry check`, so the two commands
 /// never disagree on the file set.

--- a/crates/ry-cli/tests/dump_types_e2e.rs
+++ b/crates/ry-cli/tests/dump_types_e2e.rs
@@ -319,6 +319,10 @@ fn expression_position_assignments_are_locals_with_sites() {
         !names.contains(&"inner"),
         "assigned after the position: {names:?}"
     );
+    assert!(
+        names.contains(&"outer"),
+        "inclusive boundary: starts exactly at the position: {names:?}"
+    );
 }
 
 /// A named function inside an anonymous callback that itself sits in a

--- a/crates/ry-cli/tests/dump_types_e2e.rs
+++ b/crates/ry-cli/tests/dump_types_e2e.rs
@@ -77,6 +77,20 @@ fn bindings_of(scope: &serde_json::Value) -> Vec<(&str, &str, &str)> {
         .collect()
 }
 
+/// The dump entry for one binding by name, with kind and start position.
+fn binding_entry<'a>(scope: &'a serde_json::Value, name: &str) -> (&'a str, serde_json::Value) {
+    let binding = scope["bindings"]
+        .as_array()
+        .expect("bindings array")
+        .iter()
+        .find(|binding| binding["name"].as_str() == Some(name))
+        .unwrap_or_else(|| panic!("`{name}` missing from scope: {scope}"));
+    (
+        binding["kind"].as_str().expect("kind"),
+        binding["start"].clone(),
+    )
+}
+
 #[test]
 fn dumps_json_shape_with_param_concrete_and_unknown_types() {
     let temp = fixture_package();
@@ -243,6 +257,124 @@ fn directory_input_dumps_every_discovered_file() {
     let files = dump["files"].as_array().unwrap();
     assert_eq!(files.len(), 1);
     assert!(files[0]["path"].as_str().unwrap().ends_with("R/analysis.R"));
+}
+
+/// Assignments in expression position — inside a call argument, chained
+/// onto another assignment, in an `if` condition, or through `%<>%` — bind
+/// in the enclosing scope for the checker, so the dump must classify them
+/// as `local` with a definition site (not `imported` with `start: null`),
+/// and `--position` must be able to filter on that site.
+#[test]
+fn expression_position_assignments_are_locals_with_sites() {
+    let temp = tempfile::tempdir().unwrap();
+    let file = temp.path().join("expr_assign.R");
+    fs::write(
+        &file,
+        concat!(
+            "print(side <- 5L)\n",
+            "outer <- inner <- 1L\n",
+            "if (flag <- TRUE) {\n",
+            "  message(\"yes\")\n",
+            "}\n",
+            "q %<>% abs()\n",
+        ),
+    )
+    .unwrap();
+    let file = file.to_str().unwrap();
+
+    let dump = stdout_json(&run(&["dump-types", file]));
+    let top = &dump["files"][0]["scopes"][0];
+    assert_eq!(top["kind"], "top");
+    assert_eq!(
+        binding_entry(top, "side"),
+        ("local", serde_json::json!([1, 7]))
+    );
+    assert_eq!(
+        binding_entry(top, "inner"),
+        ("local", serde_json::json!([2, 10]))
+    );
+    assert_eq!(
+        binding_entry(top, "outer"),
+        ("local", serde_json::json!([2, 1]))
+    );
+    assert_eq!(
+        binding_entry(top, "flag"),
+        ("local", serde_json::json!([3, 5]))
+    );
+    assert_eq!(
+        binding_entry(top, "q"),
+        ("local", serde_json::json!([6, 1]))
+    );
+
+    // With a site on record, --position filtering applies: at 2:1 `side`
+    // (line 1) is already assigned, while `inner` (assigned later on the
+    // same line) is not yet bound. `outer` starts exactly at the position
+    // and counts as visible there.
+    let dump = stdout_json(&run(&["dump-types", file, "--position", "2:1"]));
+    let top = &dump["files"][0]["scopes"][0];
+    assert_eq!(top["kind"], "top");
+    assert_eq!(binding_entry(top, "side").0, "local");
+    let names: Vec<&str> = bindings_of(top).iter().map(|(name, _, _)| *name).collect();
+    assert!(
+        !names.contains(&"inner"),
+        "assigned after the position: {names:?}"
+    );
+}
+
+/// A named function inside an anonymous callback that itself sits in a
+/// loop body is recorded by the checker (only the anonymous literal is
+/// discarded), so the dump's scope indexing must recurse through the call
+/// argument and the callback's body to give it its own locals. Closed-over
+/// bindings resolve to the enclosing recorded scope's site.
+#[test]
+fn named_function_inside_loop_body_callback_gets_locals() {
+    let temp = tempfile::tempdir().unwrap();
+    let file = temp.path().join("loop_cb.R");
+    fs::write(
+        &file,
+        concat!(
+            "xs <- c(1, 2, 3)\n",
+            "for (i in 1:3) {\n",
+            "  lapply(xs, function(item) {\n",
+            "    step <- function(v) {\n",
+            "      scaled <- v * i\n",
+            "      scaled\n",
+            "    }\n",
+            "    step(item)\n",
+            "  })\n",
+            "}\n",
+        ),
+    )
+    .unwrap();
+    let dump = stdout_json(&run(&["dump-types", file.to_str().unwrap()]));
+    let scopes = dump["files"][0]["scopes"].as_array().unwrap();
+    let names: Vec<&str> = scopes
+        .iter()
+        .map(|scope| scope["name"].as_str().unwrap_or("top"))
+        .collect();
+    // The anonymous callback scope is absent (discarding mode); `step`
+    // inside it is not.
+    assert_eq!(names, vec!["top", "step"], "{scopes:?}");
+
+    let step = &scopes[1];
+    assert_eq!(
+        binding_entry(step, "scaled"),
+        ("local", serde_json::json!([5, 7]))
+    );
+    assert_eq!(
+        binding_entry(step, "v"),
+        ("param", serde_json::json!([4, 22]))
+    );
+    // `i` and `xs` belong to the top scope; their sites resolve through
+    // the enclosing-scope chain (the callback between them is unrecorded).
+    assert_eq!(
+        binding_entry(step, "i"),
+        ("closed-over", serde_json::json!([2, 6]))
+    );
+    assert_eq!(
+        binding_entry(step, "xs"),
+        ("closed-over", serde_json::json!([1, 1]))
+    );
 }
 
 /// A directory dump must apply the discovered `ry.toml`'s `exclude`

--- a/crates/ry-cli/tests/dump_types_e2e.rs
+++ b/crates/ry-cli/tests/dump_types_e2e.rs
@@ -245,6 +245,143 @@ fn directory_input_dumps_every_discovered_file() {
     assert!(files[0]["path"].as_str().unwrap().ends_with("R/analysis.R"));
 }
 
+/// A directory dump must apply the discovered `ry.toml`'s `exclude`
+/// patterns with the same anchoring as `ry check`, so the two commands
+/// never disagree on the file set.
+#[test]
+fn directory_dump_applies_config_exclude_patterns_like_check() {
+    let temp = tempfile::tempdir().unwrap();
+    fs::write(temp.path().join("keep.R"), "a <- 1L\n").unwrap();
+    fs::create_dir_all(temp.path().join("vendor")).unwrap();
+    fs::write(temp.path().join("vendor/skip.R"), "b <- 2L\n").unwrap();
+    // Gitignore-style patterns are matched against paths relative to the
+    // directory owning the ry.toml; `**` on both sides tolerates the
+    // relative `./` discovery prefix.
+    fs::write(
+        temp.path().join("ry.toml"),
+        "exclude = [\"**/vendor/**\"]\n",
+    )
+    .unwrap();
+    let root = temp.path().to_str().unwrap();
+
+    let dump = stdout_json(&run(&["dump-types", root]));
+    let dumped: Vec<&str> = dump["files"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|file| file["path"].as_str().unwrap())
+        .collect();
+    assert_eq!(dumped.len(), 1, "{dumped:?}");
+    assert!(dumped[0].ends_with("keep.R"), "{dumped:?}");
+    assert!(
+        !dumped.iter().any(|path| path.contains("vendor")),
+        "excluded file must not be dumped: {dumped:?}"
+    );
+
+    // The same directory through `ry check` analyzes exactly one file:
+    // the dumped set and the checked set agree.
+    let check = run(&["check", root]);
+    let stderr = String::from_utf8_lossy(&check.stderr);
+    assert!(
+        stderr.contains("checked 1 file(s)"),
+        "check and dump disagree on the file set: {stderr}"
+    );
+}
+
+/// A file whose first statement is a bare `function` literal produces a
+/// function record whose span starts at the same byte 0 as the whole-file
+/// top scope; the dump dedup must key on the kind too and keep both.
+#[test]
+fn leading_function_literal_keeps_top_scope_and_its_bindings() {
+    let temp = tempfile::tempdir().unwrap();
+    let file = temp.path().join("f.R");
+    fs::write(&file, "function(x) x\na <- 1L\n").unwrap();
+    let file = file.to_str().unwrap();
+
+    let dump = stdout_json(&run(&["dump-types", file]));
+    let scopes = dump["files"][0]["scopes"].as_array().unwrap();
+    assert_eq!(scopes.len(), 2, "{scopes:?}");
+    assert_eq!(scopes[0]["kind"], "function");
+    assert_eq!(scopes[0]["name"], serde_json::Value::Null);
+    assert_eq!(scopes[1]["kind"], "top");
+    let top = bindings_of(&scopes[1]);
+    assert!(
+        top.iter()
+            .any(|(name, kind, _)| *name == "a" && *kind == "local"),
+        "top-level binding vanished: {top:?}"
+    );
+
+    // A position on a later line resolves through the surviving top
+    // scope instead of selecting nothing.
+    let dump = stdout_json(&run(&["dump-types", file, "--position", "2:1"]));
+    let scopes = dump["files"][0]["scopes"].as_array().unwrap();
+    assert_eq!(scopes.len(), 1, "{scopes:?}");
+    assert_eq!(scopes[0]["kind"], "top");
+    assert!(
+        bindings_of(&scopes[0])
+            .iter()
+            .any(|(name, _, _)| *name == "a")
+    );
+}
+
+/// The README records this asymmetry: an anonymous function literal used
+/// as a call argument is inferred in discarding mode and is not dumped,
+/// but a named function defined inside it completes and is.
+#[test]
+fn named_function_inside_anonymous_callback_is_recorded() {
+    let temp = tempfile::tempdir().unwrap();
+    let file = temp.path().join("g.R");
+    fs::write(
+        &file,
+        concat!(
+            "x <- lapply(1:3, function(item) {\n",
+            "  helper <- function(v) v + 1L\n",
+            "  helper(item)\n",
+            "})\n",
+        ),
+    )
+    .unwrap();
+    let dump = stdout_json(&run(&["dump-types", file.to_str().unwrap()]));
+    let scopes = dump["files"][0]["scopes"].as_array().unwrap();
+    let names: Vec<&str> = scopes
+        .iter()
+        .map(|scope| scope["name"].as_str().unwrap_or("top"))
+        .collect();
+    // The anonymous callback scope is absent; `helper` inside it is not.
+    assert_eq!(names, vec!["top", "helper"], "{scopes:?}");
+}
+
+/// Degraded scopes (serialized data over the byte cap) print a stderr
+/// note like `ry check`'s, without polluting the JSON on stdout.
+#[test]
+fn degraded_scopes_are_noted_on_stderr_only() {
+    let temp = tempfile::tempdir().unwrap();
+    fs::create_dir_all(temp.path().join("R")).unwrap();
+    fs::create_dir_all(temp.path().join("data")).unwrap();
+    fs::write(
+        temp.path().join("DESCRIPTION"),
+        "Package: degr\nVersion: 0.0.0.9000\nLazyData: true\n",
+    )
+    .unwrap();
+    fs::write(temp.path().join("R/x.R"), "a <- 1L\n").unwrap();
+    fs::write(temp.path().join("data/big.rda"), vec![0u8; 4096]).unwrap();
+    fs::write(temp.path().join("ry.toml"), "max-serialized-bytes = 16\n").unwrap();
+    let root = temp.path().to_str().unwrap();
+
+    let output = run(&["dump-types", root]);
+    assert!(output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("degraded scope"),
+        "missing parity note on stderr: {stderr}"
+    );
+    // The note never leaks into the machine-facing dump.
+    let dump = stdout_json(&output);
+    let files = dump["files"].as_array().unwrap();
+    assert_eq!(files.len(), 1);
+    assert!(files[0]["path"].as_str().unwrap().ends_with("R/x.R"));
+}
+
 #[test]
 fn exit_code_nonzero_only_for_usage_and_io_failures() {
     let temp = fixture_package();


### PR DESCRIPTION
## Summary

Adds a non-interactive CLI that dumps inferred type information per lexical scope, so downstream tooling can query "which bindings are in scope at line N, with what inferred types":

```
ry dump-types <FILE>... [--project-root <DIR>] [--format json] [--position LINE:COL]...
```

One or more R files, or a directory (expanded via `ry check`'s own discovery rules, so a dump and a check always agree on the file set). Output is JSON on stdout: files -> scopes (kind/name/start/end) -> bindings (name/kind/type/start). Deterministic order: scopes by start position, bindings by name. Types are `RType`'s Display strings - the same strings LSP hover returns - with the fully-uninformed type printed as `unknown`; one untyped binding never fails the run. One analysis pass that reuses `ry check`'s exact pipeline (config discovery, per-DESCRIPTION-package grouping, workspace resolution, shared fixpoint), so emitted types are what a check run infers.

## Implementation

Scopes are transient walk state in the checker - not retained after a check, with no positions or names - so this adds an opt-in capture path rather than changing retention:

- `ry-checker`: public `ScopeRecord`/`ScopeRecordKind` types; `capture_scopes` flag on `Checker` (off by default) with `enable_scope_capture`/`take_scope_records`. Function scopes snapshot at the end of `walk_stmt`'s function-body arms, gated on `capture && !discarding` so fixpoint/signature re-walks never double-capture; the top-level scope is recorded at the end of `emit_diagnostics`.
- `ry-checker::Project`: records ride the existing per-file tuple through the pass-3 emitter (no Mutex), with `enable_scope_capture`/`take_scope_records` wrappers.
- `ry-analysis`: `check_project_with_scope_capture`, same wiring as `check_project` via a shared private helper.
- `ry-cli`: the subcommand - parallel parse (existing thread-local parser pattern), grouping, JSON assembly, binding-kind classification, AST scan for definition sites, position filtering.

Capture is off by default, so `ry check` and the LSP paths are untouched (existing suites unchanged).

## Binding kinds

`param` = formal of this scope still marked as parameter (a reassigned formal degrades to `local`, matching R's rebinding). `local` = first assigned in this scope's body (blocks included; R has no block scope). `closed-over` = function-scope binding inherited via the enclosing-scope clone. `imported` = top-level binding never assigned in the file (ambient, e.g. Shiny server fragments). Documented in the README section.

## Documented limitations (README + code comments)

- Anonymous function literals in argument position are not recorded as scopes - the checker only ever walks them in discarding mode (checker design, not a dump limitation).
- Snapshots are end-of-body state; a nested scope reflects the enclosing scope at the inner function's definition point (ry's documented closure approximation). `--position` compensates by dropping locals first assigned after the position.
- `--format` currently accepts only `json`.

## Tests

- `crates/ry-cli/tests/dump_types_e2e.rs` (4 tests): JSON shape, a param binding with a concrete type, an `unknown` case, `--position` filtering, exit-code semantics (0 with diagnostics present; 1 for usage-adjacent IO/config failures; 2 for clap usage errors).
- Unit tests in `project.rs`, `check.rs`, and the CLI (classification, capture gating).
- The integration suite caught a real bug during development: `Scope::clone` copies the parameter-marker set, so a captured outer formal would misclassify as `param` of the inner scope; classification now requires declaration in that record's own formals.

## Performance

Release build on a 300-file package tiled from vendored purrr sources: `ry check` 0.50-0.59s vs `ry dump-types` 0.54-0.57s - parity within noise; one pass, no per-position re-analysis.

## Smoke tests (trimmed)

- `glue/R/safe.R`, full dump, exit 0: top scope locals `glue_safe`/`glue_data_safe`/`get_transformer` as `function<len=1>`; inside `glue_safe`: params `...`/`.envir` (`unknown`), `glue_safe` closed-over.
- `purrr/R/adverb-partial.R --position 98:10`, exit 0: one `function`/`partial` scope `[82,12]`-`[140,2]`; params `.f`/`...` `unknown`; locals `env` -> `opaque<len=?>`, `heterogeneous_envs` -> `logical<len=1>`; `partial` closed-over; `fn_sym` (first assigned line 105, after the position) correctly absent.

## Merge order

Touches `crates/ry-analysis/src/check.rs` and `lib.rs`, which #101 also edits (doc corrections + lib.rs reduction). Rebase this on main after #101 lands; the conflict is textual and small.

## Gates

- `cargo test --workspace` - 45 suites ok, 0 failures (includes the R oracle gate, R 4.6.1)
- `cargo clippy --workspace --all-targets -- -D warnings` - clean
- `cargo fmt --all -- --check` - clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the `ry dump-types` command to output lexical scopes and inferred bindings as JSON.
  * Supports project-root selection, directory discovery, source-position filtering, and nested scopes.
  * Reports binding kinds, definition locations, parameters, closures, imported names, and inferred types.
  * Provides distinct exit handling for usage, I/O, configuration, and analysis issues.
  * Supports opt-in lexical-scope capture during project analysis without changing existing commands.

* **Documentation**
  * Added README and changelog documentation covering output format, filtering, project discovery, and command behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->