### PR TITLE
docs: restore missing 0.5.0 changelog heading and fix stale references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -402,6 +402,8 @@ reported diagnostics.
 - RY100 subsumes the condition-type diagnostic on the same span (no
   double reporting).
 
+## [0.5.0] - 2026-07-16
+
 Driven by the ranks-301-500 audit (ry 0.4.0 on the top-500 CRAN packages).
 Minor bump: RY050's dispatch semantics, RY097's collapse criteria, and the
 new binding/quoting/narrowing rules intentionally change reported
@@ -455,6 +457,8 @@ diagnostics between versions.
   `coef.glm`. Consequently RY050 can no longer fire for generics that
   have a `.default` method (such as `print`) — dispatch always succeeds
   for them.
+
+## [0.4.1] - 2026-07-14
 
 ### Removed
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,10 +66,11 @@ When inference is uncertain, return `unknown` and say nothing.
 ## Typeshed changes
 
 Never add a function name you have not verified against R.
-`scripts/audit_typeshed.R` checks every declared name with `exists()`
-(base) or against the package namespace (package files) and runs in CI.
-`scripts/gen_typeshed.R <pkg>` drafts a stub file from a package's
-exports for hand-refinement.
+Stubs live in the standalone
+[r-typeshed](https://github.com/sims1253/r-typeshed) repository. Its CI
+runs the auditing and stub generation.
+`scripts/sync_typeshed.sh <checkout>` vendors a snapshot into
+`crates/ry-typeshed/vendor` and validates it with `ry typeshed validate`.
 
 ## Editor extensions
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ replacement for `lintr`’s style rules. It focuses on type- and
 scope-driven diagnostics that need a whole-program view.
 
 > [!IMPORTANT]
-> ry is, as of now, mostly a playground for GLM and me, meaning large portions of the project are ai generated.
+> ry is, as of now, mostly a playground for GLM and me, meaning large portions of the project are AI-generated.
 > Should you like to change that, I'd love for someone to join in on the fun.
 
 ## Install

--- a/docs/corpus/0.9-release-evidence.md
+++ b/docs/corpus/0.9-release-evidence.md
@@ -145,9 +145,9 @@ shrunk by proptest to 3 operations — well under the 10-operation bound.
 
 1. **Warm-start cache**: explicitly deferred. The unwired draft
    (`crates/ry-checker/src/cache.rs`) round-tripped only `known_vars`,
-   `callable_vars`, and `RType::Unknown`; it has since been deleted (see
-   `docs/architecture/cache-decision.md`). A future plan must specify a
-   complete `CollectedFile` round trip before wiring a cache.
+   `callable_vars`, and `RType::Unknown`; it has since been deleted
+   (148779b). A future plan must specify a complete `CollectedFile`
+   round trip before wiring a cache.
 
 2. **Precision**: 5.08% overall (4.20% `R/`). The dominant FP source is RY010
    (476 FP — imported/generated/data bindings that exist at runtime). This


### PR DESCRIPTION
## Summary

Two release headings vanished from CHANGELOG.md, fusing 0.5.0 and 0.4.1 content into the 0.6.0 section while their link refs dangled. The 0.6.0 commit (b67661d) and the 0.5.0 prep commit (e8d7408) each replaced the previous release heading with the new section instead of inserting above it. This PR restores both headings at the boundaries recorded in git history and fixes three other stale references. It repairs documentation only; no code or behavior changes.

## Changes

- CHANGELOG.md: restore `## [0.5.0] - 2026-07-16` before the "Driven by the ranks-301-500 audit" intro, and `## [0.4.1] - 2026-07-14` before the `### Removed` section. Both match the headings at the release commits (be93497, 2727b7b) and the tag dates. No entry prose changed; with the boundaries restored, each release has one `### Fixed` group and the 0.4.1 "Corrections" tail sits in its own section.
- CONTRIBUTING.md: the typeshed paragraph cited `scripts/audit_typeshed.R` and `scripts/gen_typeshed.R`, which were removed in 0.4.0. The paragraph now states that stubs live in r-typeshed (whose CI runs the auditing and stub generation) and describes `scripts/sync_typeshed.sh <checkout>` vendoring into `crates/ry-typeshed/vendor` with `ry typeshed validate`.
- docs/corpus/0.9-release-evidence.md: the warm-start cache gap linked to `docs/architecture/cache-decision.md`, deleted in 148779b. The sentence now cites that commit so the record stays reachable from git history.
- README.md: "ai generated" -> "AI-generated". The playground voice is unchanged.

## Verification

- Git history: `git log --follow -p -- CHANGELOG.md`, `git show be93497:CHANGELOG.md`, `git show 2727b7b -- CHANGELOG.md`, and `git for-each-ref refs/tags` pin both boundaries and dates. The restored sections match the release-commit layouts exactly; the diff is two inserted heading lines.
- Changelog integrity: a script cross-checks every `## [x.y.z]` heading against the link-reference list (12 headings, 12 refs, one-to-one, no duplicates) and confirms no repeated section heading inside any single release.
- Rendering: pandoc (gfm -> html) parses all four changed files; the restored headings render as linked h2s pointing at the correct compare URLs.