### PR TITLE
chore: remove dead native_registrations plumbing and fix stale p36 header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -248,9 +248,19 @@ All notable changes to ry are documented in this file.
   `textDocument/foldingRange` and `textDocument/selectionRange` above;
   none of the three was ever shipped in a release, so no released
   capability schema changes.
+- **Deleted the dead `WorkspaceContext::native_registrations` plumbing
+  (#90)**: ry-workspace populated the per-file native-routine map and the
+  CLI forwarded it into `CheckInput`, but `check_project` never applied
+  it — ry-checker's `Project` has no setter for it, and the names already
+  reach the checker through `external_bindings`. The field, its
+  population, and the forwarding are gone; diagnostics are unchanged.
 
 ### Fixed
 
+- The `p36_contract.rs` file header still claimed every test in the file
+  is `#[ignore]`'d (#90); none are — the attributes were removed as
+  P36-W2 through W7 landed. The header now records that the tests run as
+  ordinary (passing) contract gates.
 - The Zed extension's cache-precedence test asserted only that a
   constructed release path ends in "ry" (#90, the #82 test-theater
   family), so it passed with the cache branch deleted outright. Binary

--- a/crates/ry-cli/src/main.rs
+++ b/crates/ry-cli/src/main.rs
@@ -963,7 +963,6 @@ fn run_check_once(
                 imported_bindings: package_scope.imported_bindings,
                 s3_methods: package_scope.s3_methods,
                 load_bindings: package_scope.load_bindings,
-                native_registrations: package_scope.native_registrations,
                 degraded_scopes: Vec::new(),
             }),
         };
@@ -1758,7 +1757,6 @@ fn run_dump_types(
                 imported_bindings: package_scope.imported_bindings,
                 s3_methods: package_scope.s3_methods,
                 load_bindings: package_scope.load_bindings,
-                native_registrations: package_scope.native_registrations,
                 degraded_scopes: Vec::new(),
             }),
         };

--- a/crates/ry-lsp/tests/p36_contract.rs
+++ b/crates/ry-lsp/tests/p36_contract.rs
@@ -1,9 +1,10 @@
 //! P36-W1: Red contract matrix — deterministic failing cases for every
 //! remaining LSP contract gap addressed by Plan 36.
 //!
-//! Every test in this file is `#[ignore]`'d because it verifies behavior that
-//! P36-W2 through W7 will implement. Each test's `#[ignore]` message and
-//! doc-comment name the specific workstream (and issue) that will make it pass.
+//! Every case in this file was authored `#[ignore]`'d while P36-W2 through
+//! W7 were unimplemented; those attributes were removed as the workstreams
+//! landed, and the tests now run as ordinary (passing) contract gates. Each
+//! test's doc-comment names the specific workstream (and issue) it covers.
 //!
 //! Shared infrastructure reuses Plan 35's `ry-testkit` (`FixtureProject`,
 //! `LspSession`, `AsyncJsonRpcClient`) and the `ry_lsp::run_with` in-memory

--- a/crates/ry-workspace/src/lib.rs
+++ b/crates/ry-workspace/src/lib.rs
@@ -34,8 +34,6 @@ pub struct WorkspaceContext {
     pub bare_bindings: HashMap<String, HashSet<String>>,
     pub external_bindings: HashMap<String, HashSet<String>>,
     pub imported_bindings: HashMap<String, HashMap<String, String>>,
-    /// Per-file native routine names proven by `useDynLib` metadata.
-    pub native_registrations: HashMap<String, HashSet<String>>,
     pub s3_methods: HashMap<String, HashSet<(String, String)>>,
     pub load_bindings: HashMap<String, HashMap<usize, HashSet<String>>>,
     pub degraded_scopes: Vec<(PathBuf, &'static str)>,
@@ -126,7 +124,6 @@ pub fn resolve_workspace_context<'a>(
     let mut bare_attached = HashMap::new();
     let mut bindings = HashMap::new();
     let mut imported_from = HashMap::new();
-    let mut native_registrations = HashMap::new();
     let mut s3_methods = HashMap::new();
     let mut load_bindings = HashMap::new();
     // A package root is visited once per file in it, so a single oversized
@@ -147,7 +144,6 @@ pub fn resolve_workspace_context<'a>(
         let mut file_attached: HashSet<String> = configured_packages.iter().cloned().collect();
         let mut file_bindings = HashSet::new();
         let mut file_s3_methods = HashSet::new();
-        let mut file_native_registrations = HashSet::new();
         let mut file_imported_from = HashMap::new();
         let mut source_package = None;
         file_bindings.extend(configured_globals.iter().cloned());
@@ -180,9 +176,8 @@ pub fn resolve_workspace_context<'a>(
             // the evidence that a name is one of them. Without the
             // declaration the same names are ordinary unbound reads.
             if metadata.native_registration {
-                file_native_registrations.extend(source_bindings.native_symbols.iter().cloned());
-                file_native_registrations.extend(metadata.native_routines.iter().cloned());
-                file_bindings.extend(file_native_registrations.iter().cloned());
+                file_bindings.extend(source_bindings.native_symbols.iter().cloned());
+                file_bindings.extend(metadata.native_routines.iter().cloned());
             }
             file_bindings.extend(metadata.imported_bindings.iter().cloned());
             file_imported_from.extend(metadata.imported_from.clone());
@@ -301,7 +296,6 @@ pub fn resolve_workspace_context<'a>(
         bare_attached.insert(file.path.clone(), file_attached);
         bindings.insert(file.path.clone(), file_bindings);
         imported_from.insert(file.path.clone(), file_imported_from);
-        native_registrations.insert(file.path.clone(), file_native_registrations);
         s3_methods.insert(file.path.clone(), file_s3_methods);
     }
     Ok(WorkspaceContext {
@@ -309,7 +303,6 @@ pub fn resolve_workspace_context<'a>(
         bare_bindings: bare_attached,
         external_bindings: bindings,
         imported_bindings: imported_from,
-        native_registrations,
         s3_methods,
         load_bindings,
         degraded_scopes: degraded.into_iter().collect(),


### PR DESCRIPTION
Partially addresses #90 (the two mechanical leftovers from the PR #79 review; the third item stays open — see below).

## Dead plumbing: `WorkspaceContext.native_registrations`

`WorkspaceContext.native_registrations` was populated by ry-workspace's
`resolve_workspace_context`, forwarded by the CLI into `CheckInput` at both
`WorkspaceContext` construction sites (`ry check` and `ry dump-types`), but
never applied by `check_project`: ry-checker's `Project` has no setter for
it, and the native names already reach the checker through
`external_bindings`, which `resolve_workspace_context` extends with the same
`useDynLib` witness set. The field was misleading dead plumbing.

Removed end-to-end: the struct field, the accumulator map and per-file set
that populated it, and both CLI forwarding lines. The `useDynLib(.registration
= TRUE)` block now extends `file_bindings` directly with the same two witness
sets, so the resolved binding set is unchanged and diagnostics are identical.

## Stale header in `p36_contract.rs`

The file header claimed every test in the file is `#[ignore]`d because
P36-W2 through W7 "will implement" the behavior. None are: the attributes
were removed as the workstreams landed (#69–#79) and all 10 tests run (and
pass) as contract gates. The header now says so.

## Still open on #90

The w7 false-PASS silence window in `p36_contract.rs`'s drain loop needs an
owner design decision and is deliberately not addressed here.

## Gates

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`