### PR TITLE
test: consolidate copy-pasted checker tests into table-driven forms

### DIFF
--- a/crates/ry-checker/src/infer/index.rs
+++ b/crates/ry-checker/src/infer/index.rs
@@ -770,26 +770,19 @@ pub(crate) fn assigned_names_in_body(body: &[Stmt]) -> HashSet<String> {
 #[cfg(test)]
 mod operator_generic_tests {
     use super::is_operator_generic;
-    use crate::semantic_lists::OPERATORS;
 
-    /// `is_operator_generic` must recognize exactly the members of
-    /// `semantic_lists::OPERATORS`: the same constant backs the S3
-    /// method-name splitter in `lib.rs`, so any divergence between the two
-    /// representations is an inconsistency (issue #42). The negative
-    /// samples pin the set to the Arith + Compare members -- Logic,
-    /// assignment, sequence, and access operators are operator symbols
-    /// for RY010 suppression but never operator generics, `%in%` is a
-    /// function-backed infix operator outside both dispatch groups, and a
-    /// full method name like `+.foo` is split before this predicate runs.
-    /// Reinstating a separate hardcoded symbol set here fails this test.
+    /// The negative samples pin `is_operator_generic` to the Arith +
+    /// Compare members of `semantic_lists::OPERATORS` (which the
+    /// predicate reads directly, so the positive direction is a
+    /// containment check against itself): Logic, assignment,
+    /// sequence, and access operators are operator symbols for RY010
+    /// suppression but never operator generics, `%in%` is a
+    /// function-backed infix operator outside both dispatch groups,
+    /// and a full method name like `+.foo` is split before this
+    /// predicate runs. Reinstating a separate hardcoded symbol set
+    /// here fails this test.
     #[test]
-    fn operator_generic_recognizes_exactly_the_operators_list() {
-        for operator in OPERATORS {
-            assert!(
-                is_operator_generic(operator),
-                "OPERATORS member {operator:?} must be recognized as an operator generic"
-            );
-        }
+    fn non_dispatch_operators_are_not_operator_generics() {
         for non_generic in [
             "&", "|", "&&", "||", "!", ":", "<-", "<<-", "=", "~", "$", "@", "?", "%in%", "+.foo",
         ] {

--- a/crates/ry-checker/src/infer/misc.rs
+++ b/crates/ry-checker/src/infer/misc.rs
@@ -40,25 +40,11 @@ pub(crate) fn is_ffi_primitive(name: &str) -> bool {
 mod ffi_primitives_tests {
     use super::*;
 
-    /// Every entry in [`FFI_PRIMITIVES`] must cause the checker to treat its
-    /// first argument as a native entry-point symbol (skip RY010), matching
-    /// the convention for .Call/.C/.Fortran/.External: the first argument is
-    /// a bare identifier or backtick name, not a variable reference.
-    ///
-    /// A function that does NOT follow this convention (e.g. .Internal, whose
-    /// first argument is a *call*) must not be in the list.
-    #[test]
-    fn every_ffi_primitive_is_recognized() {
-        for &primitive in ry_core::FFI_PRIMITIVES {
-            assert!(
-                is_ffi_primitive(primitive),
-                "`{primitive}` is in FFI_PRIMITIVES but is_ffi_primitive returned false"
-            );
-        }
-    }
-
     /// .Internal must NOT be in FFI_PRIMITIVES: its first argument is a
-    /// call expression, not a bare entry-point symbol.
+    /// call expression, not a bare entry-point symbol. (Every listed
+    /// primitive is trivially "recognized" -- `is_ffi_primitive` is a
+    /// containment check against that very list -- so only non-members
+    /// pin the convention.)
     #[test]
     fn internal_is_not_an_ffi_primitive() {
         assert!(

--- a/crates/ry-checker/src/tests/data_frames_s3.rs
+++ b/crates/ry-checker/src/tests/data_frames_s3.rs
@@ -1,5 +1,4 @@
 use super::*;
-use ry_core::RParser;
 
 #[test]
 fn dataset_resolves_mtcars() {
@@ -466,14 +465,13 @@ fn nse_subset_resolves_columns() {
     // augmented with `mtcars`'s column schema. Without the NSE
     // handler, `cyl` would be reported as unbound (RY010). With it,
     // the expression is well-typed and produces no diagnostics.
-    let diags = check("df <- mtcars\nsmall <- subset(df, cyl == 4)\n");
+    let (diags, scope) = check_with_scope("df <- mtcars\nsmall <- subset(df, cyl == 4)\n");
     assert!(
         diags.iter().all(|d| d.code != "RY010"),
         "subset NSE handler should suppress RY010 on column refs, got {:?}",
         diags
     );
     // The result type is the same data frame type as the first arg.
-    let (_, scope) = check_with_scope("df <- mtcars\nsmall <- subset(df, cyl == 4)\n");
     let small = scope.get("small").expect("small should be bound");
     assert!(
         small.class.contains("data.frame"),
@@ -492,7 +490,7 @@ fn nse_with_evaluates_expression() {
     // `with(mtcars, sum(mpg))` evaluates `sum(mpg)` against a scope
     // where `mpg` is bound to the `mtcars` column type. Without the
     // NSE handler, `mpg` would trigger RY010 inside the `sum` call.
-    let diags = check("df <- mtcars\ntotal <- with(df, sum(mpg))\n");
+    let (diags, scope) = check_with_scope("df <- mtcars\ntotal <- with(df, sum(mpg))\n");
     assert!(
         diags.iter().all(|d| d.code != "RY010"),
         "with NSE handler should suppress RY010 on column refs, got {:?}",
@@ -500,7 +498,6 @@ fn nse_with_evaluates_expression() {
     );
     // `with` returns whatever the expression evaluates to. `sum`
     // dispatches against the typeshed to a length-1 numeric.
-    let (_, scope) = check_with_scope("df <- mtcars\ntotal <- with(df, sum(mpg))\n");
     let total = scope.get("total").expect("total should be bound");
     assert!(
         matches!(total.mode, Mode::Double | Mode::Integer),
@@ -515,7 +512,7 @@ fn nse_transform_handles_new_column() {
     // `transform(mtcars, x = mpg * 2)` evaluates `mpg * 2` against
     // an augmented scope. Without the NSE handler, `mpg` would
     // trigger RY010 inside the arithmetic expression.
-    let diags = check("df <- mtcars\ndf2 <- transform(df, x = mpg * 2)\n");
+    let (diags, scope) = check_with_scope("df <- mtcars\ndf2 <- transform(df, x = mpg * 2)\n");
     assert!(
         diags.iter().all(|d| d.code != "RY010"),
         "transform NSE handler should suppress RY010 on column refs, got {:?}",
@@ -523,7 +520,6 @@ fn nse_transform_handles_new_column() {
     );
     // `transform` returns a data frame; v1 keeps the original
     // schema (does not fold in the new column type).
-    let (_, scope) = check_with_scope("df <- mtcars\ndf2 <- transform(df, x = mpg * 2)\n");
     let df2 = scope.get("df2").expect("df2 should be bound");
     assert!(
         df2.class.contains("data.frame"),
@@ -568,15 +564,14 @@ fn nse_dplyr_filter_resolves_columns() {
     // NSE handler, `mpg` would be reported as unbound (RY010). The
     // handler injects the data frame's column schema so the
     // comparison is well-typed.
-    let diags = check("library(dplyr)\ndf <- mtcars\nsmall <- filter(df, mpg > 20)\n");
+    let (diags, scope) =
+        check_with_scope("library(dplyr)\ndf <- mtcars\nsmall <- filter(df, mpg > 20)\n");
     assert!(
         diags.iter().all(|d| d.code != "RY010"),
         "dplyr filter NSE handler should suppress RY010 on column refs, got {:?}",
         diags
     );
     // `filter` preserves the data frame type.
-    let (_, scope) =
-        check_with_scope("library(dplyr)\ndf <- mtcars\nsmall <- filter(df, mpg > 20)\n");
     let small = scope.get("small").expect("small should be bound");
     assert!(
         small.class.contains("data.frame"),
@@ -594,14 +589,13 @@ fn nse_dplyr_mutate_resolves_columns() {
     // `mutate(df, kml = mpg * 0.425)` evaluates `mpg * 0.425`
     // against an augmented scope. Without the handler, `mpg` would
     // fire RY010.
-    let diags = check("library(dplyr)\ndf <- mtcars\ndf2 <- mutate(df, kml = mpg * 0.425)\n");
+    let (diags, scope) =
+        check_with_scope("library(dplyr)\ndf <- mtcars\ndf2 <- mutate(df, kml = mpg * 0.425)\n");
     assert!(
         diags.iter().all(|d| d.code != "RY010"),
         "dplyr mutate NSE handler should suppress RY010 on column refs, got {:?}",
         diags
     );
-    let (_, scope) =
-        check_with_scope("library(dplyr)\ndf <- mtcars\ndf2 <- mutate(df, kml = mpg * 0.425)\n");
     let df2 = scope.get("df2").expect("df2 should be bound");
     assert!(
         df2.class.contains("data.frame"),
@@ -616,14 +610,13 @@ fn nse_dplyr_summarise_returns_data_frame() {
     // frame. The column reference `mpg` resolves via the augmented
     // scope. The result is a fresh data frame type with the named
     // summary outputs, not the input column schema.
-    let diags = check("library(dplyr)\ndf <- mtcars\ns <- summarise(df, m = mean(mpg))\n");
+    let (diags, scope) =
+        check_with_scope("library(dplyr)\ndf <- mtcars\ns <- summarise(df, m = mean(mpg))\n");
     assert!(
         diags.iter().all(|d| d.code != "RY010"),
         "dplyr summarise NSE handler should suppress RY010 on column refs, got {:?}",
         diags
     );
-    let (_, scope) =
-        check_with_scope("library(dplyr)\ndf <- mtcars\ns <- summarise(df, m = mean(mpg))\n");
     let s = scope.get("s").expect("s should be bound");
     assert!(
         s.class.contains("data.frame"),
@@ -648,14 +641,13 @@ fn nse_dplyr_summarize_alias_matches_summarise() {
     // The American-English `summarize` is an alias for `summarise`
     // and must dispatch to the same handler. `hp` resolves against
     // the augmented scope; the result is a data frame.
-    let diags = check("library(dplyr)\ndf <- mtcars\ns <- summarize(df, m = mean(hp))\n");
+    let (diags, scope) =
+        check_with_scope("library(dplyr)\ndf <- mtcars\ns <- summarize(df, m = mean(hp))\n");
     assert!(
         diags.iter().all(|d| d.code != "RY010"),
         "dplyr summarize alias should suppress RY010 on column refs, got {:?}",
         diags
     );
-    let (_, scope) =
-        check_with_scope("library(dplyr)\ndf <- mtcars\ns <- summarize(df, m = mean(hp))\n");
     let s = scope.get("s").expect("s should be bound");
     assert!(
         s.class.contains("data.frame"),
@@ -670,11 +662,10 @@ fn nse_dplyr_pipe_chain_resolves_columns() {
     // to nested calls. Each stage's data frame is the previous
     // stage's result (mtcars for the first), so column references
     // resolve via the augmented scope and no RY010 fires.
-    let diags = check(
-        "library(magrittr)\n\
-             library(dplyr)\n\
-             result <- mtcars %>% filter(cyl == 4) %>% select(mpg, hp)\n",
-    );
+    let src = "library(magrittr)\n\
+         library(dplyr)\n\
+         result <- mtcars %>% filter(cyl == 4) %>% select(mpg, hp)\n";
+    let (diags, scope) = check_with_scope(src);
     assert!(
         diags.iter().all(|d| d.code != "RY010"),
         "piped dplyr chain should suppress RY010 on column refs, got {:?}",
@@ -683,11 +674,6 @@ fn nse_dplyr_pipe_chain_resolves_columns() {
     // The chain's final result is a data frame (select preserves
     // the type of its input, which here is `filter`'s output =
     // mtcars' type).
-    let (_, scope) = check_with_scope(
-        "library(magrittr)\n\
-             library(dplyr)\n\
-             result <- mtcars %>% filter(cyl == 4) %>% select(mpg, hp)\n",
-    );
     let result = scope.get("result").expect("result should be bound");
     assert!(
         result.class.contains("data.frame"),
@@ -781,22 +767,15 @@ fn nse_dplyr_filter_tidyverse_counts_as_dplyr() {
 fn nse_dplyr_arrange_groupby_preserve_type() {
     // `arrange` and `group_by` walk their column-reference args in
     // the augmented scope and preserve the input data frame type.
-    let diags = check(
-        "library(dplyr)\n\
-             df <- mtcars\n\
-             sorted <- arrange(df, mpg)\n\
-             grouped <- group_by(df, cyl)\n",
-    );
+    let src = "library(dplyr)\n\
+         df <- mtcars\n\
+         sorted <- arrange(df, mpg)\n\
+         grouped <- group_by(df, cyl)\n";
+    let (diags, scope) = check_with_scope(src);
     assert!(
         diags.iter().all(|d| d.code != "RY010"),
         "arrange/group_by NSE handlers should suppress RY010 on column refs, got {:?}",
         diags
-    );
-    let (_, scope) = check_with_scope(
-        "library(dplyr)\n\
-             df <- mtcars\n\
-             sorted <- arrange(df, mpg)\n\
-             grouped <- group_by(df, cyl)\n",
     );
     let sorted = scope.get("sorted").expect("sorted should be bound");
     assert!(

--- a/crates/ry-checker/src/tests/diagnostics.rs
+++ b/crates/ry-checker/src/tests/diagnostics.rs
@@ -1,5 +1,4 @@
 use super::*;
-use ry_core::RParser;
 
 // ---- inline suppression comment tests ----
 #[test]

--- a/crates/ry-checker/src/tests/functions_classes.rs
+++ b/crates/ry-checker/src/tests/functions_classes.rs
@@ -1,5 +1,4 @@
 use super::*;
-use ry_core::RParser;
 
 #[test]
 fn closure_factory_infers_inner_return() {
@@ -7,12 +6,15 @@ fn closure_factory_infers_inner_return() {
     // function whose `fn_sig.return_type` is itself a function with
     // `fn_sig.return_type` = integer<1>. So `c <- make_counter()`
     // binds `c` to a function-typed value with an inferred signature,
-    // and `c()` resolves to integer<1>. We verify by using the
-    // result arithmetically: integer + character must fire RY040
-    // (proving the type was inferred, not opaque).
-    let (_, scope) = check_with_scope(
+    // and `c()` resolves to integer<1>. We verify the signature
+    // through the scope and prove the type was inferred (not opaque)
+    // by using the result arithmetically: integer + character must
+    // fire RY040.
+    let (diags, scope) = check_with_scope(
         "make_counter <- function() { function() { 1L } }\n\
-             c <- make_counter()\n",
+             c <- make_counter()\n\
+             v <- c()\n\
+             bad <- v + \"x\"\n",
     );
     let c = scope.get("c").expect("c should be bound");
     assert_eq!(
@@ -28,14 +30,6 @@ fn closure_factory_infers_inner_return() {
         "c() must resolve to integer, got {:?}",
         sig.return_type
     );
-    // Behavioral check: using the result arithmetically with a
-    // character operand must fire RY040.
-    let diags = check(
-        "make_counter <- function() { function() { 1L } }\n\
-             c <- make_counter()\n\
-             v <- c()\n\
-             bad <- v + \"x\"\n",
-    );
     assert!(
         diags.iter().any(|d| d.code == "RY040"),
         "expected RY040 from integer closure result + character, got {:?}",
@@ -49,12 +43,15 @@ fn closure_capture_resolves_outer_binding() {
     // `x`. The inner function's body `x + y` (both double via
     // defaults) produces double<1>; the outer function's `fn_sig`
     // carries that as the return type. `add5(3)` therefore resolves
-    // to double<1>.
-    let (_, scope) = check_with_scope(
+    // to double<1>, proven both through the scope and by the RY040
+    // on `v + "x"`.
+    let (diags, scope) = check_with_scope(
         "make_adder <- function(x = 0) {\n\
              \x20 function(y = 0) { x + y }\n\
              }\n\
-             add5 <- make_adder(5)\n",
+             add5 <- make_adder(5)\n\
+             v <- add5(3)\n\
+             bad <- v + \"x\"\n",
     );
     let add5 = scope.get("add5").expect("add5 should be bound");
     assert_eq!(add5.mode, Mode::Function);
@@ -67,15 +64,6 @@ fn closure_capture_resolves_outer_binding() {
         Mode::Double,
         "add5(3) must resolve to double, got {:?}",
         sig.return_type
-    );
-    // Behavioral check: RY040 on v + "x".
-    let diags = check(
-        "make_adder <- function(x = 0) {\n\
-             \x20 function(y = 0) { x + y }\n\
-             }\n\
-             add5 <- make_adder(5)\n\
-             v <- add5(3)\n\
-             bad <- v + \"x\"\n",
     );
     assert!(
         diags.iter().any(|d| d.code == "RY040"),
@@ -91,13 +79,16 @@ fn nested_function_definition_visible_in_outer_body() {
     // assignment so the trailing `g` picks up `g`'s inferred
     // `fn_sig`. The outer function's return type is therefore a
     // function value with an inferred signature, and `h()`
-    // resolves to integer<1>.
-    let (_, scope) = check_with_scope(
+    // resolves to integer<1>, proven through the scope and by the
+    // RY040 on `v + "x"`.
+    let (diags, scope) = check_with_scope(
         "f <- function() {\n\
              \x20 g <- function() { 1L }\n\
              \x20 g\n\
              }\n\
-             h <- f()\n",
+             h <- f()\n\
+             v <- h()\n\
+             bad <- v + \"x\"\n",
     );
     let h = scope.get("h").expect("h should be bound");
     assert_eq!(h.mode, Mode::Function);
@@ -107,15 +98,6 @@ fn nested_function_definition_visible_in_outer_body() {
         Mode::Integer,
         "h() must resolve to integer, got {:?}",
         sig.return_type
-    );
-    let diags = check(
-        "f <- function() {\n\
-             \x20 g <- function() { 1L }\n\
-             \x20 g\n\
-             }\n\
-             h <- f()\n\
-             v <- h()\n\
-             bad <- v + \"x\"\n",
     );
     assert!(
         diags.iter().any(|d| d.code == "RY040"),
@@ -147,21 +129,24 @@ fn closure_depth_cap_falls_back_to_opaque() {
 #[test]
 fn lapply_anon_callback_infers_integer() {
     // `lapply(1:3, function(i) i * 2L)` returns a list whose
-    // elements are integer (the callback's return type). We verify
-    // by accessing an element and using it arithmetically: integer
-    // + character must fire RY040, proving the element type was
-    // inferred rather than opaque.
-    let diags = check(
+    // elements carry the callback's integer return type. We assert
+    // the inferred list type through the test scope and prove the
+    // element type is real: `result[[1]]` resolves through the
+    // schema to integer, so mixing it with a character fires RY040.
+    let (diags, scope) = check_with_scope(
         "result <- lapply(1:3, function(i) i * 2L)\n\
              bad <- result[[1]] + \"x\"\n",
     );
-    // `result[[1]]` goes through IndexKind::Double on a list with
-    // a schema, so it resolves to the element type (integer).
-    // However if the index access falls back to opaque, no RY040
-    // fires. We assert no false positives at minimum.
     assert!(
         diags.iter().all(|d| d.code != "RY010"),
         "no RY010 expected in lapply callback body, got {:?}",
+        diags
+    );
+    let result = scope.get("result").expect("result should be bound");
+    assert_eq!(result.mode, Mode::List, "got {:?}", result);
+    assert!(
+        diags.iter().any(|d| d.code == "RY040"),
+        "result[[1]] must resolve to the callback's integer element type, got {:?}",
         diags
     );
 }
@@ -218,17 +203,26 @@ fn sapply_typeshed_callback_simplifies() {
 fn vapply_uses_fun_value_template() {
     // `vapply(X, FUN, FUN.VALUE)` returns FUN.VALUE's type.
     // Here FUN.VALUE = `numeric(1)` = double<1>, so the result is
-    // double. Using it with character fires RY040.
-    let diags = check(
+    // double; using it with a character fires RY040.
+    let (diags, scope) = check_with_scope(
         "v <- vapply(c(1, 2, 3), function(x) x * 2, numeric(1))\n\
              bad <- v + \"x\"\n",
     );
-    // `numeric(1)` may or may not resolve to double<1> depending
-    // on typeshed coverage; if it resolves opaque, no RY040 fires.
-    // Assert at minimum no false positives.
     assert!(
         diags.iter().all(|d| d.code != "RY010"),
         "no RY010 expected in vapply, got {:?}",
+        diags
+    );
+    let v = scope.get("v").expect("v should be bound");
+    assert_eq!(
+        v.mode,
+        Mode::Double,
+        "FUN.VALUE = numeric(1) must template the result type, got {:?}",
+        v
+    );
+    assert!(
+        diags.iter().any(|d| d.code == "RY040"),
+        "double result + character must fire RY040, got {:?}",
         diags
     );
 }

--- a/crates/ry-checker/src/tests/narrowing.rs
+++ b/crates/ry-checker/src/tests/narrowing.rs
@@ -1,28 +1,28 @@
 use super::*;
-use ry_core::RParser;
 
 #[test]
-fn type_narrowing_is_null_then_branch() {
-    // `if (!is.null(x)) { length(x) }`: the `then` branch knows
-    // `x` is non-null. Without narrowing, `x` inside the branch
-    // resolves from the enclosing scope and is well-typed either
-    // way. We test the negative: inside a `!is.null` branch, using
-    // `x` arithmetically should NOT fire RY040 when `x` was opaque
-    // (the narrowing doesn't give us a mode, just removes null).
-    let diags = check(
-        "x <- NULL\n\
-             if (!is.null(x)) {\n\
-             \x20 y <- x + 1\n\
-             }\n",
-    );
-    // `x` starts as NULL; in the `then` branch it's narrowed to
-    // opaque (non-null). `opaque + 1` should not fire RY040
-    // (opaque is permissive).
-    assert!(
-        diags.iter().all(|d| d.code != "RY040"),
-        "non-null narrowed opaque should not fire RY040, got {:?}",
-        diags
-    );
+fn type_narrowing_predicate_then_branch_stays_well_typed() {
+    // `x <- <NULL or opaque>; if (<type predicate over x>) { <use> }`:
+    // the `then` branch sees `x` narrowed. The refinement only
+    // removes NULL or installs the predicate's mode -- it never
+    // fabricates precision -- so the branch-local use stays
+    // well-typed and must not fire RY040.
+    for (binding, guard, use_expr) in [
+        ("x <- NULL\n", "!is.null(x)", "y <- x + 1\n"),
+        ("x <- some_opaque_thing\n", "is.numeric(x)", "y <- x + 1\n"),
+        (
+            "x <- some_opaque_thing\n",
+            "is.character(x)",
+            "n <- nchar(x)\n",
+        ),
+    ] {
+        let src = format!("{binding}if ({guard}) {{\n  {use_expr}}}\n");
+        let diags = check(&src);
+        assert!(
+            diags.iter().all(|d| d.code != "RY040"),
+            "`{guard}` then branch should not fire RY040, got {diags:?}"
+        );
+    }
 }
 
 #[test]
@@ -44,71 +44,82 @@ fn underscored_null_predicate_narrows_default_parameter() {
 }
 
 #[test]
-fn diverging_null_guard_makes_default_function_callable() {
-    let diagnostics = check(
-        "apply_fun <- function(x, fun = NULL) {\n\
-           if (is.null(fun)) stop(\"fun required\")\n\
-           fun(x)\n\
-         }\n\
-         apply_fun(1)\n",
-    );
-    assert!(
-        diagnostics
-            .iter()
-            .all(|diagnostic| diagnostic.code != "RY070"),
-        "the continuation of a diverging null guard must be callable: {diagnostics:?}"
-    );
-}
-
-#[test]
-fn diverging_null_guard_makes_default_value_record_like() {
-    let diagnostics = check(
-        "read_field <- function(x = NULL) {\n\
-           if (is.null(x)) stop(\"x required\")\n\
-           x$field\n\
-         }\n\
-         read_field()\n",
-    );
-    assert!(
-        diagnostics
-            .iter()
-            .all(|diagnostic| diagnostic.code != "RY061"),
-        "the continuation of a diverging null guard must exclude NULL: {diagnostics:?}"
-    );
-}
-
-#[test]
-fn diverging_negated_predicate_guard_narrows_continuation() {
-    let diagnostics = check(
-        "compare_text <- function(x = NULL) {\n\
-           if (!is.character(x)) stop(\"x must be character\")\n\
-           x == \"1\"\n\
-         }\n\
-         compare_text()\n",
-    );
-    assert!(
-        diagnostics
-            .iter()
-            .all(|diagnostic| diagnostic.code != "RY033"),
-        "the false path of !is.character must be character: {diagnostics:?}"
-    );
-}
-
-#[test]
-fn return_guard_narrows_continuation() {
-    let diagnostics = check(
-        "read_field <- function(x = NULL) {\n\
-           if (is.null(x)) return(NULL)\n\
-           x$field\n\
-         }\n\
-         read_field()\n",
-    );
-    assert!(
-        diagnostics
-            .iter()
-            .all(|diagnostic| diagnostic.code != "RY061"),
-        "returning null guard must narrow its continuation: {diagnostics:?}"
-    );
+fn diverging_guards_narrow_the_guarded_continuation() {
+    // A guard whose true branch provably diverges -- stop(), a final
+    // return(), or a block ending in stop() -- leaves only the false
+    // path for the continuation, where the guarded parameter's NULL
+    // default has been narrowed away. The continuation use must
+    // therefore not fire the diagnostic the unnarrowed default would.
+    let guarded = |params: &str, guard: &str, diverge: &str, tail: &str, call: &str| {
+        format!("f <- function({params}) {{\n  if ({guard}) {diverge}\n  {tail}\n}}\n{call}\n")
+    };
+    for (label, src, suppressed) in [
+        (
+            "a stop guard makes a default function callable",
+            guarded(
+                "x, fun = NULL",
+                "is.null(fun)",
+                "stop(\"fun required\")",
+                "fun(x)",
+                "f(1)",
+            ),
+            "RY070",
+        ),
+        (
+            "a stop guard keeps a default value record-like",
+            guarded("x = NULL", "is.null(x)", "stop(\"x required\")", "x$field", "f()"),
+            "RY061",
+        ),
+        (
+            "a negated predicate stop guard narrows the mode",
+            guarded(
+                "x = NULL",
+                "!is.character(x)",
+                "stop(\"x must be character\")",
+                "x == \"1\"",
+                "f()",
+            ),
+            "RY033",
+        ),
+        (
+            "a return guard narrows like a stop guard",
+            guarded("x = NULL", "is.null(x)", "return(NULL)", "x$field", "f()"),
+            "RY061",
+        ),
+        (
+            "a guard block ending in stop diverges",
+            guarded(
+                "x = NULL",
+                "is.null(x)",
+                "{ log(\"x required\"); stop(\"x required\") }",
+                "x$field",
+                "f()",
+            ),
+            "RY061",
+        ),
+        (
+            "a compound null guard narrows its continuation",
+            guarded(
+                "x = NULL",
+                "is.null(x) || is.na(x)",
+                "stop(\"x required\")",
+                "x$field",
+                "f()",
+            ),
+            "RY061",
+        ),
+        (
+            "a guard inside a function defined in a loop narrows independently",
+            "for (i in 1:2) {\n  read_field <- function(x = NULL) {\n    if (is.null(x)) stop(\"x required\")\n    x$field\n  }\n}\n".to_string(),
+            "RY061",
+        ),
+    ] {
+        let diagnostics = check(&src);
+        assert!(
+            diagnostics.iter().all(|d| d.code != suppressed),
+            "{label}: {diagnostics:?}"
+        );
+    }
 }
 
 #[test]
@@ -143,41 +154,6 @@ fn project_function_named_abort_does_not_diverge() {
             .iter()
             .any(|diagnostic| diagnostic.code == "RY070"),
         "a project abort() must not be treated as a terminator: {diagnostics:?}"
-    );
-}
-
-#[test]
-fn final_statement_in_guard_block_can_diverge() {
-    let diagnostics = check(
-        "read_field <- function(x = NULL) {\n\
-           if (is.null(x)) { log(\"x required\"); stop(\"x required\") }\n\
-           x$field\n\
-         }\n\
-         read_field()\n",
-    );
-    assert!(
-        diagnostics
-            .iter()
-            .all(|diagnostic| diagnostic.code != "RY061"),
-        "a guard block ending in stop must narrow its continuation: {diagnostics:?}"
-    );
-}
-
-#[test]
-fn divergence_narrowing_works_in_nested_function_inside_loop() {
-    let diagnostics = check(
-        "for (i in 1:2) {\n\
-           read_field <- function(x = NULL) {\n\
-             if (is.null(x)) stop(\"x required\")\n\
-             x$field\n\
-           }\n\
-         }\n",
-    );
-    assert!(
-        diagnostics
-            .iter()
-            .all(|diagnostic| diagnostic.code != "RY061"),
-        "nested function guard should narrow independently: {diagnostics:?}"
     );
 }
 
@@ -254,23 +230,6 @@ fn null_return_guard_alone_does_not_prove_non_empty() {
 }
 
 #[test]
-fn compound_null_guard_narrows_its_continuation() {
-    let diagnostics = check(
-        "read_field <- function(x = NULL) {\n\
-           if (is.null(x) || is.na(x)) stop(\"x required\")\n\
-           x$field\n\
-         }\n\
-         read_field()\n",
-    );
-    assert!(
-        diagnostics
-            .iter()
-            .all(|diagnostic| diagnostic.code != "RY061"),
-        "the false path of a compound null guard must exclude NULL: {diagnostics:?}"
-    );
-}
-
-#[test]
 fn missing_guard_is_ignored_for_type_narrowing() {
     let diagnostics = check(
         "apply_fun <- function(x, fun = NULL) {\n\
@@ -336,24 +295,6 @@ fn diverging_else_branch_promotes_then_refinement() {
             .iter()
             .all(|diagnostic| diagnostic.code != "RY070"),
         "a diverging else branch must promote then-branch refinements: {diagnostics:?}"
-    );
-}
-
-#[test]
-fn type_narrowing_is_numeric_then_branch() {
-    // `if (is.numeric(x)) { x + 1 }`: the `then` branch narrows
-    // `x` to numeric (double). If `x` was opaque, it's now double
-    // inside the branch. Using `x + 1` should be well-typed.
-    let diags = check(
-        "x <- some_opaque_thing\n\
-             if (is.numeric(x)) {\n\
-             \x20 y <- x + 1\n\
-             }\n",
-    );
-    assert!(
-        diags.iter().all(|d| d.code != "RY040"),
-        "numeric-narrowed opaque should not fire RY040 in then branch, got {:?}",
-        diags
     );
 }
 
@@ -471,23 +412,6 @@ fn type_narrowing_does_not_leak() {
     assert!(
         diags.iter().all(|d| d.code != "RY040"),
         "narrowing leaked into enclosing scope, got {:?}",
-        diags
-    );
-}
-
-#[test]
-fn type_narrowing_is_character_then_branch() {
-    // `if (is.character(x)) { nchar(x) }`: the `then` branch
-    // narrows `x` to character. `nchar` on character is fine.
-    let diags = check(
-        "x <- some_opaque_thing\n\
-             if (is.character(x)) {\n\
-             \x20 n <- nchar(x)\n\
-             }\n",
-    );
-    assert!(
-        diags.iter().all(|d| d.code != "RY040"),
-        "character-narrowed opaque should not fire RY040 in then branch, got {:?}",
         diags
     );
 }

--- a/crates/ry-checker/src/tests/packages_typeshed.rs
+++ b/crates/ry-checker/src/tests/packages_typeshed.rs
@@ -1,5 +1,4 @@
 use super::*;
-use ry_core::RParser;
 
 #[test]
 fn package_loading_calls_have_distinct_return_types() {

--- a/crates/ry-checker/src/tests/quoting_data_mask.rs
+++ b/crates/ry-checker/src/tests/quoting_data_mask.rs
@@ -1,5 +1,4 @@
 use super::*;
-use ry_core::RParser;
 
 #[test]
 fn confidence_defaults_follow_rule_precision_and_info_severity() {

--- a/crates/ry-checker/src/tests/scope_resolution.rs
+++ b/crates/ry-checker/src/tests/scope_resolution.rs
@@ -641,6 +641,14 @@ fn project_with(files: &[(&str, &str)]) -> Vec<(String, Vec<Diagnostic>)> {
     project.check()
 }
 
+/// Whether `path` (an absolute path key from `Project::check`) ends
+/// with the relative fixture path `rel` (written with `/` separators).
+/// `Path::ends_with` compares components, so this matches regardless
+/// of the platform's path separator.
+fn path_matches(path: &str, rel: &str) -> bool {
+    std::path::Path::new(path).ends_with(rel.split('/').collect::<std::path::PathBuf>())
+}
+
 #[test]
 fn cross_file_top_level_variables_resolve_between_files() {
     // File A defines a top-level binding whose RHS is not a function
@@ -664,7 +672,7 @@ fn cross_file_top_level_variables_resolve_between_files() {
         let diagnostics = project_with(&[("R/a.R", definition), ("R/b.R", use_src)]);
         let reader = diagnostics
             .iter()
-            .find(|(path, _)| path.ends_with("R/b.R"))
+            .find(|(path, _)| path_matches(path, "R/b.R"))
             .map(|(_, diags)| diags)
             .unwrap_or_else(|| panic!("{label}: R/b.R diagnostics missing"));
         assert!(
@@ -717,7 +725,7 @@ fn scripts_share_top_level_known_vars() {
     ]);
     let reader = diagnostics
         .iter()
-        .find(|(path, _)| path.ends_with("inst/examples/b.R"))
+        .find(|(path, _)| path_matches(path, "inst/examples/b.R"))
         .map(|(_, diags)| diags)
         .expect("reading script diagnostics");
     assert!(
@@ -746,7 +754,7 @@ fn testthat_script_sees_package_library_functions() {
     ]);
     let test = diagnostics
         .iter()
-        .find(|(path, _)| path.ends_with("tests/testthat/test-hidden.R"))
+        .find(|(path, _)| path_matches(path, "tests/testthat/test-hidden.R"))
         .map(|(_, diags)| diags)
         .expect("testthat script diagnostics");
     assert!(

--- a/crates/ry-checker/src/tests/scope_resolution.rs
+++ b/crates/ry-checker/src/tests/scope_resolution.rs
@@ -1,5 +1,4 @@
 use super::*;
-use ry_core::RParser;
 
 #[test]
 fn attach_makes_later_search_path_bindings_uncertain() {
@@ -626,31 +625,53 @@ fn s4_generics_and_methods_resolve_cross_file() {
     );
 }
 
-#[test]
-fn cross_file_literal_variable_resolves() {
-    // File A defines a top-level constant `my_const <- 42`; file B
-    // references it. Without `known_vars`, B would emit RY010 on
-    // `my_const`. With `known_vars`, the reference resolves to
-    // opaque and no diagnostic fires.
+/// Build a tempdir package project (DESCRIPTION at the root, files
+/// relative to it), check it, and return the per-file diagnostics.
+/// Mirrors how the project-mode fixtures lay out a real package.
+fn project_with(files: &[(&str, &str)]) -> Vec<(String, Vec<Diagnostic>)> {
     let dir = tempfile::tempdir().unwrap();
-    std::fs::create_dir(dir.path().join("R")).unwrap();
     std::fs::write(dir.path().join("DESCRIPTION"), "Package: fixture\n").unwrap();
-    let a = dir.path().join("R/a.R").to_string_lossy().to_string();
-    let b = dir.path().join("R/b.R").to_string_lossy().to_string();
     let mut project = Project::new();
-    project.add_file(a.clone(), parse_file(&a, "my_const <- 42\n"));
-    project.add_file(b.clone(), parse_file(&b, "x <- my_const\n"));
-    let diags = project.check();
-    let b_diags: Vec<_> = diags
-        .into_iter()
-        .filter(|(p, _)| p == &b)
-        .flat_map(|(_, d)| d)
-        .collect();
-    assert!(
-        b_diags.iter().all(|d| d.code != "RY010"),
-        "cross-file literal variable should not trigger RY010, got {:?}",
-        b_diags
-    );
+    for (path, src) in files {
+        let full = dir.path().join(path);
+        std::fs::create_dir_all(full.parent().unwrap()).unwrap();
+        let full = full.to_string_lossy().to_string();
+        project.add_file(full.clone(), parse_file(&full, src));
+    }
+    project.check()
+}
+
+#[test]
+fn cross_file_top_level_variables_resolve_between_files() {
+    // File A defines a top-level binding whose RHS is not a function
+    // literal (a constant, an opaque ggproto() call result, a list
+    // constructor), so it is not in `fns`; file B references it.
+    // Without `known_vars`, B would emit RY010 on the name. With it,
+    // the reference resolves and the reading file stays clean.
+    for (label, definition, use_src) in [
+        ("literal constant", "my_const <- 42\n", "x <- my_const\n"),
+        (
+            "opaque call result",
+            "GeomRect <- ggproto(\"GeomRect\", Geom, draw = function() NULL)\n",
+            "x <- GeomRect\n",
+        ),
+        (
+            "list constructor",
+            "config <- list(timeout = 30, retries = 3)\n",
+            "t <- config$timeout\n",
+        ),
+    ] {
+        let diagnostics = project_with(&[("R/a.R", definition), ("R/b.R", use_src)]);
+        let reader = diagnostics
+            .iter()
+            .find(|(path, _)| path.ends_with("R/b.R"))
+            .map(|(_, diags)| diags)
+            .unwrap_or_else(|| panic!("{label}: R/b.R diagnostics missing"));
+        assert!(
+            reader.iter().all(|d| d.code != "RY010"),
+            "cross-file {label} should resolve without RY010, got {reader:?}"
+        );
+    }
 }
 
 #[test]
@@ -687,98 +708,21 @@ fn open_search_path_does_not_leak_between_project_files() {
 }
 
 #[test]
-fn cross_file_opaque_call_variable_resolves() {
-    // File A defines `GeomRect <- ggproto("GeomRect", Geom, ...)`.
-    // The RHS is a CALL (not a function literal), so it would not
-    // be in `fns`; previously any reference from file B would fire
-    // RY010. With `known_vars`, `GeomRect` resolves to opaque.
-    let dir = tempfile::tempdir().unwrap();
-    std::fs::create_dir(dir.path().join("R")).unwrap();
-    std::fs::write(dir.path().join("DESCRIPTION"), "Package: fixture\n").unwrap();
-    let geom = dir.path().join("R/geom.R").to_string_lossy().to_string();
-    let user = dir.path().join("R/user.R").to_string_lossy().to_string();
-    let mut project = Project::new();
-    project.add_file(
-        geom.clone(),
-        parse_file(
-            &geom,
-            "GeomRect <- ggproto(\"GeomRect\", Geom, draw = function() NULL)\n",
-        ),
-    );
-    project.add_file(user.clone(), parse_file(&user, "x <- GeomRect\n"));
-    let diags = project.check();
-    let user_diags: Vec<_> = diags
-        .into_iter()
-        .filter(|(p, _)| p == &user)
-        .flat_map(|(_, d)| d)
-        .collect();
-    assert!(
-        user_diags.iter().all(|d| d.code != "RY010"),
-        "cross-file ggproto-defined variable should not trigger RY010, got {:?}",
-        user_diags
-    );
-}
-
-#[test]
-fn cross_file_list_constructor_variable_resolves() {
-    // File A defines `config <- list(timeout = 30, retries = 3)`:
-    // a list constructor, not a function. File B references it.
-    let dir = tempfile::tempdir().unwrap();
-    std::fs::create_dir(dir.path().join("R")).unwrap();
-    std::fs::write(dir.path().join("DESCRIPTION"), "Package: fixture\n").unwrap();
-    let config = dir.path().join("R/config.R").to_string_lossy().to_string();
-    let main = dir.path().join("R/main.R").to_string_lossy().to_string();
-    let mut project = Project::new();
-    project.add_file(
-        config.clone(),
-        parse_file(&config, "config <- list(timeout = 30, retries = 3)\n"),
-    );
-    project.add_file(main.clone(), parse_file(&main, "t <- config$timeout\n"));
-    let diags = project.check();
-    let main_diags: Vec<_> = diags
-        .into_iter()
-        .filter(|(p, _)| p == &main)
-        .flat_map(|(_, d)| d)
-        .collect();
-    assert!(
-        main_diags.iter().all(|d| d.code != "RY010"),
-        "cross-file list-constructor variable should not trigger RY010, got {:?}",
-        main_diags
-    );
-}
-
-#[test]
 fn scripts_share_top_level_known_vars() {
-    let dir = tempfile::tempdir().unwrap();
-    std::fs::create_dir_all(dir.path().join("inst/examples")).unwrap();
-    std::fs::write(dir.path().join("DESCRIPTION"), "Package: fixture\n").unwrap();
-    let defining = dir
-        .path()
-        .join("inst/examples/a.R")
-        .to_string_lossy()
-        .to_string();
-    let reading = dir
-        .path()
-        .join("inst/examples/b.R")
-        .to_string_lossy()
-        .to_string();
-    let mut project = Project::new();
-    project.add_file(
-        defining.clone(),
-        parse_file(&defining, "h <- list(pre = 1L)\n"),
-    );
-    project.add_file(reading.clone(), parse_file(&reading, "x <- h[[\"pre\"]]\n"));
-    let diagnostics: Vec<_> = project
-        .check()
-        .into_iter()
-        .find(|(path, _)| path == &reading)
-        .unwrap()
-        .1;
+    // Scripts under inst/ (outside the package's R/ code) still
+    // share top-level bindings with the rest of the project.
+    let diagnostics = project_with(&[
+        ("inst/examples/a.R", "h <- list(pre = 1L)\n"),
+        ("inst/examples/b.R", "x <- h[[\"pre\"]]\n"),
+    ]);
+    let reader = diagnostics
+        .iter()
+        .find(|(path, _)| path.ends_with("inst/examples/b.R"))
+        .map(|(_, diags)| diags)
+        .expect("reading script diagnostics");
     assert!(
-        diagnostics
-            .iter()
-            .all(|diagnostic| diagnostic.code != "RY010"),
-        "sourced scripts must share top-level bindings: {diagnostics:?}"
+        reader.iter().all(|d| d.code != "RY010"),
+        "sourced scripts must share top-level bindings: {reader:?}"
     );
 }
 
@@ -794,33 +738,20 @@ fn function_self_read_before_assignment_reports_ry010() {
 
 #[test]
 fn testthat_script_sees_package_library_functions() {
-    let dir = tempfile::tempdir().unwrap();
-    std::fs::create_dir_all(dir.path().join("R")).unwrap();
-    std::fs::create_dir_all(dir.path().join("tests/testthat")).unwrap();
-    std::fs::write(dir.path().join("DESCRIPTION"), "Package: fixture\n").unwrap();
-    let library = dir.path().join("R/hidden.R").to_string_lossy().to_string();
-    let test = dir
-        .path()
-        .join("tests/testthat/test-hidden.R")
-        .to_string_lossy()
-        .to_string();
-    let mut project = Project::new();
-    project.add_file(
-        library.clone(),
-        parse_file(&library, "hidden <- function() 1L\n"),
-    );
-    project.add_file(test.clone(), parse_file(&test, "x <- hidden()\n"));
-    let diagnostics = project
-        .check()
-        .into_iter()
-        .find(|(path, _)| path == &test)
-        .unwrap()
-        .1;
+    // tests/testthat code retains access to the package's R/
+    // library functions even though it lives outside R/.
+    let diagnostics = project_with(&[
+        ("R/hidden.R", "hidden <- function() 1L\n"),
+        ("tests/testthat/test-hidden.R", "x <- hidden()\n"),
+    ]);
+    let test = diagnostics
+        .iter()
+        .find(|(path, _)| path.ends_with("tests/testthat/test-hidden.R"))
+        .map(|(_, diags)| diags)
+        .expect("testthat script diagnostics");
     assert!(
-        diagnostics
-            .iter()
-            .all(|diagnostic| diagnostic.code != "RY010"),
-        "testthat code must retain access to package functions: {diagnostics:?}"
+        test.iter().all(|d| d.code != "RY010"),
+        "testthat code must retain access to package functions: {test:?}"
     );
 }
 
@@ -830,21 +761,11 @@ fn genuinely_undefined_variable_still_triggers_ry010() {
     // (and is not a typeshed function or dataset) must still emit
     // RY010. `known_vars` only suppresses diagnostics for names we
     // have actually seen assigned.
-    let mut project = Project::new();
-    project.add_file(
-        "a.R".to_string(),
-        parse_file("a.R", "x <- totally_undefined_thing\n"),
-    );
-    let diags = project.check();
-    let a_diags: Vec<_> = diags
-        .into_iter()
-        .filter(|(p, _)| p == "a.R")
-        .flat_map(|(_, d)| d)
-        .collect();
+    let diagnostics = project_with(&[("a.R", "x <- totally_undefined_thing\n")]);
+    let all: Vec<_> = diagnostics.into_iter().flat_map(|(_, d)| d).collect();
     assert!(
-        a_diags.iter().any(|d| d.code == "RY010"),
-        "genuinely undefined variable should still trigger RY010, got {:?}",
-        a_diags
+        all.iter().any(|d| d.code == "RY010"),
+        "genuinely undefined variable should still trigger RY010, got {all:?}"
     );
 }
 

--- a/crates/ry-checker/src/tests/type_inference.rs
+++ b/crates/ry-checker/src/tests/type_inference.rs
@@ -319,19 +319,36 @@ fn for_loop_var_is_element_type() {
 }
 
 #[test]
-fn pipe_desugars_to_call() {
-    // `c(1,2,3) %>% mean()` desugars to `mean(c(1,2,3))`, which is
-    // well-typed: no diagnostics.
-    let diags = check("result <- c(1, 2, 3) %>% mean()\n");
-    assert!(diags.is_empty(), "got {:?}", diags);
-}
-
-#[test]
-fn pipe_chain_infers() {
-    // A two-step pipe composes: `mean() -> double_or_int<1>`, then
-    // `round(<double>, digits = 2)` resolves against the typeshed.
-    let diags = check("a <- c(1, 2, 3) %>% mean() %>% round(2)\n");
-    assert!(diags.is_empty(), "got {:?}", diags);
+fn pipe_forms_desugar_to_well_typed_calls() {
+    // Every supported pipe form desugars to an ordinary call that
+    // type-checks cleanly: magrittr `%>%` (call rhs, bare function
+    // name, `.` placeholder argument, `%T>%` tee) and the native
+    // base-R `|>`.
+    for (src, note) in [
+        ("result <- c(1, 2, 3) %>% mean()\n", "call rhs"),
+        (
+            "a <- c(1, 2, 3) %>% mean() %>% round(2)\n",
+            "two-step chain",
+        ),
+        ("a <- c(1, 2, 3) |> mean()\n", "native |>"),
+        ("x <- 1L\ny <- x %>% abs\n", "bare function name rhs"),
+        (
+            "result <- c(1, 2, 3) %>% round(., digits = 2)\n",
+            "placeholder argument",
+        ),
+        (
+            "result <- c(1, 2, 3) %T>% print()\n",
+            "tee returns the lhs type",
+        ),
+    ] {
+        let diags = check(src);
+        assert!(
+            diags.is_empty(),
+            "{note} (`{}`): got {:?}",
+            src.trim(),
+            diags
+        );
+    }
 }
 
 #[test]
@@ -359,60 +376,37 @@ fn long_else_if_force_flow_completes() {
     src.push_str(r#" else { stop("nope") } }"#);
     src.push('\n');
 
-    let _ = check(&src);
+    let diags = check(&src);
+    assert!(diags.is_empty(), "got {diags:?}");
 }
 
 #[test]
-fn pipe_base_r_infers() {
-    // Base-R `|>` desugars identically to magrittr `%>%`.
-    let diags = check("a <- c(1, 2, 3) |> mean()\n");
-    assert!(diags.is_empty(), "got {:?}", diags);
-}
-
-#[test]
-fn pipe_bare_function() {
-    // Bare `rhs` becomes a one-arg call: `x %>% abs` -> `abs(x)`.
-    let diags = check("x <- 1L\ny <- x %>% abs\n");
-    assert!(diags.is_empty(), "got {:?}", diags);
-}
-
-#[test]
-fn pipe_placeholder_substitutes() {
-    // The first `.` is replaced with the LHS; `round(., digits = 2)`
-    // becomes `round(c(1,2,3), digits = 2)`.
-    let diags = check("result <- c(1, 2, 3) %>% round(., digits = 2)\n");
-    assert!(diags.is_empty(), "got {:?}", diags);
-}
-
-#[test]
-fn pipe_tee_returns_lhs_type() {
-    // `%T>%` returns the LHS; the RHS is walked for diagnostics only.
-    // `c(1,2,3) %T>% print()` should be a length-3 double vector.
-    let diags = check("result <- c(1, 2, 3) %T>% print()\n");
-    assert!(diags.is_empty(), "got {:?}", diags);
-}
-
-#[test]
-fn pipe_dot_pronoun_dollar_column() {
-    // `df %>% .$mpg` resolves `.` to the piped LHS (`mtcars`) and
-    // then indexes by column name, so `col` should be `double<32>`
-    // (the type of `mtcars$mpg`). We assert the inferred type
-    // directly via the test scope and also check that no RY010
-    // (unbound `.`) leaks out.
-    let (diags, scope) = check_with_scope("df <- mtcars\ncol <- df %>% .$mpg\n");
-    assert!(
-        diags.iter().all(|d| d.code != "RY010"),
-        "dot pronoun should not emit RY010 (unbound `.`), got {:?}",
-        diags
-    );
-    let col = scope.get("col").expect("col should be bound");
-    assert_eq!(
-        col.mode,
-        Mode::Double,
-        "df %>% .$mpg must infer double, got {:?}",
-        col
-    );
-    assert_eq!(col.length, Length::Known(32), "mpg has 32 rows");
+fn pipe_dot_pronoun_extracts_typed_column() {
+    // `df %>% .$mpg` and `df %>% .[["mpg"]]` resolve `.` to the
+    // piped LHS (`mtcars`) and index by column name -- `[[` with a
+    // string literal mirrors `$` semantics -- so `col` should be
+    // `double<32>` (the type of `mtcars$mpg`). We assert the
+    // inferred type directly via the test scope and also check that
+    // no RY010 (unbound `.`) leaks out.
+    for (label, access) in [("dollar", ".$mpg"), ("double-bracket", ".[[\"mpg\"]]")] {
+        let src = format!("df <- mtcars\ncol <- df %>% {access}\n");
+        let (diags, scope) = check_with_scope(&src);
+        assert!(
+            diags.iter().all(|d| d.code != "RY010"),
+            "{label}: dot pronoun should not emit RY010 (unbound `.`), got {:?}",
+            diags
+        );
+        let col = scope
+            .get("col")
+            .unwrap_or_else(|| panic!("{label}: col should be bound"));
+        assert_eq!(
+            col.mode,
+            Mode::Double,
+            "{label}: must infer double, got {:?}",
+            col
+        );
+        assert_eq!(col.length, Length::Known(32), "{label}: mpg has 32 rows");
+    }
 }
 
 #[test]
@@ -535,21 +529,6 @@ fn pipe_placeholders_are_specific_to_their_pipe_form() {
             diags
         );
     }
-}
-
-#[test]
-fn pipe_dot_pronoun_double_bracket() {
-    // `df %>% .[["mpg"]]` resolves `.` to the LHS and indexes by
-    // string-literal column name via `[[`, mirroring `$` semantics.
-    let (diags, scope) = check_with_scope("df <- mtcars\ncol <- df %>% .[[\"mpg\"]]\n");
-    assert!(
-        diags.iter().all(|d| d.code != "RY010"),
-        "dot pronoun should not emit RY010, got {:?}",
-        diags
-    );
-    let col = scope.get("col").expect("col should be bound");
-    assert_eq!(col.mode, Mode::Double, ".[[\"mpg\"]] must infer double");
-    assert_eq!(col.length, Length::Known(32), "mpg has 32 rows");
 }
 
 #[test]
@@ -768,203 +747,76 @@ fn neg_preserves_na_flag_and_mode() {
 // ---- Literal-based length inference: `:`, `rep`, `seq` ----
 //
 // These exercise the literal-arg fast paths that pin the result
-// length exactly instead of returning `Length::Unknown`. The
-// common pattern: build the expression, assert the inferred
-// `RType` has `Length::Known(n)` with the expected `n`, then do a
-// behavioral check that downstream code sees the precise length
-// (e.g. mixing with a character fires RY040).
+// length exactly instead of returning `Length::Unknown`, and their
+// behavioral payoff: a precisely typed vector mixed with a character
+// operand is a diagnosed type error (RY040), where an opaque result
+// would stay silent. Non-literal operands must stay `Unknown` (no
+// false precision). `mode` pins only what each case asserted.
 #[test]
-fn colon_literals_pin_length() {
-    // `1:10` has 10 elements; both endpoints are integer-valued
-    // literals so the literal-based path fires.
-    let (diags, scope) = check_with_scope("x <- 1:10\n");
-    assert!(diags.is_empty(), "got {:?}", diags);
-    let x = scope.get("x").expect("x should be bound");
-    assert_eq!(x.mode, Mode::Integer, "got {:?}", x);
-    assert_eq!(x.length, Length::Known(10), "got {:?}", x);
+fn literal_constructors_pin_exact_lengths() {
+    for (src, mode, length) in [
+        // `:` with integer-valued literal endpoints (whole-number
+        // doubles included) yields an integer vector; `5:5` is the
+        // single-element case; a non-literal LHS stays Unknown.
+        ("x <- 1:10\n", Some(Mode::Integer), Length::Known(10)),
+        ("x <- 10:1\n", Some(Mode::Integer), Length::Known(10)),
+        ("x <- 1.0:5.0\n", Some(Mode::Integer), Length::Known(5)),
+        ("x <- 5:5\n", None, Length::Known(1)),
+        ("n <- 1L\nx <- n:10\n", Some(Mode::Integer), Length::Unknown),
+        // `rep`: positional, named (`times =`), and `each =`
+        // multipliers; `rep(0, 5)` keeps double (`0` has no `L`);
+        // a non-literal `times` stays Unknown.
+        ("x <- rep(1:3, 2)\n", Some(Mode::Integer), Length::Known(6)),
+        ("x <- rep(0, 5)\n", Some(Mode::Double), Length::Known(5)),
+        ("x <- rep(c(1, 2), times = 3)\n", None, Length::Known(6)),
+        ("x <- rep(c(1, 2, 3), each = 2)\n", None, Length::Known(6)),
+        ("x <- rep(c(1, 2), 3, each = 2)\n", None, Length::Known(12)),
+        ("n <- 2\nx <- rep(1:3, n)\n", None, Length::Unknown),
+        // `seq`/`seq.int`: `by`, `length.out`, and the by-one
+        // default; whole-number double `by` still pins; a
+        // non-literal endpoint stays Unknown.
+        ("x <- seq(1, 10, 2)\n", None, Length::Known(5)),
+        ("x <- seq(1, 5, length.out = 3)\n", None, Length::Known(3)),
+        ("x <- seq(1, 5)\n", None, Length::Known(5)),
+        (
+            "x <- seq.int(1L, 10L, 2L)\n",
+            Some(Mode::Integer),
+            Length::Known(5),
+        ),
+        ("x <- seq.int(2, 10, 2.0)\n", None, Length::Known(5)),
+        ("n <- 10\nx <- seq(1, n, 1)\n", None, Length::Unknown),
+    ] {
+        let (diags, scope) = check_with_scope(src);
+        assert!(diags.is_empty(), "`{src}`: got {diags:?}");
+        let x = scope
+            .get("x")
+            .unwrap_or_else(|| panic!("`{src}`: x should be bound"));
+        if let Some(mode) = mode {
+            assert_eq!(x.mode, mode, "`{src}`: got {x:?}");
+        }
+        assert_eq!(x.length, length, "`{src}`: got {x:?}");
+    }
 }
 
 #[test]
-fn colon_literals_descending_pin_length() {
-    // `10:1` is c(10, 9, ..., 1): length 10, mode integer.
-    let (_, scope) = check_with_scope("x <- 10:1\n");
-    let x = scope.get("x").expect("x should be bound");
-    assert_eq!(x.mode, Mode::Integer, "got {:?}", x);
-    assert_eq!(x.length, Length::Known(10), "got {:?}", x);
-}
-
-#[test]
-fn colon_double_literals_pin_length() {
-    // `1.0:5.0` - whole-number doubles also trigger the literal
-    // path; R returns integer for whole-number endpoints.
-    let (_, scope) = check_with_scope("x <- 1.0:5.0\n");
-    let x = scope.get("x").expect("x should be bound");
-    assert_eq!(x.mode, Mode::Integer, "got {:?}", x);
-    assert_eq!(x.length, Length::Known(5), "got {:?}", x);
-}
-
-#[test]
-fn colon_single_element_pin_length_one() {
-    // `5:5` is a length-1 integer vector c(5).
-    let (_, scope) = check_with_scope("x <- 5:5\n");
-    let x = scope.get("x").expect("x should be bound");
-    assert_eq!(x.length, Length::Known(1), "got {:?}", x);
-}
-
-#[test]
-fn colon_literals_fire_ry040_on_char_mix() {
-    // `1:10` is integer<10>; adding a character is a type error
-    // (RY040). This is the headline benefit of precise length
-    // inference: the checker sees a real vector, not an opaque.
-    let diags = check("x <- 1:10\nbad <- x + \"hello\"\n");
-    assert!(
-        diags.iter().any(|d| d.code == "RY040"),
-        "expected RY040 for integer<10> + character, got {:?}",
-        diags
-    );
-}
-
-#[test]
-fn colon_non_literal_stays_unknown() {
-    // `n:10` where `n` is a variable: LHS isn't a literal, so the
-    // length stays Unknown (no false precision).
-    let (_, scope) = check_with_scope("n <- 1L\nx <- n:10\n");
-    let x = scope.get("x").expect("x should be bound");
-    assert_eq!(x.mode, Mode::Integer, "got {:?}", x);
-    assert_eq!(x.length, Length::Unknown, "got {:?}", x);
-}
-
-#[test]
-fn rep_literal_times_pin_length() {
-    // `rep(1:3, 2)` = c(1,2,3,1,2,3): length 6, mode integer.
-    let (diags, scope) = check_with_scope("x <- rep(1:3, 2)\n");
-    assert!(diags.is_empty(), "got {:?}", diags);
-    let x = scope.get("x").expect("x should be bound");
-    assert_eq!(x.mode, Mode::Integer, "got {:?}", x);
-    assert_eq!(x.length, Length::Known(6), "got {:?}", x);
-}
-
-#[test]
-fn rep_scalar_x_literal_times_pin_length() {
-    // `rep(0, 5)` = c(0,0,0,0,0): length 5. `0` is a double
-    // literal in R (no `L` suffix), so the mode stays double.
-    let (diags, scope) = check_with_scope("x <- rep(0, 5)\n");
-    assert!(diags.is_empty(), "got {:?}", diags);
-    let x = scope.get("x").expect("x should be bound");
-    assert_eq!(x.mode, Mode::Double, "got {:?}", x);
-    assert_eq!(x.length, Length::Known(5), "got {:?}", x);
-}
-
-#[test]
-fn rep_named_times_arg_pin_length() {
-    // `rep(c(1, 2), times = 3)` = c(1,2,1,2,1,2): length 6.
-    let (_, scope) = check_with_scope("x <- rep(c(1, 2), times = 3)\n");
-    let x = scope.get("x").expect("x should be bound");
-    assert_eq!(x.length, Length::Known(6), "got {:?}", x);
-}
-
-#[test]
-fn rep_each_arg_pin_length() {
-    // `rep(c(1, 2, 3), each = 2)` = c(1,1,2,2,3,3): length 6.
-    let (_, scope) = check_with_scope("x <- rep(c(1, 2, 3), each = 2)\n");
-    let x = scope.get("x").expect("x should be bound");
-    assert_eq!(x.length, Length::Known(6), "got {:?}", x);
-}
-
-#[test]
-fn rep_times_and_each_pin_length() {
-    // `rep(c(1, 2), 3, each = 2)`: each element twice, then the
-    // whole thing 3 times = 2 * 2 * 3 = 12.
-    let (_, scope) = check_with_scope("x <- rep(c(1, 2), 3, each = 2)\n");
-    let x = scope.get("x").expect("x should be bound");
-    assert_eq!(x.length, Length::Known(12), "got {:?}", x);
-}
-
-#[test]
-fn rep_non_literal_times_stays_unknown() {
-    // `rep(1:3, n)` where `n` is a variable: `times` isn't a
-    // literal, so the length stays Unknown.
-    let (_, scope) = check_with_scope("n <- 2\nx <- rep(1:3, n)\n");
-    let x = scope.get("x").expect("x should be bound");
-    assert_eq!(x.length, Length::Unknown, "got {:?}", x);
-}
-
-#[test]
-fn rep_literal_fire_ry040_on_char_mix() {
-    // `rep(c(1, 2), 3)` is double<6>; adding a character fires RY040.
-    let diags = check("x <- rep(c(1, 2), 3)\nbad <- x + \"hello\"\n");
-    assert!(
-        diags.iter().any(|d| d.code == "RY040"),
-        "expected RY040 for double<6> + character, got {:?}",
-        diags
-    );
-}
-
-#[test]
-fn seq_literal_by_pin_length() {
-    // `seq(1, 10, 2)` = c(1, 3, 5, 7, 9): length 5.
-    let (diags, scope) = check_with_scope("x <- seq(1, 10, 2)\n");
-    assert!(diags.is_empty(), "got {:?}", diags);
-    let x = scope.get("x").expect("x should be bound");
-    assert_eq!(x.length, Length::Known(5), "got {:?}", x);
-}
-
-#[test]
-fn seq_length_out_pin_length() {
-    // `seq(1, 5, length.out = 3)` = c(1, 3, 5): length 3.
-    let (diags, scope) = check_with_scope("x <- seq(1, 5, length.out = 3)\n");
-    assert!(diags.is_empty(), "got {:?}", diags);
-    let x = scope.get("x").expect("x should be bound");
-    assert_eq!(x.length, Length::Known(3), "got {:?}", x);
-}
-
-#[test]
-fn seq_default_by_one_pin_length() {
-    // `seq(1, 5)` (no `by`, no `length.out`): R uses by = 1, so
-    // length = 5.
-    let (_, scope) = check_with_scope("x <- seq(1, 5)\n");
-    let x = scope.get("x").expect("x should be bound");
-    assert_eq!(x.length, Length::Known(5), "got {:?}", x);
-}
-
-#[test]
-fn seq_int_literal_by_pin_length() {
-    // `seq.int(1L, 10L, 2L)` = c(1L, 3L, 5L, 7L, 9L): length 5,
-    // mode integer (all integer literals).
-    let (diags, scope) = check_with_scope("x <- seq.int(1L, 10L, 2L)\n");
-    assert!(diags.is_empty(), "got {:?}", diags);
-    let x = scope.get("x").expect("x should be bound");
-    assert_eq!(x.mode, Mode::Integer, "got {:?}", x);
-    assert_eq!(x.length, Length::Known(5), "got {:?}", x);
-}
-
-#[test]
-fn seq_int_double_by_pin_length() {
-    // `seq.int(2, 10, 2.0)` uses whole-number double for `by`:
-    // extract_literal_int accepts it, length = 5.
-    let (_, scope) = check_with_scope("x <- seq.int(2, 10, 2.0)\n");
-    let x = scope.get("x").expect("x should be bound");
-    assert_eq!(x.length, Length::Known(5), "got {:?}", x);
-}
-
-#[test]
-fn seq_non_literal_stays_unknown() {
-    // `seq(1, n, 1)` where `n` is a variable: `to` isn't a
-    // literal, so the length stays Unknown.
-    let (_, scope) = check_with_scope("n <- 10\nx <- seq(1, n, 1)\n");
-    let x = scope.get("x").expect("x should be bound");
-    assert_eq!(x.length, Length::Unknown, "got {:?}", x);
-}
-
-#[test]
-fn seq_literal_fire_ry040_on_char_mix() {
-    // `seq(1, 10, 2)` is double<5>; adding a character fires RY040.
-    let diags = check("x <- seq(1, 10, 2)\nbad <- x + \"hello\"\n");
-    assert!(
-        diags.iter().any(|d| d.code == "RY040"),
-        "expected RY040 for double<5> + character, got {:?}",
-        diags
-    );
+fn literal_constructors_fire_ry040_on_char_mix() {
+    // The precise types are visible to downstream arithmetic:
+    // `1:10` is integer<10>, `rep(c(1, 2), 3)` is double<6>, and
+    // `seq(1, 10, 2)` is double<5>, so each mixed character
+    // addition must fire RY040.
+    for (src, vector) in [
+        ("x <- 1:10\nbad <- x + \"hello\"\n", "integer<10>"),
+        ("x <- rep(c(1, 2), 3)\nbad <- x + \"hello\"\n", "double<6>"),
+        ("x <- seq(1, 10, 2)\nbad <- x + \"hello\"\n", "double<5>"),
+    ] {
+        let diags = check(src);
+        assert!(
+            diags.iter().any(|d| d.code == "RY040"),
+            "expected RY040 for {vector} + character in `{}`, got {:?}",
+            src.trim(),
+            diags
+        );
+    }
 }
 
 // ---- Pass-2 propagation + rep/seq edge cases ----

--- a/crates/ry-testkit/src/json_rpc.rs
+++ b/crates/ry-testkit/src/json_rpc.rs
@@ -401,27 +401,6 @@ mod tests {
 
     // ── cross-mode subprocess framing ──────────────────────────
 
-    /// Encode/decode round-trip preserves the message exactly.
-    ///
-    /// Protects the framing seam: if `encode` wrote a wrong Content-Length
-    /// or a malformed header terminator, the decoder would produce a
-    /// different message or fail. This catches a framing mismatch between
-    /// what the testkit client sends and what it expects to receive.
-    #[test]
-    fn encode_decode_round_trip_preserves_message() {
-        let messages = [
-            json!({"jsonrpc": "2.0", "id": 1, "result": {"capabilities": {}}}),
-            json!({"jsonrpc": "2.0", "method": "textDocument/publishDiagnostics", "params": {"uri": "file:///x.R", "diagnostics": []}}),
-            json!({"jsonrpc": "2.0", "id": 2, "method": "shutdown", "params": null}),
-        ];
-        for message in &messages {
-            let frame = encode(message).expect("encode");
-            let mut reader = BufReader::new(frame.as_slice());
-            let decoded = decode_blocking(&mut reader).expect("decode");
-            assert_eq!(&decoded, message);
-        }
-    }
-
     /// the Content-Length header matches the body byte length
     /// exactly, and the header/body separator is the correct CRLFCRLF.
     /// A wrong separator or miscounted length silently truncates or

--- a/editors/code/src/test/e2e.test.ts
+++ b/editors/code/src/test/e2e.test.ts
@@ -40,34 +40,4 @@ describe("E2E: ry extension", () => {
     // activate and produce at least this diagnostic.
     expect(codes).to.include(expectedCode);
   });
-
-  // The server launches from the single pre-resolved binary path; the
-  // unit tests in binary.test.ts verify trust-honoring resolution.
-  it("Server starts from the resolved binary path", async function () {
-    this.timeout(30000);
-
-    const fixturePath = path.join(
-      __dirname,
-      "..",
-      "..",
-      "testFixture",
-      "bad.R",
-    );
-    const uri = vscode.Uri.file(fixturePath);
-    const doc = await vscode.workspace.openTextDocument(uri);
-    await vscode.window.showTextDocument(doc);
-
-    const deadline = Date.now() + 15000;
-    let serverStarted = false;
-    while (Date.now() < deadline) {
-      const diags = vscode.languages.getDiagnostics(uri);
-      if (diags.length > 0) {
-        serverStarted = true;
-        break;
-      }
-      await new Promise((resolve) => setTimeout(resolve, 200));
-    }
-    // Server started means startServer received a valid binaryPath.
-    expect(serverStarted).to.equal(true);
-  });
 });


### PR DESCRIPTION
Cleanup sprint, PR 3 of 7. Net **−405 lines** (12 files, +378/−783). No production behavior change; all changes are tests or `#[cfg(test)]` code.

## What

- **Table-driven conversions** (~30 folded test functions): the 20 pin-length literal-constructor tests, 6 pipe smoke tests, the `$`/`[[` dot-pronoun twins, both narrowing guard clusters (including one the audit missed), and 3 cross-file scope-resolution twins that differ only in a one-line fixture.
- **Single-run restructuring**: 9 NSE tests + the closure trio ran the checker *twice* on identical sources (`check(src)` then `check_with_scope(same src)`); they now run once and assert both diagnostics and scope from that run.
- **Strengthened instead of deleted**: `lapply_anon_callback_infers_integer` and `vapply_uses_fun_value_template` previously hedged with a bare "no RY010"; they now pin the inferred modes (List / Double) plus RY040 behavioral assertions. `long_else_if_force_flow_completes` now asserts the concrete (empty) diagnostic set.
- **Deleted 4 tautological tests**: `is_operator_generic`'s positive loop was `OPERATORS.contains` checked against `OPERATORS`; same shape for the FFI test; the testkit round-trip test was subsumed by the exact-length + back-to-back framing tests; the second VS Code e2e case asserted `diagnostics.length > 0` where the surviving case asserts the specific code on the same fixture.

## Coverage argument

Test functions went 966 → 930 (−36, exact accounting per group). An independent audit verified every folded row maps 1:1 to an old test (byte-identical R sources and expectations), via literal-multiset diff old-vs-new.

## Known cosmetic deltas (flagged in review, intentionally kept)

- Folded tables rename helper functions to `f` and normalize two fixture filenames to `R/a.R`/`R/b.R` — names are not load-bearing for these cases.
- Some diagnostic assertions now run through `check_with_scope` (which additionally surfaces RY000 parse errors); outcomes verified identical for these sources.

## Gates

`cargo test --workspace` (930 pass), clippy `-D warnings`, fmt, VS Code unit/lint/tsc/compile all green locally; e2e suite runs in CI (needs xvfb).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for type inference, scope resolution, closures, pipes, data masking, and constructor lengths.
  * Added stronger assertions for inferred types, function returns, result scopes, and diagnostics.
  * Consolidated repetitive cases into clearer, table-driven test scenarios.
  * Refined cross-file and project-level resolution coverage.
  * Removed redundant test cases and imports without changing product behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->