### PR TITLE
docs: correct the editor-defaults rule table and guard it against drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,15 @@ suppression actions — and fixes a parser panic plus several editor issues.
   in the release workflow, made its version and core-tag inputs explicit,
   replaced the empty pull-request build workflow with a required one, and
   standardized the publisher identity to `sims1253.ry`.
+- **Corrected rule table in `docs/editor-defaults.md`**: RY020, RY030,
+  RY040, and RY090 now carry their registry names (`unary-minus-type`,
+  `invalid-comparison`, `invalid-arithmetic`, `unknown-argument`). RY032
+  is documented as the enabled `scalar-logical-length` warning it is, with
+  its measured 1 TP / 47 FP, instead of a disabled "test fixture" rule.
+  RY003 is documented as the only default-off rule. The baseline-findings
+  table now points at `docs/corpus/0.9-release-evidence.md` instead of
+  duplicating it, and the drift check that guards the README rule table
+  (#107) now also guards this table.
 
 ## [0.8.0] - 2026-08-04
 

--- a/crates/ry-checker/tests/readme_rule_table.rs
+++ b/crates/ry-checker/tests/readme_rule_table.rs
@@ -13,12 +13,20 @@
 //! and RY101 reword theirs; RY031/RY032 escape `|` as `&#124;` and `>` as
 //! `\>`). The stable contract is code, name, and severity, plus a non-empty
 //! summary cell so a truncated row cannot pass.
+//!
+//! The same guard covers the curated rule table in the "## Default profile
+//! policy" section of docs/editor-defaults.md. That table drifted too
+//! (RY020, RY030, RY040, and RY090 carried wrong names, and RY032 was
+//! documented as a disabled "test fixture" rule while the registry ships it
+//! enabled). Unlike the README table, it lists a curated subset of rules, so
+//! the test asserts row correctness — code, name, severity, and
+//! enabled-by-default — against the registry, not full parity.
 
 use std::collections::HashSet;
 use std::fs;
 use std::path::Path;
 
-use ry_checker::rules::RULES;
+use ry_checker::rules::{RULES, enabled_by_default};
 
 const EXPECTED_COLUMNS: [&str; 4] = ["code", "name", "severity", "summary"];
 
@@ -208,6 +216,178 @@ fn readme_rule_table_matches_rule_registry() {
     assert!(
         problems.is_empty(),
         "README.md rule table (## Rules) is out of sync with \
+         ry_checker::rules::RULES ({} problem(s)):\n  - {}",
+        problems.len(),
+        problems.join("\n  - ")
+    );
+}
+
+/// Expected columns of the docs/editor-defaults.md rule table.
+const EDITOR_DEFAULTS_COLUMNS: [&str; 5] = ["Rule", "Severity", "Default", "Verdict", "Evidence"];
+
+/// One data row of the docs/editor-defaults.md rule table.
+struct EditorDefaultsRow {
+    code: String,
+    name: String,
+    severity: String,
+    default_enabled: String,
+    /// 1-based docs/editor-defaults.md line, for actionable failure messages.
+    line: usize,
+}
+
+/// Parse the curated rule table out of the "## Default profile policy"
+/// section of docs/editor-defaults.md.
+///
+/// The first cell is `RY010 (unbound-variable)`: the registry code, then the
+/// registry name in parentheses. Every row must be a rule row — the table
+/// holds no config rows — so a row that does not fit the shape fails here
+/// instead of slipping past the registry comparison.
+fn editor_defaults_rule_rows() -> Vec<EditorDefaultsRow> {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../docs/editor-defaults.md");
+    let doc = fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+    let lines: Vec<&str> = doc.lines().collect();
+
+    let heading = lines
+        .iter()
+        .position(|l| l.trim() == "## Default profile policy")
+        .unwrap_or_else(|| {
+            panic!("docs/editor-defaults.md has no '## Default profile policy' section")
+        });
+
+    let section_end = lines[heading + 1..]
+        .iter()
+        .position(|l| l.starts_with('#'))
+        .map(|i| heading + 1 + i)
+        .unwrap_or(lines.len());
+
+    // The rule table is the first contiguous run of `|`-prefixed lines in
+    // the section; collection stops at the table's first non-table line.
+    let mut table: Vec<(usize, &str)> = Vec::new();
+    for (offset, line) in lines[heading + 1..section_end].iter().enumerate() {
+        if line.starts_with('|') {
+            table.push((heading + 2 + offset, line));
+        } else if !table.is_empty() {
+            break; // the first contiguous table has ended
+        }
+    }
+
+    assert!(
+        table.len() >= 3,
+        "docs/editor-defaults.md '## Default profile policy' section has no rule table \
+         (expected header, alignment, and data rows)"
+    );
+
+    let header = cells(table[0].1);
+    assert_eq!(
+        header, EDITOR_DEFAULTS_COLUMNS,
+        "unexpected column header for the docs/editor-defaults.md rule table"
+    );
+    assert!(
+        is_alignment_row(&cells(table[1].1)),
+        "expected an alignment row right after the docs/editor-defaults.md rule table header"
+    );
+
+    table[2..]
+        .iter()
+        .map(|(line, raw)| {
+            let cells = cells(raw);
+            assert_eq!(
+                cells.len(),
+                5,
+                "docs/editor-defaults.md rule table row at line {line} has {} cells \
+                 (Rule, Severity, Default, Verdict, Evidence expected); an unescaped '|' \
+                 in a cell splits the row",
+                cells.len()
+            );
+            let (code, name) = split_rule_cell(&cells[0], *line);
+            EditorDefaultsRow {
+                code,
+                name,
+                severity: cells[1].clone(),
+                default_enabled: cells[2].clone(),
+                line: *line,
+            }
+        })
+        .collect()
+}
+
+/// Split a `RY010 (unbound-variable)` rule cell into code and name.
+fn split_rule_cell(cell: &str, line: usize) -> (String, String) {
+    let (code, rest) = cell.split_once(' ').unwrap_or_else(|| {
+        panic!(
+            "docs/editor-defaults.md rule table row at line {line}: rule cell `{cell}` is not \
+             `CODE (name)`; the table holds only rule rows"
+        )
+    });
+    let name = rest
+        .strip_prefix('(')
+        .and_then(|r| r.strip_suffix(')'))
+        .unwrap_or_else(|| {
+            panic!(
+                "docs/editor-defaults.md rule table row at line {line}: rule cell `{cell}` does \
+                 not wrap the rule name in parentheses"
+            )
+        });
+    (code.to_string(), name.to_string())
+}
+
+#[test]
+fn editor_defaults_rule_table_matches_rule_registry() {
+    let rows = editor_defaults_rule_rows();
+    let mut problems: Vec<String> = Vec::new();
+
+    // The table is a curated subset, so each row must be checked on its own:
+    // an unknown rule, a wrong name or severity, or a wrong enabled-by-default
+    // status would otherwise pass unnoticed, and a pasted-duplicate row must
+    // be caught too.
+    let mut seen: HashSet<&str> = HashSet::new();
+    for row in &rows {
+        let Some(rule) = RULES.iter().find(|r| r.code == row.code) else {
+            problems.push(format!(
+                "unknown row: docs/editor-defaults.md line {} documents {} (`{}`) but no rule \
+                 with that code is registered; remove the row or fix the code",
+                row.line, row.code, row.name
+            ));
+            continue;
+        };
+        if row.name != rule.name {
+            problems.push(format!(
+                "name mismatch: docs/editor-defaults.md line {} calls {} `{}` but the registry \
+                 calls it `{}`",
+                row.line, row.code, row.name, rule.name
+            ));
+        }
+        let severity = rule.default_severity.as_str();
+        if row.severity != severity {
+            problems.push(format!(
+                "severity mismatch: docs/editor-defaults.md line {} lists {} as `{}` but its \
+                 registry default severity is `{}`",
+                row.line, row.code, row.severity, severity
+            ));
+        }
+        let default = if enabled_by_default(&row.code) {
+            "Enabled"
+        } else {
+            "Disabled"
+        };
+        if row.default_enabled != default {
+            problems.push(format!(
+                "default mismatch: docs/editor-defaults.md line {} lists {} as `{}` but the \
+                 registry default is `{}`",
+                row.line, row.code, row.default_enabled, default
+            ));
+        }
+        if !seen.insert(row.code.as_str()) {
+            problems.push(format!(
+                "duplicate row: docs/editor-defaults.md line {} repeats {} ({})",
+                row.line, row.code, row.name
+            ));
+        }
+    }
+
+    assert!(
+        problems.is_empty(),
+        "docs/editor-defaults.md rule table (## Default profile policy) is out of sync with \
          ry_checker::rules::RULES ({} problem(s)):\n  - {}",
         problems.len(),
         problems.join("\n  - ")

--- a/docs/editor-defaults.md
+++ b/docs/editor-defaults.md
@@ -5,35 +5,39 @@
 The default editor configuration (`minConfidence: "low"`, default rule set)
 is designed to be safe for untrusted workspaces and broad real-world code.
 This document records the corpus evidence behind those defaults and the
-policy decisions for each rule.
+policy decisions behind them.
 
-## Corpus baseline (reconciled by CI gate)
+## Corpus baseline
 
-| Metric | Value |
-| :-- | --: |
-| Total findings | 728 |
-| True positives | 37 |
-| False positives | 691 |
-| Overall precision | 5.08% |
-| `R/` precision | 4.20% |
-
-The corpus is dominated by RY010 (unbound variable) false positives from
-upstream package bindings, generated code, and test fixtures.
+The 0.9 corpus baseline is measured and gated in
+[docs/corpus/0.9-release-evidence.md](corpus/0.9-release-evidence.md):
+728 findings, 37 true positives, 691 false positives, 5.08% overall
+precision. The corpus is dominated by RY010 (unbound-variable) false
+positives from imported, generated, and data bindings that exist at
+runtime.
 
 ## Default profile policy
 
 The default-enabled rules use the ordinary ry configuration/filter seam
-(no client-only suppression), preserving CLI/LSP parity.
+(no client-only suppression), preserving CLI/LSP parity. Every rule is
+enabled by default except RY003 (numeric-condition). `minConfidence`
+stays `"low"`: it filters zero-confidence heuristics and retains every
+corpus TP.
 
-| Rule | Default | Verdict | Evidence |
-| :-- | :-- | :-- | :-- |
-| RY010 (unbound variable) | Enabled | **Keep** | 4 TP in production source; dominant FP source but TP are real bugs |
-| RY020 (type mismatch) | Enabled | **Keep** | High signal in production source |
-| RY030 (scope error) | Enabled | **Keep** | High signal |
-| RY040 (invalid operation) | Enabled | **Keep** | High signal |
-| RY090 (partial argument name) | Enabled | **Keep** | Consistent, byte-for-byte correct |
-| RY032 (test fixture) | Disabled | **Default-off** | 70/70 false positives in test fixtures |
-| minConfidence | "low" | **Keep** | Filters zero-confidence heuristics while retaining all corpus TP |
+The table below is a curated subset of the registry, not the full rule
+list. Codes, names, severities, and defaults mirror
+`crates/ry-checker/src/rules.rs`. Verdicts and corpus counts come from
+[docs/corpus/rule-evidence-0.9.md](corpus/rule-evidence-0.9.md).
+
+| Rule | Severity | Default | Verdict | Evidence |
+| :-- | :-- | :-- | :-- | :-- |
+| RY003 (numeric-condition) | info | Disabled | **Default-off** | 0 corpus findings. Valid claim, but style advice. |
+| RY010 (unbound-variable) | warning | Enabled | **Keep** | 4 TP / 472 FP. Dominant FP source, but the TP are real bugs. |
+| RY020 (unary-minus-type) | error | Enabled | **Keep** | 0 TP / 0 FP in the corpus. Verified claim; lift-reachable through scalar defaults. |
+| RY030 (invalid-comparison) | error | Enabled | **Keep** | 0 TP / 25 FP. FPs come from typeshed coverage gaps. |
+| RY032 (scalar-logical-length) | warning | Enabled | **Keep** | 1 TP / 47 FP. Fires on non-literal parameter-dependent expressions. |
+| RY040 (invalid-arithmetic) | error | Enabled | **Keep** | 0 TP / 23 FP. FPs come from typeshed coverage gaps. |
+| RY090 (unknown-argument) | warning | Enabled | **Keep** | 0 TP / 4 FP. Valid syntactic claim. |
 
 ## Precision implications
 
@@ -50,9 +54,3 @@ particularly for RY010 in packages with dynamic bindings. To reduce them:
 Editor defaults are enforced through the server configuration, not through
 client-side filtering, so CLI and LSP produce identical diagnostics for
 the same project (the differential test contract).
-
-## Future improvements
-
-A future external semantic catalog targets the dominant RY010 false-positive
-sources through catalog-driven package binding resolution. The precision
-target for the post-catalog default profile is 50%.


### PR DESCRIPTION
## Summary

docs/editor-defaults.md claimed wrong rule names and wrong defaults. The rule table said RY020 was "type mismatch", RY030 "scope error", RY040 "invalid operation", and RY090 "partial argument name". None match the registry in `crates/ry-checker/src/rules.rs`. It also called RY032 a disabled "test fixture" rule with 70/70 false positives. The registry ships RY032 as `scalar-logical-length`, severity `warning`, enabled by default. The corpus ledger shows 1 TP / 47 FP (`docs/corpus/rule-evidence-0.9.md`). The table also gave RY020, RY030, and RY040 "High signal" evidence. All three have 0 TP in the corpus. This PR rebuilds the table from the registry and the rule-evidence ledger, and extends the README drift guard to cover it.

## Changes

- docs/editor-defaults.md
  - Corrected rows (old -> new, verified against `rules::RULES`):
    - RY020: "type mismatch" -> `unary-minus-type`; evidence "High signal in production source" -> "0 TP / 0 FP in the corpus. Verified claim; lift-reachable through scalar defaults."
    - RY030: "scope error" -> `invalid-comparison`; evidence "High signal" -> "0 TP / 25 FP. FPs come from typeshed coverage gaps."
    - RY040: "invalid operation" -> `invalid-arithmetic`; evidence "High signal" -> "0 TP / 23 FP. FPs come from typeshed coverage gaps."
    - RY090: "partial argument name" -> `unknown-argument`; evidence "Consistent, byte-for-byte correct" -> "0 TP / 4 FP. Valid syntactic claim."
    - RY032: "test fixture", Disabled, "70/70 false positives in test fixtures" -> `scalar-logical-length`, warning, Enabled, "1 TP / 47 FP. Fires on non-literal parameter-dependent expressions."
  - Added a row for RY003 (`numeric-condition`), the only default-off rule. The old table gave that role to RY032.
  - Added a Severity column and reordered rows by code, so every shared fact sits next to its registry value.
  - Moved the `minConfidence` row into prose, so every table row is a rule row.
  - Replaced the baseline-findings table with one sentence linking to `docs/corpus/0.9-release-evidence.md`. The numbers were an exact duplicate. The RY010 dominance note stays, since it drives the advice below.
  - Deleted the "Future improvements" roadmap paragraph. It described unfinished work with a precision target. That belongs in an issue, not shipped docs. File one if you want to track it.
- crates/ry-checker/tests/readme_rule_table.rs
  - New test `editor_defaults_rule_table_matches_rule_registry`. It parses the "## Default profile policy" table and asserts each row's code, name, severity, and Enabled/Disabled value against `RULES` and `enabled_by_default`. It also rejects unknown, mismatched, and duplicate rows. The doc table is a curated subset, so the test checks row correctness, not full registry parity like the README test.
- CHANGELOG.md
  - One entry under `## [Unreleased]` -> `### Fixed`.

## Verification

- `cargo fmt -p ry-checker --check` — pass.
- `cargo clippy -p ry-checker --all-targets -- -D warnings` — pass, no warnings.
- `cargo test -p ry-checker --test readme_rule_table` — 2 passed (both the README and editor-defaults guards).
- Fault injection: renaming RY020 back to "type mismatch" and flipping RY032 to "Disabled" made `editor_defaults_rule_table_matches_rule_registry` fail with both problems listed. Reverted; suite green again.