### PR TITLE
fix(cli): honor -vv as trace, repair garbled strings and stale docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,7 +108,8 @@ suppression actions — and fixes a parser panic plus several editor issues.
 - **`-vv` now enables trace logging**: the CLI mapped every verbosity
   level above `-v` to `ry=debug`, so the trace tier promised by the help
   text never activated. `-vv` and higher now set `ry=trace`; `-v` and the
-  quiet flags are unchanged.
+  quiet flags are unchanged. The help text also claimed `-v` selects
+  debug; it now says info, matching the filter `init_tracing` applies.
 - **Oversized-file warning no longer contains stray spaces**: the
   `index.max-file-bytes` warning printed a wide run of stray spaces
   inside the sentence. The message now uses single spaces.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,13 @@ suppression actions — and fixes a parser panic plus several editor issues.
 
 ### Fixed
 
+- **`-vv` now enables trace logging**: the CLI mapped every verbosity
+  level above `-v` to `ry=debug`, so the trace tier promised by the help
+  text never activated. `-vv` and higher now set `ry=trace`; `-v` and the
+  quiet flags are unchanged.
+- **Oversized-file warning no longer contains stray spaces**: the
+  `index.max-file-bytes` warning printed a wide run of stray spaces
+  inside the sentence. The message now uses single spaces.
 - Parsing no longer panics when a string literal ends inside a multi-byte
   UTF-8 character.
 - Re-running the checker on a single file no longer leaks inference state

--- a/crates/ry-cli/src/main.rs
+++ b/crates/ry-cli/src/main.rs
@@ -380,7 +380,7 @@ fn init_tracing(verbose: u8, quiet: u8) {
         match verbose {
             0 => "ry=warn",
             1 => "ry=info",
-            _ => "ry=debug",
+            _ => "ry=trace",
         }
     };
     let _ = tracing_subscriber::fmt()
@@ -457,16 +457,8 @@ fn render_diagnostics(
     ry_checker::format::render_with_color(diagnostics, format, srcs, color)
 }
 
-/// Compute the path of `file` relative to `root`, as a forward-slash
-/// string suitable for matching against `ry.toml` `exclude` patterns.
-///
-/// Both inputs are first canonicalized so that a relative `ry check
-/// ./src` invocation still matches patterns written against the
-/// project-relative form (e.g. `src/**`). If canonicalization fails
-/// (e.g. a missing path), we fall back to a best-effort strip of the
-/// root prefix from the literal path, and finally to the file's full
-/// display string, so exclude matching degrades gracefully rather than
-/// panicking.
+/// Drive `ry check`: merge the CLI flags with `ry.toml`, discover the
+/// R files, check them once, and keep re-checking in watch mode.
 #[allow(clippy::too_many_arguments)]
 fn run_check(
     paths: Vec<PathBuf>,
@@ -656,12 +648,7 @@ fn run_check(
         sort_and_deduplicate_paths(&mut current_paths);
 
         // Check for any file modification or file set change.
-        let mut changed = current_paths.len() != all_paths.len();
-        if !changed {
-            if current_paths != all_paths {
-                changed = true;
-            }
-        }
+        let mut changed = current_paths != all_paths;
         if !changed {
             for p in &current_paths {
                 if let Ok(meta) = std::fs::metadata(p) {
@@ -1001,10 +988,9 @@ fn run_check_once(
 
     let rendered = render_diagnostics(&all_diagnostics, format, &srcs, color);
     if !rendered.is_empty() {
-        // Diagnostics go to STDOUT (matches ruff/ty): `ry check > log`
+        // Diagnostics go to stdout (matches ruff/ty): `ry check > log`
         // captures the diagnostics, while the summary line and watch-
-        // mode chrome go to stderr. Machine formats (json/github/...)
-        // already used stdout; human formats (concise/full) now do too.
+        // mode chrome go to stderr.
         print!("{}", rendered);
     }
 
@@ -1044,7 +1030,6 @@ fn sort_and_deduplicate_diagnostics(diagnostics: &mut Vec<ry_checker::Diagnostic
                 .then(a.span.start.cmp(&b.span.start))
                 .then(a.span.end.cmp(&b.span.end))
                 .then(a.code.cmp(b.code))
-                .then(a.confidence.cmp(&b.confidence))
                 .then(a.severity.as_str().cmp(b.severity.as_str()))
                 .then(a.message.cmp(&b.message)),
         )
@@ -1252,7 +1237,7 @@ fn report_truncation(report: &ry_workspace::TruncationReport, root: &std::path::
     }
     for (path, size) in &report.oversized_files {
         eprintln!(
-            "ry: warning: {} ({} bytes) exceeds the per-file size cap              (index.max-file-bytes) and was not discovered",
+            "ry: warning: {} ({} bytes) exceeds the per-file size cap (index.max-file-bytes) and was not discovered",
             path.display(),
             size
         );

--- a/crates/ry-cli/src/main.rs
+++ b/crates/ry-cli/src/main.rs
@@ -80,7 +80,7 @@ impl ColorChoice {
 struct Cli {
     #[command(subcommand)]
     cmd: Option<Cmd>,
-    /// Increase verbosity. Use -v for debug, -vv for trace.
+    /// Increase verbosity. Use -v for info, -vv for trace.
     #[arg(short, long, action = clap::ArgAction::Count, global = true)]
     verbose: u8,
     /// Decrease verbosity. Use -q for quiet, -qq for silent.


### PR DESCRIPTION
## Summary

Small user-facing fixes for the CLI. `-vv` now enables the trace tier the help text promises. The oversized-file warning no longer prints stray spaces. This PR also removes stale docs and dead code in `main.rs`.

## Changes

- `init_tracing` maps `verbose >= 2` to `ry=trace`, so `-vv` honors the help text. `-v` still selects `ry=info`; the quiet handling is unchanged. `init_tracing` also consumes the merged `ry.toml` verbosity, so both entry paths get the fix.
- The `index.max-file-bytes` warning collapses a run of stray interior spaces to single spaces. A scan of `main.rs` found no other strings with interior double spaces.
- `run_check`'s doc comment now describes what the function does. The old text described exclude matching that lives elsewhere.
- `sort_and_deduplicate_diagnostics` drops the `confidence` tiebreak. The comparator's outer key already orders by confidence, so the tiebreak can never discriminate.
- The watch loop collapses three nested `if !changed` checks into one flat `current_paths != all_paths` comparison; the length check was implied by the inequality. The crate-level `#![allow(clippy::collapsible_if)]` stays, because clippy still fails without it on the nested `if let` stamp loops.
- The diagnostics-print comment keeps the stdout/stderr contract and drops the change narration.
- `CHANGELOG.md` gains two `Fixed` entries.

## Verification

- `cargo fmt -p ry-cli` — no changes.
- `cargo clippy -p ry-cli --all-targets -- -D warnings` — passes.
- `cargo test -p ry-cli` — 92 tests pass, 0 fail (34 unit, 58 integration).
