### PR TITLE
ci: pin cargo-xwin image by digest, ignore zizmor unpinned-images

### DIFF
--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -38,9 +38,15 @@ rules:
   #   outputs computed over the repo's own dist-workspace.toml
   #   (pr-run-mode = "skip": the workflow has no pull_request trigger),
   #   so no untrusted input reaches these run blocks.
+  # - unpinned-images: the `container:` value is dist's runtime plan
+  #   matrix expression, which zizmor cannot expand; the image it
+  #   resolves to is digest-pinned in dist-workspace.toml.
   excessive-permissions:
     ignore:
       - release.yml
   template-injection:
+    ignore:
+      - release.yml
+  unpinned-images:
     ignore:
       - release.yml

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -38,7 +38,10 @@ runner = "windows-2022"
 [dist.github-custom-runners.aarch64-pc-windows-msvc]
 runner = "ubuntu-latest"
 host = "x86_64-unknown-linux-gnu"
-container = { image = "messense/cargo-xwin", host = "x86_64-unknown-linux-musl", package_manager = "apt" }
+# Digest-pinned so a retag of cargo-xwin can't reach the release build
+# (zizmor: unpinned-images; release.yml only sees the runtime plan matrix).
+# To update: resolve the new digest and re-run `dist generate`.
+container = { image = "messense/cargo-xwin@sha256:9856b895265d4966f212228ba64802cf89337e2a2a537aa2533c1b8784cbc81b", host = "x86_64-unknown-linux-musl", package_manager = "apt" }
 
 # Pin the GitHub Actions dist references in the generated release.yml to
 # immutable commit SHAs (zizmor: unpinned-uses). Update by changing the SHA


### PR DESCRIPTION
## Context

GitHub code scanning surfaced a zizmor `unpinned-images` alert at `release.yml:114` (bumping `zizmorcore/zizmor-action` 0.1.1 → 0.6.2 brought the newer audit). The job's `container:` value is dist's runtime plan matrix expression, which zizmor cannot statically expand — but the image behind it (`messense/cargo-xwin`, used to cross-compile `aarch64-pc-windows-msvc`) was genuinely referenced by mutable tag, so a retag would execute in a job holding a `contents: write` `GITHUB_TOKEN` during releases.

## Changes

- **`dist-workspace.toml`**: pin the image by digest (`messense/cargo-xwin@sha256:9856b895…c81b`, the 4-platform OCI index `latest` currently resolves to). dist passes the string through to the plan matrix; `release.yml` itself is unchanged.
- **`.github/zizmor.yml`**: ignore `unpinned-images` for `release.yml` with a justification bullet in the existing generated-file comment block (matching `excessive-permissions` / `template-injection`), since the generated workflow cannot carry inline ignores.

## Verification

- `dist generate --check` passes (dist 0.32.0): generated workflow byte-identical, dist-check job stays green.
- `dist plan` confirms the aarch64-windows matrix entry carries the digest-pinned reference.
- `zizmor` 1.29.0 on `release.yml` reports no findings (10 ignored, up from 9).

## Note

The open code scanning alert closes on the next zizmor SARIF upload on `main`; since this change doesn't touch `.github/workflows/**`, the zizmor job's `paths` filter skips this PR — dismiss the alert in the UI if you want it gone immediately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Pinned the Windows cross-compilation container to an immutable digest for more reliable and secure builds.
  * Updated security scanning configuration to recognize the digest-pinned runtime image.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->