### PR TITLE
docs: second orwell pass over comments and prose

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,8 +81,8 @@ ry check demo.R
 ```
 
 Diagnostics use the `full` format by default – the offending line with
-the span underlined – and messages carry the context you need to act;
-for example, an undefined-column diagnostic lists the available columns.
+the span underlined. Messages carry context: an undefined-column
+diagnostic lists the available columns.
 
 ``` bash
 ry check /tmp/ry-readme/analysis.R
@@ -185,11 +185,11 @@ at column candidates.
 ## Dumping inferred types
 
 `ry dump-types` is the non-interactive counterpart of the LSP's inline
-type hints: it runs one analysis pass (the same pass `ry check` runs,
-over the same package-aware environment) and prints every lexical scope
-of the requested files as JSON on stdout, so downstream tooling can
-query a scope's bindings and their inferred types without re-running
-the checker per position.
+type hints. It runs the same analysis pass as `ry check`, over the same
+package-aware environment, and prints every lexical scope of the
+requested files as JSON on stdout, so downstream tooling can query a
+scope's bindings and their inferred types without re-running the checker
+per position.
 
 ``` bash
 ry dump-types R/analysis.R
@@ -402,8 +402,7 @@ Settings (in `settings.json`):
 
 > **Note:** Diagnostics cover only files you have open in the editor.
 > `ry check .` may report additional findings in files you haven't
-> opened. This is a known limitation being addressed in incremental
-> core work.
+> opened. This is a known limitation.
 
 ### Zed
 

--- a/README.md
+++ b/README.md
@@ -80,9 +80,9 @@ ry check demo.R
 #> ry: checked 1 file(s), 1 error(s), 3 warning(s)
 ```
 
