### PR TITLE
docs: orwell cleanup pass over comments and prose

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,7 +71,6 @@ Never add a function name you have not verified against R.
 `scripts/gen_typeshed.R <pkg>` drafts a stub file from a package's
 exports for hand-refinement.
 
-
 ## Editor extensions
 
 The VS Code / Positron extension lives in `editors/code/`. It uses
@@ -104,8 +103,8 @@ Bundling with esbuild avoids this.
 ### Zed extension
 
 The Zed extension lives in `editors/zed/`. It has its own `Cargo.lock`
-and is excluded from the root workspace (see R1 in the plan) because
-`zed_extension_api` is not held to ry's MSRV.
+and is excluded from the root workspace because `zed_extension_api` is
+not held to ry's MSRV.
 
 ```bash
 cargo build --manifest-path editors/zed/Cargo.toml

--- a/README.md
+++ b/README.md
@@ -185,11 +185,10 @@ at column candidates.
 ## Dumping inferred types
 
 `ry dump-types` is the non-interactive counterpart of the LSP's inline
-type hints: it
-runs one analysis pass (the same pass `ry check` runs, over the same
-package-aware environment) and prints every lexical scope of the
-requested files as JSON on stdout. Downstream tooling can query which
-bindings a scope holds and with what inferred types, without re-running
+type hints: it runs one analysis pass (the same pass `ry check` runs,
+over the same package-aware environment) and prints every lexical scope
+of the requested files as JSON on stdout, so downstream tooling can
+query a scope's bindings and their inferred types without re-running
 the checker per position.
 
 ``` bash

--- a/crates/ry-checker/src/collect.rs
+++ b/crates/ry-checker/src/collect.rs
@@ -476,23 +476,6 @@ impl Checker {
         self.deferred_captures.pop();
         self.inferring.pop();
     }
-
-    // The unified statement walker. Handles BOTH diagnostic emission (gated by
-    // `self.discarding`) AND return-type collection (when `returns` is
-    // `Some`).
-    //
-    // Callers:
-    //   * `check_stmt` (pass 3): discarding=false, returns=None.
-    //   * `refine_fn_return` (pass 2 fixpoint): discarding=true (set by
-    //     caller), returns=Some.
-    //   * `build_function_signature` (closure literals, both passes):
-    //     discarding=true (set by caller), returns=Some.
-    //
-    // Approximations (documented):
-    //   * `if` branches use `apply_narrowing` + separate child scopes
-    //     (then/else); bindings leak into subsequent statements.
-    //   * Loop bodies are walked once (not to fixpoint).
-    //   * Indexed assignment (`x[i] <- v`) does not update the scope.
 }
 
 /// Whether `parameter` is captured without evaluation by this function.

--- a/crates/ry-checker/src/diagnostics.rs
+++ b/crates/ry-checker/src/diagnostics.rs
@@ -1,7 +1,6 @@
 //! Diagnostic data types, severity overrides, and inline-suppression
 //! parsing/filtering.
 //!
-//! Extracted from `lib.rs` without behavior change.
 //! This module is self-contained: it depends only on `ry_core::Span`,
 //! `ry_core::ast::Comment`, and the rule registry (`crate::rules`).
 

--- a/crates/ry-checker/src/higher_order.rs
+++ b/crates/ry-checker/src/higher_order.rs
@@ -371,7 +371,7 @@ impl Checker {
     /// Infer the return type of a single callback invocation, given the
     /// argument types the higher-order function will pass to it.
     ///
-    /// Covers three callback forms:
+    /// Covers four callback forms:
     ///   * `Expr::Function { params, body }` (anonymous literal): walk
     ///     the body with a scope containing the params bound to the
     ///     element types, collecting returns. Bounded by

--- a/crates/ry-checker/src/infer/binop.rs
+++ b/crates/ry-checker/src/infer/binop.rs
@@ -351,27 +351,6 @@ impl Checker {
             self.emit(Severity::Warning, span, "RY032", message);
         }
     }
