### PR TITLE
chore(checker): delete dead state, dedupe closure loop, share the test fixpoint

### DIFF
--- a/crates/ry-checker/src/lib.rs
+++ b/crates/ry-checker/src/lib.rs
@@ -36,8 +36,9 @@ pub use diagnostics::{
     parse_suppressions_from_comments,
 };
 
-// Configuration-driven filter builders moved here from ry-config
-// to break the ry-config → ry-checker dependency.
+// These builders construct a `SeverityFilter`, a checker type, from a
+// config's rule lists. They live here because ry-checker depends on
+// ry-config; the reverse direction would be a cycle.
 
 /// Build a [`SeverityFilter`] from the `error`, `warn`, and `ignore`
 /// rule lists in a config.

--- a/crates/ry-checker/src/nse.rs
+++ b/crates/ry-checker/src/nse.rs
@@ -14,7 +14,7 @@ impl Checker {
         name: &str,
         args: &[Arg],
         scope: &mut Scope,
-        span: Span,
+        _span: Span,
     ) -> Option<RType> {
         let sig = self.resolve_schema_sig(name)?;
         let effect = sig.schema_effect?;
@@ -97,7 +97,6 @@ impl Checker {
             SchemaEffect::Pivot => RType::new(Mode::List, Length::Unknown)
                 .with_class(ClassVector::single("data.frame")),
         };
-        let _ = span;
         Some(result)
     }
 