-Diagnostics use the `full` format by default – the offending line with
-the span underlined. Messages carry context: an undefined-column
-diagnostic lists the available columns.
+Diagnostics use the `full` format by default: the output shows the
+offending line with the span underlined. Messages carry context: an
+undefined-column diagnostic lists the available columns.
 
 ``` bash
 ry check /tmp/ry-readme/analysis.R
@@ -399,10 +399,6 @@ Settings (in `settings.json`):
 | `ry.lint.error` | `[]` | Rules to treat as errors |
 | `ry.lint.warn` | `[]` | Rules to treat as warnings |
 | `ry.logLevel` | `"warn"` | Server log level (`error`, `warn`, `info`, `debug`, `trace`) |
-
-> **Note:** Diagnostics cover only files you have open in the editor.
-> `ry check .` may report additional findings in files you haven't
-> opened. This is a known limitation.
 
 ### Zed
 

--- a/crates/ry-checker/src/collect.rs
+++ b/crates/ry-checker/src/collect.rs
@@ -392,7 +392,7 @@ impl Checker {
             .collect();
         let slot = self.return_slots.0.len();
         Arc::make_mut(&mut self.return_slots).set(slot, RType::unknown());
-        // Wrap the body in an Rc so the per-fixpoint clone in
+        // Wrap the body in an Arc so the per-fixpoint clone in
         // refine_fn_return is a refcount bump, not a deep copy.
         let body: Arc<[Stmt]> = Arc::from(body);
         let prev = Arc::make_mut(&mut self.fn_table).fns.insert(

--- a/crates/ry-checker/src/higher_order.rs
+++ b/crates/ry-checker/src/higher_order.rs
@@ -622,7 +622,7 @@ impl Checker {
                 }
             }
         }
-        // 3. A default method is the final S3 dispatch fallback. Consult
+        // A default method is the final S3 dispatch fallback. Consult
         // every source used for specific methods above (plus external
         // registrations), and do not report a missing class method when
         // dispatch can reach one.
@@ -640,7 +640,7 @@ impl Checker {
             return Some(RType::unknown());
         }
 
-        // 4. Without a default, use the project-owned-method fallback gate.
+        // Without a default, use the project-owned-method fallback gate.
         // External/typeshed methods alone cannot prove that this project owns
         // the class, so suppress RY050 for potentially un-stubbed packages.
         let has_known_s3_method =

--- a/crates/ry-checker/src/infer/construct.rs
+++ b/crates/ry-checker/src/infer/construct.rs
@@ -195,6 +195,9 @@ impl Checker {
         //     before concatenating. Total length = `length(x) * each`.
         //   * Combined: `length(x) * times * each`.
         //
+        // `length.out` is not modeled: in R it takes precedence over
+        // `times`, but the length here ignores it.
+        //
         // The result mode is `x`'s mode (matching the typeshed's
         // `"mode": "arg0"` spec). We preserve `x`'s class and column
         // schema too, so `rep(factor(...), 3)` stays a factor.

--- a/crates/ry-checker/src/infer/construct.rs
+++ b/crates/ry-checker/src/infer/construct.rs
@@ -140,25 +140,8 @@ impl Checker {
         }
     }
 
-    // Infer the result type of `rep(x, times, each)`. R's `rep` has
-    // two relevant parameters for length:
-    //   * `times` (default 1): how many times to repeat the whole
-    //     vector. Total length = `length(x) * times`.
-    //   * `each` (default 1): how many times to repeat each element
-    //     before concatenating. Total length = `length(x) * each`.
-    //   * Combined: `length(x) * times * each`.
-    //
-    // The result mode is `x`'s mode (matching the typeshed's
-    // `"mode": "arg0"` spec). We preserve `x`'s class and column
-    // schema too, so `rep(factor(...), 3)` stays a factor.
-    //
-    // We read `times` / `each` from the raw AST (not the inferred
-    // `RType`) because the type lattice discards the runtime value.
-    // When the values aren't literal integers or `x`'s length is
-    // unknown, we fall back to `Length::Unknown`. Named args win over
-    // positional ones; if `times`/`each` is supplied but isn't a
-    // literal, the length is Unknown (we can't know the runtime
-    // value, unlike the "not supplied" case which defaults to 1).
+    // Infer the result type of `vector(mode, length)`: pin the mode and
+    // length from literal arguments when possible.
     pub(crate) fn infer_vector(&self, args: &[Arg]) -> RType {
         let mode_expr = args
             .iter()
@@ -204,6 +187,26 @@ impl Checker {
     }
 
     pub(crate) fn infer_rep(&self, args: &[Arg], arg_types: &[RType], _span: Span) -> RType {
+        // Infer the result type of `rep(x, times, each)`. R's `rep` has
+        // two relevant parameters for length:
+        //   * `times` (default 1): how many times to repeat the whole
+        //     vector. Total length = `length(x) * times`.
+        //   * `each` (default 1): how many times to repeat each element
+        //     before concatenating. Total length = `length(x) * each`.
+        //   * Combined: `length(x) * times * each`.
+        //
+        // The result mode is `x`'s mode (matching the typeshed's
+        // `"mode": "arg0"` spec). We preserve `x`'s class and column
+        // schema too, so `rep(factor(...), 3)` stays a factor.
+        //
+        // We read `times` / `each` from the raw AST (not the inferred
+        // `RType`) because the type lattice discards the runtime value.
+        // When the values aren't literal integers or `x`'s length is
+        // unknown, we fall back to `Length::Unknown`. Named args win over
+        // positional ones; if `times`/`each` is supplied but isn't a
+        // literal, the length is Unknown (we can't know the runtime
+        // value, unlike the "not supplied" case which defaults to 1).
+        //
         // Helper: find the index in `args` of a named or positional
         // argument. Named args win over positional. The `pos` index
         // counts only unnamed args, so `rep(each = 2, c(1,2,3), 1)`
@@ -348,9 +351,8 @@ impl Checker {
         let (by_supplied, by_val) = find("by", 2);
         let (lo_supplied, lo_val) = find("length.out", 3);
 
-        // Mode: integer if `from` is an integer literal, else double
-        // (mirrors the typeshed's "double_or_int" rule). We look at
-        // the named `from = ...` first, then the first positional arg.
+        // Look at the named `from = ...` first, then the first
+        // positional arg.
         let from_expr = args
             .iter()
             .find(|a| a.name.as_deref() == Some("from"))

--- a/crates/ry-checker/src/infer/construct.rs
+++ b/crates/ry-checker/src/infer/construct.rs
@@ -187,34 +187,20 @@ impl Checker {
     }
 
     pub(crate) fn infer_rep(&self, args: &[Arg], arg_types: &[RType], _span: Span) -> RType {
-        // Infer the result type of `rep(x, times, each)`. R's `rep` has
-        // two relevant parameters for length:
-        //   * `times` (default 1): how many times to repeat the whole
-        //     vector. Total length = `length(x) * times`.
-        //   * `each` (default 1): how many times to repeat each element
-        //     before concatenating. Total length = `length(x) * each`.
-        //   * Combined: `length(x) * times * each`.
+        // Infer `rep(x, times, each)`: length = `length(x) * times * each`
+        // with `times`/`each` defaulting to 1, and the result keeping
+        // `x`'s mode, class, and schema (so `rep(factor(...), 3)` stays
+        // a factor). `length.out` is not modeled: in R it takes
+        // precedence over `times`, but the length here ignores it.
         //
-        // `length.out` is not modeled: in R it takes precedence over
-        // `times`, but the length here ignores it.
+        // `times`/`each` come from the raw AST, not the inferred
+        // `RType`, because the type lattice discards the runtime value:
+        // a supplied non-literal means `Length::Unknown`; an unsupplied
+        // one defaults to 1.
         //
-        // The result mode is `x`'s mode (matching the typeshed's
-        // `"mode": "arg0"` spec). We preserve `x`'s class and column
-        // schema too, so `rep(factor(...), 3)` stays a factor.
-        //
-        // We read `times` / `each` from the raw AST (not the inferred
-        // `RType`) because the type lattice discards the runtime value.
-        // When the values aren't literal integers or `x`'s length is
-        // unknown, we fall back to `Length::Unknown`. Named args win over
-        // positional ones; if `times`/`each` is supplied but isn't a
-        // literal, the length is Unknown (we can't know the runtime
-        // value, unlike the "not supplied" case which defaults to 1).
-        //
-        // Helper: find the index in `args` of a named or positional
-        // argument. Named args win over positional. The `pos` index
-        // counts only unnamed args, so `rep(each = 2, c(1,2,3), 1)`
-        // still matches `x` at positional index 0 and `times` at 1.
-        // Mirrors `infer_seq`'s positional-counting approach.
+        // `find_idx`'s `pos` counts only unnamed args, so
+        // `rep(each = 2, c(1,2,3), 1)` matches `x` at 0 and `times`
+        // at 1 (mirrors `infer_seq`).
         let find_idx = |name: &str, pos: usize| -> Option<usize> {
             for (i, a) in args.iter().enumerate() {
                 if a.name.as_deref() == Some(name) {

--- a/crates/ry-checker/src/infer/misc.rs
+++ b/crates/ry-checker/src/infer/misc.rs
@@ -502,12 +502,10 @@ pub(crate) fn apply_narrowing(
     match narrowing {
         Narrowing::None => {}
         Narrowing::Positive { var, target } => {
-            // A predicate narrows only
-            // when the existing type is opaque (untyped) or a union that
-            // already contains the predicate's mode. A KNOWN type is
-            // never rewritten: `is.numeric(x)` on a known Integer must
-            // NOT rewrite it to Double (the old coerce_rank comparison
-            // did exactly that).
+            // A mode-only predicate never rewrites a KNOWN type
+            // (`is.numeric` on Integer must not become Double);
+            // class targets and incompatible parameter defaults
+            // do install.
             if let Some(existing) = then_scope.get(var).cloned() {
                 let class_narrowing = target.class.has_known_class();
                 let incompatible_parameter_default =

--- a/crates/ry-checker/src/infer/misc.rs
+++ b/crates/ry-checker/src/infer/misc.rs
@@ -502,7 +502,7 @@ pub(crate) fn apply_narrowing(
     match narrowing {
         Narrowing::None => {}
         Narrowing::Positive { var, target } => {
-            // New rule: a predicate narrows only
+            // A predicate narrows only
             // when the existing type is opaque (untyped) or a union that
             // already contains the predicate's mode. A KNOWN type is
             // never rewritten: `is.numeric(x)` on a known Integer must

--- a/crates/ry-checker/src/infer/mod.rs
+++ b/crates/ry-checker/src/infer/mod.rs
@@ -202,7 +202,7 @@ fn discarded_value_expression(expression: &Expr) -> bool {
 
 // The T7b "mutually-exclusive branch" loop refinement was removed after two
 // rounds of corpus regressions (it ended up flagging loop iterators inside
-// their own bodies). Loop bodies simply pre-bind every name assigned anywhere
+// their own bodies). Loop bodies pre-bind every name assigned anywhere
 // in the body before walking; a use-before-first-assignment inside a loop is
 // statically indistinguishable from a legitimate loop-carried binding.
 
@@ -1163,7 +1163,6 @@ impl Checker {
                 self.infer(target, scope);
             }
             _ => {
-                // Indexed assignment `x[i] <- v` etc. is too dynamic for v1.
                 self.infer(target, scope);
             }
         }

--- a/crates/ry-checker/src/infer/recall.rs
+++ b/crates/ry-checker/src/infer/recall.rs
@@ -79,7 +79,7 @@ fn mistyped_element_name(target: &Expr) -> Option<&str> {
     }
 }
 
-/// Strip any leading unary `!` operators, returning the negated expression.
+/// Strip any leading unary `!` operators, returning the operand under them.
 fn strip_negation(expr: &Expr) -> &Expr {
     let mut inner = expr;
     while let Expr::UnaryOp {
@@ -393,10 +393,7 @@ impl Checker {
     }
 
     /// Whether the typeshed stub for `callee` declares a concrete return
-    /// length of exactly 1. This replaces a hardcoded list of function
-    /// This eliminates the need for a hardcoded function list: the data lives in
-    /// the stubs, is maintained in one place, and automatically covers
-    /// every function the typeshed documents as scalar.
+    /// length of exactly 1.
     fn is_typeshed_scalar_reduction(&self, callee: &str) -> bool {
         let Some(sig) = self.resolve_typeshed_sig(callee) else {
             return false;

--- a/crates/ry-checker/src/lib.rs
+++ b/crates/ry-checker/src/lib.rs
@@ -36,7 +36,7 @@ pub use diagnostics::{
     parse_suppressions_from_comments,
 };
 
-// P38-W3: Configuration-driven filter builders moved here from ry-config
+// Configuration-driven filter builders moved here from ry-config
 // to break the ry-config → ry-checker dependency.
 
 /// Build a [`SeverityFilter`] from the `error`, `warn`, and `ignore`
@@ -745,8 +745,7 @@ impl Checker {
         // run's diagnostics. Also reset the function table and return
         // slots: `collect_fns` appends to the table, so without a reset
         // a reused Checker leaks functions and known-vars from the
-        // previous file into the current check (P35-W9 accumulated-
-        // diagnostics defect).
+        // previous file into the current check.
         self.diagnostics.clear();
         self.fn_table = Arc::new(FnTable::default());
         self.return_slots = Arc::new(ReturnSlots::default());
@@ -902,19 +901,10 @@ impl Checker {
         Arc::unwrap_or_clone(std::mem::take(&mut self.loaded))
     }
 
-    // Pass 2: refine all function return types until convergence.
-    // Iterates the shared `FnTable`; safe to call once after all files
-    // have been collected.
-    //
-    // S3 methods (`print.foo`, etc.) are inserted into `fns` under
-    // their full name during pass 1, with `s3_methods` pointing at
-    // the same return slot. Iterating `fns.keys()` therefore refines
-    // S3 method bodies alongside regular functions; dispatch reads
-    // the refined slot via the `s3_methods` map.
     /// Overlay previously-refined return types onto the current return slots.
     ///
     /// Called before [`run_fixpoint`](Self::run_fixpoint) to seed the fixpoint
-    /// with the previous solution (Plan 33 W2). Functions whose definition
+    /// with the previous solution. Functions whose definition
     /// has not changed and whose callees' return types are unchanged will
     /// keep their seeded value, reducing the number of fixpoint iterations
     /// needed to re-stabilise.
@@ -950,6 +940,15 @@ impl Checker {
         }
     }
 
+    // Pass 2: refine all function return types until convergence.
+    // Iterates the shared `FnTable`; safe to call once after all files
+    // have been collected.
+    //
+    // S3 methods (`print.foo`, etc.) are inserted into `fns` under
+    // their full name during pass 1, with `s3_methods` pointing at
+    // the same return slot. Iterating `fns.keys()` therefore refines
+    // S3 method bodies alongside regular functions; dispatch reads
+    // the refined slot via the `s3_methods` map.
     pub(crate) fn run_fixpoint(&mut self) {
         self.run_fixpoint_inner(None);
     }
@@ -957,7 +956,7 @@ impl Checker {
     /// Run the fixpoint, but only refine functions in `scope`. Functions
     /// outside the scope keep their current (seeded) return type. Used by
     /// `Project` for incremental checks where only a subset of functions
-    /// can have changed (Plan 33 W2).
+    /// can have changed.
     ///
     /// The set must include every function whose definition or callees
     /// changed; functions outside the set are assumed stable. The fixpoint

--- a/crates/ry-checker/src/lib.rs
+++ b/crates/ry-checker/src/lib.rs
@@ -941,14 +941,12 @@ impl Checker {
     }
 
     // Pass 2: refine all function return types until convergence.
-    // Iterates the shared `FnTable`; safe to call once after all files
-    // have been collected.
+    // Safe to call once, after all files have been collected.
     //
-    // S3 methods (`print.foo`, etc.) are inserted into `fns` under
-    // their full name during pass 1, with `s3_methods` pointing at
-    // the same return slot. Iterating `fns.keys()` therefore refines
-    // S3 method bodies alongside regular functions; dispatch reads
-    // the refined slot via the `s3_methods` map.
+    // S3 methods (`print.foo`, etc.) sit in `fns` under their full
+    // name, with `s3_methods` pointing at the same return slot, so
+    // iterating `fns` refines their bodies alongside regular
+    // functions; dispatch reads the refined slot via `s3_methods`.
     pub(crate) fn run_fixpoint(&mut self) {
         self.run_fixpoint_inner(None);
     }

--- a/crates/ry-checker/src/project.rs
+++ b/crates/ry-checker/src/project.rs
@@ -784,9 +784,9 @@ impl Project {
         // Record state for the next incremental check.
         self.prev_loaded = Some(self.loaded.clone());
         self.prev_return_slots = Some(self.return_slots.0.clone());
-        // Save refined return types keyed by function name for the next
-        // fixpoint seeding (W2).
         self.prev_known_vars = self.fn_table.known_vars.clone();
+        // Save refined return types keyed by function name for the next
+        // fixpoint seeding.
         self.prev_fn_returns = self
             .fn_table
             .fns

--- a/crates/ry-checker/src/rules.rs
+++ b/crates/ry-checker/src/rules.rs
@@ -233,7 +233,7 @@ pub fn find(code: &str) -> Option<&'static Rule> {
     RULES.iter().find(|r| r.code == code || r.name == code)
 }
 
-/// Severity for `all` shorthand in CLI filters.
+/// All rule codes, expanded for the `all` shorthand in CLI severity filters.
 pub fn all_codes() -> Vec<&'static str> {
     RULES.iter().map(|r| r.code).collect()
 }

--- a/crates/ry-checker/src/suppress.rs
+++ b/crates/ry-checker/src/suppress.rs
@@ -304,30 +304,10 @@ impl Checker {
         self.user_s3_dispatch_return(generic, first).is_some()
     }
 
-    /// Whether the callee `name` resolves to `base::bare_name` at this call
-    /// site, given the current lexical scope and project metadata.
-    ///
-    /// This is the single canonical base-call resolution operation (Plan 35
-    /// W7). It replaces scattered ad-hoc "is this the base function or a
-    /// shadow?" guards. Callers ask this method; they do not duplicate lookup
-    /// order.
-    ///
-    /// Lookup order (first match decides):
-    ///
-    /// 1. `base::name` or `base:::name` → resolves to base (explicit).
-    /// 2. `otherpkg::name` → does not resolve to base.
-    /// 3. A lexical data binding of `name` → shadowed.
-    /// 4. A lexical function binding of `name` → shadowed.
-    /// 5. A project `fn_table` definition of `name` → shadowed.
-    /// 6. `importFrom(base, name)` → resolves to base.
-    /// 7. Any other external binding or `importFrom` source → shadowed.
-    /// 8. A non-empty search path (`bare_loaded` or `search_path_unknown`)
-    ///    → cannot prove base resolution.
-    /// 9. Otherwise the bare name falls through to base.
+    /// Lenient variant of [`Self::resolves_to_base`]: same resolution
+    /// order minus the search-path guard, because a loaded package rarely
+    /// redefines `list` or `length`.
     pub(crate) fn resolves_to_base_lenient(&self, name: &str, scope: &Scope) -> bool {
-        // Same as resolves_to_base but the search_path_unknown / bare_loaded
-        // guard is relaxed. A loaded package rarely redefines `list` or
-        // `length`, and the old code only checked fn_table shadowing.
         if name.rsplit_once("::").is_some() {
             return crate::semantic_lists::is_base_qualified(name);
         }
@@ -351,6 +331,24 @@ impl Checker {
         true
     }
 
+    /// Whether the callee `name` resolves to `base::bare_name` at this call
+    /// site, given the current lexical scope and project metadata.
+    ///
+    /// This is the canonical base-call resolution operation. Callers ask
+    /// this method; they do not duplicate lookup order.
+    ///
+    /// Lookup order (first match decides):
+    ///
+    /// 1. `base::name` or `base:::name` → resolves to base (explicit).
+    /// 2. `otherpkg::name` → does not resolve to base.
+    /// 3. A lexical data binding of `name` → shadowed.
+    /// 4. A lexical function binding of `name` → shadowed.
+    /// 5. A project `fn_table` definition of `name` → shadowed.
+    /// 6. `importFrom(base, name)` → resolves to base.
+    /// 7. Any other external binding or `importFrom` source → shadowed.
+    /// 8. A non-empty search path (`bare_loaded` or `search_path_unknown`)
+    ///    → cannot prove base resolution.
+    /// 9. Otherwise the bare name falls through to base.
     pub(crate) fn resolves_to_base(&self, name: &str, scope: &Scope) -> bool {
         // (a) Explicit base:: qualification.
         if name.rsplit_once("::").is_some() {

--- a/crates/ry-checker/src/suppress.rs
+++ b/crates/ry-checker/src/suppress.rs
@@ -341,7 +341,7 @@ impl Checker {
     ///
     /// 1. `base::name` or `base:::name` → resolves to base (explicit).
     /// 2. `otherpkg::name` → does not resolve to base.
-    /// 3. A lexical data binding of `name` → shadowed.
+    /// 3. A lexical parameter binding of `name` → shadowed.
     /// 4. A lexical function binding of `name` → shadowed.
     /// 5. A project `fn_table` definition of `name` → shadowed.
     /// 6. `importFrom(base, name)` → resolves to base.

--- a/crates/ry-checker/src/suppress.rs
+++ b/crates/ry-checker/src/suppress.rs
@@ -334,8 +334,8 @@ impl Checker {
     /// Whether the callee `name` resolves to `base::bare_name` at this call
     /// site, given the current lexical scope and project metadata.
     ///
-    /// This is the canonical base-call resolution operation. Callers ask
-    /// this method; they do not duplicate lookup order.
+    /// The canonical base-call resolution operation: callers ask this
+    /// method instead of duplicating the lookup order.
     ///
     /// Lookup order (first match decides):
     ///

--- a/crates/ry-checker/src/tests.rs
+++ b/crates/ry-checker/src/tests.rs
@@ -2037,7 +2037,7 @@ fn parse_standalone_comment_applies_to_next_line() {
     let src = "# ry: ignore\nx <- bad\n";
     let supps = parse_suppressions(src);
     assert_eq!(supps.len(), 1);
-    assert_eq!(supps[0].line, 1); // next line
+    assert_eq!(supps[0].line, 1);
 }
 
 #[test]
@@ -3065,9 +3065,6 @@ fn structure_call_sets_class() {
     let mut c = Checker::new("test.R");
     c.check(&f);
     let diags = c.take_diagnostics();
-    // Without `Summary.foo` (or `Summary.default`), RY050 should fire - proving the class was
-    // attached. (If `structure` had failed to set the class, the
-    // value would be classless and no RY050 would appear.)
     assert!(
         diags.iter().any(|d| d.code == "RY050"),
         "expected RY050 proving class was attached, got {:?}",
@@ -3091,7 +3088,6 @@ fn mtcars_mpg_column_infers_double() {
         x
     );
     assert_eq!(x.length, Length::Known(32), "mpg has 32 rows");
-    // Behavioral check: arithmetic on the inferred double works.
     let diags = check("df <- mtcars\nx <- df$mpg\ny <- x + 1L\n");
     assert!(
         diags.iter().all(|d| d.code != "RY040"),
@@ -3706,8 +3702,7 @@ fn closure_capture_resolves_outer_binding() {
         "add5(3) must resolve to double, got {:?}",
         sig.return_type
     );
-    // Behavioral check: using the result arithmetically with a
-    // character operand must fire RY040.
+    // Behavioral check: RY040 on v + "x".
     let diags = check(
         "make_adder <- function(x = 0) {\n\
              \x20 function(y = 0) { x + y }\n\
@@ -3747,7 +3742,6 @@ fn nested_function_definition_visible_in_outer_body() {
         "h() must resolve to integer, got {:?}",
         sig.return_type
     );
-    // Behavioral check.
     let diags = check(
         "f <- function() {\n\
              \x20 g <- function() { 1L }\n\

--- a/crates/ry-checker/tests/metamorphic.rs
+++ b/crates/ry-checker/tests/metamorphic.rs
@@ -896,7 +896,7 @@ fn r10_pipe_placeholder_matrix_no_panic_deterministic() {
         "x <- 1L\ny <- x |> identity()\n",
         // No pipe control: named-argument call.
         "x <- 1L\ny <- identity(z = x)\n",
-        // Native pipe into a one-argument function.
+        // Native pipe with no explicit extra arguments.
         "x <- 1L\ny <- x |> sum()\n",
         // Native pipe into a data-frame call.
         "df <- data.frame(a = 1L)\nresult <- df |> nrow()\n",

--- a/crates/ry-checker/tests/metamorphic.rs
+++ b/crates/ry-checker/tests/metamorphic.rs
@@ -894,11 +894,11 @@ fn r10_pipe_placeholder_matrix_no_panic_deterministic() {
     let cases: &[&str] = &[
         // Native pipe, no placeholder.
         "x <- 1L\ny <- x |> identity()\n",
-        // Native pipe, underscore placeholder (R 4.2+).
+        // No pipe control: named-argument call.
         "x <- 1L\ny <- identity(z = x)\n",
-        // Magrittr pipe, no placeholder (prepended as first arg).
+        // Native pipe into a one-argument function.
         "x <- 1L\ny <- x |> sum()\n",
-        // Magrittr pipe, dot placeholder.
+        // Native pipe into a data-frame call.
         "df <- data.frame(a = 1L)\nresult <- df |> nrow()\n",
         // Chained pipes.
         "x <- c(1L, 2L, 3L)\ny <- x |> sum() |> identity()\n",

--- a/crates/ry-cli/src/main.rs
+++ b/crates/ry-cli/src/main.rs
@@ -724,9 +724,10 @@ struct CheckResult {
 
 /// Whether parser recovery indicates that a file is probably not R source.
 ///
-/// Keep the original majority-error guard, and also catch foreign files whose
-/// syntax happens to produce many recoverable R expressions.  The absolute
-/// floor avoids suppressing ordinary R files with a few syntax errors.
+/// Two guards, so foreign files whose syntax produces many recoverable R
+/// expressions are still caught while ordinary R files with a few syntax
+/// errors pass: more parse errors than statements, or at least 5 errors
+/// making up 15% of statements.
 fn is_probably_not_r_source(file: &ry_core::SourceFile) -> bool {
     let parse_errors = file.parse_errors.len();
     let statements = file.stmts.len();
@@ -738,8 +739,7 @@ impl CheckResult {
     fn print_summary(&self, format: ry_checker::format::OutputFormat, statistics: bool) {
         // Suppress the human summary line for machine-readable formats
         // so it can't corrupt JSON/Github/Gitlab/Junit output (it goes
-        // to stderr, but consumers that merge stderr would see it). The
-        // plan calls for printing it only for the human formats.
+        // to stderr, but consumers that merge stderr would see it).
         let is_human = matches!(
             format,
             ry_checker::format::OutputFormat::Full | ry_checker::format::OutputFormat::Concise

--- a/crates/ry-config/src/baseline.rs
+++ b/crates/ry-config/src/baseline.rs
@@ -1,16 +1,11 @@
 //! Baseline and severity-filter helpers shared between the CLI and the
 //! LSP server.
-//!
-//! These types were previously embedded in `ry-cli`'s `main.rs` where
-//! they were unreachable from the language server.
 
 use miette::{IntoDiagnostic, Result};
 use ry_core::BaselineDiagnostic;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::Path;
-
-// `build_filter` and `filter_from_config` moved to `ry-checker` (P38-W3).
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Baseline {

--- a/crates/ry-config/src/config.rs
+++ b/crates/ry-config/src/config.rs
@@ -21,14 +21,14 @@ use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 
 /// Default output format when neither the config file nor the CLI
-/// specifies one. Matches the CLI's pre-config default.
+/// specifies one.
 pub const DEFAULT_OUTPUT_FORMAT: &str = "full";
 
 /// The on-disk filename ry looks for.
 pub const CONFIG_FILENAME: &str = "ry.toml";
 pub const DEFAULT_MAX_SERIALIZED_BYTES: u64 = 2 * 1024 * 1024;
 
-/// Defaults for bounded directory discovery (P36-W7 / issue #48).
+/// Defaults for bounded directory discovery.
 pub const DEFAULT_INDEX_MAX_FILES: u64 = 20_000;
 pub const DEFAULT_INDEX_MAX_FILE_BYTES: u64 = 2 * 1024 * 1024;
 pub const DEFAULT_INDEX_MAX_DEPTH: u64 = 64;
@@ -151,15 +151,12 @@ pub struct Config {
     pub typeshed: Vec<PathBuf>,
     /// Baseline file. Relative paths are anchored at the config directory.
     pub baseline: Option<PathBuf>,
-    /// Bounded directory discovery limits (P36-W7 / issue #48).
+    /// Bounded directory discovery limits.
     pub index: IndexConfig,
 }
 
 impl Default for Config {
-    /// Built-in defaults. Mirrors `Config::defaults()` so callers can
-    /// use either spelling interchangeably, and so a struct-literal
-    /// `Config { ..Config::default() }` picks up the right output
-    /// format rather than the empty string.
+    /// Same as [`Config::defaults`].
     fn default() -> Self {
         Self::defaults()
     }
@@ -175,9 +172,7 @@ fn default_output_format() -> String {
 }
 
 impl Config {
-    /// Built-in defaults. Equivalent to `Config::default()` but named
-    /// for symmetry with the spec and for callers that want to be
-    /// explicit about "no config file present".
+    /// Built-in defaults, as if no config file were present.
     pub fn defaults() -> Self {
         Self {
             error_on_warning: false,
@@ -249,7 +244,7 @@ impl Config {
 
     /// Validate that bounded discovery limits are positive integers.
     /// Zero is a configuration error rather than an undocumented
-    /// "unlimited" sentinel (P36-W7 / issue #48). Returns the offending
+    /// "unlimited" sentinel. Returns the offending
     /// field name on failure.
     pub fn validate(&self) -> Result<(), &'static str> {
         if self.index.max_files == 0 {
@@ -450,7 +445,7 @@ pub enum ConfigError {
         source: toml::de::Error,
     },
     /// A bounded discovery limit was set to zero, which is a
-    /// configuration error (P36-W7 / issue #48).
+    /// configuration error.
     #[error(
         "config file {path} has invalid value for {field}:              bounded discovery limits must be positive integers,              zero is not permitted"
     )]

--- a/crates/ry-config/src/lib.rs
+++ b/crates/ry-config/src/lib.rs
@@ -10,10 +10,6 @@
 //! - [`Baseline`], [`load_baseline`], [`write_baseline_file`],
 //!   [`subtract_baseline`]: the diagnostics-baseline machinery.
 //! - [`build_filter`]: rule severity remapping from a [`Config`].
-//!
-//! Previously these lived in the `ry-cli` binary crate, where they were
-//! unreachable from `ry-lsp`. Extracting them into a library crate lets
-//! the LSP server honour the same configuration as the CLI.
 
 pub mod baseline;
 pub mod config;

--- a/crates/ry-core/src/ast.rs
+++ b/crates/ry-core/src/ast.rs
@@ -10,8 +10,8 @@ use crate::types::RType;
 #[derive(Debug, Clone, Default)]
 pub struct SourceFile {
     pub path: String,
-    /// Original UTF-8 text. Checker fixes slice this production parse input by
-    /// AST spans rather than attempting to print or scrape diagnostic prose.
+    /// Original UTF-8 text. The checker slices this string by AST spans
+    /// rather than scraping diagnostic prose.
     pub source: String,
     pub stmts: Vec<Stmt>,
     /// Parse errors (tree-sitter `ERROR` / `MISSING` nodes) discovered

--- a/crates/ry-core/src/parser.rs
+++ b/crates/ry-core/src/parser.rs
@@ -40,8 +40,8 @@ impl RParser {
         Ok(file)
     }
 
-    /// Parse with an old tree-sitter `Tree` for incremental re-parsing
-    /// (Plan 33 W6). The old tree must have been edited via `InputEdit`
+    /// Parse with an old tree-sitter `Tree` for incremental re-parsing.
+    /// The old tree must have been edited via `InputEdit`
     /// before calling this method. The AST is rebuilt from the new tree,
     /// but tree-sitter reuses unchanged subtrees internally, making
     /// reparse cost proportional to the edited region, not the file size.
@@ -97,12 +97,9 @@ impl RParser {
         let start = n.start_byte();
         let end = n.end_byte();
         let pos = n.start_position();
-        // tree-sitter reports both row and column for free; the previous
-        // implementation discarded `.column` and recomputed a *char*
-        // column by rescanning the whole file from byte 0 for every node
-        // (O(n^2) total). We now use the byte column tree-sitter gives us
-        // directly. `Span::col` is therefore byte-indexed within the line;
-        // diagnostics rendering that need a char column convert per-line.
+        // `Span::col` is tree-sitter's byte-indexed column within the
+        // line; diagnostics rendering that needs a char column converts
+        // per-line.
         Span::new(start, end, pos.row, pos.column)
     }
 
@@ -152,10 +149,10 @@ impl RParser {
     fn try_lower_assign(&self, n: Node, src: &str) -> Option<Stmt> {
         let op_node = n.child_by_field_name("operator")?;
         let op_text = text(op_node, src)?;
-        // Note: tree-sitter-r emits the super-assignment operator as the
-        // token `<<-`, NOT `<<`. Matching `<<` (as this code once did)
-        // silently fails for every super-assignment and lets it fall
-        // through to `lower_binary`, which mis-lowers it.
+        // tree-sitter-r emits the super-assignment operator as the token
+        // `<<-`, not `<<`. Matching `<<` silently fails for every
+        // super-assignment and lets it fall through to `lower_binary`,
+        // which mis-lowers it.
         if !matches!(op_text.as_str(), "<-" | "<<-" | "=" | "->" | "->>" | ":=") {
             return None;
         }
@@ -276,10 +273,8 @@ impl RParser {
 
     /// Preserve a brace used in statement position as one block expression.
     ///
-    /// Keeping only the last lowered child used to delete all earlier statements;
-    /// assigning each lowering result directly to `last` could also turn an
-    /// already-preserved child back into `None`. A block carries every represented
-    /// child, while malformed children remain owned by `SourceFile::parse_errors`.
+    /// A block carries every represented child; malformed children remain
+    /// owned by `SourceFile::parse_errors`.
     fn lower_braced_as_stmt(&self, n: Node, src: &str) -> Stmt {
         Stmt::Expr(Expr::Block {
             body: self.lower_block(n, src),
@@ -347,12 +342,9 @@ impl RParser {
                 let stripped = raw.trim_end_matches('L').trim_end_matches('l');
                 let span = self.span(n, src);
                 // Integer literals that don't fit `i64` (e.g. `1e5L`,
-                // `0x10L` for non-hex, very large values) must NOT cause
-                // the whole statement to vanish. Earlier code returned
-                // `None` here, and `?`-propagation in `lower_binary` /
-                // `try_lower_assign` dropped the enclosing statement
-                // entirely. Fall back to a double, then to `Unknown`, but
-                // always produce *some* expression.
+                // `0x10L` for non-hex, very large values) must NOT vanish
+                // via `?`-propagation and take the enclosing statement
+                // with them. Fall back to a double, then to `Unknown`.
                 if let Ok(v) = stripped.parse::<i64>() {
                     Some(Expr::Integer(v, span))
                 } else if let Ok(d) = stripped.parse::<f64>() {
@@ -370,11 +362,9 @@ impl RParser {
                     "NaN" | "nan" => f64::NAN,
                     s => match s.parse::<f64>() {
                         Ok(v) => v,
-                        // A float-looking token we couldn't parse (e.g.
-                        // exotic locale or a tree-sitter quirk): do NOT
-                        // return None -- that propagates up via `?` and
-                        // drops the enclosing statement entirely. Yield
-                        // Unknown so the statement survives.
+                        // Unparseable float token: yield Unknown rather
+                        // than `None`, which would drop the enclosing
+                        // statement via `?`-propagation.
                         Err(_) => return Some(Expr::Unknown(span)),
                     },
                 };
@@ -560,8 +550,7 @@ impl RParser {
             // inner assignment in `a <- b <- 1L`). These return the
             // assigned value in R, so `infer_binop` returns the RHS
             // type for them. `->` and `->>` are right-to-left, so we
-            // swap the operands. tree-sitter-r emits the
-            // super-assignment token as `<<-` (not `<<`).
+            // swap the operands.
             "<-" | "=" => BinOpKind::Assign,
             "<<-" => BinOpKind::SuperAssign,
             "->" | "->>" => {
@@ -689,7 +678,7 @@ impl RParser {
         // For identifier RHS the raw text is the bare name. For a string
         // RHS (e.g. `pkg::"my func"`, used for non-syntactic names) we
         // strip the surrounding quotes.  Use the shared boundary-safe
-        // helper (P37-W1): `raw.len() - 1` need not be a char boundary
+        // helper: `raw.len() - 1` need not be a char boundary
         // when the string token is malformed/truncated, which would
         // panic on the naive slice `raw[1..raw.len() - 1]`.
         let name = if rhs.kind() == "string" {
@@ -769,8 +758,8 @@ fn unquote_r_string(raw: &str) -> String {
 /// a multi-byte character).
 ///
 /// Both `lower_namespace` and `unquote_r_string` call this helper so the
-/// two string-stripping call sites share one boundary-safe code path
-/// (P37-W1).  Escape processing is NOT performed here; callers that need
+/// two string-stripping call sites share one boundary-safe code path.
+/// Escape processing is NOT performed here; callers that need
 /// R escape handling apply it to the returned slice.
 fn strip_quotes_at_boundaries(raw: &str) -> &str {
     if raw.len() < 2 {
@@ -780,7 +769,7 @@ fn strip_quotes_at_boundaries(raw: &str) -> &str {
     // quote is always a single ASCII byte, so byte 1 is a char boundary.
     let start = 1;
     // End: walk back from `raw.len() - 1` to the nearest preceding char
-    // boundary, mirroring the original fuzz-discovered fix.
+    // boundary.
     let mut end = raw.len() - 1;
     while end > start && !raw.is_char_boundary(end) {
         end -= 1;
@@ -1056,10 +1045,9 @@ fn namespace_op(n: Node, src: &str) -> Option<&'static str> {
 
 /// Convert a byte column within a single line to a character column.
 ///
-/// Used by diagnostic rendering when a human-visible column is needed. The
-/// previous per-node column computation rescanned the entire file from byte
-/// 0 for every AST node (O(n^2) total, 47s on 20k lines); this only ever
-/// scans the one line the column lives on.
+/// Used by diagnostic rendering when a human-visible column is needed.
+/// Only the single line containing the column is scanned, never the
+/// whole file.
 ///
 /// `line_start` is the byte offset of the start of the line containing the
 /// column, and `byte_col` is the byte offset of the target within that line.

--- a/crates/ry-core/src/types.rs
+++ b/crates/ry-core/src/types.rs
@@ -271,9 +271,7 @@ impl ClassVector {
 /// Stores an ordered `(name, RType)` list so we can both look up by
 /// name (column access) and iterate in source order (display, audit).
 ///
-/// Stored behind an `Arc` on `RType` (see `RType::columns`); the Arc is
-/// released when the owning `RType` is dropped, so column schemas no
-/// longer leak for the lifetime of the process.
+/// Stored behind an `Arc` on `RType` (see `RType::columns`).
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct ColumnSchema {
     pub columns: Vec<(String, RType)>,
@@ -362,10 +360,7 @@ pub struct FunctionSignature {
 ///
 /// `RType` is `Clone` (not `Copy`): the `columns` and `fn_sig` fields
 /// hold `Arc`-shared heap data, and the `class` names are `Arc<str>`.
-/// Cloning bumps refcounts and is cheap. The previous design held these
-/// as `&'static` references into globally-leaked intern tables; the Arcs
-/// are released when the owning value is dropped, so long-running LSP
-/// sessions no longer accumulate schemas and class names unboundedly.
+/// Cloning bumps refcounts and is cheap.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RType {
     pub mode: Mode,
