### PR TITLE
test(checker): guard README rule table against registry drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,6 +151,14 @@ All notable changes to ry are documented in this file.
   `textDocument/rename` out; and `p38-progress.md` no longer marks
   W11/W12 as future work and records W12's acceptance record as
   invalidated, not accepted.
+- **README rule-table drift guard (#107)**: a workspace integration test
+  (`cargo test -p ry-checker --test readme_rule_table`) parses the README
+  "## Rules" table and asserts parity with `ry_checker::rules::RULES` on
+  rule code, name, and severity, with per-rule failure messages naming the
+  README line and the direction of the drift. A registry change without a
+  matching README edit (or vice versa) now fails `cargo test --workspace`
+  in the default PR workflow, so the #83 manual table restore cannot
+  silently recur.
 - **Deduplicated the operator S3-generic list (#42)**: `is_operator_generic`
   now answers from `semantic_lists::OPERATORS` instead of restating the same
   13 Arith + Compare symbols as match arms, so the S3 method-name splitter

--- a/crates/ry-checker/tests/readme_rule_table.rs
+++ b/crates/ry-checker/tests/readme_rule_table.rs
@@ -1,0 +1,182 @@
+//! #107: keep the README rule table honest against the rule registry.
+//!
+//! The "## Rules" table in README.md is hand-maintained and has drifted
+//! before (#83: RY003, RY102, RY103, and RY105 disappeared from the table
+//! while all four stayed active). This test parses the table out of README.md
+//! and asserts exact parity with [`ry_checker::rules::RULES`] on code, name,
+//! and severity, so a registry change without a matching README edit (or vice
+//! versa) fails `cargo test --workspace` — the check rides the default PR
+//! workflow with no CI wiring of its own.
+//!
+//! Summaries are deliberately not compared verbatim: the table lightly edits
+//! several registry summaries for presentation (RY033, RY093, RY097, RY100,
+//! and RY101 reword theirs; RY031/RY032 escape `|` as `&#124;` and `>` as
+//! `\>`). The stable contract is code, name, and severity, plus a non-empty
+//! summary cell so a truncated row cannot pass.
+
+use std::fs;
+use std::path::Path;
+
+use ry_checker::rules::RULES;
+
+const EXPECTED_COLUMNS: [&str; 4] = ["code", "name", "severity", "summary"];
+
+/// One data row of the README "## Rules" table.
+struct Row {
+    code: String,
+    name: String,
+    severity: String,
+    summary: String,
+    /// 1-based README.md line, for actionable failure messages.
+    line: usize,
+}
+
+/// Split a table line `| a | b |` into trimmed cells.
+fn cells(raw: &str) -> Vec<String> {
+    let trimmed = raw.trim();
+    let trimmed = trimmed.strip_prefix('|').unwrap_or(trimmed);
+    let trimmed = trimmed.strip_suffix('|').unwrap_or(trimmed);
+    trimmed.split('|').map(|c| c.trim().to_string()).collect()
+}
+
+fn is_alignment_row(cells: &[String]) -> bool {
+    !cells.is_empty()
+        && cells.iter().all(|c| {
+            let dashes = c.trim_matches(':');
+            !dashes.is_empty() && dashes.chars().all(|ch| ch == '-')
+        })
+}
+
+/// Parse the rule table out of the "## Rules" section of README.md.
+fn rule_table_rows() -> Vec<Row> {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../README.md");
+    let readme =
+        fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+    let lines: Vec<&str> = readme.lines().collect();
+
+    let heading = lines
+        .iter()
+        .position(|l| l.trim() == "## Rules")
+        .unwrap_or_else(|| panic!("README.md has no '## Rules' section"));
+
+    let section_end = lines[heading + 1..]
+        .iter()
+        .position(|l| l.starts_with("## "))
+        .map(|i| heading + 1 + i)
+        .unwrap_or(lines.len());
+
+    let table: Vec<(usize, &str)> = lines[heading + 1..section_end]
+        .iter()
+        .enumerate()
+        .filter(|(_, l)| l.starts_with('|'))
+        .map(|(i, l)| (heading + 2 + i, *l))
+        .collect();
+
+    assert!(
+        table.len() >= 3,
+        "README '## Rules' section has no rule table (expected header, alignment, and data rows)"
+    );
+
+    let header = cells(table[0].1);
+    assert_eq!(
+        header, EXPECTED_COLUMNS,
+        "unexpected column header for the README rule table"
+    );
+    assert!(
+        is_alignment_row(&cells(table[1].1)),
+        "expected an alignment row right after the README rule table header"
+    );
+
+    table[2..]
+        .iter()
+        .map(|(line, raw)| {
+            let cells = cells(raw);
+            assert_eq!(
+                cells.len(),
+                4,
+                "README rule table row at line {line} has {} cells (code, name, severity, summary expected); an unescaped '|' in a cell splits the row",
+                cells.len()
+            );
+            Row {
+                code: cells[0].clone(),
+                name: cells[1].clone(),
+                severity: cells[2].clone(),
+                summary: cells[3].clone(),
+                line: *line,
+            }
+        })
+        .collect()
+}
+
+#[test]
+fn readme_rule_table_matches_rule_registry() {
+    let rows = rule_table_rows();
+    let mut problems: Vec<String> = Vec::new();
+
+    // Registry -> README: every registered rule needs a matching row.
+    for rule in RULES {
+        let Some(row) = rows.iter().find(|r| r.code == rule.code) else {
+            problems.push(format!(
+                "missing row: {} ({}) is registered in ry_checker::rules::RULES \
+                 but the README '## Rules' table has no row for it; add one",
+                rule.code, rule.name
+            ));
+            continue;
+        };
+        if row.name != rule.name {
+            problems.push(format!(
+                "name mismatch: README line {} calls {} `{}` but the registry \
+                 calls it `{}`",
+                row.line, row.code, row.name, rule.name
+            ));
+        }
+        let severity = rule.default_severity.as_str();
+        if row.severity != severity {
+            problems.push(format!(
+                "severity mismatch: README line {} lists {} as `{}` but its \
+                 registry default severity is `{}`",
+                row.line, row.code, row.severity, severity
+            ));
+        }
+        if row.summary.is_empty() {
+            problems.push(format!(
+                "empty summary: README line {} ({}) has no summary text",
+                row.line, row.code
+            ));
+        }
+    }
+
+    // README -> registry: no row may document an unregistered rule.
+    for row in &rows {
+        if !RULES.iter().any(|r| r.code == row.code) {
+            problems.push(format!(
+                "unknown row: README line {} documents {} (`{}`) but no rule \
+                 with that code is registered; remove the row or fix the code",
+                row.line, row.code, row.name
+            ));
+        }
+    }
+
+    // The registry keeps codes lexicographic; the table must follow it.
+    // Only checked when membership matches, so a missing/unknown row does
+    // not also produce a noisy order diff on top of its own message.
+    let readme_order: Vec<&str> = rows.iter().map(|r| r.code.as_str()).collect();
+    let registry_order: Vec<&str> = RULES.iter().map(|r| r.code).collect();
+    let same_membership =
+        rows.len() == RULES.len() && rows.iter().all(|r| RULES.iter().any(|g| g.code == r.code));
+    if same_membership && readme_order != registry_order {
+        problems.push(format!(
+            "row order: README rows are ordered {readme_order:?} but the \
+             registry order is {registry_order:?}; keep the table in registry \
+             (lexicographic code) order"
+        ));
+    }
+
+    assert!(
+        problems.is_empty(),
+        "README.md rule table (## Rules) is out of sync with \
+         ry_checker::rules::RULES ({} problem(s)):\n  - {}",
+        problems.len(),
+        problems.join("\n  - ")
+    );
+}

--- a/crates/ry-checker/tests/readme_rule_table.rs
+++ b/crates/ry-checker/tests/readme_rule_table.rs
@@ -66,12 +66,18 @@ fn rule_table_rows() -> Vec<Row> {
         .map(|i| heading + 1 + i)
         .unwrap_or(lines.len());
 
-    let table: Vec<(usize, &str)> = lines[heading + 1..section_end]
-        .iter()
-        .enumerate()
-        .filter(|(_, l)| l.starts_with('|'))
-        .map(|(i, l)| (heading + 2 + i, *l))
-        .collect();
+    // The rule table is the first contiguous run of `|`-prefixed lines in
+    // the section: a second table later in the same section (examples,
+    // tier tables, …) is legal prose and must not be parsed as rule rows,
+    // so collection stops at the table's first non-table line.
+    let mut table: Vec<(usize, &str)> = Vec::new();
+    for (offset, line) in lines[heading + 1..section_end].iter().enumerate() {
+        if line.starts_with('|') {
+            table.push((heading + 2 + offset, line));
+        } else if !table.is_empty() {
+            break; // the first contiguous table has ended
+        }
+    }
 
     assert!(
         table.len() >= 3,
@@ -169,12 +175,18 @@ fn readme_rule_table_matches_rule_registry() {
     }
 
     // The registry keeps codes lexicographic; the table must follow it.
-    // Only checked when membership matches, so a missing/unknown row does
-    // not also produce a noisy order diff on top of its own message.
+    // Only checked when membership is exact and duplicate-free, so a
+    // missing/unknown row does not also produce a noisy order diff on top
+    // of its own message — and a duplicate row paired with a missing one
+    // (which preserves the row count) cannot slip through either.
+    // `seen` holds every distinct *registered* row code (unknown rows are
+    // skipped above), so equal row and `seen` lengths mean no duplicate or
+    // unknown rows, and `seen` equal to the registry codes means nothing
+    // is missing.
     let readme_order: Vec<&str> = rows.iter().map(|r| r.code.as_str()).collect();
     let registry_order: Vec<&str> = RULES.iter().map(|r| r.code).collect();
-    let same_membership =
-        rows.len() == RULES.len() && rows.iter().all(|r| RULES.iter().any(|g| g.code == r.code));
+    let registry_codes: HashSet<&str> = RULES.iter().map(|r| r.code).collect();
+    let same_membership = rows.len() == seen.len() && seen == registry_codes;
     if same_membership && readme_order != registry_order {
         problems.push(format!(
             "row order: README rows are ordered {readme_order:?} but the \

--- a/crates/ry-checker/tests/readme_rule_table.rs
+++ b/crates/ry-checker/tests/readme_rule_table.rs
@@ -186,6 +186,16 @@ fn readme_rule_table_matches_rule_registry() {
     let readme_order: Vec<&str> = rows.iter().map(|r| r.code.as_str()).collect();
     let registry_order: Vec<&str> = RULES.iter().map(|r| r.code).collect();
     let registry_codes: HashSet<&str> = RULES.iter().map(|r| r.code).collect();
+    // The registry's own order is part of the contract: if RULES and the
+    // table drifted to the same non-lexicographic order together, the
+    // comparison below would still pass while the invariant above fails.
+    // Strict `<` also rejects duplicate codes in the registry itself.
+    if !registry_order.windows(2).all(|pair| pair[0] < pair[1]) {
+        problems.push(format!(
+            "registry order: rule codes are not lexicographically ordered: \
+             {registry_order:?}"
+        ));
+    }
     let same_membership = rows.len() == seen.len() && seen == registry_codes;
     if same_membership && readme_order != registry_order {
         problems.push(format!(

--- a/crates/ry-checker/tests/readme_rule_table.rs
+++ b/crates/ry-checker/tests/readme_rule_table.rs
@@ -14,6 +14,7 @@
 //! `\>`). The stable contract is code, name, and severity, plus a non-empty
 //! summary cell so a truncated row cannot pass.
 
+use std::collections::HashSet;
 use std::fs;
 use std::path::Path;
 
@@ -146,12 +147,22 @@ fn readme_rule_table_matches_rule_registry() {
         }
     }
 
-    // README -> registry: no row may document an unregistered rule.
+    // README -> registry: no row may document an unregistered rule, and a
+    // pasted-duplicate row must be caught even though the registry -> README
+    // loop only ever looks at the first row per code.
+    let mut seen: HashSet<&str> = HashSet::new();
     for row in &rows {
         if !RULES.iter().any(|r| r.code == row.code) {
             problems.push(format!(
                 "unknown row: README line {} documents {} (`{}`) but no rule \
                  with that code is registered; remove the row or fix the code",
+                row.line, row.code, row.name
+            ));
+            continue;
+        }
+        if !seen.insert(row.code.as_str()) {
+            problems.push(format!(
+                "duplicate row: README line {} repeats {} ({})",
                 row.line, row.code, row.name
             ));
         }

--- a/docs/architecture/project-remediation-plan.md
+++ b/docs/architecture/project-remediation-plan.md
@@ -396,6 +396,13 @@ remove it from the schema and documentation:
 
 - Generate or verify the README rule table from the registry so new codes do
   not disappear from documentation.
+
+  **Since resolved (#107).** `crates/ry-checker/tests/readme_rule_table.rs`
+  parses the README "## Rules" table and asserts parity with
+  `ry_checker::rules::RULES` on code, name, and severity (summaries must be
+  present), with actionable per-rule failure messages. Any drift — a rule
+  missing from the table, an unregistered row, or a severity/name mismatch —
+  fails `cargo test --workspace` in the default PR workflow.
 - Update editor limitations after unopened-file indexing and interactive
   migrations are complete.
 - Do not record a plan as accepted while its required default gate is red.


### PR DESCRIPTION
Resolve #107

## What

The README "## Rules" table was hand-maintained and had drifted before (#83: RY003,
RY102, RY103, and RY105 disappeared from the table while all four stayed active).
This adds a mechanical drift guard: a workspace integration test
(`crates/ry-checker/tests/readme_rule_table.rs`) that parses the table out of
README.md and asserts parity with `ry_checker::rules::RULES`.

## How it works

- Locates README.md via `CARGO_MANIFEST_DIR` and anchors on the `## Rules`
  section, so the earlier VS Code settings table cannot confuse the parser.
- Validates the table structure (header must be `| code | name | severity | summary |`
  with an alignment row; every row must have exactly 4 cells).
- Asserts exact parity with the registry on **code, name, and severity**, and that
  rows follow the registry's lexicographic code order.
- Summaries are checked for presence only, not verbatim: the README lightly edits
  several registry summaries for presentation (RY033, RY093, RY097, RY100, RY101
  reword theirs; RY031/RY032 escape `|` as `&#124;` and `>` as `\>`). The stable
  contract is code/name/severity.
- All problems are reported in a single panic with actionable per-rule messages
  naming the README line and the drift direction, e.g.
  `missing row: RY105 (constant-length-comparison) is registered in
   ry_checker::rules::RULES but the README '## Rules' table has no row for it`.

Rides the existing `cargo test --workspace` CI step — no new workflow, no script
language, per the issue's requirement that the check belongs in the default PR
workflow.

## Verification

- `cargo fmt --all -- --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test --workspace` — all green (45 test binaries)
- Proven to fail: deleting the RY105 row makes the test fail with
  `missing row: RY105 ...`; perturbing a severity, name, and code produces
  mismatch/missing/unknown-row messages pointing at the exact README lines.

Also marks U4.3's rule-table bullet resolved in
`docs/architecture/project-remediation-plan.md` and adds a CHANGELOG entry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added automated validation ensuring the README rules table matches the registered rules, including codes, names, severity, summaries, ordering, and duplicates.
  - Reports actionable failures with README line numbers when entries are missing, unknown, malformed, or out of sync.
  - Validation runs with the workspace test suite to detect documentation drift early.

- **Documentation**
  - Updated the changelog and project remediation plan to record the rules-table verification coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->