### PR TITLE
fix: address surviving #90 review leftovers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -169,6 +169,26 @@ All notable changes to ry are documented in this file.
 
 ### Fixed
 
+- The Zed extension's cache-precedence test asserted only that a
+  constructed release path ends in "ry" (#90, the #82 test-theater
+  family), so it passed with the cache branch deleted outright. Binary
+  resolution now runs through an extracted `BinarySource` precedence
+  function whose tests pin settings > PATH lookup > previous download >
+  download and require the cached file to still exist on disk
+  (editors/zed/src/lib.rs).
+- The P36-W6 many-files test's drain loop stopped at the first silent
+  500 ms window (#90), so a loaded machine could end collection before
+  the background index plus the publish debounce had emitted anything,
+  failing the sentinel assertions with no production defect. The loop
+  now drains until both sentinel files have published, bounded by a
+  total deadline instead of a per-message gap
+  (ry-lsp/tests/p36_contract.rs).
+- `ecosystem/check-ledger.py` compared each summary block per observed
+  key only (#90), so a negative entry for an unseen label offset by a
+  positive one preserved both the total and every observed count. Each
+  summary is now compared over the union of summary and observed keys;
+  zero-valued entries for categories no finding carries remain valid
+  (the classification taxonomy is fixed), and any other mismatch fails.
 - Tests that could not fail were fixed or deleted (#82): the ry-analysis
   workspace-context test now asserts the rlang/RY070 flip in both
   directions (check.rs), the same-name symbol test asserts reference

--- a/crates/ry-lsp/tests/p36_contract.rs
+++ b/crates/ry-lsp/tests/p36_contract.rs
@@ -1267,20 +1267,30 @@ fn p36_w6_many_files_flat_filter_construction() {
             "textDocument": {"uri": trigger_uri, "languageId": "r", "version": 1, "text": trigger_text}
         })).await.unwrap();
 
-        // Drain ALL diagnostic publications with a timeout-based approach
-        // (like p36_w7). The background index + debounced publish will send
-        // diagnostics for trigger.R and all indexed files. We collect
-        // diagnostics for file_00 and file_31 from the drain.
+        // Collect diagnostics for the first and last indexed files from
+        // the background index's publications. The background index +
+        // debounced publish will send diagnostics for trigger.R and all
+        // indexed files; we keep receiving until both sentinel files have
+        // published.
         let first_uri = file_uri(&fixture.path("file_00.R"));
         let last_uri = file_uri(&fixture.path("file_31.R"));
         let mut first_diags: Vec<Published> = Vec::new();
         let mut last_diags: Vec<Published> = Vec::new();
 
-        for _ in 0..256 {
-            match tokio::time::timeout(
-                std::time::Duration::from_millis(500),
-                client.receive(),
-            ).await {
+        // Drain until diagnostics for both sentinel files have been
+        // published, bounded by a total deadline. Quiescence (one silent
+        // 500 ms window) cannot decide completion here: on a loaded
+        // machine the background index of 32 files plus the publish
+        // debounce can pause longer than a single window before the first
+        // indexed-file publication, which used to end collection with both
+        // sentinel vectors still empty and fail the assertions below with
+        // no production defect (#90).
+        let drain_deadline =
+            tokio::time::Instant::now() + std::time::Duration::from_secs(30);
+        while (first_diags.is_empty() || last_diags.is_empty())
+            && tokio::time::Instant::now() < drain_deadline
+        {
+            match tokio::time::timeout_at(drain_deadline, client.receive()).await {
                 Ok(Ok(message)) => {
                     if message.get("method") == Some(&json!("textDocument/publishDiagnostics")) {
                         if message.pointer("/params/uri") == Some(&json!(first_uri)) {
@@ -1300,7 +1310,7 @@ fn p36_w6_many_files_flat_filter_construction() {
                     }
                 }
                 Ok(Err(e)) => panic!("transport error during drain: {e}"),
-                Err(_) => break, // timeout: server has quiesced
+                Err(_) => break, // total deadline exhausted before both files published
             }
         }
 

--- a/ecosystem/check-ledger.py
+++ b/ecosystem/check-ledger.py
@@ -5,8 +5,15 @@ its findings array.
 Asserts:
   - sum(classification.values()) == len(findings)
   - sum(workstream_counts.values()) == len(findings)
-  - classification counts match the labels in findings
-  - workstream_counts match the workstream field in findings
+  - every classification entry equals the actual label count (entries for
+    categories no finding carries must be 0)
+  - every workstream_counts entry equals the actual workstream count,
+    likewise
+
+Comparing per key over the union of summary and observed labels rejects
+what per-key loops over the observed labels alone miss: a negative entry
+for an unseen category offset by a positive one preserves both the total
+and every observed count.
 
 Usage:
   python3 ecosystem/check-ledger.py docs/corpus/posit-0.9.0.json
@@ -15,6 +22,24 @@ Usage:
 import json
 import sys
 from collections import Counter
+
+
+def compare_summary(name: str, summary: dict, actual: Counter, errors: list) -> None:
+    """Require every summary entry to equal its count computed from findings.
+
+    The summary may carry zero-valued entries for categories no finding
+    uses (the classification taxonomy is fixed), so maps are compared per
+    key rather than for exact equality: any key present in the summary
+    must hold its actual count (0 for unseen categories), and any key the
+    findings carry must be present.
+    """
+    for key in sorted(set(summary) | set(actual), key=repr):
+        summary_count = summary.get(key, 0)
+        actual_count = actual[key]  # Counter: unseen keys count as 0.
+        if summary_count != actual_count:
+            errors.append(
+                f"{name}[{key!r}] ({summary_count}) != actual count ({actual_count})"
+            )
 
 
 def check_ledger(path: str) -> int:
@@ -34,15 +59,9 @@ def check_ledger(path: str) -> int:
             f"classification sum ({cls_sum}) != findings length ({n})"
         )
 
-    # Check classification matches labels
+    # Check classification matches labels exactly
     label_counts = Counter(f.get("label") for f in findings)
-    for label, count in label_counts.items():
-        summary_count = classification.get(label, 0)
-        if count != summary_count:
-            errors.append(
-                f"classification[{label}] ({summary_count}) != "
-                f"actual label count ({count})"
-            )
+    compare_summary("classification", classification, label_counts, errors)
 
     # Check workstream counts
     ws_counts = data.get("workstream_counts", {})
@@ -52,15 +71,9 @@ def check_ledger(path: str) -> int:
             f"workstream_counts sum ({ws_sum}) != findings length ({n})"
         )
 
-    # Check workstream counts match
+    # Check workstream counts match exactly
     actual_ws = Counter(f.get("workstream") for f in findings)
-    for ws, count in actual_ws.items():
-        summary_count = ws_counts.get(ws, 0)
-        if count != summary_count:
-            errors.append(
-                f"workstream_counts[{ws}] ({summary_count}) != "
-                f"actual count ({count})"
-            )
+    compare_summary("workstream_counts", ws_counts, actual_ws, errors)
 
     if errors:
         print(f"FAIL: {path}")

--- a/editors/zed/src/lib.rs
+++ b/editors/zed/src/lib.rs
@@ -34,6 +34,26 @@ struct GithubReleaseDetails {
     downloaded_binary_path: String,
 }
 
+/// Where `language_server_binary` obtains the `ry` binary from, in
+/// precedence order. Split out from the resolution flow so the precedence
+/// itself is unit-testable: the settings and PATH lookups are host calls
+/// (`LspSettings::for_worktree`, `Worktree::which`) that only answer
+/// inside a running Zed process.
+#[derive(Debug, PartialEq)]
+enum BinarySource {
+    /// Explicit `binary.path` from the user's language-server settings.
+    Settings(String),
+
+    /// `ry` found through the worktree's PATH lookup.
+    PathLookup(String),
+
+    /// A previously downloaded binary that is still on disk.
+    Cache(String),
+
+    /// No local candidate; download from the latest GitHub release.
+    Download,
+}
+
 impl RyExtension {
     fn language_server_binary(
         &mut self,
@@ -53,34 +73,34 @@ impl RyExtension {
             .as_ref()
             .and_then(|binary_settings| binary_settings.arguments.clone());
 
-        // 1. Use user-specified path to the `ry` binary, if specified.
-        if let Some(path) = binary_settings.and_then(|binary_settings| binary_settings.path) {
-            return Ok(RyBinary {
-                path,
-                args: binary_args,
-            });
-        }
+        // The user-specified path, a `ry` on the PATH, or a previous
+        // download, in that order. A cached download is only a candidate
+        // while its file is still on disk: Zed may clear the extension's
+        // working directory between versions, leaving
+        // `cached_binary_path` dangling.
+        let cached_path = self
+            .cached_binary_path
+            .as_deref()
+            .filter(|path| Self::cached_binary_on_disk(path));
 
-        // 2. Use binary on the `PATH`, if it exists.
-        if let Some(path) = worktree.which("ry") {
-            return Ok(RyBinary {
-                path,
-                args: binary_args,
-            });
-        }
-
-        // 3. Use binary from a previous download, if we can find one.
-        if let Some(path) = &self.cached_binary_path {
-            if fs::metadata(path).is_ok_and(|stat| stat.is_file()) {
+        match Self::resolve_binary_source(
+            binary_settings.and_then(|binary_settings| binary_settings.path),
+            worktree.which("ry"),
+            cached_path,
+        ) {
+            BinarySource::Settings(path)
+            | BinarySource::PathLookup(path)
+            | BinarySource::Cache(path) => {
                 return Ok(RyBinary {
-                    path: path.clone(),
+                    path,
                     args: binary_args,
                 });
             }
+            BinarySource::Download => {}
         }
 
-        // 4. All other methods failed; download the binary from the latest
-        //    GitHub release.
+        // All local candidates failed; download the binary from the latest
+        // GitHub release.
         zed::set_language_server_installation_status(
             language_server_id,
             &zed::LanguageServerInstallationStatus::CheckingForUpdate,
@@ -214,6 +234,32 @@ impl GithubReleaseDetails {
 }
 
 impl RyExtension {
+    /// Resolve the binary source by precedence: the user-specified path,
+    /// then a PATH lookup, then a previous download, and only then a
+    /// fresh download. The caller offers the cached path as a candidate
+    /// only while the file is still on disk.
+    fn resolve_binary_source(
+        settings_path: Option<String>,
+        path_lookup: Option<String>,
+        cached_path: Option<&str>,
+    ) -> BinarySource {
+        if let Some(path) = settings_path {
+            return BinarySource::Settings(path);
+        }
+        if let Some(path) = path_lookup {
+            return BinarySource::PathLookup(path);
+        }
+        if let Some(path) = cached_path {
+            return BinarySource::Cache(path.to_string());
+        }
+        BinarySource::Download
+    }
+
+    /// Whether a cached download still exists as a regular file.
+    fn cached_binary_on_disk(path: &str) -> bool {
+        fs::metadata(path).is_ok_and(|stat| stat.is_file())
+    }
+
     /// Compute SHA-256 hash and return as lowercase hex string.
     /// Uses a pure-Rust implementation that works in WASM.
     ///
@@ -393,8 +439,6 @@ zed::register_extension!(RyExtension);
 
 #[cfg(test)]
 mod p37_w4_tests {
-    use crate::GithubReleaseDetails;
-
     /// P37-W4: SHA-256 known-answer test (NIST FIPS 180-4).
     #[test]
     fn sha256_empty_string() {
@@ -447,30 +491,61 @@ mod p37_w4_tests {
             "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
         );
     }
-
-    /// P37-W4: Binary path precedence test — cached binary is used before
-    /// download. This is verified through the GithubReleaseDetails path
-    /// construction, which determines what a downloaded binary looks like.
-    #[test]
-    fn cached_path_precedence() {
-        let details = GithubReleaseDetails::new(
-            zed_extension_api::Os::Linux,
-            zed_extension_api::Architecture::X8664,
-            "0.9.0".into(),
-        );
-        // The cached path must be non-empty and point to a ry binary.
-        assert!(!details.downloaded_binary_path.is_empty());
-        assert!(
-            details.downloaded_binary_path.ends_with("ry"),
-            "binary path must end with 'ry': {}",
-            details.downloaded_binary_path
-        );
-    }
 }
 
 #[cfg(test)]
 mod test {
-    use crate::GithubReleaseDetails;
+    use crate::{BinarySource, GithubReleaseDetails, RyExtension};
+
+    /// Binary resolution precedence: the user-specified path, a PATH hit,
+    /// and a previous download win in that order; only when no candidate
+    /// exists does the extension fall back to a download. The predecessor
+    /// of this test (`cached_path_precedence`, swept in #90) asserted only
+    /// that a constructed release path ends in "ry", which passes even if
+    /// the cache branch is deleted outright.
+    #[test]
+    fn binary_source_precedence() {
+        let cached = "ry-0.9.0/ry-cli-x86_64-unknown-linux-gnu/ry";
+
+        assert_eq!(
+            RyExtension::resolve_binary_source(
+                Some("/opt/ry".into()),
+                Some("/usr/bin/ry".into()),
+                Some(cached),
+            ),
+            BinarySource::Settings("/opt/ry".into())
+        );
+        assert_eq!(
+            RyExtension::resolve_binary_source(
+                None,
+                Some("/usr/bin/ry".into()),
+                Some(cached),
+            ),
+            BinarySource::PathLookup("/usr/bin/ry".into())
+        );
+        assert_eq!(
+            RyExtension::resolve_binary_source(None, None, Some(cached)),
+            BinarySource::Cache(cached.into())
+        );
+        assert_eq!(
+            RyExtension::resolve_binary_source(None, None, None),
+            BinarySource::Download
+        );
+    }
+
+    /// The cache candidate is offered only while the downloaded file is
+    /// still on disk, so a cache wiped between versions falls through to
+    /// a download rather than returning a dangling path.
+    #[test]
+    fn cached_binary_on_disk_requires_a_file() {
+        let file = std::env::temp_dir().join(format!("ry-zed-cache-{}", std::process::id()));
+        std::fs::write(&file, b"").unwrap();
+        let path = file.to_str().unwrap();
+        assert!(RyExtension::cached_binary_on_disk(path));
+        std::fs::remove_file(&file).unwrap();
+        assert!(!RyExtension::cached_binary_on_disk(path));
+        assert!(!RyExtension::cached_binary_on_disk("ry-no-such-cached-binary"));
+    }
 
     /// Tests path construction for all six cargo-dist targets, locking down
     /// the asset prefix / binary name asymmetry: the asset is

--- a/editors/zed/src/lib.rs
+++ b/editors/zed/src/lib.rs
@@ -535,9 +535,14 @@ mod test {
 
     /// The cache candidate is offered only while the downloaded file is
     /// still on disk, so a cache wiped between versions falls through to
-    /// a download rather than returning a dangling path.
+    /// a download rather than returning a dangling path. Only a regular
+    /// file counts: a directory at the cached path is not a usable
+    /// binary and must fall through to a download as well.
     #[test]
     fn cached_binary_on_disk_requires_a_file() {
+        let directory = std::env::temp_dir();
+        assert!(!RyExtension::cached_binary_on_disk(directory.to_str().unwrap()));
+
         let file = std::env::temp_dir().join(format!("ry-zed-cache-{}", std::process::id()));
         std::fs::write(&file, b"").unwrap();
         let path = file.to_str().unwrap();


### PR DESCRIPTION
## Summary

Addresses the surviving findings from #90 (PR #79 review leftovers triaged as real but never implemented). The other two #90 items (SetOpenFile version guard, snapshot/symbols ordering) live in crates/ry-analysis code that #101 deletes, so they ride with that PR and are out of scope here.

Part of #90.

## 1. Zed test theater - fixed (test(zed): pin binary-resolution cache precedence)

`cached_path_precedence` only checked that a constructed path ends in `ry` - path construction is already exhaustively covered elsewhere. Binary resolution now decides through an extracted pure `BinarySource` precedence function plus a `cached_binary_on_disk` check, and new tests pin the full order: settings > PATH lookup > cache > download, with the cache entry backed by a real temp file. Mutation check: deleting the cache branch fails `binary_source_precedence`; the old test passed under the same mutation (the #82 failure mode).

`Worktree`/`LspSettings::for_worktree` are host-IPC backed (WIT re-exports), so end-to-end `language_server_binary` coverage is not feasible in unit tests. One disclosed nuance: `worktree.which("ry")` is now evaluated even when a settings path is configured - a pure, read-only host query whose result is discarded.

## 2. p36_contract drain loop - fixed, harness only (test(lsp): drain p36-w6 until sentinel files publish)

The issue text maps to the w6 loop (`first_diags`/`last_diags`, file_00/file_31), not the w7 loop the drifted line number pointed at. The loop now drains until both sentinel files publish, bounded by a 30 s total deadline via `timeout_at`, replacing the first-500-ms-silence termination. The quiescence tail is gone too. No production code touched. Verified: 5 consecutive runs all 10/10, including 2 under 8-way CPU load on an already-loaded machine (load avg ~20).

## 3. check-ledger.py validation gap - fixed (fix(ecosystem): reject offsetting ledger summary corruption)

Demonstrated the gap first: the old script accepted a `classification` map doctored with `{ghost_label: -1, phantom_label: +1}` - totals and observed counts preserved. `compare_summary` now walks the union of summary and observed keys. Key discovery: strict map equality would be wrong - the committed posit-0.9.0.json legitimately carries `uncertain: 0` (fixed taxonomy), so zero-valued entries for unseen categories stay valid; every other mismatch (extra non-zero, negative, missing, drift) fails. Validated against the committed posit-0.9.0.json and posit-0.8.0.json, which are the only CI callers (two ecosystem.yml invocations).

## 4. Dropped degraded_scopes in ry-cli - declined as already handled

Two-part evidence:
- The reporting exists: `package_scope.degraded_scopes` is collected into `CheckResult.degraded` and printed by `print_degraded` in both the human summary and `--statistics` (landed in #39, before #90 was filed). Verified end-to-end with a package fixture carrying a >2 MiB-decoded `.rda` (default cap is 2 MiB): `ry check` prints the note, `--output-format json` stays clean by design.
- The literal `degraded_scopes: Vec::new()` into `WorkspaceContext` is inert - `check_project` never reads that field, so forwarding it would be a dead assignment with no observable effect.

No CHANGELOG entry for this item (no behavior change).

## New findings posted back to #90

Three items surfaced during verification that belong on the issue rather than in this PR - see the #90 comment: the w7 drain loop's false-PASS silence-window weakness (needs a design decision), the dead `WorkspaceContext.native_registrations` plumbing, and a stale file-header claim in p36_contract.rs.

## Gates

- `cargo test --workspace` - 1004 passed, 0 failed, 44 binaries (includes the R oracle gate)
- `cargo clippy --workspace --all-targets -- -D warnings` - clean
- `cargo fmt --all -- --check` - clean
- `cargo build` + `cargo test --manifest-path editors/zed/Cargo.toml` - 8 passed, 0 failed
- `cargo test -p ry-lsp --test p36_contract` - 5 runs, all 10/10


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved language-server binary selection by prioritizing configured paths, system-installed binaries, valid cached files, and downloads.
  - Prevented stale or invalid cached binaries from being selected.
  - Improved diagnostics collection for large, multi-file language-server projects.
  - Strengthened ledger validation to detect incorrect counts for newly observed categories.

- **Documentation**
  - Updated the unreleased changelog with these fixes and validation improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->