@@ -409,8 +404,7 @@ impl RType {
     /// or schema. Used whenever inference gives up.
     ///
     /// This is a function (not a `const`) because `RType`'s `Arc` fields
-    /// cannot be constructed in a const context. Callers that previously
-    /// wrote `RType::UNKNOWN` should call `RType::unknown()`.
+    /// cannot be constructed in a const context.
     pub fn unknown() -> RType {
         RType {
             mode: Mode::Opaque,
@@ -488,7 +482,6 @@ impl RType {
             return RType::unknown();
         }
         if members.len() == 1 {
-            // A single-member "union" is just that member.
             return (*members.first().unwrap()).clone();
         }
         // Length: common across members if they all agree, else Unknown.
@@ -598,8 +591,7 @@ impl RType {
     /// the two branches have the same type, that type wins. Otherwise
     /// we build an honest **union** of the two (deduplicated, capped at
     /// `MAX_UNION_MEMBERS`, collapsing to `RType::unknown()` beyond the
-    /// cap). This replaces the old coercion-ladder join, which silently
-    /// promoted `if (p) 1L else "a"` to `character`.
+    /// cap).
     ///
     /// Opaque is absorbing: joining anything with unknown yields unknown.
     ///

--- a/crates/ry-lsp/src/backend.rs
+++ b/crates/ry-lsp/src/backend.rs
@@ -910,8 +910,6 @@ impl LanguageServer for Backend {
                 break;
             }
         }
-        // Debounced: a burst of keystrokes coalesces into a single
-        // diagnostic publish.
         self.schedule_diagnostics(uri).await;
         // P36-W4 (#53): test-only scheduling seam. Signals that the
         // document version has been bumped and diagnostics re-scheduled,
@@ -1429,8 +1427,6 @@ impl Backend {
                     build_input_edit_from_span(&old_text, start_byte, end_byte, &change.text);
                 self.update_doc(path.to_string(), new_text, version).await;
 
-                // Apply the edit to the old tree so the next parse is
-                // incremental.
                 let mut tree_mut = old_tree;
                 if let Some(ref mut tree) = tree_mut {
                     tree.edit(&edit);
@@ -1537,7 +1533,6 @@ impl Backend {
                 }
                 Arc::new(parsed)
             } else {
-                // Full parse: also store the tree so subsequent edits can be incremental.
                 let (parsed, new_tree) = parser.parse_with_tree(path, &text, None).ok()?;
                 {
                     let mut state = self.state.lock().await;
@@ -1712,7 +1707,6 @@ impl Backend {
                 .await;
         }
 
-        // Build the combined file list from open documents and disk files.
         let mut project_files = Vec::with_capacity(doc_paths.len());
         for doc_path in &doc_paths {
             let Some((file, _)) = self.parsed_file(doc_path).await else {
@@ -1727,6 +1721,7 @@ impl Backend {
             let state = self.state.lock().await;
             state.disk_files.clone()
         };
+        // Disk files never shadow open documents.
         let open_paths: std::collections::HashSet<String> =
             project_files.iter().map(|(p, _, _)| p.clone()).collect();
         for (p, file) in &disk_files {
@@ -1736,7 +1731,7 @@ impl Backend {
             project_files.push((p.clone(), 0, Arc::clone(file)));
         }
 
-        // P36-W2: Partition files by owning folder and check each folder
+        // Partition files by owning folder and check each folder
         // independently so two roots defining the same package differently
         // never collide (#54). Each folder gets its own ProjectCache, stubs,
         // and workspace context.
@@ -2062,7 +2057,6 @@ impl Backend {
         };
         tokio::spawn(async move {
             tokio::time::sleep(std::time::Duration::from_millis(180)).await;
-            // Only publish if no newer edit arrived during the sleep.
             let stale = {
                 let state = backend.state.lock().await;
                 state.diag_generation != generation

--- a/crates/ry-lsp/src/diagnostics.rs
+++ b/crates/ry-lsp/src/diagnostics.rs
@@ -47,10 +47,9 @@ pub(super) fn diagnostic_to_lsp(d: RyDiagnostic) -> LspDiagnostic {
 
 /// Convert a `ry_checker::Diagnostic` to an LSP `Diagnostic` using a
 /// precise multi-character range derived from the span's byte offsets
-/// against the source text. The production path
-/// (`publish_diagnostics`); editors squiggle exactly the offending
-/// token. Zero-width spans are extended by one character so the squiggle
-/// is still visible.
+/// against the source text. This is the path `publish_diagnostics`
+/// uses, so editors squiggle exactly the offending token. Zero-width
+/// spans are extended by one character so the squiggle is still visible.
 pub(super) fn diagnostic_to_lsp_with_source(d: &RyDiagnostic, text: &str) -> LspDiagnostic {
     let start = byte_offset_to_position(text, d.span.start);
     let end = byte_offset_to_position(text, d.span.end);

--- a/crates/ry-lsp/src/hints.rs
+++ b/crates/ry-lsp/src/hints.rs
@@ -15,9 +15,8 @@ use crate::util::byte_offset_to_position;
 ///
 /// The walk recurses into `Stmt::FunctionDef` bodies so that local
 /// bindings inside named functions are annotated too (the top-level
-/// scope may or may not track them; if it doesn't, the lookup simply
-/// yields `None` and no hint is emitted, which is the right call for
-/// v1).
+/// scope may or may not track them; if it doesn't, the lookup yields
+/// `None` and no hint is emitted).
 ///
 /// Opaque (`Mode::Opaque`) types are deliberately skipped: they
 /// represent "we don't know" and would only clutter the editor with
@@ -52,19 +51,13 @@ fn collect_inlay_hints_from_stmt(
             ..
         } => {
             if let Some(t) = scope.get(name) {
-                // Skip opaque types: they're not useful to the
-                // user (they represent "we don't know"). Showing
-                // `: opaque<len=?>?NA?` next to every unknown
-                // binding would just be visual noise.
+                // Opaque types are skipped; see the rationale on
+                // `collect_inlay_hints`.
                 if matches!(t.mode, ry_core::types::Mode::Opaque) {
                     return;
                 }
-                // Place the hint right after the identifier name.
-                // `span.start + name.len()` lands on the first
-                // character past the identifier (the identifier's
-                // byte end); `byte_offset_to_position` converts it to
-                // a UTF-16 LSP `Position`, so non-ASCII identifiers
-                // are handled correctly too.
+                // UTF-16 conversion matters here: non-ASCII identifiers
+                // must land the hint past their last code unit.
                 let pos = byte_offset_to_position(text, span.start + name.len());
                 hints.push(InlayHint {
                     position: pos,

--- a/crates/ry-lsp/src/tests.rs
+++ b/crates/ry-lsp/src/tests.rs
@@ -233,7 +233,6 @@ fn inlay_hints_skip_opaque_types() {
     // the non-opaque binding.
     let src = "result <- some_unknown_function()\nx <- 1L + 2L\n";
     let hints = inlay_hints(src);
-    // Only `x` should produce a hint; `result` is opaque and skipped.
     // Each hint's position is right after its identifier:
     //   `result` is at col 0..6 -> hint at col 6 (line 0)
     //   `x`      is at col 0..1 -> hint at col 1 (line 1)
@@ -498,10 +497,8 @@ fn position_to_byte_offset_basic() {
 
 #[test]
 fn utf16_position_roundtrip_on_non_ascii() {
-    // A line with a 2-byte UTF-8 char ('é', U+00E9) before the
-    // cursor. The LSP character column is a UTF-16 code-unit count,
-    // so 'é' contributes 1 unit (BMP). Byte offset of the char
-    // after 'é' is 2 (1 for 'x'... wait, build a clearer case).
+    // The LSP character column is a UTF-16 code-unit count, so 'é'
+    // contributes 1 unit despite being 2 UTF-8 bytes.
     // Text: "café_x" -- 'c','a','f','é'(2 bytes),'_','x'.
     let text = "café_x";
     // The byte offset of '_': c(0) a(1) f(2) é(3,4) _(5).
@@ -869,7 +866,6 @@ fn file_added_after_initial_check_is_emitted() {
     ];
     let diags = cache.check(files, std::sync::Arc::clone(&stubs));
 
-    // The second file must be present in the output.
     assert_eq!(diags.len(), 2, "both files after adding b.R");
     assert!(diags.iter().any(|(p, _)| p == "b.R"), "b.R in output");
 }
@@ -959,7 +955,7 @@ fn return_type_change_propagates_to_callers() {
     let files = vec![
         (
             "utils.R".to_string(),
-            2, // version bumped
+            2,
             parse_src("utils.R", "make_value <- function() 1L\n"),
         ),
         (
@@ -1009,7 +1005,7 @@ fn changing_stubs_invalidates_cached_diagnostics() {
     // This exercises the incremental path after a content change.
     let files = vec![(
         "pkg.R".to_string(),
-        2, // version bumped → forces update
+        2,
         parse_src("pkg.R", "x <- \"str\" + 1L\n"),
     )];
     let diags = cache.check(files, std::sync::Arc::clone(&empty_stubs));

--- a/crates/ry-lsp/tests/configuration_refresh.rs
+++ b/crates/ry-lsp/tests/configuration_refresh.rs
@@ -105,9 +105,7 @@ fn did_change_configuration_refreshes_cached_filters() {
             .await
             .unwrap();
 
-        // The recomputed cached min_confidence must now suppress RY090. Without
-        // the refresh the cached value is stale and RY090 persists until a
-        // filesystem rebuild or server restart.
+        // The recomputed min_confidence must suppress RY090.
         assert_eq!(
             count_code(&after, "RY090"),
             0,
@@ -155,8 +153,7 @@ async fn spawn_pull_session(root: &Path) -> (Session, tokio::task::JoinHandle<()
 fn did_change_configuration_pull_applies_per_folder_settings() {
     run(async {
         let fixture = FixtureProject::empty().unwrap();
-        // RY090 (partial argument name) is emitted at Medium confidence by
-        // default, so raising `minConfidence` to "high" suppresses it.
+        // Same RY090/min-confidence setup as the test above.
         fixture
             .write_file("R/diag.R", "z <- length(xx = 1L)\n")
             .unwrap();

--- a/crates/ry-lsp/tests/p36_contract.rs
+++ b/crates/ry-lsp/tests/p36_contract.rs
@@ -678,7 +678,7 @@ fn p36_w3_workspace_folder_add_remove_convergence() {
             .ok();
         let clear_mark = live2.publication_mark();
 
-        // Await the post-removal republish for root-b's file.
+        // Wait for a possible post-removal publication for root-b's file.
         let republish = tokio::time::timeout(
             std::time::Duration::from_secs(2),
             live2.published_diagnostics_after(&main_b_uri, clear_mark),
@@ -1179,22 +1179,19 @@ fn p36_w5_publish_path_performs_no_baseline_disk_io() {
 }
 
 // ──────────────────────────────────────────────────────────────────────────
-// P36-W6 — Precompute filters once per folder (#46)
+// Precompute filters once per folder (#46)
 //
 // `folder_config_for_path` plus filter/confidence/exclude construction runs
 // inside the per-file publish loop. The fix compiles these once while
 // building each `FolderAnalysisContext` and borrows the compiled values in
-// the loop.
-//
-// P36-W6 adds a construction-count test hook so the count can be asserted
-// directly rather than inferred from wall time; until it landed, this test
-// created the many-files fixture and verified diagnostic correctness.
+// the loop. A construction-count test hook lets this test assert the count
+// directly instead of inferring it from wall time.
 // ──────────────────────────────────────────────────────────────────────────
 
-/// P36-W6 (#46): for a fixed folder count, filter/glob construction must be
-/// flat as file count grows. This test creates many files in one folder,
-/// opens a trigger document, and verifies that all published diagnostics are
-/// byte-for-byte correct.
+/// #46: for a fixed folder count, filter/glob construction must be flat
+/// as file count grows. This test creates many files in one folder,
+/// opens a trigger document, and verifies that all published diagnostics
+/// are byte-for-byte correct.
 #[test]
 fn p36_w6_many_files_flat_filter_construction() {
     let fixture = FixtureProject::empty().unwrap();

--- a/crates/ry-lsp/tests/p36_contract.rs
+++ b/crates/ry-lsp/tests/p36_contract.rs
@@ -157,23 +157,18 @@ fn published_from_lsp(message: &Value, path: &Path, root: &Path) -> Vec<Publishe
 // ──────────────────────────────────────────────────────────────────────────
 // P36-W2a — Per-folder editor settings (#44)
 //
-// The server currently stores a single server-wide `folder_settings`
+// Bug being pinned: the server stored a single server-wide `folder_settings`
 // (`State::folder_settings`) taken from the first `initializationOptions`
-// entry. Per-folder editor settings are not honored. This test creates two
-// roots whose `ry.toml` already configures different behavior and supplies
-// matching per-folder editor settings so that the correct LSP output equals
-// an independent CLI run in each root.
-//
-// Fix: P36-W2a replaces the single `folder_settings` with per-root values.
+// entry, so per-folder editor settings were not honored. W2a replaced it
+// with per-root values.
 // ──────────────────────────────────────────────────────────────────────────
 
 /// P36-W2a (#44): two roots with different editor settings must produce
 /// per-file CLI/LSP parity. Root A ignores RY002 (both in `ry.toml` and
 /// editor settings); root B does not. Both files trigger RY002.
 ///
-/// The current code applies only the first folder's settings server-wide, so
-/// root B's editor ignore list incorrectly suppresses RY002. This fails
-/// against `ry check` run independently in root B.
+/// Before W2a, root A's ignore list was applied server-wide and wrongly
+/// suppressed RY002 in root B, diverging from `ry check` run there.
 #[test]
 fn p36_w2a_two_roots_different_editor_settings_differential() {
     let fixture = FixtureProject::empty().unwrap();
@@ -319,11 +314,10 @@ fn p36_w2a_two_roots_different_editor_settings_differential() {
 // ──────────────────────────────────────────────────────────────────────────
 // P36-W2b — Per-folder typeshed isolation (#54)
 //
-// `load_workspace_stubs` takes a single `root: Option<&Path>` and returns
-// empty when the root has no `ry.toml`. In a multi-root workspace it is
-// called with `root_uri`, not with each workspace folder. Two roots may
-// define the same package differently; the fix loads stubs per root and
-// resolves them through longest-prefix ownership.
+// Bug being pinned: stubs were loaded only for the root URI, so in a
+// multi-root workspace two roots defining the same package differently
+// collided. The fix loads stubs per root and resolves them through
+// longest-prefix ownership.
 // ──────────────────────────────────────────────────────────────────────────
 
 /// P36-W2b (#54): two roots define the same stub package (`localdep`) with
@@ -331,9 +325,8 @@ fn p36_w2a_two_roots_different_editor_settings_differential() {
 /// diagnostic); root B's stub returns character (RY001 — `if` condition is
 /// character). Each root's LSP output must equal its independent CLI run.
 ///
-/// Currently the LSP loads no stubs (root_uri has no typeshed config), so
-/// `my_func` has an unknown return type and neither root produces RY001.
-/// Root B diverges from its CLI run.
+/// Before W2b, neither root loaded its local stubs: `my_func` had an
+/// unknown return type and neither root produced RY001.
 #[test]
 fn p36_w2b_colliding_local_stubs_isolation() {
     let fixture = FixtureProject::empty().unwrap();
@@ -476,18 +469,15 @@ fn p36_w2b_colliding_local_stubs_isolation() {
 // ──────────────────────────────────────────────────────────────────────────
 // P36-W2c — Honor the configuration override (#56)
 //
-// `FolderSettings::configuration` is deserialized but has no read site. The
-// fix resolves it relative to the workspace root and loads that file instead
-// of directory discovery.
+// Bug being pinned: `FolderSettings::configuration` was deserialized but
+// never read. The fix resolves it relative to the workspace root and loads
+// that file instead of directory discovery.
 // ──────────────────────────────────────────────────────────────────────────
 
 /// P36-W2c (#56): a folder whose `ry.toml` lives at a custom path
 /// (`config/custom.toml`) should honor the `configuration` editor setting.
-/// The custom config ignores RY002; the source triggers RY002.
-///
-/// Currently `configuration` is dead code, so the server falls back to
-/// directory discovery (no `ry.toml` at root) and RY002 appears. The test
-/// asserts RY002 is absent — it fails against current code.
+/// The custom config ignores RY002; the source triggers RY002. Asserts
+/// RY002 is absent, proving the override was honored.
 #[test]
 fn p36_w2c_per_folder_custom_config_path() {
     let fixture = FixtureProject::empty().unwrap();
@@ -584,15 +574,14 @@ fn p36_w2c_per_folder_custom_config_path() {
 // ──────────────────────────────────────────────────────────────────────────
 // P36-W3 — Workspace-folder mutation converges to cold state (#55)
 //
-// `did_change_workspace_folders` updates `workspace_folders` but does not
-// remove `disk_files`, trees, diagnostics, or contexts owned by removed
-// roots, and does not cancel results from an old folder set.
+// Bug being pinned: `did_change_workspace_folders` updated
+// `workspace_folders` but left behind `disk_files`, trees, diagnostics,
+// and contexts owned by removed roots.
 // ──────────────────────────────────────────────────────────────────────────
 
 /// P36-W3 (#55): add and remove a workspace folder. After each mutation the
 /// final diagnostics must equal a fresh server initialized on the same final
 /// roots. Removed roots must leave no reachable state.
-///
 #[test]
 fn p36_w3_workspace_folder_add_remove_convergence() {
     use ry_testkit::LspSession;
@@ -689,9 +678,7 @@ fn p36_w3_workspace_folder_add_remove_convergence() {
             .ok();
         let clear_mark = live2.publication_mark();
 
-        // Give the server a chance to republish for root-b's file.
-        // After removal, root-b's file should clear its diagnostics.
-        // The server republishes after the folder change.
+        // Await the post-removal republish for root-b's file.
         let republish = tokio::time::timeout(
             std::time::Duration::from_secs(2),
             live2.published_diagnostics_after(&main_b_uri, clear_mark),
@@ -704,7 +691,6 @@ fn p36_w3_workspace_folder_add_remove_convergence() {
 
         // After removing root-b, the server must clear diagnostics for files
         // owned by root-b (empty publish or no publish at all).
-        // Currently disk_files from root-b persist, so diagnostics remain.
         match republish {
             Ok(Ok(publish)) => {
                 let diags = publish
@@ -1200,18 +1186,15 @@ fn p36_w5_publish_path_performs_no_baseline_disk_io() {
 // building each `FolderAnalysisContext` and borrows the compiled values in
 // the loop.
 //
-// P36-W6 adds a construction-count test hook so the count is asserted
-// directly rather than inferred from wall time. Until then, this test
-// creates the many-files fixture and verifies diagnostic correctness.
+// P36-W6 adds a construction-count test hook so the count can be asserted
+// directly rather than inferred from wall time; until it landed, this test
+// created the many-files fixture and verified diagnostic correctness.
 // ──────────────────────────────────────────────────────────────────────────
 
 /// P36-W6 (#46): for a fixed folder count, filter/glob construction must be
 /// flat as file count grows. This test creates many files in one folder,
 /// opens a trigger document, and verifies that all published diagnostics are
 /// byte-for-byte correct.
-///
-/// P36-W6 adds the construction-count instrumentation. Currently the filter
-/// is recomputed per file inside `publish_diagnostics`.
 #[test]
 fn p36_w6_many_files_flat_filter_construction() {
     let fixture = FixtureProject::empty().unwrap();
@@ -1353,26 +1336,22 @@ fn p36_w6_many_files_flat_filter_construction() {
 // ──────────────────────────────────────────────────────────────────────────
 // P36-W7 — Shared, bounded discovery (#48)
 //
-// The CLI (`collect_r_files`) and LSP (`index::discover_r_files`) use
-// different discovery rules. For example, the CLI skips `target/` and
-// `node_modules/` directories, while the LSP only skips hidden directories.
-// The fix moves discovery behind a shared module so both modes agree.
+// Bug being pinned: the CLI (`collect_r_files`) and LSP
+// (`index::discover_r_files`) used different discovery rules — for example,
+// the CLI skipped `target/` while the LSP did not. The fix moved discovery
+// behind a shared module so both modes agree.
 // ──────────────────────────────────────────────────────────────────────────
 
 /// P36-W7 (#48): the same fixture tree must produce the same discovered path
-/// set in CLI and LSP. The fixture includes a `target/` directory (CLI skips
-/// it; the LSP currently does not), a hidden directory (both skip), and a
-/// normal file. Every file has a diagnostic so the discovery set is
-/// observable through published diagnostic paths.
-///
-/// Currently the CLI and LSP discovery sets differ (CLI excludes
-/// `target/`, LSP includes it). The equality assertion fails.
+/// set in CLI and LSP. The fixture includes a `target/` directory, a hidden
+/// directory (both skip), and a normal file. Every file has a diagnostic so
+/// the discovery set is observable through published diagnostic paths.
 #[test]
 fn p36_w7_cli_lsp_discovery_set_equality() {
     let fixture = FixtureProject::empty().unwrap();
     // Normal file with a diagnostic.
     fixture.write_file("normal.R", "length(xx = 1L)\n").unwrap();
-    // File in target/ — CLI skips this directory, LSP does not.
+    // File in target/ — both modes skip this directory.
     fixture
         .write_file("target/skipped.R", "length(xx = 1L)\n")
         .unwrap();

--- a/crates/ry-lsp/tests/session.rs
+++ b/crates/ry-lsp/tests/session.rs
@@ -858,11 +858,9 @@ async fn fresh_server_diagnostics(
     publish
 }
 
-/// Issue a request/response round-trip that drains leftover publications
-/// from the previous step's multi-URI broadcast into the session's pending
-/// queue.  After this barrier the next `publication_mark` captures only
-/// future arrivals — the pattern documented on
-/// `LspSession::publication_mark`.
+/// Synchronization barrier: a request/response round-trip that drains
+/// leftover publications so the next `publication_mark` captures only
+/// future arrivals. See the module docs and `LspSession::publication_mark`.
 async fn sync_barrier(live: &mut ClientSession, uri: &str) {
     let _ = live
         .request(

--- a/crates/ry-typeshed/src/lib.rs
+++ b/crates/ry-typeshed/src/lib.rs
@@ -892,13 +892,13 @@ fn parse_typeshed(json: &str, path: &Path) -> Result<Typeshed, TypeshedError> {
     parse_typeshed_with_order(json, path).map(|(typeshed, _)| typeshed)
 }
 
-/// Load the base typeshed once and cache it for the life of the process.
+/// Load the base typeshed and cache it for the life of the process.
 ///
 /// The base typeshed is compile-time-embedded and never changes, so
 /// parsing it on every `Checker::new` (once per file in a `Project`, and
 /// once per keystroke in the LSP) is wasted work. This caches the parsed
-/// value in a `OnceLock` so the JSON is deserialized exactly once;
-/// subsequent callers receive a reference to the cached `Typeshed`.
+/// value in a `OnceLock`; concurrent first callers may each parse, but
+/// all receive the same cached `Typeshed`.
 ///
 /// Callers that mutate the typeshed (none do today, but the API allows it)
 /// should `.clone()` the returned reference rather than mutating the cache.
@@ -927,7 +927,7 @@ pub fn load_base_cached() -> Result<&'static Typeshed, TypeshedError> {
 
 /// Load a non-base package's typeshed. Returns `None` for an unknown
 /// package name (the checker treats that as "no signatures available",
-/// i.e. opaque). The known packages are those in [`PACKAGE_SPECS`]; each
+/// i.e. opaque). The known packages are those in `PACKAGE_SPECS`; each
 /// maps one-to-one to a vendored JSON file.
 ///
 /// Results are cached for the life of the process (the JSON documents

--- a/crates/ry-typeshed/src/lib.rs
+++ b/crates/ry-typeshed/src/lib.rs
@@ -894,22 +894,21 @@ fn parse_typeshed(json: &str, path: &Path) -> Result<Typeshed, TypeshedError> {
 
 /// Load the base typeshed once and cache it for the life of the process.
 ///
-/// The base typeshed is a compile-time-embedded 61KB JSON document that
-/// never changes after startup. Parsing it on every `Checker::new` (which
-/// happens once per file in a `Project`, and once per keystroke in the
-/// LSP) is pure waste. This caches the parsed value in a `OnceLock` so the
-/// JSON is deserialized exactly once; subsequent callers receive a
-/// reference to the cached `Typeshed`.
+/// The base typeshed is compile-time-embedded and never changes, so
+/// parsing it on every `Checker::new` (once per file in a `Project`, and
+/// once per keystroke in the LSP) is wasted work. This caches the parsed
+/// value in a `OnceLock` so the JSON is deserialized exactly once;
+/// subsequent callers receive a reference to the cached `Typeshed`.
 ///
 /// Callers that mutate the typeshed (none do today, but the API allows it)
 /// should `.clone()` the returned reference rather than mutating the cache.
 pub fn load_base_cached() -> Result<&'static Typeshed, TypeshedError> {
     static CACHE: std::sync::OnceLock<Typeshed> = std::sync::OnceLock::new();
     // `get_or_try_init` is still unstable, so initialize eagerly via
-    // `get_or_init`. The base typeshed is a compile-time-embedded JSON
-    // document that always parses; a failure here is a build-time data
-    // bug, not a runtime condition, so panicking during first access is
-    // acceptable (and matches the existing `load_base().expect()` callers).
+    // `get_or_init`. The embedded JSON always parses; a failure here is
+    // a build-time data bug, not a runtime condition, so panicking
+    // during first access is acceptable (and matches the existing
+    // `load_base().expect()` callers).
     if let Some(cached) = CACHE.get() {
         return Ok(cached);
     }
@@ -928,15 +927,8 @@ pub fn load_base_cached() -> Result<&'static Typeshed, TypeshedError> {
 
 /// Load a non-base package's typeshed. Returns `None` for an unknown
 /// package name (the checker treats that as "no signatures available",
-/// i.e. opaque). Known packages and their JSON sources:
-///
-/// - `dplyr` -> `data/dplyr.json` (bare function names).
-/// - `purrr` -> `data/purrr.json` (bare function names).
-/// - `mirai` -> `data/mirai.json` (bare function names).
-/// - `survival` -> `data/survival.json` (bare function names).
-/// - `testthat` -> `data/testthat.json` (bare function names).
-/// - `brms`, `posterior`, `loo`, `bayesplot`, `cmdstanr` each map to a
-///   separate vendored package file with bare function names.
+/// i.e. opaque). The known packages are those in [`PACKAGE_SPECS`]; each
+/// maps one-to-one to a vendored JSON file.
 ///
 /// Results are cached for the life of the process (the JSON documents
 /// are compile-time-embedded and never change), so repeated lookups are

--- a/crates/ry-workspace/src/lib.rs
+++ b/crates/ry-workspace/src/lib.rs
@@ -66,11 +66,9 @@ struct DataInventory {
 }
 
 /// A single file-stem binding, used as the conservative fallback when a
-/// serialized workspace cannot be enumerated. A package's `sysdata.rda`
-/// over the byte cap used to disable RY010 for every file in the package
-/// (via [`SERIALIZED_BINDINGS_UNENUMERABLE`]); reducing it to its stem
-/// (`sysdata`) keeps unbound-variable analysis live and only masks the
-/// single colliding name.
+/// serialized workspace cannot be enumerated within the byte cap. The
+/// bare file stem (`sysdata`) keeps unbound-variable analysis live and
+/// only masks the single colliding name.
 fn file_stem_binding(path: &Path) -> HashSet<String> {
     path.file_stem()
         .and_then(|stem| stem.to_str())
@@ -341,7 +339,7 @@ struct SourceBindings {
     /// Names used as the entry-point argument of an FFI primitive somewhere
     /// in the package, which proves they are native routines rather than
     /// ordinary variables. Only meaningful when the NAMESPACE declares
-    /// `useDynLib(..., .registration = TRUE)`; see [`resolve`].
+    /// `useDynLib(..., .registration = TRUE)`; see [`resolve_workspace_context`].
     native_symbols: HashSet<String>,
 }
 
@@ -717,8 +715,7 @@ fn source_package_datasets(root: &Path, max_serialized_bytes: u64) -> DataInvent
 /// Returns the enumerated object names plus a `degraded` flag. When the
 /// decoded payload exceeds the byte cap, enumeration is skipped and the
 /// binding set is reduced to a single file-stem fallback ([`file_stem_binding`])
-/// so unbound-variable analysis (RY010) stays live instead of being disabled
-/// package-wide (the previous behavior via [`SERIALIZED_BINDINGS_UNENUMERABLE`]).
+/// so unbound-variable analysis (RY010) stays live.
 fn serialized_inventory(path: &Path, cap: u64) -> SerializedInventory {
     /// What the cached inventory was derived from. A mismatch on any field
     /// means the entry is stale. `cap` is part of it because raising
@@ -764,10 +761,8 @@ fn serialized_inventory(path: &Path, cap: u64) -> SerializedInventory {
 }
 
 fn serialized_inventory_uncached(path: &Path, cap: u64) -> SerializedInventory {
-    // Decoded payload exceeded the byte cap: rather than disabling
-    // unbound-variable analysis package-wide (the former
-    // `SERIALIZED_BINDINGS_UNENUMERABLE` path), fall back to the file
-    // stem as a single conservative binding. Callers flag the scope as
+    // Decoded payload exceeded the byte cap: fall back to the file stem
+    // as a single conservative binding. Callers flag the scope as
     // degraded so the user knows RY010 precision dropped for that file.
     let degraded = |path: &Path| SerializedInventory {
         bindings: file_stem_binding(path),
@@ -1193,7 +1188,7 @@ pub fn is_file_eligible_with_excludes(
 }
 
 // ─────────────────────────────────────────────────────────────────────────
-// P36-W7 — Shared, bounded directory discovery (#48)
+// Shared, bounded directory discovery (#48)
 // ─────────────────────────────────────────────────────────────────────────
 
 /// Bounded directory discovery limits derived from `[index]` in `ry.toml`.
@@ -1225,7 +1220,7 @@ impl Default for DiscoveryLimits {
     }
 }
 
-/// Structured report when a discovery cap is hit (P36-W7).
+/// Structured report when a discovery cap is hit .
 /// A cap hit is never silent: the caller emits a tracing event,
 /// LSP warning, or CLI warning based on this report.
 #[derive(Clone, Debug, Default)]
@@ -1266,7 +1261,7 @@ pub struct DiscoveryResult {
 
 /// Discover all eligible R source files under `walk_root`, applying the
 /// same eligibility, extension, hidden-directory, symlink, exclude, and
-/// test-fixture rules to both CLI and LSP (P36-W7 / issue #48).
+/// test-fixture rules to both CLI and LSP (#48).
 ///
 /// `exclude_root` anchors the compiled `exclude` patterns from `config`.
 /// It should be the directory containing the originating `ry.toml`. When
@@ -1378,7 +1373,7 @@ fn discover_recursive(
             if package_root.is_some_and(|root| is_excluded_package_directory(root, &path)) {
                 continue;
             }
-            // P36-W7: depth cap prunes further descent.
+            // depth cap prunes further descent.
             if depth >= limits.max_depth {
                 truncated.depth_pruned_dirs.push(path);
                 continue;
@@ -1407,12 +1402,12 @@ fn discover_recursive(
         ) && (check_test_fixtures
             || file_kind::package_file_kind(&path) != file_kind::PackageFileKind::TestFixture)
         {
-            // P36-W7: max-files cap.
+            // max-files cap.
             if out.len() >= limits.max_files {
                 truncated.max_files_hit = true;
                 break;
             }
-            // P36-W7: max-file-bytes cap.
+            // max-file-bytes cap.
             if let Ok(metadata) = std::fs::metadata(&path) {
                 let size = metadata.len();
                 if size > limits.max_file_bytes {

--- a/crates/ry-workspace/src/lib.rs
+++ b/crates/ry-workspace/src/lib.rs
@@ -1220,7 +1220,7 @@ impl Default for DiscoveryLimits {
     }
 }
 
-/// Structured report when a discovery cap is hit .
+/// Structured report when a discovery cap is hit.
 /// A cap hit is never silent: the caller emits a tracing event,
 /// LSP warning, or CLI warning based on this report.
 #[derive(Clone, Debug, Default)]

--- a/crates/ry-workspace/src/packages.rs
+++ b/crates/ry-workspace/src/packages.rs
@@ -16,7 +16,7 @@ pub const NATIVE_ROUTINE_PREFIX_SENTINEL: &str = "\0useDynLib:";
 /// External-binding sentinel recording `useDynLib(..., .registration = TRUE)`.
 /// The registered entry points are declared in `src/`'s `R_registerRoutines`
 /// table, which ry does not read, so the flag instead licenses bare symbols in
-/// native-call argument position (see `is_native_symbol_call`).
+/// native-call argument position.
 pub const NATIVE_REGISTRATION_SENTINEL: &str = "\0useDynLibRegistration";
 
 /// Re-export FFI primitives from ry-core for convenience.

--- a/docs/editor-defaults.md
+++ b/docs/editor-defaults.md
@@ -39,8 +39,7 @@ The default-enabled rules use the ordinary ry configuration/filter seam
 
 At `minConfidence: "low"` with the default rule set, the editor shows all
 rules with at least low confidence. Some false positives still appear,
-particularly for RY010 in packages with dynamic bindings. Users who want
-fewer false positives can:
+particularly for RY010 in packages with dynamic bindings. To reduce them:
 
 1. Set `minConfidence: "medium"` or `"high"` to filter lower-confidence findings.
 2. Use `ry.toml` to disable specific rules per-project.
@@ -49,8 +48,8 @@ fewer false positives can:
 ## No client-only suppression
 
 Editor defaults are enforced through the server configuration, not through
-client-side filtering. This ensures CLI and LSP produce identical diagnostics
-for the same project, preserving the differential test contract.
+client-side filtering, so CLI and LSP produce identical diagnostics for
+the same project (the differential test contract).
 
 ## Future improvements
 

--- a/editors/code/README.md
+++ b/editors/code/README.md
@@ -50,12 +50,6 @@ Install from Open VSX via Positron's extension gallery.
 | `ry.debugInformation` | Dump binary path, version, strategy, and settings |
 | `ry.explainRule`      | Show the explanation for a rule                   |
 
-## Known limitations
-
-**Diagnostics cover only files you have open in the editor.** `ry check .`
-may report additional findings in files you haven't opened. This is a
-known limitation.
-
 ## License
 
 MIT

--- a/editors/code/README.md
+++ b/editors/code/README.md
@@ -54,7 +54,7 @@ Install from Open VSX via Positron's extension gallery.
 
 **Diagnostics cover only files you have open in the editor.** `ry check .`
 may report additional findings in files you haven't opened. This is a
-known limitation being addressed in incremental core work.
+known limitation.
 
 ## License
 

--- a/editors/code/src/common/commands.ts
+++ b/editors/code/src/common/commands.ts
@@ -9,13 +9,6 @@ import { Logger } from "./logger";
 import { ResolvedBinary } from "./binary";
 import { type ISettings } from "./settings";
 
-export async function restartCommand(): Promise<void> {
-  // The actual restart is handled by the extension's restart
-  // orchestration; this command just triggers it via the
-  // requestRestart callback set up in extension.ts.
-  await vscode.commands.executeCommand("_ry.internalRestart");
-}
-
 export function showLogsCommand(logger: Logger): void {
   logger.channel.show();
 }

--- a/editors/code/src/common/commands.ts
+++ b/editors/code/src/common/commands.ts
@@ -1,6 +1,6 @@
 /**
- * Command implementations — `ry.restart`, `ry.showLogs`,
- * `ry.showServerLogs`, `ry.debugInformation`, `ry.explainRule`.
+ * Command implementations — `ry.showLogs`, `ry.showServerLogs`,
+ * `ry.debugInformation`, `ry.explainRule`.
  */
 
 import * as vscode from "vscode";

--- a/editors/code/src/common/constants.ts
+++ b/editors/code/src/common/constants.ts
@@ -39,7 +39,7 @@ export const RY_BINARY_NAME = process.platform === "win32" ? "ry.exe" : "ry";
  * Path to the `ry` executable that is bundled with the extension.
  *
  * CI injects the platform-specific binary here; the directory is
- * gitignored. Binary resolution (E2) picks between this path and a
+ * gitignored. Binary resolution picks between this path and a
  * user-installed `ry`.
  */
 export const BUNDLED_RY_EXECUTABLE = path.join(

--- a/editors/code/src/common/server.ts
+++ b/editors/code/src/common/server.ts
@@ -53,11 +53,9 @@ export type ServerState = {
 /**
  * Construct and start the language server client.
  *
- * P37-W2: `binaryPath` is the already-resolved binary path from
- * `extension.ts`, which called `findRyBinaryPath()` with the correct
- * `isUntrusted` flag. The server no longer resolves its own binary —
- * eliminating the split-brain where a different binary could be
- * version-gated/displayed vs. launched.
+ * `binaryPath` must be pre-resolved by the caller via
+ * `findRyBinaryPath()` (which honors workspace trust) so the launched
+ * binary is the same one that was version-gated and displayed.
  */
 export async function startServer(
   namespace: string,
@@ -70,7 +68,6 @@ export async function startServer(
     `Initialization options: ${JSON.stringify(initializationOptions, null, 4)}`,
   );
 
-  // M10: Pass --log-level to the server if configured.
   const logLevel = getConfiguration(namespace).get<string>("logLevel");
   const serverArgs: string[] = logLevel
     ? [RY_SERVER_SUBCOMMAND, "--log-level", logLevel]

--- a/editors/code/src/common/settings.ts
+++ b/editors/code/src/common/settings.ts
@@ -3,7 +3,7 @@
  *
  * Provides `ISettings`, `getWorkspaceSettings`, `getGlobalSettings`,
  * `getExtensionSettings` (returning the per-folder array that feeds
- * S2's `initializationOptions`), and `checkIfConfigurationChanged`.
+ * `initializationOptions`), and `checkIfConfigurationChanged`.
  */
 
 import * as vscode from "vscode";
@@ -112,9 +112,8 @@ export function getGlobalSettings(namespace: string): ISettings {
 }
 
 /**
- * Build the per-folder settings array that feeds S2's
- * `initializationOptions`. This is what the server receives at
- * initialize time.
+ * Build the per-folder settings array sent as
+ * `initializationOptions` at `initialize` time.
  */
 export function getExtensionSettings(namespace: string): ISettings[] {
   const folders = getWorkspaceFolders();

--- a/editors/code/src/common/utilities.ts
+++ b/editors/code/src/common/utilities.ts
@@ -21,9 +21,8 @@ async function pathExists(p: string): Promise<boolean> {
  * Pick the single workspace folder to use as the project root.
  *
  * With one folder, that folder wins. With several, the shortest
- * existing folder path is chosen — the pre-S4 heuristic that
- * treats the top-most (least nested) directory as the project root.
- * With no folders, falls back to the process working directory.
+ * existing folder path is chosen (the top-most, least nested
+ * directory). With no folders, falls back to the process working directory.
  *
  * This mirrors ruff-vscode's `getProjectRoot`.
  */
@@ -71,8 +70,7 @@ export async function getProjectRoot(): Promise<WorkspaceFolder> {
  * `file`, `untitled`, and notebook schemes are enumerated explicitly.
  *
  * `ry.toml` is included so that config edits arrive as ordinary
- * `didOpen`/`didChange` syncs — a cheap path toward S3's reload that
- * complements `didChangeWatchedFiles`.
+ * `didOpen`/`didChange` syncs, complementing `didChangeWatchedFiles`.
  */
 export function getDocumentSelector(): DocumentSelector {
   return isVirtualWorkspace()

--- a/editors/code/src/common/version.ts
+++ b/editors/code/src/common/version.ts
@@ -38,7 +38,7 @@ export function versionGte(a: VersionInfo, b: VersionInfo): boolean {
 
 /**
  * The minimum server version that supports the initializationOptions
- * settings channel (S2). Older binaries will produce an actionable
+ * settings channel. Older binaries will produce an actionable
  * error message instead of launching.
  */
 export const MINIMUM_SETTINGS_CHANNEL_VERSION: VersionInfo = {

--- a/editors/code/src/extension.ts
+++ b/editors/code/src/extension.ts
@@ -51,7 +51,6 @@ export async function activate(
   statusItem.setBusy();
   context.subscriptions.push(statusItem);
 
-  // The `ry.enable` gate: return early from activation when disabled.
   const enable = getConfiguration(serverId).get<boolean>("enable", true);
   if (!enable) {
     logger.info(
@@ -61,7 +60,7 @@ export async function activate(
     return;
   }
 
-  // E2: Resolve the binary and probe its version before starting.
+  // Resolve the binary and probe its version before starting.
   const isUntrusted = !vscode.workspace.isTrusted;
   const settings = getWorkspaceSettings(serverId, {
     uri: vscode.Uri.file(process.cwd()),
@@ -134,7 +133,7 @@ export async function activate(
     await restartPromise;
   };
 
-  // E3: Configuration change triggers restart only for settings
+  // Configuration change triggers restart only for settings
   // that need a respawn. Live-updatable settings go via
   // didChangeConfiguration instead.
   context.subscriptions.push(
@@ -157,7 +156,7 @@ export async function activate(
         await requestRestart();
       }
     }),
-    // E3: Workspace trust changes respawn because trust affects binary resolution.
+    // Workspace trust changes respawn because trust affects binary resolution.
     vscode.workspace.onDidGrantWorkspaceTrust(async () => {
       await requestRestart();
     }),

--- a/editors/code/src/test/binary.test.ts
+++ b/editors/code/src/test/binary.test.ts
@@ -1,11 +1,10 @@
 /**
- * P37-W2: Unit tests for binary resolution trust behavior.
+ * Unit tests for binary resolution trust behavior.
  *
- * After the split-brain fix, the server uses the path resolved by
- * `findRyBinaryPath()` from `binary.ts`, which honors workspace trust.
- * An untrusted workspace must NOT use a `ry.path` setting, even if the
- * file exists — that would allow a checked-in `.vscode/settings.json`
- * to execute an arbitrary binary.
+ * `findRyBinaryPath()` honors workspace trust: an untrusted workspace
+ * must NOT use a `ry.path` setting, even if the file exists — that
+ * would allow a checked-in `.vscode/settings.json` to execute an
+ * arbitrary binary.
  */
 
 import { describe, it, expect } from "bun:test";
@@ -15,7 +14,7 @@ import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
 
-describe("findRyBinaryPath trust behavior (P37-W2)", () => {
+describe("findRyBinaryPath trust behavior", () => {
   it("ignores ry.path in an untrusted workspace and returns the bundled binary", () => {
     // Create a decoy binary that exists on disk.
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ry-test-"));

--- a/editors/code/src/test/e2e.test.ts
+++ b/editors/code/src/test/e2e.test.ts
@@ -41,13 +41,9 @@ describe("E2E: ry extension", () => {
     expect(codes).to.include(expectedCode);
   });
 
-  // P37-W2: After the split-brain fix, startServer() receives the
-  // pre-resolved binaryPath from extension.ts (which called
-  // findRyBinaryPath with the isUntrusted flag). The server starting
-  // and producing diagnostics proves a single binary identity — no
-  // separate resolveBinary() path can launch a different binary.
-  // The unit tests in binary.test.ts verify trust-honoring resolution.
-  it("Server starts from the resolved binary path (P37-W2 no split-brain)", async function () {
+  // The server launches from the single pre-resolved binary path; the
+  // unit tests in binary.test.ts verify trust-honoring resolution.
+  it("Server starts from the resolved binary path", async function () {
     this.timeout(30000);
 
     const fixturePath = path.join(


### PR DESCRIPTION
Follow-up to #118. Comment-only and docs-only cleanup guided by the Orwell/STE style filters: cut words that do no work, kill history narration, one term per concept, keep load-bearing technical constraints.

## What changed

- **History narration removed from doc comments** — stories about replaced implementations (Arc migration, split-brain fix, coercion-ladder join) told in past tense; the design rationale stays, the archaeology goes.
- **Deduplicated explanations** — sysdata byte-cap fallback, debounce invariant, superassignment token, RY090/min-confidence setup, and the base-resolution lookup order each now live once.
- **Misplaced blocks moved** — `rep()` explanation onto `infer_rep`, fixpoint pass 2 onto `run_fixpoint`, canonical base-call lookup order onto `resolves_to_base` (it was documenting the lenient variant).
- **Stale references fixed** — dead `[resolve]` intra-doc link, nonexistent `is_native_symbol_call` cross-ref, removed `RType::UNKNOWN` migration note, stale typeshed `data/` paths, a doc stating the opposite of `strip_negation`, Rc-vs-Arc mismatch in `collect.rs`.
- **p36_contract banners** rewritten from present-tense bug descriptions ("This test fails against current code") to past-tense bug-pinning statements matching the module header's framing.
- **Opaque plan-phase tags stripped** (~20 sites); issue references kept.
- **Dead code deleted**: `restartCommand` invoked `_ry.internalRestart`, which nothing registers; extension.ts wires `ry.restart` directly.
- **metamorphic R10 labels corrected** to describe the actual sources; the missing underscore/magrittr shapes are tracked in #119.

Docs: README dump-types intro condensed, vague limitation notes trimmed, editor-defaults tightened.

`comms.md` untouched (append-only by contract), as is the CHANGELOG.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `bun x tsc --noEmit`
- `cargo test --workspace` — all green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified documentation across the CLI, editor integration, language server, configuration, parsing, diagnostics, workspace, and typeshed features.
  * Updated guidance on diagnostic formats, editor limitations, configuration defaults, discovery limits, and synchronization behavior.
  * Removed outdated implementation notes and internal work-item references.

* **Refactor**
  * Improved internal function-body sharing and added more precise base-call resolution support.
  * Removed the obsolete editor restart command.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->