--- a/crates/ry-checker/src/project.rs
+++ b/crates/ry-checker/src/project.rs
@@ -88,9 +88,11 @@ pub struct Project {
     /// The `loaded` set from the previous emit, used to detect project-wide
     /// invalidation (a new `library()` call changes diagnostics everywhere).
     prev_loaded: Option<HashSet<String>>,
-    /// Return-type slots from the previous emit, used to detect which
-    /// functions' inferred return types changed during pass 2 refinement.
-    prev_return_slots: Option<Vec<ry_core::RType>>,
+    /// Whether `refine_and_emit` has completed at least once. Separates
+    /// the first check (refine and emit everything) from incremental
+    /// ones. The compared values live in `prev_fn_returns` and
+    /// `prev_fn_signatures`.
+    has_prev_emit: bool,
     /// Per-file set of function names called (from `call_sites`), cached
     /// so the dirty-set computation in `refine_and_emit` can check whether
     /// a file references any function whose return slot changed.
@@ -156,7 +158,7 @@ impl Project {
             dirty_paths: HashSet::new(),
             invalidated_fns: HashSet::new(),
             prev_loaded: None,
-            prev_return_slots: None,
+            has_prev_emit: false,
             file_called_fns: HashMap::new(),
             prev_fn_returns: HashMap::new(),
             prev_fn_signatures: HashMap::new(),
@@ -375,7 +377,7 @@ impl Project {
         // state (if any) is discarded.
         self.dirty_paths = self.files.iter().map(|(p, _)| p.clone()).collect();
         self.prev_loaded = None;
-        self.prev_return_slots = None;
+        self.has_prev_emit = false;
         self.prev_fn_returns.clear();
         self.prev_fn_signatures.clear();
         self.prev_known_vars.clear();
@@ -448,7 +450,9 @@ impl Project {
     /// transitive callers via the reverse call graph.
     fn compute_fixpoint_scope(&self) -> Option<HashSet<String>> {
         // First call → refine everything.
-        self.prev_return_slots.as_ref()?;
+        if !self.has_prev_emit {
+            return None;
+        }
         // If loaded changed (library() calls appeared/disappeared), the stub
         // environment changed — full refinement is needed because package
         // signatures affect return types.
@@ -499,24 +503,8 @@ impl Project {
         affected.extend(affected_generics);
 
         // Transitive closure: if function G's defining file calls function F,
-        // and F is affected, then G is also affected. Iterate until fixpoint.
-        let mut changed = true;
-        while changed {
-            changed = false;
-            for (path, collected) in &self.collected_files {
-                let Some(calls) = self.file_called_fns.get(path) else {
-                    continue;
-                };
-                // Does this file call any affected function?
-                if !calls.iter().any(|name| affected.contains(name)) {
-                    continue;
-                }
-                // All functions defined in this file are potential callers.
-                for fn_name in collected.fn_table.fns.keys() {
-                    changed |= affected.insert(fn_name.clone());
-                }
-            }
-        }
+        // and F is affected, then G is also affected.
+        let affected = self.with_transitive_callers(affected);
 
         Some(affected)
     }
@@ -637,10 +625,10 @@ impl Project {
         // Combine: a file is dirty if it was content-changed, if loaded
         // changed at all, or if it calls any function whose return slot
         // changed. When loaded changes, every file is dirty.
-        // On the first call (prev_return_slots is None), every file must be
-        // emitted. Otherwise, use the incremental dirty set.
+        // On the first call, every file must be emitted. Otherwise, use
+        // the incremental dirty set.
         let known_vars_changed = self.prev_known_vars != self.fn_table.known_vars;
-        let first_call = self.prev_return_slots.is_none();
+        let first_call = !self.has_prev_emit;
         let must_emit: HashSet<&str> = if first_call || loaded_changed || known_vars_changed {
             self.files.iter().map(|(p, _)| p.as_str()).collect()
         } else {
@@ -783,7 +771,7 @@ impl Project {
 
         // Record state for the next incremental check.
         self.prev_loaded = Some(self.loaded.clone());
-        self.prev_return_slots = Some(self.return_slots.0.clone());
+        self.has_prev_emit = true;
         self.prev_known_vars = self.fn_table.known_vars.clone();
         // Save refined return types keyed by function name for the next
         // fixpoint seeding.
@@ -830,12 +818,6 @@ impl Project {
 
 /// File classification — re-exported from ry-workspace.
 pub use ry_workspace::{PackageFileKind, package_file_kind};
-
-/// Whether a file is directly under a package's `R/` directory.
-#[cfg(test)]
-pub(crate) fn is_package_library_file(path: &str) -> bool {
-    package_file_kind(std::path::Path::new(path)) == PackageFileKind::Library
-}
 
 #[cfg(test)]
 mod tests {

--- a/crates/ry-checker/src/tests/mod.rs
+++ b/crates/ry-checker/src/tests/mod.rs
@@ -22,30 +22,14 @@ fn check(src: &str) -> Vec<Diagnostic> {
 
 /// Test-only variant of `check` that also returns the final
 /// top-level scope so tests can assert on the inferred `RType` of a
-/// binding (mode, length, class, columns). Mirrors what `Checker::check`
-/// does internally, but keeps the scope around for inspection.
+/// binding (mode, length, class, columns). Delegates to the public
+/// `Checker::check_with_scope`, so the tests exercise the real pass
+/// structure and cannot diverge from it.
 fn check_with_scope(src: &str) -> (Vec<Diagnostic>, Scope) {
     let mut p = RParser::new().unwrap();
     let f = p.parse("test.R", src).unwrap();
     let mut c = Checker::new("test.R");
-    // Mirror `Checker::check`'s pass structure so user-fn return
-    // types are refined before we walk for the final scope.
-    c.collect_fns(&f.stmts);
-    for _ in 0..MAX_FIXPOINT_DEPTH {
-        let before = (*c.return_slots).clone();
-        let names: Vec<String> = c.fn_table.fns.keys().cloned().collect();
-        for name in names {
-            c.refine_fn_return(&name);
-        }
-        if c.return_slots.0 == before.0 {
-            break;
-        }
-    }
-    let mut scope = Scope::default();
-    for s in &f.stmts {
-        c.check_stmt(s, &mut scope);
-    }
-    (c.take_diagnostics(), scope)
+    c.check_with_scope(&f)
 }
 
 /// Parse helper for project-mode tests, mirroring the one in

--- a/crates/ry-checker/src/tests/scope_resolution.rs
+++ b/crates/ry-checker/src/tests/scope_resolution.rs
@@ -637,7 +637,6 @@ fn cross_file_literal_variable_resolves() {
     std::fs::write(dir.path().join("DESCRIPTION"), "Package: fixture\n").unwrap();
     let a = dir.path().join("R/a.R").to_string_lossy().to_string();
     let b = dir.path().join("R/b.R").to_string_lossy().to_string();
-    assert!(crate::project::is_package_library_file(&a));
     let mut project = Project::new();
     project.add_file(a.clone(), parse_file(&a, "my_const <- 42\n"));
     project.add_file(b.clone(), parse_file(&b, "x <- my_const\n"));

--- a/crates/ry-checker/tests/rule_evidence.rs
+++ b/crates/ry-checker/tests/rule_evidence.rs
@@ -503,183 +503,150 @@ fn ry032_standing_case_parameter_is_not_literal_only_actionable() {
 // Deliverable 3: Verdict enforcement
 // =======================================================================
 
-#[allow(dead_code)]
+// Evidence rationale for each verdict lives in
+// `docs/corpus/rule-evidence-0.9.md`; only the enforced fields are
+// kept here.
 struct Verdict {
     code: &'static str,
     verdict: &'static str,
-    rationale: &'static str,
 }
 
 const VERDICTS: &[Verdict] = &[
     Verdict {
         code: "RY000",
         verdict: "keep",
-        rationale: "True syntax errors; 2 TP / 4 FP.",
     },
     Verdict {
         code: "RY001",
         verdict: "keep",
-        rationale: "Valid claim; 6 TP / 23 FP. Lift-reachable.",
     },
     Verdict {
         code: "RY002",
         verdict: "keep",
-        rationale: "Valid claim; 0 TP / 3 FP. Param-unreachable for c() defaults.",
     },
     Verdict {
         code: "RY003",
         verdict: "default-off",
-        rationale: "Style advice; 0 corpus. Already Info, disabled by enabled_by_default.",
     },
     Verdict {
         code: "RY010",
         verdict: "keep",
-        rationale: "Core reachability; 4 TP / 472 FP from resolution gaps.",
     },
     Verdict {
         code: "RY020",
         verdict: "keep",
-        rationale: "Valid claim; 0 corpus. Lift-reachable.",
     },
     Verdict {
         code: "RY021",
         verdict: "keep",
-        rationale: "Valid claim; 0 corpus. Lift-reachable.",
     },
     Verdict {
         code: "RY030",
         verdict: "keep",
-        rationale: "Valid claim; 0 TP / 25 FP from typeshed gaps.",
     },
     Verdict {
         code: "RY031",
         verdict: "keep",
-        rationale: "Valid claim; 0 TP / 2 FP. Known gap. Lift-reachable.",
     },
     Verdict {
         code: "RY032",
         verdict: "keep",
-        rationale: "Standing case; 1 TP / 47 FP. Literal-only by policy.",
     },
     Verdict {
         code: "RY033",
         verdict: "keep",
-        rationale: "Valid claim; 6 TP / 35 FP. Lift-reachable.",
     },
     Verdict {
         code: "RY034",
         verdict: "keep",
-        rationale: "Valid claim; 3 TP / 0 FP. Consistent under R7.",
     },
     Verdict {
         code: "RY040",
         verdict: "keep",
-        rationale: "Valid claim; 0 TP / 23 FP. Lift-reachable.",
     },
     Verdict {
         code: "RY041",
         verdict: "keep",
-        rationale: "Valid claim; 0 corpus.",
     },
     Verdict {
         code: "RY042",
         verdict: "keep",
-        rationale: "Valid claim; 0 corpus.",
     },
     Verdict {
         code: "RY050",
         verdict: "keep",
-        rationale: "Valid claim; 0 corpus.",
     },
     Verdict {
         code: "RY060",
         verdict: "keep",
-        rationale: "Valid claim; 0 TP / 5 FP.",
     },
     Verdict {
         code: "RY061",
         verdict: "keep",
-        rationale: "Valid claim; 0 TP / 21 FP.",
     },
     Verdict {
         code: "RY070",
         verdict: "keep",
-        rationale: "Valid claim; 2 TP / 6 FP.",
     },
     Verdict {
         code: "RY080",
         verdict: "keep",
-        rationale: "Valid claim; 0 TP / 2 FP.",
     },
     Verdict {
         code: "RY090",
         verdict: "keep",
-        rationale: "Valid syntactic claim; 0 TP / 4 FP.",
     },
     Verdict {
         code: "RY091",
         verdict: "keep",
-        rationale: "Valid claim; 1 TP / 4 FP.",
     },
     Verdict {
         code: "RY092",
         verdict: "keep",
-        rationale: "Valid claim; 0 TP / 3 FP.",
     },
     Verdict {
         code: "RY093",
         verdict: "keep",
-        rationale: "Valid claim; 4 TP / 0 FP. Consistent under R7.",
     },
     Verdict {
         code: "RY094",
         verdict: "keep",
-        rationale: "Valid claim; 0 corpus.",
     },
     Verdict {
         code: "RY096",
         verdict: "keep",
-        rationale: "Valid claim; 0 corpus.",
     },
     Verdict {
         code: "RY097",
         verdict: "keep",
-        rationale: "CLI file heuristic; 0 corpus. Probe via CLI exclusion.",
     },
     Verdict {
         code: "RY098",
         verdict: "keep",
-        rationale: "Valid claim; 0 TP / 1 FP.",
     },
     Verdict {
         code: "RY099",
         verdict: "keep",
-        rationale: "Valid claim; 0 corpus. Consistent under R7.",
     },
     Verdict {
         code: "RY100",
         verdict: "keep",
-        rationale: "Valid claim; 4 TP / 0 FP. Consistent under R7.",
     },
     Verdict {
         code: "RY101",
         verdict: "keep",
-        rationale: "Valid claim; 0 corpus.",
     },
     Verdict {
         code: "RY102",
         verdict: "keep",
-        rationale: "Valid claim; 1 TP / 0 FP.",
     },
     Verdict {
         code: "RY103",
         verdict: "keep",
-        rationale: "Valid claim; 2 TP / 0 FP. Consistent under R7.",
     },
     Verdict {
         code: "RY105",
         verdict: "keep",
-        rationale: "Valid claim; 1 TP / 11 FP.",
     },
 ];
 


### PR DESCRIPTION
## Summary

Internal cleanup in `crates/ry-checker`. No behavior change. Net -68 lines.

## Changes

- `Project::prev_return_slots` was an `Option<Vec<RType>>` cloned in full on every emit and only tested for presence. Replaced with the `has_prev_emit` bool. The compared values already live in `prev_fn_returns` and `prev_fn_signatures`, keyed by name.
- `compute_fixpoint_scope` re-implemented the reverse-caller closure that `with_transitive_callers` provides 25 lines below. The two loops were line-for-line identical. The method call replaces the copy.
- The shared test helper `check_with_scope` replayed `collect_fns` plus its own fixpoint loop, which skipped quoting propagation and the discarding flag. It now delegates to the public `Checker::check_with_scope`, so unit tests run the real pass structure.
- `Verdict` in `tests/rule_evidence.rs` carried a `rationale` field no assertion read. Dropped it and the `#[allow(dead_code)]`. `code` and `verdict` stay; three tests enforce them. The evidence text lives in `docs/corpus/rule-evidence-0.9.md`.
- Removed the `#[cfg(test)]` `is_package_library_file` helper and its single assertion in `scope_resolution.rs`. It re-tested `ry_workspace::package_file_kind`, which exercises that classification through its own code paths. The cross-file resolution test itself stays.
- `infer_schema_call` silenced its unused `span` parameter with `let _ = span;`. Renamed the parameter to `_span`. The sole caller lives in `src/infer/call.rs`, which this PR does not touch.
- The filter-builder comment narrated a past move. It now states the current constraint: the builders construct `SeverityFilter`, a checker type, and the reverse dependency would be a cycle.

Skipped: deleting `Checker::native_registration`. The brief called it dead, but `src/infer/call.rs:446` reads it (`is_registered_ffi_wrapper(...) && self.native_registration`). That file belongs to the `src/infer/` PRs, so the field stays.

## Verification

- `cargo fmt -p ry-checker` — clean.
- `cargo clippy -p ry-checker --all-targets -- -D warnings` — clean.
- `cargo test -p ry-checker` — 595 passed, 0 failed, 9 ignored.
- `cargo check -p ry-cli -p ry-lsp` — clean.