-
-    // Desugar `lhs %>% rhs` (and `lhs |> rhs`, `lhs %<>% rhs`) into a
-    // call to `rhs` with `lhs` injected into the argument list.
-    //
-    // Magrittr `%>%` semantics: if `rhs` is a call, prepend `lhs` as
-    // the first positional argument - unless one of the args is the
-    // bare placeholder `.` (or base-R `_`), in which case the first
-    // such occurrence is replaced with `lhs`. Bare `rhs` (e.g. `x %>% abs`)
-    // becomes a one-arg call.
-    //
-    // Data pronoun: when `rhs` is an index expression whose base is
-    // the magrittr `.` pronoun (`df %>% .$col`, `df %>% .[i]`,
-    // `df %>% .[[i]]`), the `.` resolves to the piped LHS value and
-    // the index is inferred against `lhs`'s type. A bare `x %>% .`
-    // returns the LHS value itself.
-    //
-    // `%<>%` (assignment pipe) shares the result type with `%>%` at v1.
-    // The assignment side-effect (`x <- ...`) is handled by the caller
-    // when it appears in an `Assign` statement; for a bare binop we
-    // cannot reassign without a target expression, so we leave that to
-    // a future pass.
 }
 
 /// Recognize the high-confidence parameter guard patterns found in package

--- a/crates/ry-checker/src/infer/call.rs
+++ b/crates/ry-checker/src/infer/call.rs
@@ -1388,27 +1388,6 @@ impl Checker {
         let _ = span;
         base_type
     }
-
-    // Handle R's Non-Standard Evaluation verbs (`subset`, `with`,
-    // `within`, `transform`). These evaluate their expression
-    // arguments in an augmented scope where the data frame's columns
-    // are bound as names, so `subset(df, cyl == 4)` resolves `cyl`
-    // against `df`'s column schema rather than the enclosing scope.
-    //
-    // Returns `Some(t)` when the call was recognized as an NSE verb
-    // (the caller uses `t` verbatim and skips the regular arg-inference
-    // path). Returns `None` for non-NSE names so `infer_call` falls
-    // through to the regular path.
-    //
-    // Behavior when the first arg has no column schema: we cannot
-    // enumerate the columns, so the expression arguments cannot be
-    // type-checked meaningfully. We still infer them against the bare
-    // scope (no column augmentation) so any genuinely unbound name in
-    // the expression still emits RY010; this mirrors the conservative
-    // approach for unknown data throughout the checker.
-    //
-    // The augmented scope is local to this call: column bindings must
-    // NOT leak back into the enclosing scope (we operate on a clone).
 }
 
 /// Whether an `R6Class()` call opts out of R6's portable evaluation model.

--- a/crates/ry-checker/src/infer/construct.rs
+++ b/crates/ry-checker/src/infer/construct.rs
@@ -546,22 +546,6 @@ impl Checker {
             }
         }
     }
-
-    // Resolve the type of a subset/extract expression given the base
-    // type, the kind of index (`[`, `[[`, `$`), and the (already
-    // lowered) argument list.
-    //
-    // v1 column-access semantics:
-    // * `df$col` (`Dollar`): the column name lives on `args[0].name`.
-    //   If `bt` has a column schema, return that column's type; if the
-    //   name isn't in the schema, emit RY060. Otherwise (no schema) we
-    //   conservatively return a length-1 value of `bt`'s mode.
-    // * `df[["col"]]` (`Double`): same idea, but the name comes from a
-    //   string-literal positional argument. Non-string-literal args
-    //   fall through to the conservative length-1 default.
-    // * `df[i]` or `df[i, j]` (`Single`): keep the existing opaque
-    //   behavior (returns `bt`). Subsetting semantics are complex and
-    //   out of scope for v1.
 }
 
 fn semantic_return_length(

--- a/crates/ry-checker/src/infer/index.rs
+++ b/crates/ry-checker/src/infer/index.rs
@@ -31,6 +31,20 @@ fn dollar_receiver_mode_description(receiver: &RType) -> String {
 }
 
 impl Checker {
+    /// Resolve the type of a subset/extract expression given the base
+    /// type, the kind of index (`[`, `[[`, `$`), and the (already
+    /// lowered) argument list.
+    ///
+    /// * `df$col` (`Dollar`): the column name lives on `args[0].name`.
+    ///   With a column schema, return that column's type (RY060 on a
+    ///   miss); without one, degrade conservatively: opaque for
+    ///   list-like bases, else a length-1 value of `bt`'s mode.
+    /// * `df[["col"]]` (`Double`): same idea, but the name comes from a
+    ///   string-literal positional argument. Non-string-literal args
+    ///   fall through to the conservative default.
+    /// * `df[i]` or `df[i, j]` (`Single`): two-index selection on a
+    ///   schema'd frame resolves the column's type (`drop = FALSE`
+    ///   yields a one-column frame); otherwise returns `bt`.
     pub(crate) fn infer_index(
         &mut self,
         bt: RType,
@@ -407,15 +421,6 @@ fn literal_negative_exclusion_length(base: Length, expr: &Expr) -> Option<Length
     })
 }
 
