### PR TITLE
ci(ecosystem): validate --check against a clean checkout (#50)

### DIFF
--- a/.github/workflows/ecosystem.yml
+++ b/.github/workflows/ecosystem.yml
@@ -103,34 +103,6 @@ jobs:
         run: ecosystem/test-posit-drift-detection.sh
       - name: Posit label falsification integration test
         run: ecosystem/test-posit-label-falsification.sh
-  # P37-W7b: Clean-checkout validation gate (#50)
-  # Validates that the repo is releasable from a fresh clone with no
-  # gitignored artifacts.
-  clean-checkout:
-    if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
-      - name: Remove all gitignored files
-        run: git clean -fdX
-      - name: Build release binary from source
-        run: cargo build --release --locked -p ry-cli --bin ry
-      - name: Validate ledger consistency
-        run: python3 ecosystem/check-ledger.py docs/corpus/posit-0.9.0.json
-      - name: Verify no ignored artifact is required
-        run: |
-          set -euo pipefail
-          # Verify that after clean -fdX, the repo still builds and the
-          # ledger is valid. If this fails, an ignored file is required
-          # for a gate, which means a release-time clean checkout breaks.
-          test -f docs/corpus/posit-0.9.0.json
-          test -f ecosystem/check-ledger.py
-          test -f ecosystem/run.sh
-          echo "Clean-checkout validation passed"
 
   # P38-W3: Dependency direction CI gate
   # Asserts that forbidden internal Cargo edges (ry-config -> ry-checker,

--- a/.github/workflows/ecosystem.yml
+++ b/.github/workflows/ecosystem.yml
@@ -41,6 +41,13 @@ jobs:
             ecosystem-${{ runner.os }}-
       - name: Build release binary
         run: cargo build --release --locked -p ry-cli --bin ry
+      # A developer's working tree can carry gitignored *.full.txt reports
+      # from earlier update runs, and drift-check logic must never be able to
+      # compare against them. Removing them first makes the --check run below
+      # validate against the same state as a fresh checkout, proving the
+      # committed .txt snapshots are the sole baseline (#50).
+      - name: Remove gitignored full reports
+        run: rm -f ecosystem/reports/*.full.txt
       - name: Check ecosystem snapshots
         run: ecosystem/run.sh --check
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,6 +137,15 @@ All notable changes to ry are documented in this file.
 
 ### Changed
 
+- **Ecosystem CI validates `--check` against a cleaned state (#50)**: the
+  PR-time `ecosystem` job removes gitignored `ecosystem/reports/*.full.txt`
+  reports before the snapshot check, and the drift-detection test now plants
+  a poisoned `.full.txt` sentinel before its first `--check`, so a
+  drift-check change that starts comparing gitignored baselines fails on any
+  machine rather than surfacing only as a CI failure. The schedule-only
+  `clean-checkout` job, which delivered neither protection at merge or
+  release time, is removed; the release runbook points at the PR-time job's
+  fresh-checkout build instead.
 - **Documentation truth pass (#83)**: the README rule table lists every
   registered rule again — RY003, RY102, RY103, and RY105 had silently
   disappeared from the hand-maintained table — with a note that RY003 is

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -17,11 +17,10 @@ Before starting any release:
    - `ecosystem/test-drift-detection.sh`
    - `ecosystem/test-posit-drift-detection.sh`
 
-2. **Tracked-only build validated:** the scheduled `clean-checkout` CI job
-   passes (it builds from a fresh clone, which contains only tracked
-   files, but it runs only on schedule or manual dispatch and never gates
-   the commit about to be tagged), or validate the release commit directly
-   with a tracked-only `git archive` build:
+2. **Tracked-only build validated:** every PR's `ecosystem` CI job builds
+   `--locked` from a fresh checkout, which contains only tracked files; for
+   the exact commit about to be tagged, validate directly with a
+   tracked-only `git archive` build:
 
    ```bash
    (

--- a/ecosystem/test-drift-detection.sh
+++ b/ecosystem/test-drift-detection.sh
@@ -16,7 +16,22 @@ run_sh="$root/ecosystem/run.sh"
 # Use the local (vendored glue) path: no git cloning, fast, hermetic. This
 # intentionally tests report drift only: --local skips ledger reconciliation;
 # test-posit-drift-detection.sh covers the real non-local ledger path.
+
+# Pin the #50 invariant where it runs locally too: gitignored .full.txt
+# reports are never drift baselines. Plant a poisoned sentinel before the
+# first --check; current logic ignores it, so --check must still exit 0,
+# while a drift-check change that starts comparing .full.txt fails here on
+# any machine instead of surfacing only as a CI failure.
+sentinel="$reports_dir/glue.full.txt"
+printf 'POISONED_FULL_TXT_BASELINE\n' > "$sentinel"
+trap 'rm -f "$sentinel"' EXIT
+trap 'rm -f "$sentinel"; exit 130' INT TERM
+
 "$run_sh" --local --check 2>/dev/null
+echo "PASS: gitignored .full.txt report is not used as a baseline"
+
+rm -f "$sentinel"
+trap - EXIT INT TERM
 
 fail=0
 tested=0


### PR DESCRIPTION
Closes #50.

## Problem

Changes to `ecosystem/run.sh`'s drift-check logic were validated against the developer's working tree, which can carry gitignored `ecosystem/reports/*.full.txt` files from earlier update runs. A broken change that compared against those gitignored baselines passed locally and failed only in CI.

## Change

Two edits in `.github/workflows/ecosystem.yml`:

1. **PR-time clean-state validation** — one step inserted in the existing `ecosystem` job, between the release build and the snapshot check:
   - `rm -f ecosystem/reports/*.full.txt`
   - the existing `run.sh --check` now doubles as the exit-0 assertion on a clean state (proving the committed `.txt` snapshots are the sole baseline)
   - the existing drift-detection integration test follows immediately, as before
2. **Drop the `clean-checkout` job** — it was schedule/dispatch-only, so its fresh-clone build was never consumed; the PR-time step above delivers the actual protection it aimed at, on every PR instead of on a cron nobody watched.

For reference: `--check` generates reports into a throwaway temp dir and `cmp -s`s them against the committed per-package `.txt`/`.root.txt` snapshots and summaries; the message-bearing `.full.txt` variants are never compared. The committed logic is already correct — this makes it impossible for future drift-check changes to pass by leaning on files absent from a fresh checkout.

## Verification

Reproduced (1) locally against the real drift logic (`run.sh --local` with a prebuilt binary at the same commit):

- stray gitignored `.full.txt` files present → confirmed gitignored; current logic ignores them
- after the cleanup step → `--check` exits 0 ("committed reports are current")
- corrupted a committed baseline → `--check` exits 1 with report drift; restored
- full `test-drift-detection.sh` → PASS

And (2) for the job removal: YAML parses (`pyyaml`), remaining jobs (`ecosystem`, `posit`, `cargo-edges`) intact. The workflow itself only fully executes on GitHub.

Not run locally: the full non-local `--check` over all ~90 manifest packages (needs network clones).