-/// Apply a `SeverityFilter` to a vec of diagnostics in place. Each
-/// diagnostic's severity is replaced by the filter's effective
-/// severity for its code; diagnostics for codes the filter suppresses
-/// are dropped entirely.
-///
-/// Both `Checker::apply_filter`, `Project::apply_filter`, and the CLI
-/// (for per-file diagnostic vecs produced by `Project::check`) call
-/// this. Keeping the logic here avoids duplicating the resolution
-/// rules.
 /// Quick literal-only inference for function parameter defaults. We
 /// don't have a scope yet at the point of `record_fn`, but for typed
 /// defaults (`x = 1L`, `trim = 0`, `verbose = TRUE`) the literal

--- a/crates/ry-checker/src/infer/misc.rs
+++ b/crates/ry-checker/src/infer/misc.rs
@@ -727,23 +727,8 @@ pub(crate) fn parse_class_literal(e: &Expr) -> ClassLiteral {
     }
 }
 
-/// Build a `ColumnSchema` from a `list(...)` / `data.frame(...)` argument
-/// Match call arguments to function parameters using R's standard
-/// argument matching rules. Returns a vector indexed by parameter
-/// position, where each entry is the type of the argument bound to
-/// that parameter (or `RType::unknown()` if no argument was provided).
-///
-/// Algorithm (simplified v1):
-///   1. Exact name match: a named arg `x = ...` binds to the parameter
-///      named `x` if one exists.
-///   2. Positional fill: unmatched positional args fill remaining
-///      unmatched parameters in declaration order.
-///   3. `...` in the parameter list absorbs any extra args; those are
-///      inaccessible by index and get `UNKNOWN`.
-///
-/// Partial matching (R's prefix-based arg matching) is intentionally
-/// not implemented; it's rarely used in modern R code and adds
-/// significant complexity.
+/// Walk `stmts` collecting calls inside `caller`'s body that forward its
+/// `params` to nested calls.
 pub(crate) fn collect_forwarded_calls_in_stmts(
     caller: &str,
     params: &[Param],

--- a/crates/ry-checker/src/infer/mod.rs
+++ b/crates/ry-checker/src/infer/mod.rs
@@ -207,6 +207,22 @@ fn discarded_value_expression(expression: &Expr) -> bool {
 // statically indistinguishable from a legitimate loop-carried binding.
 
 impl Checker {
+    /// The unified statement walker. Handles both diagnostic emission
+    /// (gated by `self.discarding`) and return-type collection (when
+    /// `returns` is `Some`).
+    ///
+    /// Callers:
+    ///   * `check_stmt` (pass 3): discarding=false, returns=None.
+    ///   * `refine_fn_return` (pass 2 fixpoint): discarding=true (set by
+    ///     caller), returns=Some.
+    ///   * `build_function_signature` (closure literals, both passes):
+    ///     discarding=true (set by caller), returns=Some.
+    ///
+    /// Approximations:
+    ///   * `if` branches use `apply_narrowing` + separate child scopes
+    ///     (then/else); bindings leak into subsequent statements.
+    ///   * Loop bodies are walked once (not to fixpoint).
+    ///   * Indexed assignment (`x[i] <- v`) does not update the scope.
     pub(crate) fn walk_stmt(
         &mut self,
         s: &Stmt,

--- a/crates/ry-checker/src/infer/recall.rs
+++ b/crates/ry-checker/src/infer/recall.rs
@@ -7,7 +7,7 @@
 //! their false-positive surface is bounded by the syntax they match.
 //!
 //! `tests/plan31_recall_rules.rs` pins both the positive and the negative
-//! direction of each.
+//! direction of each rule.
 //!
 //! Two of the plan's sketches are deliberately **not** implemented.
 //!

--- a/crates/ry-checker/src/lib.rs
+++ b/crates/ry-checker/src/lib.rs
@@ -1388,19 +1388,6 @@ impl Checker {
     pub fn set_load_bindings(&mut self, bindings: HashMap<usize, HashSet<String>>) {
         self.load_bindings = bindings;
     }
-
-    // Resolve a function signature by name, consulting (in order):
-    //   1. a `pkg::fun` / `pkg:::fun` qualified name -- looked up in
-    //      `load_package(pkg)` directly, bypassing base and loaded
-    //      packages (a qualified call is an explicit reference);
-    //   2. the base typeshed (`self.typeshed`);
-    //   3. each loaded package that ships signatures (reverse load
-    //      order so the most-recently-loaded package wins, mirroring
-    //      R's search path).
-    //
-    // Returns the signature and the resolved call name (the bare
-    // function name, suitable for `apply_sig`'s slot resolution).
-    // Returns `None` when no package knows the name.
 }
 
 fn embedded_base() -> Arc<Typeshed> {

--- a/crates/ry-checker/src/project.rs
+++ b/crates/ry-checker/src/project.rs
@@ -241,7 +241,6 @@ impl Project {
         self.mark_all_dirty();
     }
 
-    /// Equality-aware: reinstalling the value already in place is a no-op.
     pub fn set_bare_loaded(&mut self, loaded: HashMap<String, HashSet<String>>) {
         if self.bare_loaded == loaded {
             return;
@@ -290,7 +289,6 @@ impl Project {
     /// Declare per-file names provided by project metadata, such as
     /// `NAMESPACE`'s `importFrom()` directives. Per-file scoping prevents an
     /// import in one checked package from leaking into an unrelated package.
-    /// Equality-aware: reinstalling the value already in place is a no-op.
     pub fn set_external_bindings(&mut self, bindings: HashMap<String, HashSet<String>>) {
         if self.external_bindings == bindings {
             return;
@@ -299,7 +297,6 @@ impl Project {
         self.mark_all_dirty();
     }
 
-    /// Equality-aware: reinstalling the value already in place is a no-op.
     pub fn set_imported_from(&mut self, imports: HashMap<String, HashMap<String, String>>) {
         if self.imported_from == imports {
             return;
@@ -308,7 +305,6 @@ impl Project {
         self.mark_all_dirty();
     }
 
-    /// Equality-aware: reinstalling the value already in place is a no-op.
     pub fn set_external_s3_methods(&mut self, methods: HashMap<String, HashSet<(String, String)>>) {
         if self.external_s3_methods == methods {
             return;
@@ -317,7 +313,6 @@ impl Project {
         self.mark_all_dirty();
     }
 
-    /// Equality-aware: reinstalling the value already in place is a no-op.
     pub fn set_load_bindings(
         &mut self,
         bindings: HashMap<String, HashMap<usize, HashSet<String>>>,
@@ -768,7 +763,6 @@ impl Project {
                 .collect();
         }
 
-        // Build a lookup from emitted results.
         let mut emitted_map: HashMap<usize, (String, Vec<Diagnostic>)> = per_file
             .into_iter()
             .map(|(i, p, d, _)| (i, (p, d)))

--- a/crates/ry-checker/src/suppress.rs
+++ b/crates/ry-checker/src/suppress.rs
@@ -147,6 +147,17 @@ impl Checker {
         None
     }
 
+    /// Resolve a function signature by name, consulting (in order):
+    ///   1. a `pkg::fun` / `pkg:::fun` qualified name -- looked up in
+    ///      `package_typeshed(pkg)` directly, bypassing base and loaded
+    ///      packages (a qualified call is an explicit reference);
+    ///   2. an unqualified name with a recorded `importFrom` binding --
+    ///      resolved against that package's typeshed (exact provenance);
+    ///   3. the base typeshed (`self.typeshed`);
+    ///   4. each loaded package that ships signatures, in a fixed
+    ///      deterministic priority order approximating R's search path.
+    ///
+    /// Returns the signature; `None` when no package knows the name.
     pub(crate) fn resolve_typeshed_sig(&self, name: &str) -> Option<FunctionSig> {
         // Qualified call: explicit package reference.
         if let Some((pkg_raw, fun)) = name.rsplit_once("::") {
@@ -472,13 +483,6 @@ impl Checker {
             );
         }
     }
-
-    // Pass 1: walk top-level (and only top-level) statements, collecting
-    // function definitions of the form `name <- function(...) body` into
-    // the FnTable. Nested function definitions are recorded only if they
-    // are themselves bound to a name at their enclosing scope; this is
-    // sufficient for v2 since R-style nested defs typically close over
-    // locals and are tricky to type without proper closure analysis.
 }
 
 fn has_schema_semantics(signature: &FunctionSig) -> bool {

--- a/crates/ry-cli/src/check.rs
+++ b/crates/ry-cli/src/check.rs
@@ -1,10 +1,7 @@
 //! Unified diagnostics query — one entry point for the CLI.
 //!
-//! P38-W8: This module encapsulates the Project coordination that was
-//! previously duplicated between ry-cli and ry-lsp. The caller supplies
-//! parsed files and workspace context; the module returns diagnostics.
-//! ry-lsp since moved to coordinating `ry_checker::Project` directly, so
-//! only ry-cli consumes this today.
+//! The caller supplies parsed files and workspace context; the module
+//! returns diagnostics.
 
 use std::collections::BTreeMap;
 use std::sync::Arc;
@@ -36,12 +33,10 @@ pub fn check_project(input: CheckInput) -> CheckOutput {
         &input.user_stubs,
     );
 
-    // Add all files.
     for (path, _, file) in &input.files {
         project.add_file(path.clone(), (**file).clone());
     }
 
-    // Run the checker.
     let diagnostics = project.check();
 
     CheckOutput { diagnostics }

--- a/crates/ry-cli/src/main.rs
+++ b/crates/ry-cli/src/main.rs
@@ -240,12 +240,8 @@ enum TypeshedCmd {
 }
 
 fn main() -> Result<ExitCode> {
-    // We parse into the typed `Cli` for ergonomic access to argument
-    // values, but we ALSO retain the underlying `ArgMatches` so we can
-    // distinguish "the user passed --error-on-warning on the command
-    // line" from "the default value of false". That distinction is what
-    // lets a `ry.toml` `error-on-warning = true` take effect when the
-    // user runs a bare `ry check` (no flags).
+    // `ArgMatches` is kept alongside the typed `Cli` so `flag_set` can
+    // tell a user-passed flag from its clap default (see `flag_set`).
     //
     // clap derive's `from_arg_matches` is infallible for our schema
     // (every arg has a default or is optional); the unwrap is safe.
@@ -524,10 +520,8 @@ fn run_check(
         }
     };
 
-    // Determine which scalar CLI flags were explicitly set on the
-    // command line. `value_source == CommandLine` distinguishes a
-    // user-provided value from the clap default. When the CLI did NOT
-    // set a scalar, we forward `None` so the config file's value wins.
+    // Forward `None` for scalars the CLI did not set explicitly, so the
+    // config file's value wins.
     let m = check_matches;
     let cli_error_on_warning = flag_set(m, "error_on_warning").then_some(error_on_warning);
     let cli_exit_zero = flag_set(m, "exit_zero").then_some(exit_zero);
@@ -602,7 +596,6 @@ fn run_check(
         return Ok(ExitCode::SUCCESS);
     }
 
-    // Run the initial check.
     let result = run_check_once(
         &all_paths,
         &filter,

--- a/crates/ry-lsp/src/backend.rs
+++ b/crates/ry-lsp/src/backend.rs
@@ -56,8 +56,8 @@ pub(super) struct State {
     versions: HashMap<String, i32>,
     /// path -> (version, parsed SourceFile). Populated lazily by the
     /// request handlers and invalidated by `update_doc`. Reading the
-    /// cached parse lets every handler avoid re-parsing on each request
-    ///. `SourceFile` is `Send`; `RParser` is NOT, so the
+    /// cached parse lets every handler avoid re-parsing on each request.
+    /// `SourceFile` is `Send`; `RParser` is NOT, so the
     /// parser is constructed per request and only the result is cached.
     parsed: HashMap<String, (i32, Arc<SourceFile>)>,
     /// path -> (version, top-level Scope from `check_with_scope`).
@@ -85,8 +85,7 @@ pub(super) struct State {
     /// Counts every actual parse (`RParser::parse`) performed by
     /// `parsed_file` -- i.e. every cache MISS. The E1 acceptance test
     /// asserts that editing one file in a multi-file workspace parses
-    /// only that file, so this counter must NOT rise for cache hits
-    ///.
+    /// only that file, so this counter must NOT rise for cache hits.
     #[cfg(test)]
     pub(super) parse_count: Arc<std::sync::atomic::AtomicUsize>,
 
@@ -444,11 +443,9 @@ impl State {
         self.parse_count.load(std::sync::atomic::Ordering::Relaxed)
     }
 
-    /// P36-W4 (#53): Return the cached tree-sitter `Tree` for `path`
-    /// only when its recorded generation matches the current document
-    /// version. A stale tree from a superseded generation is never
-    /// served — the cache read enforces the same invariant as the
-    /// write (`store_tree`).
+    /// Return the cached tree-sitter `Tree` for `path`, but only when
+    /// its recorded version matches the current document version (the
+    /// read half of `store_tree`'s write-side invariant).
     fn tree_for(&self, path: &str) -> Option<ry_core::Tree> {
         let current_version = self.versions.get(path).copied()?;
         let (tree_version, tree) = self.trees.get(path)?;
@@ -459,12 +456,11 @@ impl State {
         }
     }
 
-    /// P36-W4 (#53): Store a tree-sitter `Tree` for `path`, tagged with
-    /// `version`. The tree replaces the cache entry only if `version`
-    /// still matches the current document version. A stale parse whose
-    /// version was superseded by a concurrent edit is dropped rather
-    /// than overwriting the current tree, so no cached tree can ever
-    /// be served for a different document generation.
+    /// Store a tree-sitter `Tree` for `path`, tagged with `version`.
+    /// The entry is written only if `version` still matches the current
+    /// document version, so a parse superseded by a concurrent edit is
+    /// dropped and no cached tree is ever served for a different
+    /// document generation.
     fn store_tree(&mut self, path: &str, version: i32, tree: ry_core::Tree) {
         if self.versions.get(path).copied() == Some(version) {
             self.trees.insert(path.to_string(), (version, tree));
@@ -509,15 +505,11 @@ impl State {
 
     // --- S2: effective config computation ---
 
-    /// Compute the effective `SeverityFilter` from editor settings
-    /// merged over `ry.toml`. Editor settings take precedence: if the
-    /// editor provides an `ignore`/`error`/`warn` list, it replaces
-    /// the `ry.toml` value; otherwise the `ry.toml` value (which may
-    /// itself be the empty default) is used.
-    /// Merge editor lint settings over a given `ry.toml` config.
-    /// `settings` provides per-folder editor values (P36-W2a/#44);
-    /// when `None`, the server-wide `folder_settings` is used as fallback.
-    /// Test helper kept for future filter tests.
+    /// Merge editor lint settings over a given `ry.toml` config: for
+    /// each `ignore`/`error`/`warn` field, an editor-provided list
+    /// replaces the config value; `settings` supplies per-folder editor
+    /// values (P36-W2a/#44), falling back to the server-wide
+    /// `folder_settings`. Test-only.
     #[cfg(test)]
     #[allow(dead_code)]
     pub(super) fn merge_filter(
@@ -802,18 +794,11 @@ impl LanguageServer for Backend {
                     // tree-sitter InputEdit for incremental reparse.
                     TextDocumentSyncKind::INCREMENTAL,
                 )),
-                // Enable `textDocument/inlayHint` so the client can
-                // request inline "ghost text" annotations showing the
-                // inferred type of each binding. For a checker with no
-                // annotation syntax (like R), this is the primary way
-                // users see the checker's work. The handler is
-                // `inlay_hint` below.
+                // Inlay hints are the primary way users see the checker's
+                // inference: R has no annotation syntax to attach types to.
                 inlay_hint_provider: Some(OneOf::Left(true)),
-                // Enable `textDocument/codeAction` so editors can offer
-                // quick fixes for diagnostics. The handler is
-                // `code_action` below; it offers per-diagnostic
-                // `# ry: ignore[CODE]` line-suppression comments and a
-                // file-level `# ry: ignore-file` action.
+                // Quick fixes that insert `# ry: ignore[CODE]` line
+                // suppressions, plus a file-level `# ry: ignore-file` action.
                 code_action_provider: Some(CodeActionProviderCapability::Simple(true)),
                 // S4: Advertise workspace folder support so clients send
                 // multi-root workspace folders and change notifications.
@@ -1444,12 +1429,12 @@ impl Backend {
                     build_input_edit_from_span(&old_text, start_byte, end_byte, &change.text);
                 self.update_doc(path.to_string(), new_text, version).await;
 
-                // Build InputEdit and do incremental parse.
+                // Apply the edit to the old tree so the next parse is
+                // incremental.
                 let mut tree_mut = old_tree;
                 if let Some(ref mut tree) = tree_mut {
                     tree.edit(&edit);
                 }
-                // Store the tree for next time so the next parse is incremental.
                 let mut state = self.state.lock().await;
                 if let Some(tree) = tree_mut {
                     state.store_tree(path, version, tree);
@@ -1488,16 +1473,14 @@ impl Backend {
         state.scopes.remove(&path);
     }
 
-    /// Return the parsed `SourceFile` for `path`, reusing the cached
-    /// parse when its version matches the latest known version. The
-    /// cache is read + repopulated under the state lock; parsing itself
-    /// (which needs a non-`Send` `RParser`) happens after releasing the
     /// Return the current AST for `path` together with the exact source
     /// text it was parsed from. Pairing the two is atomic: handlers use
     /// the text for byte-offset / UTF-16 conversions that must match the
     /// AST's span offsets, so a concurrent `didChange` racing the parse
     /// can never yield a stale text applied to a fresher AST (or vice
-    /// versa).
+    /// versa). The parse cache is read and repopulated under the state
+    /// lock; parsing itself (which needs a non-`Send` `RParser`) happens
+    /// outside it.
     ///
     /// Returns `None` when the path is not an open document or parsing
     /// fails.
@@ -1526,9 +1509,8 @@ impl Backend {
                 (Some(t), Some(v)) => (t, v),
                 _ => return None,
             };
-            // W6: Use incremental parse when we have an old tree.
-            // P36-W4 (#53): tree_for returns the cached tree only when its
-            // recorded generation matches the current document version.
+            // Incremental reparse when an old tree exists (`tree_for`
+            // already enforces the version match).
             let old_tree = {
                 let state = self.state.lock().await;
                 state.tree_for(path)
@@ -1548,9 +1530,7 @@ impl Backend {
             let mut parser = RParser::new().ok()?;
             let file = if let Some(tree) = old_tree {
                 let (parsed, new_tree) = parser.parse_with_tree(path, &text, Some(&tree)).ok()?;
-                // P36-W4 (#53): Store the tree only if the version still
-                // matches. A parse whose version was superseded by a
-                // concurrent edit must not overwrite the current tree.
+                // Store only if the version still matches (`store_tree`).
                 {
                     let mut state = self.state.lock().await;
                     state.store_tree(path, version, new_tree);

--- a/crates/ry-lsp/tests/p36_contract.rs
+++ b/crates/ry-lsp/tests/p36_contract.rs
@@ -12,19 +12,6 @@
 //! contract is "LSP published diagnostics equal `ry check` run independently
 //! in the same root."
 //!
-//! ## Plan 35 green prerequisites
-//!
-//! Before authoring these red cases, Plan 35's green gates were re-run and
-//! confirmed passing:
-//!
-//! - **Package metadata parity**: `package_import_from_value_position_is_clean_in_both_modes`
-//!   and the `complete-package` rows in `cli_and_run_with_publish_the_same_single_root_matrix`.
-//! - **File eligibility**: the single-root rows in the same matrix plus
-//!   `excluded-influence`.
-//! - **Checker parameter-metadata dirty propagation (issue #52)**:
-//!   `parameter_signature_change_reemits_transitive_callers` in
-//!   `ry-checker/tests/project.rs`.
-//!
 //! No test below adds package-import or filtering differences to `normalise()`.
 
 use ry_testkit::{

--- a/editors/code/src/common/server.ts
+++ b/editors/code/src/common/server.ts
@@ -30,11 +30,8 @@ export type InitializationOptions = {
 };
 
 /**
- * Build the `initializationOptions` to send at `initialize`.
- *
- * Returns the global settings as both the single folder entry and the
- * global fallback. E3's `getExtensionSettings` will replace this with a
- * proper per-workspace-folder array (consumed by S4 multi-root support).
+ * Build the `initializationOptions` to send at `initialize`: the
+ * per-folder array from `getExtensionSettings`, plus the global fallback.
  */
 export function getInitializationOptions(
   namespace: string,

--- a/scripts/oracle.sh
+++ b/scripts/oracle.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Run the R oracle suite (PLAN Phase 7 item 2).
+# Run the R oracle suite (see CONTRIBUTING.md, "Build and test gate").
 #
 # The oracle tests are #[ignore]'d by default so the standard CI test
 # job does not require R to be installed. This script runs them when


### PR DESCRIPTION
## Summary

A condensation pass over in-code comments and remaining prose, guided by Orwell's rules plus Simplified Technical English: cut what does no work, keep every real constraint. No behavior change.

## What changed

**Orphaned comment blocks (the big one).** An old file-split refactor left comment blocks stranded at the bottom of impl blocks describing functions that live elsewhere:

- Three carried real design information and now document their actual owners, which had no docs: `walk_stmt` (collect.rs -> infer/mod.rs), `resolve_typeshed_sig` (lib.rs -> suppress.rs), and `infer_index` (construct.rs -> infer/index.rs).
- Four were stale or duplicated the destination's existing docs, so they were deleted (pipe-desugaring design notes in binop.rs superseded by pipe.rs; the NSE contract in call.rs already documented at the implementation site).

**Fused/truncated doc comments.** Two stacked descriptions of `parsed_file` in ry-lsp backend, one cut off mid-sentence; stray `///.` orphan lines from a broken edit.

**Copy-pasted explanations, deduplicated to one canonical site each:** CLI flag-vs-config rationale (3x in main.rs), tree version-stamp invariant (4x in backend.rs), root-isolation rationale (3x), equality-aware setter sentence (5x), severity-filter merge (2 stacked versions).

**Stale references:** deleted `docs/plans/` pointers (semantic_lists.rs, recall.rs), "Extracted from lib.rs" relocation note, "see R1 in the plan" (CONTRIBUTING.md), "PLAN Phase 7 item 2" (oracle.sh), future-tense comment about code that already shipped (server.ts).

**Small fixes:** "Covers three callback forms" over four items; comments restating the next line (`// Add all files.` above a loop that adds files); awkward line wrap in README's dump-types section.

Net: 21 files, +86/−223.

## Review notes

- Rebased onto 148779b; conflicts with #114 (completion/signatureHelp removal) resolved by keeping main's deletions — no comment edits remain on removed code.
- Comment-only changes; verified with clippy (workspace, all targets), `cargo fmt --check`, and the ry-checker/ry-lsp/ry-cli test suites.
