### PR TITLE
refactor: one shared AST walker for the hand-rolled visitors

### DIFF
--- a/crates/ry-checker/src/collect.rs
+++ b/crates/ry-checker/src/collect.rs
@@ -1,6 +1,8 @@
 use super::*;
 use crate::infer::*;
 use crate::semantic_lists::bare_name;
+use ry_core::walk::{AstNode, Descend, Walk, walk_expr, walk_stmt};
+use std::ops::ControlFlow;
 
 impl Checker {
     pub(crate) fn collect_fns(&mut self, stmts: &[Stmt]) {
@@ -517,67 +519,43 @@ fn parameter_is_quoted(body: &[Stmt], params: &[Param], parameter: &str) -> bool
                 && parameter_has_normal_use(body, parameter)))
 }
 
-/// Generic statement walker shared by the quoting-capture predicates.
-/// Tests `pred` at every call node and recurses into compound
-/// statements. Short-circuits on the first hit. `Expr::Function` bodies
-/// and `Stmt::FunctionDef` are opaque: quoting inside a nested function
+/// Generic statement walker shared by the quoting-capture predicates:
+/// the shared ry-core walker in "does any expression satisfy `pred`"
+/// mode. Tests `pred` at every expression node and short-circuits on
+/// the first hit. Function bodies are opaque (skips `Expr::Function`
+/// and `Stmt::FunctionDef` bodies): quoting inside a nested function
 /// belongs to that function's own formals.
 fn stmt_any(statement: &Stmt, pred: &impl Fn(&Expr) -> bool) -> bool {
-    match statement {
-        Stmt::Assign { target, value, .. } => expr_any(target, pred) || expr_any(value, pred),
-        Stmt::Expr(expression) => expr_any(expression, pred),
-        Stmt::If {
-            cond, then, else_, ..
-        } => {
-            expr_any(cond, pred)
-                || then.iter().any(|s| stmt_any(s, pred))
-                || else_.iter().flatten().any(|s| stmt_any(s, pred))
-        }
-        Stmt::For { iter, body, .. } => {
-            expr_any(iter, pred) || body.iter().any(|s| stmt_any(s, pred))
-        }
-        Stmt::While { cond, body, .. } => {
-            expr_any(cond, pred) || body.iter().any(|s| stmt_any(s, pred))
-        }
-        Stmt::FunctionDef { .. } => false,
-        Stmt::Return { value, .. } => value.as_ref().is_some_and(|e| expr_any(e, pred)),
-    }
+    walk_stmt(
+        statement,
+        Walk {
+            fn_bodies: false,
+            ..Walk::ALL
+        },
+        |node, _| match node {
+            AstNode::Expr(e) if pred(e) => ControlFlow::Break(()),
+            _ => ControlFlow::Continue(Descend::Into),
+        },
+    )
+    .is_break()
 }
 
-/// Expression half of `stmt_any`. Tests `pred` at call nodes; every
-/// other expression recurses into its children. The quoting-capture
-/// predicates all early-return on non-call nodes, so testing at call
-/// nodes alone is equivalent to testing at every node.
+/// Expression half of `stmt_any`. The quoting-capture predicates all
+/// early-return on non-call nodes, so testing at every node is
+/// equivalent to testing at call nodes alone.
 fn expr_any(expression: &Expr, pred: &impl Fn(&Expr) -> bool) -> bool {
-    match expression {
-        Expr::Call { func, args, .. } => {
-            pred(expression)
-                || expr_any(func, pred)
-                || args.iter().any(|argument| expr_any(&argument.value, pred))
-        }
-        Expr::BinOp { lhs, rhs, .. } => expr_any(lhs, pred) || expr_any(rhs, pred),
-        Expr::UnaryOp { expr, .. } => expr_any(expr, pred),
-        Expr::Index { base, args, .. } => {
-            expr_any(base, pred) || args.iter().any(|argument| expr_any(&argument.value, pred))
-        }
-        Expr::Block { body, .. } => body.iter().any(|s| stmt_any(s, pred)),
-        Expr::If {
-            cond, then, else_, ..
-        } => {
-            expr_any(cond, pred)
-                || expr_any(then, pred)
-                || else_.as_ref().is_some_and(|e| expr_any(e, pred))
-        }
-        Expr::Function { .. }
-        | Expr::Ident { .. }
-        | Expr::Logical(_, _)
-        | Expr::Integer(_, _)
-        | Expr::Double(_, _)
-        | Expr::String(_, _)
-        | Expr::Null(_)
-        | Expr::Na(_, _)
-        | Expr::Unknown(_) => false,
-    }
+    walk_expr(
+        expression,
+        Walk {
+            fn_bodies: false,
+            ..Walk::ALL
+        },
+        |node, _| match node {
+            AstNode::Expr(e) if pred(e) => ControlFlow::Break(()),
+            _ => ControlFlow::Continue(Descend::Into),
+        },
+    )
+    .is_break()
 }
 
 /// Leaf predicate for `stmt_any`: the call reflects its complete call

--- a/crates/ry-checker/src/infer/binop.rs
+++ b/crates/ry-checker/src/infer/binop.rs
@@ -1,4 +1,6 @@
 use super::*;
+use ry_core::walk::{AstNode, Descend, Walk, walk_expr};
+use std::ops::ControlFlow;
 
 impl Checker {
     pub(crate) fn infer_binop(
@@ -470,61 +472,39 @@ fn merge_condition_assignments(scope: &mut Scope, evaluated: &Scope, expr: &Expr
     }
 }
 
+/// Skips assignment targets, function bodies, and (inside value blocks)
+/// every statement form other than plain assignments and expressions.
 fn collect_condition_assignment_names(expr: &Expr, names: &mut HashSet<String>) {
-    match expr {
-        Expr::BinOp { op, lhs, rhs, .. } => {
-            if matches!(op, BinOpKind::Assign | BinOpKind::SuperAssign)
-                && let Expr::Ident { name, .. } = lhs.as_ref()
-            {
-                names.insert(name.clone());
-            }
-            collect_condition_assignment_names(lhs, names);
-            collect_condition_assignment_names(rhs, names);
-        }
-        Expr::Call { func, args, .. } => {
-            collect_condition_assignment_names(func, names);
-            for arg in args {
-                collect_condition_assignment_names(&arg.value, names);
-            }
-        }
-        Expr::UnaryOp { expr, .. } => collect_condition_assignment_names(expr, names),
-        Expr::Index { base, args, .. } => {
-            collect_condition_assignment_names(base, names);
-            for arg in args {
-                collect_condition_assignment_names(&arg.value, names);
-            }
-        }
-        Expr::Block { body, .. } => {
-            for stmt in body {
-                match stmt {
-                    Stmt::Assign { target, value, .. } => {
-                        if let Expr::Ident { name, .. } = target {
-                            names.insert(name.clone());
-                        }
-                        collect_condition_assignment_names(value, names);
+    let _ = walk_expr(
+        expr,
+        Walk {
+            assign_targets: false,
+            fn_bodies: false,
+            ..Walk::ALL
+        },
+        |node: AstNode<'_>, _: usize| -> ControlFlow<(), Descend> {
+            match node {
+                AstNode::Expr(Expr::BinOp {
+                    op: BinOpKind::Assign | BinOpKind::SuperAssign,
+                    lhs,
+                    ..
+                }) => {
+                    if let Expr::Ident { name, .. } = lhs.as_ref() {
+                        names.insert(name.clone());
                     }
-                    Stmt::Expr(expr) => collect_condition_assignment_names(expr, names),
-                    _ => {}
                 }
+                AstNode::Stmt(Stmt::Assign {
+                    target: Expr::Ident { name, .. },
+                    ..
+                }) => {
+                    names.insert(name.clone());
+                }
+                // Inside a `{ ... }` value, only assignments and bare
+                // expressions can bind a name in the current environment.
+                AstNode::Stmt(_) => return ControlFlow::Continue(Descend::Skip),
+                _ => {}
             }
-        }
-        Expr::If {
-            cond, then, else_, ..
-        } => {
-            collect_condition_assignment_names(cond, names);
-            collect_condition_assignment_names(then, names);
-            if let Some(else_) = else_ {
-                collect_condition_assignment_names(else_, names);
-            }
-        }
-        Expr::Ident { .. }
-        | Expr::Logical(_, _)
-        | Expr::Integer(_, _)
-        | Expr::Double(_, _)
-        | Expr::String(_, _)
-        | Expr::Null(_)
-        | Expr::Na(_, _)
-        | Expr::Function { .. }
-        | Expr::Unknown(_) => {}
-    }
+            ControlFlow::Continue(Descend::Into)
+        },
+    );
 }

--- a/crates/ry-checker/src/infer/binop.rs
+++ b/crates/ry-checker/src/infer/binop.rs
@@ -472,13 +472,32 @@ fn merge_condition_assignments(scope: &mut Scope, evaluated: &Scope, expr: &Expr
     }
 }
 
-/// Skips assignment targets, function bodies, and (inside value blocks)
-/// every statement form other than plain assignments and expressions.
+/// Records `expr`'s name only when it is a plain identifier binding;
+/// complex targets (`d$k <- v`, `m[i] <- v`) bind no name at the
+/// target itself.
+fn insert_bound_name(expr: &Expr, names: &mut HashSet<String>) {
+    if let Expr::Ident { name, .. } = expr {
+        names.insert(name.clone());
+    }
+}
+
+/// Records names bound by assignments nested anywhere in a condition
+/// expression: the identifier LHS of expression-position `<-`/`<<-`
+/// (descending into both operands, so a complex target like
+/// `m[i <- f()]` still records `i`), and inside `{ ... }` value blocks,
+/// plain assignments of any target shape (descending into the value)
+/// plus bare expressions. Skips assignment targets, function bodies,
+/// and the remaining statement forms (if, while, for, function
+/// definitions, return), which cannot bind a name in the current
+/// environment from inside a condition value.
 fn collect_condition_assignment_names(expr: &Expr, names: &mut HashSet<String>) {
     let _ = walk_expr(
         expr,
         Walk {
             assign_targets: false,
+            // The `<-`/`<<-` LHS is walked, not pruned: base recursed
+            // into it unconditionally.
+            assign_operands: true,
             fn_bodies: false,
             ..Walk::ALL
         },
@@ -488,23 +507,103 @@ fn collect_condition_assignment_names(expr: &Expr, names: &mut HashSet<String>) 
                     op: BinOpKind::Assign | BinOpKind::SuperAssign,
                     lhs,
                     ..
-                }) => {
-                    if let Expr::Ident { name, .. } = lhs.as_ref() {
-                        names.insert(name.clone());
-                    }
-                }
-                AstNode::Stmt(Stmt::Assign {
-                    target: Expr::Ident { name, .. },
-                    ..
-                }) => {
-                    names.insert(name.clone());
+                }) => insert_bound_name(lhs, names),
+                // Any target shape: a complex target (`d$k <- v`) binds
+                // no name at the target, but its value still can.
+                AstNode::Stmt(Stmt::Assign { target, .. }) => {
+                    insert_bound_name(target, names);
                 }
                 // Inside a `{ ... }` value, only assignments and bare
-                // expressions can bind a name in the current environment.
-                AstNode::Stmt(_) => return ControlFlow::Continue(Descend::Skip),
+                // expressions can bind a name in the current
+                // environment; control flow, definitions, and returns
+                // cannot.
+                AstNode::Stmt(
+                    Stmt::If { .. }
+                    | Stmt::While { .. }
+                    | Stmt::For { .. }
+                    | Stmt::FunctionDef { .. }
+                    | Stmt::Return { .. },
+                ) => return ControlFlow::Continue(Descend::Skip),
                 _ => {}
             }
             ControlFlow::Continue(Descend::Into)
         },
     );
+}
+
+/// Pins the traversal shape of [`collect_condition_assignment_names`]
+/// to the hand-rolled recursion it replaced: short-circuit `&&`/`||`
+/// operands are walked like base did, including `{ ... }` value blocks
+/// whose statements bind in the current environment.
+#[cfg(test)]
+mod collect_condition_assignment_names_tests {
+    use super::*;
+    use ry_core::RParser;
+    use std::collections::HashSet;
+
+    /// Collects the names bound in the RHS operand of a `flag && ...`
+    /// expression -- the position `merge_condition_assignments` scans.
+    fn collected(operand_src: &str) -> HashSet<String> {
+        let src = format!("flag && {operand_src}\n");
+        let file = RParser::new()
+            .expect("parser")
+            .parse("cond_assign_test.R", &src)
+            .expect("parse");
+        let [Stmt::Expr(Expr::BinOp { rhs, .. })] = file.stmts.as_slice() else {
+            panic!("test source must be a single `flag && ...` expression");
+        };
+        let mut names = HashSet::new();
+        collect_condition_assignment_names(rhs, &mut names);
+        names
+    }
+
+    fn assert_exact(operand_src: &str, expected: &[&str]) {
+        let found = collected(operand_src);
+        let expected: HashSet<String> = expected.iter().map(|name| name.to_string()).collect();
+        assert_eq!(found, expected, "names from operand `{operand_src}`");
+    }
+
+    /// Assignments nested in an `&&`/`||` operand's value block bind in
+    /// the current environment: both the identifier target `total` and
+    /// the expression-position `delta` inside its value.
+    #[test]
+    fn records_assignments_inside_condition_value_blocks() {
+        assert_exact(
+            "({ total <- total + (delta <- f()); total })",
+            &["total", "delta"],
+        );
+    }
+
+    /// A non-identifier statement target (`d$k <- ...`) binds nothing
+    /// itself, but its value still can: `y` must be recorded. A
+    /// wildcard `Stmt(_) => Skip` callback arm pruned the whole
+    /// statement -- the review blocker this pins.
+    #[test]
+    fn records_value_assignments_behind_complex_statement_targets() {
+        assert_exact("{ d$k <- (y <- 1); TRUE }", &["y"]);
+    }
+
+    /// A bare expression statement inside a condition value block can
+    /// itself carry an expression-position assignment.
+    #[test]
+    fn records_bare_expression_assignments_inside_condition_blocks() {
+        assert_exact("{ (z <- 2); TRUE }", &["z"]);
+    }
+
+    /// The left operand of expression-position `<-`/`<<-` is walked
+    /// (base recursed into it unconditionally), so a complex target
+    /// like `m[i <- compute()]` still records `i`.
+    #[test]
+    fn walks_expression_position_assignment_lhs() {
+        assert_exact("(m[i <- compute()] <- v)", &["i"]);
+    }
+
+    /// Negative controls: calls and index arguments are walked, while
+    /// control statements inside value blocks stay pruned.
+    #[test]
+    fn prunes_control_statements_but_not_call_arguments() {
+        assert_exact("g(a <- 1)", &["a"]);
+        assert_exact("m[b <- 1]", &["b"]);
+        assert_exact("{ for (q in 1:3) { w <- 1 }; TRUE }", &[]);
+    }
 }

--- a/crates/ry-checker/src/infer/call.rs
+++ b/crates/ry-checker/src/infer/call.rs
@@ -1,5 +1,7 @@
 use super::*;
 use crate::higher_order::s3_group_generic;
+use ry_core::walk::{AstNode, Descend, Walk, walk_expr};
+use std::ops::ControlFlow;
 
 impl Checker {
     pub(crate) fn infer_call(
@@ -1435,88 +1437,29 @@ fn r6_rebound_members(member_lists: &[&Expr]) -> HashSet<String> {
             _ => {}
         }
     }
-    fn visit_stmt(statement: &Stmt, names: &mut HashSet<String>) {
-        match statement {
-            Stmt::Assign { target, value, .. } => {
-                record_target(target, names);
-                visit_expr(value, names);
-            }
-            Stmt::Expr(expr) => visit_expr(expr, names),
-            Stmt::If {
-                cond, then, else_, ..
-            } => {
-                visit_expr(cond, names);
-                for statement in then.iter().chain(else_.iter().flatten()) {
-                    visit_stmt(statement, names);
-                }
-            }
-            Stmt::For { iter, body, .. } => {
-                visit_expr(iter, names);
-                for statement in body {
-                    visit_stmt(statement, names);
-                }
-            }
-            Stmt::While { cond, body, .. } => {
-                visit_expr(cond, names);
-                for statement in body {
-                    visit_stmt(statement, names);
-                }
-            }
-            Stmt::FunctionDef { body, .. } => {
-                for statement in body {
-                    visit_stmt(statement, names);
-                }
-            }
-            Stmt::Return { value, .. } => {
-                if let Some(value) = value {
-                    visit_expr(value, names);
-                }
-            }
-        }
-    }
-    fn visit_expr(expr: &Expr, names: &mut HashSet<String>) {
-        match expr {
-            Expr::BinOp { op, lhs, rhs, .. } => {
-                if matches!(op, BinOpKind::Assign | BinOpKind::SuperAssign) {
-                    record_target(lhs, names);
-                } else {
-                    visit_expr(lhs, names);
-                }
-                visit_expr(rhs, names);
-            }
-            Expr::Call { func, args, .. } => {
-                visit_expr(func, names);
-                for argument in args {
-                    visit_expr(&argument.value, names);
-                }
-            }
-            Expr::Index { base, args, .. } => {
-                visit_expr(base, names);
-                for argument in args {
-                    visit_expr(&argument.value, names);
-                }
-            }
-            Expr::UnaryOp { expr, .. } => visit_expr(expr, names),
-            Expr::Function { body, .. } | Expr::Block { body, .. } => {
-                for statement in body {
-                    visit_stmt(statement, names);
-                }
-            }
-            Expr::If {
-                cond, then, else_, ..
-            } => {
-                visit_expr(cond, names);
-                visit_expr(then, names);
-                if let Some(else_) = else_ {
-                    visit_expr(else_, names);
-                }
-            }
+    let mut names = HashSet::new();
+    // Skips assignment targets (recorded by `record_target` instead);
+    // walks nested function bodies, where activators and methods do
+    // their rebinding.
+    let policy = Walk {
+        assign_targets: false,
+        assign_operands: false,
+        ..Walk::ALL
+    };
+    let mut visit = |node: AstNode<'_>, _: usize| -> ControlFlow<(), Descend> {
+        match node {
+            AstNode::Stmt(Stmt::Assign { target, .. }) => record_target(target, &mut names),
+            AstNode::Expr(Expr::BinOp {
+                op: BinOpKind::Assign | BinOpKind::SuperAssign,
+                lhs,
+                ..
+            }) => record_target(lhs, &mut names),
             _ => {}
         }
-    }
-    let mut names = HashSet::new();
+        ControlFlow::Continue(Descend::Into)
+    };
     for list in member_lists {
-        visit_expr(list, &mut names);
+        let _ = walk_expr(list, policy, &mut visit);
     }
     names
 }

--- a/crates/ry-checker/src/infer/index.rs
+++ b/crates/ry-checker/src/infer/index.rs
@@ -675,9 +675,14 @@ pub(crate) fn insert_s3_dispatch_context(method_name: &str, scope: &mut Scope, g
 }
 
 /// Names assigned anywhere in a body, for closure-capture candidates.
-/// Skips function bodies, assignment targets, control tests (if/while
-/// conditions, for iterators), and every expression form except blocks,
-/// `if`, and assignment operators.
+/// Enters assignment values, `if`/`for`/`while` statement bodies,
+/// braced-block values, and `if`-expression branches; records the names
+/// bound by plain assignments, `for` iterators, function definitions,
+/// and expression-position `<-`/`<<-`. Skips function bodies, control
+/// tests (`if`/`while` conditions, `for` iterators), the assignment
+/// target and `<-`/`<<-` left-operand subtrees (only the bound name is
+/// recorded -- R does not evaluate them), and every expression form
+/// except blocks, `if`, and assignment operators.
 pub(crate) fn assigned_names_in_body(body: &[Stmt]) -> HashSet<String> {
     let mut names = HashSet::new();
     let _ = walk_stmts(
@@ -713,9 +718,13 @@ pub(crate) fn assigned_names_in_body(body: &[Stmt]) -> HashSet<String> {
                         names.insert(name.clone());
                     }
                 }
-                // Only blocks and `if` can carry further statements, and
-                // only assignment operators bind from expression position;
-                // calls, indexing, and literals cannot introduce names.
+                // Blocks and `if` expressions carry further statements;
+                // the control_tests=false knob already prunes their
+                // conditions. Every other expression form cannot
+                // introduce names: calls, indexing, and literals only
+                // read, and only assignment operators bind from
+                // expression position.
+                AstNode::Expr(Expr::Block { .. } | Expr::If { .. }) => {}
                 AstNode::Expr(_) => return ControlFlow::Continue(Descend::Skip),
                 AstNode::Stmt(_) => {}
             }
@@ -723,6 +732,76 @@ pub(crate) fn assigned_names_in_body(body: &[Stmt]) -> HashSet<String> {
         },
     );
     names
+}
+
+/// Pins the traversal shape of [`assigned_names_in_body`] to the
+/// hand-rolled walker it replaced: names bound inside braced-block
+/// values and `if`-expression branches are locals of the enclosing
+/// body (closure-capture and loop-carried-binding candidates), while
+/// control tests and unevaluated assignment targets stay pruned.
+#[cfg(test)]
+mod assigned_names_in_body_tests {
+    use super::*;
+    use ry_core::RParser;
+    use std::collections::HashSet;
+
+    /// The collection runs on a function body (its callers extract the
+    /// body from the literal first), so wrap the test source in one.
+    fn assigned(body_src: &str) -> HashSet<String> {
+        let src = format!("f <- function() {{\n{body_src}\n}}\n");
+        let file = RParser::new()
+            .expect("parser")
+            .parse("assigned_names_test.R", &src)
+            .expect("parse");
+        let [
+            Stmt::Assign {
+                value: Expr::Function { body, .. },
+                ..
+            },
+        ] = file.stmts.as_slice()
+        else {
+            panic!("test source must be a single `f <- function()` assignment");
+        };
+        assigned_names_in_body(body)
+    }
+
+    fn assert_exact(body_src: &str, expected: &[&str]) {
+        let found = assigned(body_src);
+        let expected: HashSet<String> = expected.iter().map(|name| name.to_string()).collect();
+        assert_eq!(found, expected, "names from body `{body_src}`");
+    }
+
+    /// A braced-block value carries statements, so `x` is assigned in
+    /// the enclosing body. A wildcard `Expr(_) => Skip` callback arm
+    /// pruned it -- the review blocker this pins.
+    #[test]
+    fn records_names_assigned_inside_braced_block_values() {
+        assert_exact("out <- { x <- 1; out }", &["out", "x"]);
+    }
+
+    /// `if` in expression position evaluates both branches in the
+    /// current environment, so bindings in either branch are locals.
+    #[test]
+    fn records_names_assigned_inside_if_expression_branches() {
+        assert_exact("res <- if (c) a else { b <- 1 }", &["res", "b"]);
+    }
+
+    /// Negative controls: the `for` iterator is a control test and the
+    /// `if`-expression condition is not walked, so assignments nested
+    /// there are not recorded even though R evaluates the test.
+    #[test]
+    fn does_not_record_control_test_assignments() {
+        assert_exact("for (i in g(a <- 1)) print(i)", &["i"]);
+        assert_exact("res <- if (mk(w <- 1)) a else b", &["res"]);
+    }
+
+    /// Names bound through `<-`/`<<-` in expression position are
+    /// recorded, but the left operand subtree is not walked (only the
+    /// bound identifier is recorded, matching R's unevaluated target).
+    #[test]
+    fn records_expression_position_assignment_names_without_walking_lhs() {
+        assert_exact("z <- (y <- f(x <- 1))", &["z", "y"]);
+    }
 }
 
 #[cfg(test)]

--- a/crates/ry-checker/src/infer/index.rs
+++ b/crates/ry-checker/src/infer/index.rs
@@ -1,4 +1,6 @@
 use super::*;
+use ry_core::walk::{AstNode, Descend, Walk, walk_stmts};
+use std::ops::ControlFlow;
 
 fn atomic_mode(member: &RType) -> bool {
     matches!(
@@ -672,85 +674,54 @@ pub(crate) fn insert_s3_dispatch_context(method_name: &str, scope: &mut Scope, g
     }
 }
 
+/// Names assigned anywhere in a body, for closure-capture candidates.
+/// Skips function bodies, assignment targets, control tests (if/while
+/// conditions, for iterators), and every expression form except blocks,
+/// `if`, and assignment operators.
 pub(crate) fn assigned_names_in_body(body: &[Stmt]) -> HashSet<String> {
-    fn visit(statement: &Stmt, names: &mut HashSet<String>) {
-        match statement {
-            Stmt::Assign { target, value, .. } => {
-                if let Expr::Ident { name, .. } = target {
-                    names.insert(name.clone());
-                }
-                // A nested closure has its own locals; do not leak them into
-                // the enclosing closure's capture candidates.
-                if !matches!(value, Expr::Function { .. }) {
-                    visit_expr(value, names);
-                }
-            }
-            Stmt::If { then, else_, .. } => {
-                for statement in then {
-                    visit(statement, names);
-                }
-                if let Some(else_) = else_ {
-                    for statement in else_ {
-                        visit(statement, names);
+    let mut names = HashSet::new();
+    let _ = walk_stmts(
+        body,
+        Walk {
+            assign_targets: false,
+            assign_operands: false,
+            fn_bodies: false,
+            control_tests: false,
+            ..Walk::ALL
+        },
+        |node: AstNode<'_>, _: usize| -> ControlFlow<(), Descend> {
+            match node {
+                AstNode::Stmt(Stmt::Assign { target, .. }) => {
+                    if let Expr::Ident { name, .. } = target {
+                        names.insert(name.clone());
                     }
                 }
-            }
-            Stmt::For { name, body, .. } => {
-                names.insert(name.clone());
-                for statement in body {
-                    visit(statement, names);
-                }
-            }
-            Stmt::While { body, .. } => {
-                for statement in body {
-                    visit(statement, names);
-                }
-            }
-            Stmt::FunctionDef { name, .. } => {
-                if let Some(name) = name {
+                AstNode::Stmt(Stmt::For { name, .. }) => {
                     names.insert(name.clone());
                 }
-            }
-            Stmt::Expr(expr) => visit_expr(expr, names),
-            Stmt::Return { value, .. } => {
-                if let Some(value) = value {
-                    visit_expr(value, names);
-                }
-            }
-        }
-    }
-    fn visit_expr(expr: &Expr, names: &mut HashSet<String>) {
-        match expr {
-            Expr::BinOp {
-                op: BinOpKind::Assign | BinOpKind::SuperAssign,
-                lhs,
-                rhs,
-                ..
-            } => {
-                if let Expr::Ident { name, .. } = lhs.as_ref() {
+                AstNode::Stmt(Stmt::FunctionDef {
+                    name: Some(name), ..
+                }) => {
                     names.insert(name.clone());
                 }
-                visit_expr(rhs, names);
-            }
-            Expr::Block { body, .. } => {
-                for statement in body {
-                    visit(statement, names);
+                AstNode::Expr(Expr::BinOp {
+                    op: BinOpKind::Assign | BinOpKind::SuperAssign,
+                    lhs,
+                    ..
+                }) => {
+                    if let Expr::Ident { name, .. } = lhs.as_ref() {
+                        names.insert(name.clone());
+                    }
                 }
+                // Only blocks and `if` can carry further statements, and
+                // only assignment operators bind from expression position;
+                // calls, indexing, and literals cannot introduce names.
+                AstNode::Expr(_) => return ControlFlow::Continue(Descend::Skip),
+                AstNode::Stmt(_) => {}
             }
-            Expr::If { then, else_, .. } => {
-                visit_expr(then, names);
-                if let Some(else_) = else_ {
-                    visit_expr(else_, names);
-                }
-            }
-            _ => {}
-        }
-    }
-
-    let mut names = HashSet::new();
-    for statement in body {
-        visit(statement, &mut names);
-    }
+            ControlFlow::Continue(Descend::Into)
+        },
+    );
     names
 }
 

--- a/crates/ry-checker/src/infer/misc.rs
+++ b/crates/ry-checker/src/infer/misc.rs
@@ -1,5 +1,7 @@
 use super::*;
 use crate::semantic_lists::DEFUSING_CALLS;
+use ry_core::walk::{AstNode, Descend, Walk, walk_expr, walk_stmts};
+use std::ops::ControlFlow;
 
 pub(crate) fn equality_list_leaf_type(value: &RType) -> Option<RType> {
     if !matches!(value.mode, Mode::List) {
@@ -732,55 +734,25 @@ pub(crate) fn parse_class_literal(e: &Expr) -> ClassLiteral {
 }
 
 /// Walk `stmts` collecting calls inside `caller`'s body that forward its
-/// `params` to nested calls.
+/// `params` to nested calls. Skips nested function bodies: a nested
+/// function has its own formals and is collected separately when it has
+/// a binding.
 pub(crate) fn collect_forwarded_calls_in_stmts(
     caller: &str,
     params: &[Param],
     stmts: &[Stmt],
     calls: &mut Vec<ForwardedCall>,
 ) {
-    for statement in stmts {
-        match statement {
-            Stmt::Assign { target, value, .. } => {
-                collect_forwarded_calls_in_expr(caller, params, target, calls);
-                collect_forwarded_calls_in_expr(caller, params, value, calls);
-            }
-            Stmt::Expr(expr) => collect_forwarded_calls_in_expr(caller, params, expr, calls),
-            Stmt::If {
-                cond, then, else_, ..
-            } => {
-                collect_forwarded_calls_in_expr(caller, params, cond, calls);
-                collect_forwarded_calls_in_stmts(caller, params, then, calls);
-                if let Some(else_) = else_ {
-                    collect_forwarded_calls_in_stmts(caller, params, else_, calls);
-                }
-            }
-            Stmt::For { iter, body, .. }
-            | Stmt::While {
-                cond: iter, body, ..
-            } => {
-                collect_forwarded_calls_in_expr(caller, params, iter, calls);
-                collect_forwarded_calls_in_stmts(caller, params, body, calls);
-            }
-            Stmt::FunctionDef { .. } => {}
-            Stmt::Return { value, .. } => {
-                if let Some(value) = value {
-                    collect_forwarded_calls_in_expr(caller, params, value, calls);
-                }
-            }
-        }
-    }
-}
-
-pub(crate) fn collect_forwarded_calls_in_expr(
-    caller: &str,
-    params: &[Param],
-    expr: &Expr,
-    calls: &mut Vec<ForwardedCall>,
-) {
-    match expr {
-        Expr::Call { func, args, .. } => {
-            if let Expr::Ident { name, .. } = func.as_ref() {
+    let _ = walk_stmts(
+        stmts,
+        Walk {
+            fn_bodies: false,
+            ..Walk::ALL
+        },
+        |node: AstNode<'_>, _: usize| -> ControlFlow<(), Descend> {
+            if let AstNode::Expr(Expr::Call { func, args, .. }) = node
+                && let Expr::Ident { name, .. } = func.as_ref()
+            {
                 let callee = crate::semantic_lists::bare_name(name);
                 calls.push(ForwardedCall {
                     caller: caller.to_string(),
@@ -799,44 +771,9 @@ pub(crate) fn collect_forwarded_calls_in_expr(
                         .collect(),
                 });
             }
-            collect_forwarded_calls_in_expr(caller, params, func, calls);
-            for argument in args {
-                collect_forwarded_calls_in_expr(caller, params, &argument.value, calls);
-            }
-        }
-        Expr::BinOp { lhs, rhs, .. } => {
-            collect_forwarded_calls_in_expr(caller, params, lhs, calls);
-            collect_forwarded_calls_in_expr(caller, params, rhs, calls);
-        }
-        Expr::UnaryOp { expr, .. } => collect_forwarded_calls_in_expr(caller, params, expr, calls),
-        Expr::Index { base, args, .. } => {
-            collect_forwarded_calls_in_expr(caller, params, base, calls);
-            for argument in args {
-                collect_forwarded_calls_in_expr(caller, params, &argument.value, calls);
-            }
-        }
-        Expr::Block { body, .. } => collect_forwarded_calls_in_stmts(caller, params, body, calls),
-        Expr::If {
-            cond, then, else_, ..
-        } => {
-            collect_forwarded_calls_in_expr(caller, params, cond, calls);
-            collect_forwarded_calls_in_expr(caller, params, then, calls);
-            if let Some(else_) = else_ {
-                collect_forwarded_calls_in_expr(caller, params, else_, calls);
-            }
-        }
-        // A nested function has its own formals; it is collected separately
-        // when it has a binding, so do not attribute its calls to this caller.
-        Expr::Function { .. }
-        | Expr::Logical(_, _)
-        | Expr::Integer(_, _)
-        | Expr::Double(_, _)
-        | Expr::String(_, _)
-        | Expr::Null(_)
-        | Expr::Na(_, _)
-        | Expr::Ident { .. }
-        | Expr::Unknown(_) => {}
-    }
+            ControlFlow::Continue(Descend::Into)
+        },
+    );
 }
 
 impl Checker {
@@ -950,6 +887,17 @@ fn build_trusted_defusers(fn_table: &FnTable) -> HashSet<String> {
     trusted
 }
 
+// The force/identifier family below (`guaranteed_force_before_replacement`,
+// `definitely_forced_identifier{,_in_stmt}`, `first_executed_identifier{,_in_stmt}`)
+// is deliberately NOT expressed through the shared walker in
+// `ry_core::walk`: its rules select individual children of a node —
+// call arguments are skipped unless the callee is a known strict
+// builtin, an `if` with a literal condition visits only the taken
+// branch, a `$` subscript's synthesized ident is skipped while the base
+// is kept — and the walk must stop at the first identifier forced in
+// evaluation order. That is an evaluation-order analysis with
+// per-child laziness rules, not a subtree-skip policy, so it keeps its
+// hand-rolled recursion.
 fn guaranteed_force_before_replacement(
     body: &[Stmt],
     wanted: &str,
@@ -1169,93 +1117,26 @@ fn first_executed_identifier(
     }
 }
 
+/// Identifiers the expression evaluates when forced. Skips assignment
+/// targets (R does not evaluate them), `$` subscript idents, and nested
+/// function bodies.
 fn collect_executed_identifiers(expr: &Expr, names: &mut HashSet<String>) {
-    match expr {
-        Expr::Ident { name, .. } => {
-            names.insert(name.clone());
-        }
-        Expr::Call { func, args, .. } => {
-            collect_executed_identifiers(func, names);
-            for argument in args {
-                collect_executed_identifiers(&argument.value, names);
+    let _ = walk_expr(
+        expr,
+        Walk {
+            assign_targets: false,
+            assign_operands: false,
+            dollar_args: false,
+            fn_bodies: false,
+            ..Walk::ALL
+        },
+        |node: AstNode<'_>, _: usize| -> ControlFlow<(), Descend> {
+            if let AstNode::Expr(Expr::Ident { name, .. }) = node {
+                names.insert(name.clone());
             }
-        }
-        Expr::BinOp { lhs, rhs, op, .. } => {
-            if !matches!(op, BinOpKind::Assign | BinOpKind::SuperAssign) {
-                collect_executed_identifiers(lhs, names);
-            }
-            collect_executed_identifiers(rhs, names);
-        }
-        Expr::UnaryOp { expr, .. } => collect_executed_identifiers(expr, names),
-        Expr::Index {
-            base, kind, args, ..
-        } => {
-            collect_executed_identifiers(base, names);
-            if !matches!(kind, IndexKind::Dollar) {
-                for argument in args {
-                    collect_executed_identifiers(&argument.value, names);
-                }
-            }
-        }
-        Expr::Block { body, .. } => {
-            for statement in body {
-                collect_identifiers_in_stmt(statement, names);
-            }
-        }
-        Expr::If {
-            cond, then, else_, ..
-        } => {
-            collect_executed_identifiers(cond, names);
-            collect_executed_identifiers(then, names);
-            if let Some(else_) = else_ {
-                collect_executed_identifiers(else_, names);
-            }
-        }
-        Expr::Function { .. }
-        | Expr::Logical(_, _)
-        | Expr::Integer(_, _)
-        | Expr::Double(_, _)
-        | Expr::String(_, _)
-        | Expr::Null(_)
-        | Expr::Na(_, _)
-        | Expr::Unknown(_) => {}
-    }
-}
-
-fn collect_identifiers_in_stmt(statement: &Stmt, names: &mut HashSet<String>) {
-    match statement {
-        Stmt::Assign { value, .. } | Stmt::Expr(value) => {
-            collect_executed_identifiers(value, names);
-        }
-        Stmt::If {
-            cond, then, else_, ..
-        } => {
-            collect_executed_identifiers(cond, names);
-            for statement in then {
-                collect_identifiers_in_stmt(statement, names);
-            }
-            if let Some(else_) = else_ {
-                for statement in else_ {
-                    collect_identifiers_in_stmt(statement, names);
-                }
-            }
-        }
-        Stmt::For { iter, body, .. }
-        | Stmt::While {
-            cond: iter, body, ..
-        } => {
-            collect_executed_identifiers(iter, names);
-            for statement in body {
-                collect_identifiers_in_stmt(statement, names);
-            }
-        }
-        Stmt::Return { value, .. } => {
-            if let Some(value) = value {
-                collect_executed_identifiers(value, names);
-            }
-        }
-        Stmt::FunctionDef { .. } => {}
-    }
+            ControlFlow::Continue(Descend::Into)
+        },
+    );
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/ry-checker/src/infer/mod.rs
+++ b/crates/ry-checker/src/infer/mod.rs
@@ -2,6 +2,8 @@ use super::*;
 pub(crate) use index::*;
 pub(crate) use misc::*;
 pub(crate) use pipe::PipeForm;
+use ry_core::walk::{AstNode, Descend, Walk, walk_stmts};
+use std::ops::ControlFlow;
 pub(crate) mod binop;
 pub(crate) mod call;
 pub(crate) mod construct;
@@ -110,97 +112,43 @@ fn expression_has_list_origin(expression: &Expr, scope: &Scope) -> bool {
 }
 
 fn vector_intent_parameters(params: &[Param], body: &[Stmt]) -> HashSet<String> {
-    fn visit_expr(expr: &Expr, formals: &HashSet<&str>, intent: &mut HashSet<String>) {
-        match expr {
-            Expr::Call { func, args, .. } => {
-                if ident_name(func).is_some_and(|name| {
-                    matches!(crate::semantic_lists::bare_name(name), "paste" | "paste0")
-                }) && args
-                    .iter()
-                    .any(|argument| matches!(argument.name.as_deref(), Some("collapse")))
-                {
-                    for argument in args {
-                        if argument.name.as_deref() != Some("collapse")
-                            && let Expr::Ident { name, .. } = &argument.value
-                            && formals.contains(name.as_str())
-                        {
-                            intent.insert(name.clone());
-                        }
-                    }
-                }
-                visit_expr(func, formals, intent);
-                for argument in args {
-                    visit_expr(&argument.value, formals, intent);
-                }
-            }
-            Expr::BinOp { lhs, rhs, .. } => {
-                visit_expr(lhs, formals, intent);
-                visit_expr(rhs, formals, intent);
-            }
-            Expr::UnaryOp { expr, .. } => visit_expr(expr, formals, intent),
-            Expr::Index { base, args, .. } => {
-                visit_expr(base, formals, intent);
-                for argument in args {
-                    visit_expr(&argument.value, formals, intent);
-                }
-            }
-            Expr::Block { body, .. } | Expr::Function { body, .. } => {
-                visit_stmts(body, formals, intent)
-            }
-            Expr::If {
-                cond, then, else_, ..
-            } => {
-                visit_expr(cond, formals, intent);
-                visit_expr(then, formals, intent);
-                if let Some(else_) = else_ {
-                    visit_expr(else_, formals, intent);
-                }
-            }
-            _ => {}
-        }
-    }
-
-    fn visit_stmts(stmts: &[Stmt], formals: &HashSet<&str>, intent: &mut HashSet<String>) {
-        for statement in stmts {
-            match statement {
-                Stmt::Assign { target, value, .. } => {
-                    visit_expr(target, formals, intent);
-                    visit_expr(value, formals, intent);
-                }
-                Stmt::Expr(expr) => visit_expr(expr, formals, intent),
-                Stmt::If {
-                    cond, then, else_, ..
-                } => {
-                    visit_expr(cond, formals, intent);
-                    visit_stmts(then, formals, intent);
-                    if let Some(else_) = else_ {
-                        visit_stmts(else_, formals, intent);
-                    }
-                }
-                Stmt::For { iter, body, .. } => {
-                    visit_expr(iter, formals, intent);
-                    visit_stmts(body, formals, intent);
-                }
-                Stmt::While { cond, body, .. } => {
-                    visit_expr(cond, formals, intent);
-                    visit_stmts(body, formals, intent);
-                }
-                Stmt::Return { value, .. } => {
-                    if let Some(value) = value {
-                        visit_expr(value, formals, intent);
-                    }
-                }
-                Stmt::FunctionDef { .. } => {}
-            }
-        }
-    }
-
     let formals: HashSet<&str> = params
         .iter()
         .map(|parameter| parameter.name.as_str())
         .collect();
     let mut intent = HashSet::new();
-    visit_stmts(body, &formals, &mut intent);
+    // Skips nested `function(...)` statements (their formals are their
+    // own) but walks function-literal bodies, where paste calls still
+    // evaluate the enclosing formals.
+    let _ = walk_stmts(
+        body,
+        Walk::ALL,
+        |node: AstNode<'_>, _: usize| -> ControlFlow<(), Descend> {
+            if let AstNode::Expr(Expr::Call { func, args, .. }) = node
+                && ident_name(func).is_some_and(|name| {
+                    matches!(crate::semantic_lists::bare_name(name), "paste" | "paste0")
+                })
+                && args
+                    .iter()
+                    .any(|argument| matches!(argument.name.as_deref(), Some("collapse")))
+            {
+                for argument in args {
+                    if argument.name.as_deref() != Some("collapse")
+                        && let Expr::Ident { name, .. } = &argument.value
+                        && formals.contains(name.as_str())
+                    {
+                        intent.insert(name.clone());
+                    }
+                }
+            }
+            match node {
+                // A nested `function(...)` statement's formals are its own;
+                // calls inside it do not evaluate this function's formals.
+                AstNode::Stmt(Stmt::FunctionDef { .. }) => ControlFlow::Continue(Descend::Skip),
+                _ => ControlFlow::Continue(Descend::Into),
+            }
+        },
+    );
     intent
 }
 

--- a/crates/ry-cli/src/dump.rs
+++ b/crates/ry-cli/src/dump.rs
@@ -5,10 +5,13 @@
 //! emitted types are exactly what a `ry check` run infers.
 
 use std::collections::HashMap;
+use std::ops::ControlFlow;
 use std::path::PathBuf;
 use std::process::ExitCode;
 
 use miette::{IntoDiagnostic, Result};
+use ry_core::ast::{BinOpKind, Expr, Stmt};
+use ry_core::walk::{AstNode, Descend, Walk, walk_stmts};
 
 use crate::check;
 use crate::pipeline;
@@ -109,230 +112,86 @@ fn line_char_col_to_offset(source: &str, row: usize, col: usize) -> Option<usize
 ///
 /// R has no separate block scoping, so assignments inside `if`/`for`/
 /// `while` bodies and braced value blocks bind in the enclosing function
-/// scope. Function-literal bodies are excluded: those are their own
-/// scopes (recorded separately), though the *name* bound to a function
-/// literal (`inner <- function(...)`) is itself a local of this scope.
-fn collect_local_bindings(stmts: &[ry_core::ast::Stmt], out: &mut HashMap<String, ry_core::Span>) {
-    for statement in stmts {
-        match statement {
-            ry_core::ast::Stmt::Assign { target, value, .. } => {
-                match target {
-                    ry_core::ast::Expr::Ident { name, span }
-                    | ry_core::ast::Expr::String(name, span) => {
-                        out.entry(name.clone()).or_insert(*span);
-                    }
-                    // Indexed targets (`d$col <- v`) mutate an existing
-                    // binding rather than creating one; the base name's
-                    // plain assignment (if any) is found elsewhere. The
-                    // target's index arguments are not walked either: the
-                    // checker does not bind assignments hidden there
-                    // (`m[i <- 1L] <- v` leaves `i` unbound), and the dump
-                    // reports exactly what a `ry check` run infers.
-                    _ => {}
-                }
-                collect_local_bindings_in_expr(value, out);
-            }
-            ry_core::ast::Stmt::Expr(e) => collect_local_bindings_in_expr(e, out),
-            ry_core::ast::Stmt::If {
-                cond, then, else_, ..
-            } => {
-                collect_local_bindings_in_expr(cond, out);
-                collect_local_bindings(then, out);
-                if let Some(else_) = else_ {
-                    collect_local_bindings(else_, out);
-                }
-            }
-            ry_core::ast::Stmt::For {
-                name,
-                name_span,
-                iter,
-                body,
-                ..
-            } => {
-                out.entry(name.clone()).or_insert(*name_span);
-                collect_local_bindings_in_expr(iter, out);
-                collect_local_bindings(body, out);
-            }
-            ry_core::ast::Stmt::While { cond, body, .. } => {
-                collect_local_bindings_in_expr(cond, out);
-                collect_local_bindings(body, out);
-            }
-            // `return(e)` still binds any assignment inside `e`; a bare
-            // function definition binds no name in this scope.
-            ry_core::ast::Stmt::Return { value, .. } => {
-                if let Some(value) = value {
-                    collect_local_bindings_in_expr(value, out);
-                }
-            }
-            ry_core::ast::Stmt::FunctionDef { .. } => {}
-        }
-    }
-}
-
-/// Statement-level assignment scan through expression positions. R nests
-/// both statements (braced blocks) and side-effecting assignments
-/// (`f(x <- 1L)`, chained `a <- b <- 1L`, `if (flag <- f())`) inside
-/// arbitrary expressions, and all of them bind in the enclosing function
-/// scope. The recursion set mirrors the checker's own expression walker
-/// (`ry_checker::infer`'s `visit_expr`); literal leaves bind nothing.
-/// Function-literal bodies are excluded: those are their own scopes
-/// (recorded separately), though the *name* bound to a function literal
+/// scope. Runs on the shared walker; skips function bodies and
+/// assignment targets (indexed targets mutate rather than bind, and the
+/// checker does not bind assignments hidden in a target's index
+/// arguments, so the dump reports exactly what a `ry check` run
+/// infers). The *name* bound to a function literal
 /// (`inner <- function(...)`) is itself a local of this scope.
-fn collect_local_bindings_in_expr(
-    expr: &ry_core::ast::Expr,
-    out: &mut HashMap<String, ry_core::Span>,
-) {
-    match expr {
-        ry_core::ast::Expr::Call { func, args, .. } => {
-            collect_local_bindings_in_expr(func, out);
-            for argument in args {
-                collect_local_bindings_in_expr(&argument.value, out);
-            }
-        }
-        // Assignment operators in expression position bind the LHS in
-        // the current scope — the checker's `Expr::BinOp` arm does the
-        // same for `<-`/`<<-` (R's `<-` returns the value invisibly) and
-        // `%<>%` (which rebinds its LHS ident).
-        ry_core::ast::Expr::BinOp {
-            op:
-                ry_core::ast::BinOpKind::Assign
-                | ry_core::ast::BinOpKind::SuperAssign
-                | ry_core::ast::BinOpKind::PipeAssign,
-            lhs,
-            rhs,
-            ..
-        } => {
-            match lhs.as_ref() {
-                ry_core::ast::Expr::Ident { name, span }
-                | ry_core::ast::Expr::String(name, span) => {
+fn collect_local_bindings(stmts: &[ry_core::ast::Stmt], out: &mut HashMap<String, ry_core::Span>) {
+    let _ = walk_stmts(
+        stmts,
+        Walk {
+            assign_targets: false,
+            fn_bodies: false,
+            ..Walk::ALL
+        },
+        |node: AstNode<'_>, _: usize| -> ControlFlow<(), Descend> {
+            match node {
+                AstNode::Stmt(Stmt::Assign {
+                    target: Expr::Ident { name, span } | Expr::String(name, span),
+                    ..
+                }) => {
                     out.entry(name.clone()).or_insert(*span);
                 }
-                // Replacement-function targets (`names(d) <- v`) and
-                // indexed targets mutate; the checker's assignment arms
-                // decide those, not this walk.
+                AstNode::Stmt(Stmt::For {
+                    name, name_span, ..
+                }) => {
+                    out.entry(name.clone()).or_insert(*name_span);
+                }
+                // Assignment operators in expression position bind the
+                // LHS in the current scope: `<-`/`<<-` (R's `<-` returns
+                // the value invisibly) and `%<>%` (which rebinds its LHS
+                // ident). The LHS subtree is still walked: a nested
+                // `a <- b <- 1L` chain binds both names.
+                AstNode::Expr(Expr::BinOp {
+                    op: BinOpKind::Assign | BinOpKind::SuperAssign | BinOpKind::PipeAssign,
+                    lhs,
+                    ..
+                }) => {
+                    if let Expr::Ident { name, span } | Expr::String(name, span) = lhs.as_ref() {
+                        out.entry(name.clone()).or_insert(*span);
+                    }
+                }
                 _ => {}
             }
-            collect_local_bindings_in_expr(lhs, out);
-            collect_local_bindings_in_expr(rhs, out);
-        }
-        ry_core::ast::Expr::BinOp { lhs, rhs, .. } => {
-            collect_local_bindings_in_expr(lhs, out);
-            collect_local_bindings_in_expr(rhs, out);
-        }
-        ry_core::ast::Expr::UnaryOp { expr, .. } => collect_local_bindings_in_expr(expr, out),
-        ry_core::ast::Expr::Index { base, args, .. } => {
-            collect_local_bindings_in_expr(base, out);
-            for argument in args {
-                collect_local_bindings_in_expr(&argument.value, out);
-            }
-        }
-        ry_core::ast::Expr::Block { body, .. } => collect_local_bindings(body, out),
-        ry_core::ast::Expr::If {
-            then, else_, cond, ..
-        } => {
-            collect_local_bindings_in_expr(cond, out);
-            collect_local_bindings_in_expr(then, out);
-            if let Some(else_) = else_ {
-                collect_local_bindings_in_expr(else_, out);
-            }
-        }
-        // Function literals are separate scopes; their bodies are indexed
-        // by index_scope_bodies instead. Literals and `Unknown` bind
-        // nothing.
-        _ => {}
-    }
+            ControlFlow::Continue(Descend::Into)
+        },
+    );
 }
 
 /// Map every function body in the file to its start byte, so each
-/// recorded scope can look up its own local bindings. Mirrors the
-/// statement recursion of `collect_local_bindings` to find nested named
-/// functions at any block depth.
+/// recorded scope can look up its own local bindings. Walks into
+/// function bodies (that is what is being indexed) but skips assignment
+/// targets; each discovered body is indexed and pruned in one step.
 fn index_scope_bodies(
     stmts: &[ry_core::ast::Stmt],
     index: &mut HashMap<usize, HashMap<String, ry_core::Span>>,
 ) {
-    for statement in stmts {
-        match statement {
-            ry_core::ast::Stmt::Assign { value, .. } => match value {
-                ry_core::ast::Expr::Function { body, span, .. } => {
+    let _ = walk_stmts(
+        stmts,
+        Walk {
+            assign_targets: false,
+            ..Walk::ALL
+        },
+        |node: AstNode<'_>, _: usize| -> ControlFlow<(), Descend> {
+            match node {
+                AstNode::Stmt(Stmt::FunctionDef { body, span, .. }) => {
                     index_function_body(*span, body, index);
+                    return ControlFlow::Continue(Descend::Skip);
                 }
-                _ => index_scope_bodies_in_expr(value, index),
-            },
-            ry_core::ast::Stmt::FunctionDef { body, span, .. } => {
-                index_function_body(*span, body, index);
-            }
-            ry_core::ast::Stmt::If {
-                cond, then, else_, ..
-            } => {
-                index_scope_bodies_in_expr(cond, index);
-                index_scope_bodies(then, index);
-                if let Some(else_) = else_ {
-                    index_scope_bodies(else_, index);
+                AstNode::Stmt(Stmt::Assign {
+                    value: Expr::Function { body, span, .. },
+                    ..
+                }) => {
+                    index_function_body(*span, body, index);
+                    return ControlFlow::Continue(Descend::Skip);
                 }
+                _ => {}
             }
-            ry_core::ast::Stmt::For { iter, body, .. } => {
-                index_scope_bodies_in_expr(iter, index);
-                index_scope_bodies(body, index);
-            }
-            ry_core::ast::Stmt::While { cond, body, .. } => {
-                index_scope_bodies_in_expr(cond, index);
-                index_scope_bodies(body, index);
-            }
-            ry_core::ast::Stmt::Expr(e) => index_scope_bodies_in_expr(e, index),
-            ry_core::ast::Stmt::Return { value, .. } => {
-                if let Some(value) = value {
-                    index_scope_bodies_in_expr(value, index);
-                }
-            }
-        }
-    }
-}
-
-/// Same expression recursion as [`collect_local_bindings_in_expr`]: named
-/// functions are reachable through any expression position (a callback's
-/// body, a call argument, an index argument), and only finding them there
-/// gives their scopes `function_locals` entries.
-fn index_scope_bodies_in_expr(
-    expr: &ry_core::ast::Expr,
-    index: &mut HashMap<usize, HashMap<String, ry_core::Span>>,
-) {
-    match expr {
-        ry_core::ast::Expr::Call { func, args, .. } => {
-            index_scope_bodies_in_expr(func, index);
-            for argument in args {
-                index_scope_bodies_in_expr(&argument.value, index);
-            }
-        }
-        ry_core::ast::Expr::BinOp { lhs, rhs, .. } => {
-            index_scope_bodies_in_expr(lhs, index);
-            index_scope_bodies_in_expr(rhs, index);
-        }
-        ry_core::ast::Expr::UnaryOp { expr, .. } => index_scope_bodies_in_expr(expr, index),
-        ry_core::ast::Expr::Index { base, args, .. } => {
-            index_scope_bodies_in_expr(base, index);
-            for argument in args {
-                index_scope_bodies_in_expr(&argument.value, index);
-            }
-        }
-        ry_core::ast::Expr::Block { body, .. } => index_scope_bodies(body, index),
-        ry_core::ast::Expr::If {
-            then, else_, cond, ..
-        } => {
-            index_scope_bodies_in_expr(cond, index);
-            index_scope_bodies_in_expr(then, index);
-            if let Some(else_) = else_ {
-                index_scope_bodies_in_expr(else_, index);
-            }
-        }
-        // An anonymous function literal gets no `ScopeRecord` of its own
-        // (the checker infers it in discarding mode), but named functions
-        // defined inside it complete and are recorded — walk the body so
-        // those nested definitions are indexed. The literal itself needs
-        // no `function_locals` entry: no record will ever look it up.
-        ry_core::ast::Expr::Function { body, .. } => index_scope_bodies(body, index),
-        _ => {}
-    }
+            ControlFlow::Continue(Descend::Into)
+        },
+    );
 }
 
 fn index_function_body(

--- a/crates/ry-core/src/lib.rs
+++ b/crates/ry-core/src/lib.rs
@@ -5,6 +5,7 @@ pub mod ast;
 pub mod parser;
 pub mod span;
 pub mod types;
+pub mod walk;
 
 pub use ast::*;
 pub use parser::{ParseError, RParser};

--- a/crates/ry-core/src/walk.rs
+++ b/crates/ry-core/src/walk.rs
@@ -275,7 +275,12 @@ mod tests {
 
     /// The policy knobs skip exactly their documented subtrees: the
     /// `$field` identifier, the `<-` LHS and `Stmt::Assign` target, the
-    /// function body, and the `if` condition.
+    /// function body, and the `if` condition. The combined off-policy
+    /// here is deliberately not per-knob proof: `assign_targets` and
+    /// `dollar_args` overlap on `field`, and `assign_operands` is never
+    /// exercised (no expression-position assignment). The companion
+    /// `assign_knobs_each_prune_a_subtree_only_they_reach` test isolates
+    /// those two knobs.
     #[test]
     fn policy_flags_skip_exactly_their_subtrees() {
         let src = "if (cond(x)) { d$field <- f(d$other, function(y) z) }";
@@ -308,6 +313,56 @@ mod tests {
             assert!(
                 skipped.contains(&name.to_string()),
                 "kept {name}: {skipped:?}"
+            );
+        }
+    }
+
+    /// Each assignment knob alone must prune a subtree only that knob
+    /// reaches. `assign_targets` is isolated from `dollar_args` with a
+    /// plain `[` subscript target (`arr[f(t)] <- ...`: no `$` argument
+    /// anywhere), and `assign_operands` gets an expression-position
+    /// assignment with a compound LHS (`out <- (m[j <- 1L] <- v)`),
+    /// whose inner `<-` LHS is only reachable through that knob. In
+    /// both cases the value side must stay visited.
+    #[test]
+    fn assign_knobs_each_prune_a_subtree_only_they_reach() {
+        let targets = visited(
+            "arr[f(t)] <- g(u)",
+            Walk {
+                assign_targets: false,
+                ..Walk::ALL
+            },
+        );
+        for name in ["arr", "f", "t"] {
+            assert!(
+                !targets.contains(&name.to_string()),
+                "assign_targets=false must skip the subscripted target {name}: {targets:?}"
+            );
+        }
+        for name in ["g", "u"] {
+            assert!(
+                targets.contains(&name.to_string()),
+                "the value side must stay visited: {targets:?}"
+            );
+        }
+
+        let operands = visited(
+            "out <- (m[j <- 1L] <- v)",
+            Walk {
+                assign_operands: false,
+                ..Walk::ALL
+            },
+        );
+        for name in ["m", "j"] {
+            assert!(
+                !operands.contains(&name.to_string()),
+                "assign_operands=false must skip the expression-position LHS {name}: {operands:?}"
+            );
+        }
+        for name in ["out", "v"] {
+            assert!(
+                operands.contains(&name.to_string()),
+                "the outer target and RHS must stay visited: {operands:?}"
             );
         }
     }

--- a/crates/ry-core/src/walk.rs
+++ b/crates/ry-core/src/walk.rs
@@ -1,0 +1,357 @@
+//! The shared Stmt/Expr recursion skeleton for collection-style AST
+//! analyses (name collection, call indexing, binding scans).
+//!
+//! The walkers this replaces differ on purpose: some treat nested
+//! function bodies as opaque, some skip assignment targets because R
+//! does not evaluate them, some skip the synthesized identifier a `$`
+//! subscript stores in the AST. Those differences are policy knobs on
+//! one walker ([`Walk`]) plus a per-node "don't descend" answer from
+//! the callback — not a dozen hand-rolled recursions.
+//!
+//! Evaluation-order analyses (does this call force its arguments?
+//! which `if` branch runs?) do not fit this shape: their rules select
+//! individual children of a node (call arguments, one branch) rather
+//! than whole subtrees. They stay hand-rolled at their call sites.
+
+use crate::ast::{BinOpKind, Expr, IndexKind, Stmt};
+use std::ops::ControlFlow;
+
+/// One node handed to a [`walk_stmts`](fn@walk_stmts) callback.
+#[derive(Debug, Copy, Clone)]
+pub enum AstNode<'a> {
+    Stmt(&'a Stmt),
+    Expr(&'a Expr),
+}
+
+/// What the walker does with a node's children after the callback saw
+/// the node itself (pre-order: the callback always runs first).
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum Descend {
+    /// Recurse into the node's children (subject to the [`Walk`] policy).
+    Into,
+    /// Skip this node's children; the callback's own logic is the last
+    /// word on this subtree.
+    Skip,
+}
+
+/// Which well-known subtrees a walk enters. Every field defaults to
+/// "visit"; a family opts out of exactly the edges its hand-rolled
+/// predecessor skipped.
+#[derive(Debug, Copy, Clone)]
+pub struct Walk {
+    /// Descend into `Stmt::Assign` targets. R does not evaluate the
+    /// target of an assignment, so identifier-execution and
+    /// binding-collection walks leave this off.
+    pub assign_targets: bool,
+    /// Descend into the left operand of `<-` / `<<-` in expression
+    /// position (`y <- x <- 1L`). Walks that only record the bound
+    /// name leave this off.
+    pub assign_operands: bool,
+    /// Descend into `$field` subscript arguments. The parser stores the
+    /// field as a synthesized identifier node, but R never evaluates it
+    /// as an expression; identifier-execution walks leave this off.
+    pub dollar_args: bool,
+    /// Descend into nested function bodies (`Expr::Function` literals
+    /// and `Stmt::FunctionDef`). A closure has its own scope and its
+    /// own formals, so scope- and quoting-sensitive walks leave this
+    /// off.
+    pub fn_bodies: bool,
+    /// Descend into `if`/`while` conditions and `for` iterators.
+    /// Binding-collection walks that model only the body leave this
+    /// off.
+    pub control_tests: bool,
+}
+
+impl Walk {
+    /// Visit every subtree. The policy of walkers with no skip rules.
+    pub const ALL: Walk = Walk {
+        assign_targets: true,
+        assign_operands: true,
+        dollar_args: true,
+        fn_bodies: true,
+        control_tests: true,
+    };
+}
+
+/// Walk a statement slice in source order, pre-order per node. Returns
+/// the first [`ControlFlow::Break`] payload from the callback, or
+/// `Continue(())` after the last node.
+///
+/// The callback receives each statement and expression node together
+/// with `fn_depth`, the number of function bodies entered so far (0 at
+/// the top level of the walk; braced blocks do not count).
+pub fn walk_stmts<B>(
+    stmts: &[Stmt],
+    policy: Walk,
+    mut visit: impl FnMut(AstNode<'_>, usize) -> ControlFlow<B, Descend>,
+) -> ControlFlow<B> {
+    for stmt in stmts {
+        stmt_step(stmt, policy, 0, &mut visit)?;
+    }
+    ControlFlow::Continue(())
+}
+
+/// Walk one statement (and its subtree). See [`walk_stmts`].
+pub fn walk_stmt<B>(
+    stmt: &Stmt,
+    policy: Walk,
+    mut visit: impl FnMut(AstNode<'_>, usize) -> ControlFlow<B, Descend>,
+) -> ControlFlow<B> {
+    stmt_step(stmt, policy, 0, &mut visit)
+}
+
+/// Walk one expression (and its subtree). See [`walk_stmts`].
+pub fn walk_expr<B>(
+    expr: &Expr,
+    policy: Walk,
+    mut visit: impl FnMut(AstNode<'_>, usize) -> ControlFlow<B, Descend>,
+) -> ControlFlow<B> {
+    expr_step(expr, policy, 0, &mut visit)
+}
+
+fn stmt_step<B>(
+    stmt: &Stmt,
+    policy: Walk,
+    fn_depth: usize,
+    visit: &mut impl FnMut(AstNode<'_>, usize) -> ControlFlow<B, Descend>,
+) -> ControlFlow<B> {
+    match visit(AstNode::Stmt(stmt), fn_depth) {
+        ControlFlow::Break(b) => return ControlFlow::Break(b),
+        ControlFlow::Continue(Descend::Skip) => return ControlFlow::Continue(()),
+        ControlFlow::Continue(Descend::Into) => {}
+    }
+    match stmt {
+        Stmt::Assign { target, value, .. } => {
+            if policy.assign_targets {
+                expr_step(target, policy, fn_depth, visit)?;
+            }
+            expr_step(value, policy, fn_depth, visit)?;
+        }
+        Stmt::Expr(expression) => expr_step(expression, policy, fn_depth, visit)?,
+        Stmt::If {
+            cond, then, else_, ..
+        } => {
+            if policy.control_tests {
+                expr_step(cond, policy, fn_depth, visit)?;
+            }
+            for stmt in then {
+                stmt_step(stmt, policy, fn_depth, visit)?;
+            }
+            if let Some(else_) = else_ {
+                for stmt in else_ {
+                    stmt_step(stmt, policy, fn_depth, visit)?;
+                }
+            }
+        }
+        Stmt::For { iter, body, .. } => {
+            if policy.control_tests {
+                expr_step(iter, policy, fn_depth, visit)?;
+            }
+            for stmt in body {
+                stmt_step(stmt, policy, fn_depth, visit)?;
+            }
+        }
+        Stmt::While { cond, body, .. } => {
+            if policy.control_tests {
+                expr_step(cond, policy, fn_depth, visit)?;
+            }
+            for stmt in body {
+                stmt_step(stmt, policy, fn_depth, visit)?;
+            }
+        }
+        Stmt::FunctionDef { body, .. } => {
+            if policy.fn_bodies {
+                for stmt in body {
+                    stmt_step(stmt, policy, fn_depth + 1, visit)?;
+                }
+            }
+        }
+        Stmt::Return { value, .. } => {
+            if let Some(value) = value {
+                expr_step(value, policy, fn_depth, visit)?;
+            }
+        }
+    }
+    ControlFlow::Continue(())
+}
+
+fn expr_step<B>(
+    expr: &Expr,
+    policy: Walk,
+    fn_depth: usize,
+    visit: &mut impl FnMut(AstNode<'_>, usize) -> ControlFlow<B, Descend>,
+) -> ControlFlow<B> {
+    match visit(AstNode::Expr(expr), fn_depth) {
+        ControlFlow::Break(b) => return ControlFlow::Break(b),
+        ControlFlow::Continue(Descend::Skip) => return ControlFlow::Continue(()),
+        ControlFlow::Continue(Descend::Into) => {}
+    }
+    match expr {
+        Expr::Call { func, args, .. } => {
+            expr_step(func, policy, fn_depth, visit)?;
+            for argument in args {
+                expr_step(&argument.value, policy, fn_depth, visit)?;
+            }
+        }
+        Expr::BinOp { op, lhs, rhs, .. } => {
+            let assignment = matches!(op, BinOpKind::Assign | BinOpKind::SuperAssign);
+            if !(assignment && !policy.assign_operands) {
+                expr_step(lhs, policy, fn_depth, visit)?;
+            }
+            expr_step(rhs, policy, fn_depth, visit)?;
+        }
+        Expr::UnaryOp { expr, .. } => expr_step(expr, policy, fn_depth, visit)?,
+        Expr::Index {
+            base, kind, args, ..
+        } => {
+            expr_step(base, policy, fn_depth, visit)?;
+            if !(*kind == IndexKind::Dollar && !policy.dollar_args) {
+                for argument in args {
+                    expr_step(&argument.value, policy, fn_depth, visit)?;
+                }
+            }
+        }
+        Expr::Function { body, .. } => {
+            if policy.fn_bodies {
+                for stmt in body {
+                    stmt_step(stmt, policy, fn_depth + 1, visit)?;
+                }
+            }
+        }
+        Expr::Block { body, .. } => {
+            for stmt in body {
+                stmt_step(stmt, policy, fn_depth, visit)?;
+            }
+        }
+        Expr::If {
+            cond, then, else_, ..
+        } => {
+            if policy.control_tests {
+                expr_step(cond, policy, fn_depth, visit)?;
+            }
+            expr_step(then, policy, fn_depth, visit)?;
+            if let Some(else_) = else_ {
+                expr_step(else_, policy, fn_depth, visit)?;
+            }
+        }
+        Expr::Logical(_, _)
+        | Expr::Integer(_, _)
+        | Expr::Double(_, _)
+        | Expr::String(_, _)
+        | Expr::Null(_)
+        | Expr::Na(_, _)
+        | Expr::Ident { .. }
+        | Expr::Unknown(_) => {}
+    }
+    ControlFlow::Continue(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{RParser, SourceFile};
+    use std::collections::HashSet;
+
+    fn parse(src: &str) -> SourceFile {
+        RParser::new()
+            .expect("parser")
+            .parse("walk_test.R", src)
+            .expect("parse")
+    }
+
+    fn visited(src: &str, policy: Walk) -> Vec<String> {
+        let file = parse(src);
+        let mut seen = Vec::new();
+        let _ = walk_stmts(&file.stmts, policy, |node, _| {
+            match node {
+                AstNode::Stmt(Stmt::Assign { .. }) => seen.push("stmt-assign".into()),
+                AstNode::Expr(Expr::Ident { name, .. }) => seen.push(name.clone()),
+                _ => {}
+            }
+            ControlFlow::<(), Descend>::Continue(Descend::Into)
+        });
+        seen
+    }
+
+    /// The policy knobs skip exactly their documented subtrees: the
+    /// `$field` identifier, the `<-` LHS and `Stmt::Assign` target, the
+    /// function body, and the `if` condition.
+    #[test]
+    fn policy_flags_skip_exactly_their_subtrees() {
+        let src = "if (cond(x)) { d$field <- f(d$other, function(y) z) }";
+        let all = visited(src, Walk::ALL);
+        for name in ["cond", "x", "d", "field", "f", "other", "z"] {
+            assert!(
+                all.contains(&name.to_string()),
+                "ALL must visit {name}: {all:?}"
+            );
+        }
+        let skipped = visited(
+            src,
+            Walk {
+                assign_targets: false,
+                assign_operands: false,
+                dollar_args: false,
+                fn_bodies: false,
+                control_tests: false,
+            },
+        );
+        for name in ["cond", "x", "field", "other", "z"] {
+            assert!(
+                !skipped.contains(&name.to_string()),
+                "policy must skip {name}: {skipped:?}"
+            );
+        }
+        // The callee and a `$` index base in value position are still
+        // evaluated, so both remain visited.
+        for name in ["d", "f"] {
+            assert!(
+                skipped.contains(&name.to_string()),
+                "kept {name}: {skipped:?}"
+            );
+        }
+    }
+
+    /// `fn_depth` counts entered function bodies; braced blocks do not.
+    #[test]
+    fn fn_depth_counts_function_bodies_not_blocks() {
+        let file = parse("{ f(function() g(function() h)) }");
+        let mut depths = HashSet::new();
+        let _ = walk_stmts(&file.stmts, Walk::ALL, |node, depth| {
+            if let AstNode::Expr(Expr::Ident { name, .. }) = node {
+                depths.insert((name.clone(), depth));
+            }
+            ControlFlow::<(), Descend>::Continue(Descend::Into)
+        });
+        assert!(depths.contains(&("f".to_string(), 0)));
+        assert!(depths.contains(&("g".to_string(), 1)));
+        assert!(depths.contains(&("h".to_string(), 2)));
+    }
+
+    /// `Break` stops the walk with its payload; `Skip` prunes a subtree
+    /// the callback has fully handled.
+    #[test]
+    fn break_stops_and_skip_prunes() {
+        let file = parse("f(a, { b <- g(c); h(d) })");
+        let mut seen = Vec::new();
+        let hit = walk_stmts(&file.stmts, Walk::ALL, |node, _| match node {
+            AstNode::Expr(Expr::Call { func, .. }) if matches!(func.as_ref(), Expr::Ident { name, .. } if name == "g") => {
+                ControlFlow::Continue(Descend::Skip)
+            }
+            AstNode::Expr(Expr::Ident { name, .. }) if name == "h" => {
+                ControlFlow::Break(name.clone())
+            }
+            AstNode::Expr(Expr::Ident { name, .. }) => {
+                seen.push(name.clone());
+                ControlFlow::Continue(Descend::Into)
+            }
+            _ => ControlFlow::Continue(Descend::Into),
+        });
+        // `c` was pruned with the `g` call, and `d` never ran: `h` broke.
+        assert_eq!(hit, ControlFlow::Break("h".to_string()));
+        assert_eq!(
+            seen,
+            vec!["f".to_string(), "a".to_string(), "b".to_string()]
+        );
+    }
+}

--- a/crates/ry-workspace/src/lib.rs
+++ b/crates/ry-workspace/src/lib.rs
@@ -1428,6 +1428,143 @@ fn is_excluded_package_directory(package_root: &Path, path: &Path) -> bool {
         || matches!(components.as_slice(), ["tests", "testthat", "_snaps"])
 }
 
+/// Pins the recording conditions of [`collect_dynamic_bindings_stmts`].
+/// The environment argument's *presence* is what records, never its
+/// value: any `envir`/`env`/`assign.env` expression, or an unnamed
+/// positional argument in the environment slot (third for
+/// `assign`/`makeActiveBinding`, fourth for `delayedAssign`), makes the
+/// target explicit. Bare `assign` records only via the `fn_depth == 0`
+/// arm; bare `makeActiveBinding`/`delayedAssign` never do.
+#[cfg(test)]
+mod dynamic_binding_tests {
+    use super::*;
+
+    fn collect_from(src: &str) -> SourceBindings {
+        let mut parser = ry_core::RParser::new().unwrap();
+        let file = parser.parse("dynamic_binding_test.R", src).unwrap();
+        let mut found = SourceBindings::default();
+        collect_dynamic_bindings_stmts(&file.stmts, &mut found);
+        found
+    }
+
+    fn assert_exact(src: &str, expected: &[&str]) {
+        let found = collect_from(src).bindings;
+        let expected: HashSet<String> = expected.iter().map(|name| name.to_string()).collect();
+        assert_eq!(found, expected, "bindings from `{src}`");
+    }
+
+    /// A bare two-argument `assign("x", v)` targets the package namespace
+    /// only at the file top level (`fn_depth == 0`; braced blocks do not
+    /// count). Inside a function body the same call binds in that call's
+    /// execution environment and records nothing.
+    #[test]
+    fn bare_assign_records_only_at_top_level() {
+        assert_exact("assign(\"top\", value)", &["top"]);
+        assert_exact("{ assign(\"in_block\", value) }", &["in_block"]);
+        assert_exact(
+            "on_load <- function() assign(\"nested\", value)
+assign(\"top\", value)",
+            &["top"],
+        );
+    }
+
+    /// Only `assign` has the top-level bare arm: bare
+    /// `makeActiveBinding`/`delayedAssign` record nothing even at the
+    /// file top level.
+    #[test]
+    fn bare_make_active_binding_and_delayed_assign_never_record() {
+        assert_exact(
+            "makeActiveBinding(\"active\", getter)
+delayedAssign(\"later\", value)",
+            &[],
+        );
+    }
+
+    /// A named `envir`/`env`/`assign.env` argument records at any depth,
+    /// whatever the environment expression is -- `asNamespace(...)`,
+    /// `globalenv()`, or a namespace variable threaded through an
+    /// `.onLoad` helper.
+    #[test]
+    fn named_environment_argument_records_inside_function_bodies() {
+        assert_exact(
+            "on_load <- function(libname, pkgname) {
+  assign(\"ns_var\", 1, envir = asNamespace(\"pkg\"))
+  assign(\"global_var\", 1, envir = globalenv())
+  assign(\"env_alias\", 1, env = ns)
+  makeActiveBinding(\"active\", getter, assign.env = ns)
+}
+",
+            &["ns_var", "global_var", "env_alias", "active"],
+        );
+    }
+
+    /// The environment passed positionally -- third argument of
+    /// `assign`/`makeActiveBinding`, fourth of `delayedAssign` -- also
+    /// records inside function bodies, matching `.onLoad` helpers that
+    /// thread the namespace through positionally.
+    #[test]
+    fn positional_environment_argument_records_inside_function_bodies() {
+        assert_exact(
+            "on_load <- function(libname, pkgname) {
+  assign(\"positional\", 1, ns)
+  makeActiveBinding(\"lazy_active\", getter, ns)
+  delayedAssign(\"lazy_later\", value, NULL, ns)
+}
+",
+            &["positional", "lazy_active", "lazy_later"],
+        );
+    }
+
+    /// A named third argument that is not an environment alias
+    /// (`inherits = TRUE`) leaves the call bare for depth purposes:
+    /// ignored inside a function body, recorded at the file top level by
+    /// the `assign`-only arm.
+    #[test]
+    fn named_non_environment_argument_stays_depth_gated() {
+        assert_exact("f <- function() assign(\"flag\", 1, inherits = TRUE)", &[]);
+        assert_exact("assign(\"flag\", 1, inherits = TRUE)", &["flag"]);
+    }
+
+    /// Only a literal string target is statically knowable. An
+    /// identifier target computes the binding name at runtime and
+    /// records nothing -- even at the top level with an explicit
+    /// environment, so an unknown dynamic name cannot mask an unresolved
+    /// variable.
+    #[test]
+    fn non_literal_target_names_record_nothing() {
+        assert_exact("assign(name_var, value)", &[]);
+        assert_exact("assign(name_var, value, envir = ns)", &[]);
+        assert_exact("f <- function() assign(name_var, value, envir = ns)", &[]);
+    }
+
+    /// `.Call(ffi_enquo, ...)` proves `ffi_enquo` names a native routine
+    /// rather than a variable (rlang later passes the same symbol as an
+    /// ordinary value). Every FFI primitive records its first argument
+    /// when it is an unnamed symbol; a string entry point or a named
+    /// first argument is not a symbol witness.
+    #[test]
+    fn ffi_primitives_record_unnamed_symbol_first_arguments() {
+        assert_eq!(
+            collect_from(".Call(ffi_enquo, quote(arg))").native_symbols,
+            HashSet::from(["ffi_enquo".to_string()])
+        );
+        assert_eq!(
+            collect_from(".External2(entry, x)").native_symbols,
+            HashSet::from(["entry".to_string()])
+        );
+        assert!(
+            collect_from(".Call(\"as_string\", x)")
+                .native_symbols
+                .is_empty()
+        );
+        assert!(
+            collect_from(".Call(name = ffi_enquo, x)")
+                .native_symbols
+                .is_empty()
+        );
+    }
+}
+
 #[cfg(test)]
 mod shared_tests {
     use super::*;

--- a/crates/ry-workspace/src/lib.rs
+++ b/crates/ry-workspace/src/lib.rs
@@ -17,8 +17,10 @@ pub use ry_core::FFI_PRIMITIVES;
 use ry_core::SERIALIZED_BINDINGS_UNENUMERABLE;
 use ry_core::SourceFile;
 use ry_core::ast::{Expr, Stmt};
+use ry_core::walk::{AstNode, Descend, Walk, walk_stmts};
 use std::collections::{BTreeSet, HashMap, HashSet};
 use std::io::Read;
+use std::ops::ControlFlow;
 use std::path::{Path, PathBuf};
 
 /// Inputs which describe the analysis environment without evaluating R code.
@@ -361,9 +363,7 @@ fn source_package_dynamic_bindings(root: &Path) -> SourceBindings {
         let Ok(file) = parser.parse(&path.to_string_lossy(), &source) else {
             continue;
         };
-        for statement in &file.stmts {
-            collect_dynamic_bindings_stmt(statement, 0, &mut found);
-        }
+        collect_dynamic_bindings_stmts(&file.stmts, &mut found);
     }
     found
 }
@@ -389,142 +389,59 @@ fn collect_r_source_files(directory: &Path, paths: &mut Vec<PathBuf>) {
     }
 }
 
-fn collect_dynamic_bindings_stmt(
-    statement: &Stmt,
-    function_depth: usize,
-    found: &mut SourceBindings,
-) {
-    match statement {
-        Stmt::Assign { target, value, .. } => {
-            collect_dynamic_bindings_expr(target, function_depth, found);
-            collect_dynamic_bindings_expr(value, function_depth, found);
+/// Collect the dynamic-binding calls from one file's statements.
+/// Walks every subtree including function bodies; the walker's
+/// `fn_depth` (number of enclosing function bodies) decides whether a
+/// bare two-argument `assign("x", v)` still targets the namespace:
+/// only the file's top level does.
+fn collect_dynamic_bindings_stmts(stmts: &[Stmt], found: &mut SourceBindings) {
+    let _ = walk_stmts(stmts, Walk::ALL, |node: AstNode<'_>, fn_depth: usize| {
+        let AstNode::Expr(Expr::Call { func, args, .. }) = node else {
+            return ControlFlow::<(), Descend>::Continue(Descend::Into);
+        };
+        let Expr::Ident { name, .. } = func.as_ref() else {
+            return ControlFlow::<(), Descend>::Continue(Descend::Into);
+        };
+        // `.Call(ffi_enquo, ...)` proves `ffi_enquo` names a native
+        // routine, not a variable. rlang then passes the same symbol
+        // as an ordinary value (`capture_arg = ffi_enquo`), which the
+        // call-position rule alone cannot see. Record the witness so
+        // every later use of the name resolves.
+        if FFI_PRIMITIVES.contains(&name.as_str())
+            && let Some(Expr::Ident { name: symbol, .. }) = args
+                .first()
+                .filter(|arg| arg.name.is_none())
+                .map(|arg| &arg.value)
+        {
+            found.native_symbols.insert(symbol.clone());
         }
-        Stmt::Expr(expr) => collect_dynamic_bindings_expr(expr, function_depth, found),
-        Stmt::If {
-            cond, then, else_, ..
-        } => {
-            collect_dynamic_bindings_expr(cond, function_depth, found);
-            for statement in then {
-                collect_dynamic_bindings_stmt(statement, function_depth, found);
-            }
-            if let Some(else_) = else_ {
-                for statement in else_ {
-                    collect_dynamic_bindings_stmt(statement, function_depth, found);
-                }
-            }
+        let has_named_environment = args.iter().any(|argument| {
+            matches!(
+                argument.name.as_deref(),
+                Some("envir" | "env" | "assign.env")
+            )
+        });
+        // The environment parameter is commonly passed positionally
+        // from .onLoad helpers (for example `assign("x", value,
+        // env)`). Treat only its documented position as explicit;
+        // a two-argument assign inside a function remains local.
+        let has_positional_environment = match name.as_str() {
+            "assign" | "makeActiveBinding" => args.get(2).is_some_and(|arg| arg.name.is_none()),
+            "delayedAssign" => args.get(3).is_some_and(|arg| arg.name.is_none()),
+            _ => false,
+        };
+        if matches!(
+            name.as_str(),
+            "assign" | "makeActiveBinding" | "delayedAssign"
+        ) && (has_named_environment
+            || has_positional_environment
+            || (name == "assign" && fn_depth == 0))
+            && let Some(Expr::String(binding, _)) = args.first().map(|argument| &argument.value)
+        {
+            found.bindings.insert(binding.clone());
         }
-        Stmt::For { iter, body, .. } => {
-            collect_dynamic_bindings_expr(iter, function_depth, found);
-            for statement in body {
-                collect_dynamic_bindings_stmt(statement, function_depth, found);
-            }
-        }
-        Stmt::While { cond, body, .. } => {
-            collect_dynamic_bindings_expr(cond, function_depth, found);
-            for statement in body {
-                collect_dynamic_bindings_stmt(statement, function_depth, found);
-            }
-        }
-        Stmt::FunctionDef { body, .. } => {
-            for statement in body {
-                collect_dynamic_bindings_stmt(statement, function_depth + 1, found);
-            }
-        }
-        Stmt::Return { value, .. } => {
-            if let Some(value) = value {
-                collect_dynamic_bindings_expr(value, function_depth, found);
-            }
-        }
-    }
-}
-
-fn collect_dynamic_bindings_expr(expr: &Expr, function_depth: usize, found: &mut SourceBindings) {
-    match expr {
-        Expr::Call { func, args, .. } => {
-            if let Expr::Ident { name, .. } = func.as_ref() {
-                // `.Call(ffi_enquo, ...)` proves `ffi_enquo` names a native
-                // routine, not a variable. rlang then passes the same symbol
-                // as an ordinary value (`capture_arg = ffi_enquo`), which the
-                // call-position rule alone cannot see. Record the witness so
-                // every later use of the name resolves.
-                if FFI_PRIMITIVES.contains(&name.as_str())
-                    && let Some(Expr::Ident { name: symbol, .. }) = args
-                        .first()
-                        .filter(|arg| arg.name.is_none())
-                        .map(|arg| &arg.value)
-                {
-                    found.native_symbols.insert(symbol.clone());
-                }
-                let has_named_environment = args.iter().any(|argument| {
-                    matches!(
-                        argument.name.as_deref(),
-                        Some("envir" | "env" | "assign.env")
-                    )
-                });
-                // The environment parameter is commonly passed positionally
-                // from .onLoad helpers (for example `assign("x", value,
-                // env)`). Treat only its documented position as explicit;
-                // a two-argument assign inside a function remains local.
-                let has_positional_environment = match name.as_str() {
-                    "assign" | "makeActiveBinding" => {
-                        args.get(2).is_some_and(|arg| arg.name.is_none())
-                    }
-                    "delayedAssign" => args.get(3).is_some_and(|arg| arg.name.is_none()),
-                    _ => false,
-                };
-                if matches!(
-                    name.as_str(),
-                    "assign" | "makeActiveBinding" | "delayedAssign"
-                ) && (has_named_environment
-                    || has_positional_environment
-                    || (name == "assign" && function_depth == 0))
-                    && let Some(Expr::String(binding, _)) =
-                        args.first().map(|argument| &argument.value)
-                {
-                    found.bindings.insert(binding.clone());
-                }
-            }
-            collect_dynamic_bindings_expr(func, function_depth, found);
-            for argument in args {
-                collect_dynamic_bindings_expr(&argument.value, function_depth, found);
-            }
-        }
-        Expr::BinOp { lhs, rhs, .. } => {
-            collect_dynamic_bindings_expr(lhs, function_depth, found);
-            collect_dynamic_bindings_expr(rhs, function_depth, found);
-        }
-        Expr::UnaryOp { expr, .. } => collect_dynamic_bindings_expr(expr, function_depth, found),
-        Expr::Index { base, args, .. } => {
-            collect_dynamic_bindings_expr(base, function_depth, found);
-            for argument in args {
-                collect_dynamic_bindings_expr(&argument.value, function_depth, found);
-            }
-        }
-        Expr::Function { body, .. } | Expr::Block { body, .. } => {
-            let function_depth =
-                function_depth + usize::from(matches!(expr, Expr::Function { .. }));
-            for statement in body {
-                collect_dynamic_bindings_stmt(statement, function_depth, found);
-            }
-        }
-        Expr::If {
-            cond, then, else_, ..
-        } => {
-            collect_dynamic_bindings_expr(cond, function_depth, found);
-            collect_dynamic_bindings_expr(then, function_depth, found);
-            if let Some(else_) = else_ {
-                collect_dynamic_bindings_expr(else_, function_depth, found);
-            }
-        }
-        Expr::Logical(_, _)
-        | Expr::Integer(_, _)
-        | Expr::Double(_, _)
-        | Expr::String(_, _)
-        | Expr::Null(_)
-        | Expr::Na(_, _)
-        | Expr::Ident { .. }
-        | Expr::Unknown(_) => {}
-    }
+        ControlFlow::<(), Descend>::Continue(Descend::Into)
+    });
 }
 
 #[derive(Default)]

--- a/crates/ry-workspace/src/packages.rs
+++ b/crates/ry-workspace/src/packages.rs
@@ -6,7 +6,9 @@
 
 use ry_core::SourceFile;
 use ry_core::ast::{Expr, Stmt};
+use ry_core::walk::{AstNode, Descend, Walk, walk_stmts};
 use std::collections::{HashMap, HashSet};
+use std::ops::ControlFlow;
 
 /// External-binding sentinel carrying a `useDynLib(..., .fixes = "prefix")`
 /// prefix. Any name starting with the prefix resolves to a native routine.
@@ -120,12 +122,20 @@ pub fn namespace_metadata(file: &SourceFile) -> NamespaceMetadata {
 /// Find packages attached by `library()` or `require()` calls.
 ///
 /// `requireNamespace()` is deliberately excluded: it makes `pkg::name`
-/// available but does not place `name` on R's search path.
+/// available but does not place `name` on R's search path. Walks every
+/// subtree including function bodies: an attachment counts wherever the
+/// call appears.
 pub fn attached_packages(file: &SourceFile) -> HashSet<String> {
     let mut packages = HashSet::new();
-    for stmt in &file.stmts {
-        visit_stmt_for_attachments(stmt, &mut packages);
-    }
+    let _ = walk_stmts(&file.stmts, Walk::ALL, |node: AstNode<'_>, _: usize| {
+        if let AstNode::Expr(Expr::Call { func, args, .. }) = node
+            && matches!(func.as_ref(), Expr::Ident { name, .. } if name == "library" || name == "require")
+            && let Some(package) = args.first().and_then(|arg| static_name(&arg.value))
+        {
+            packages.insert(package);
+        }
+        ControlFlow::<(), Descend>::Continue(Descend::Into)
+    });
     packages
 }
 
@@ -133,99 +143,6 @@ fn static_name(expr: &Expr) -> Option<String> {
     match expr {
         Expr::Ident { name, .. } | Expr::String(name, _) => Some(name.clone()),
         _ => None,
-    }
-}
-
-fn visit_stmt_for_attachments(stmt: &Stmt, packages: &mut HashSet<String>) {
-    match stmt {
-        Stmt::Assign { target, value, .. } => {
-            visit_expr_for_attachments(target, packages);
-            visit_expr_for_attachments(value, packages);
-        }
-        Stmt::Expr(expr) => visit_expr_for_attachments(expr, packages),
-        Stmt::If {
-            cond, then, else_, ..
-        } => {
-            visit_expr_for_attachments(cond, packages);
-            for stmt in then {
-                visit_stmt_for_attachments(stmt, packages);
-            }
-            if let Some(else_) = else_ {
-                for stmt in else_ {
-                    visit_stmt_for_attachments(stmt, packages);
-                }
-            }
-        }
-        Stmt::For { iter, body, .. }
-        | Stmt::While {
-            cond: iter, body, ..
-        } => {
-            visit_expr_for_attachments(iter, packages);
-            for stmt in body {
-                visit_stmt_for_attachments(stmt, packages);
-            }
-        }
-        Stmt::FunctionDef { body, .. } => {
-            for stmt in body {
-                visit_stmt_for_attachments(stmt, packages);
-            }
-        }
-        Stmt::Return { value, .. } => {
-            if let Some(value) = value {
-                visit_expr_for_attachments(value, packages);
-            }
-        }
-    }
-}
-
-#[allow(clippy::collapsible_if)]
-fn visit_expr_for_attachments(expr: &Expr, packages: &mut HashSet<String>) {
-    match expr {
-        Expr::Call { func, args, .. } => {
-            if matches!(func.as_ref(), Expr::Ident { name, .. } if name == "library" || name == "require")
-            {
-                if let Some(package) = args.first().and_then(|arg| static_name(&arg.value)) {
-                    packages.insert(package);
-                }
-            }
-            visit_expr_for_attachments(func, packages);
-            for arg in args {
-                visit_expr_for_attachments(&arg.value, packages);
-            }
-        }
-        Expr::BinOp { lhs, rhs, .. } => {
-            visit_expr_for_attachments(lhs, packages);
-            visit_expr_for_attachments(rhs, packages);
-        }
-        Expr::UnaryOp { expr, .. } => visit_expr_for_attachments(expr, packages),
-        Expr::Index { base, args, .. } => {
-            visit_expr_for_attachments(base, packages);
-            for arg in args {
-                visit_expr_for_attachments(&arg.value, packages);
-            }
-        }
-        Expr::Function { body, .. } | Expr::Block { body, .. } => {
-            for stmt in body {
-                visit_stmt_for_attachments(stmt, packages);
-            }
-        }
-        Expr::If {
-            cond, then, else_, ..
-        } => {
-            visit_expr_for_attachments(cond, packages);
-            visit_expr_for_attachments(then, packages);
-            if let Some(else_) = else_ {
-                visit_expr_for_attachments(else_, packages);
-            }
-        }
-        Expr::Logical(..)
-        | Expr::Integer(..)
-        | Expr::Double(..)
-        | Expr::String(..)
-        | Expr::Null(..)
-        | Expr::Na(..)
-        | Expr::Ident { .. }
-        | Expr::Unknown(..) => {}
     }
 }
 

--- a/crates/ry-workspace/src/packages.rs
+++ b/crates/ry-workspace/src/packages.rs
@@ -150,6 +150,46 @@ fn static_name(expr: &Expr) -> Option<String> {
 mod tests {
     use super::*;
 
+    fn assert_exact(src: &str, expected: &[&str]) {
+        let mut parser = ry_core::RParser::new().unwrap();
+        let file = parser.parse("attach_test.R", src).unwrap();
+        let expected: HashSet<String> = expected.iter().map(|name| name.to_string()).collect();
+        assert_eq!(attached_packages(&file), expected, "attached from `{src}`");
+    }
+
+    /// An attachment counts wherever the call appears: the walker uses
+    /// `Walk::ALL`, so `library()`/`require()` calls nested inside
+    /// function bodies (an `.onLoad` hook, a helper defined for tests)
+    /// attach their package just like top-level ones.
+    #[test]
+    fn attaches_calls_at_top_level_and_inside_function_bodies() {
+        assert_exact(
+            "library(dplyr)
+run <- function() {
+  require(\"stringr\")
+  if (verbose) library(rlang)
+}
+",
+            &["dplyr", "stringr", "rlang"],
+        );
+    }
+
+    /// `requireNamespace()`/`loadNamespace()` make `pkg::name` available
+    /// without placing exports on the search path, and a package name
+    /// computed at runtime is not statically knowable. None of these
+    /// attach anything.
+    #[test]
+    fn does_not_attach_namespace_helpers_or_dynamic_arguments() {
+        assert_exact(
+            "requireNamespace(\"rlang\")
+loadNamespace(\"tibble\")
+library(get_option(\"pkg\"))
+my_library(dplyr)
+",
+            &[],
+        );
+    }
+
     #[test]
     fn import_from_preserves_binding_provenance_without_attaching_package() {
         let mut parser = ry_core::RParser::new().unwrap();


### PR DESCRIPTION
Cleanup sprint, PR 6 of 7 (stacks on #160). **Closes #152.** Net **−18 lines** overall, but that's a new 357-line reusable walker module (+tests) against a **−605 line** reduction across the eleven files that had hand-rolled walkers. Every consumer is now a thin policy + callback.

## The walker (`ry_core::walk`)

- `walk_stmts`/`walk_stmt`/`walk_expr`: pre-order, `ControlFlow<B>` early-termination with payload, `fn_depth` counting.
- `Walk` policy struct, five boolean knobs: `assign_targets`, `assign_operands`, `dollar_args` (`$`-synthesized idents), `fn_bodies`, `control_tests` — constructed via `..Walk::ALL` (no `Default`, so partial-literal misuse is impossible).
- The #148-era `stmt_any`/`expr_any` in collect.rs now delegate to it: **exactly one walker exists in the codebase**, where before this PR there were two designs.

## Conversion table

| Family | Outcome |
|---|---|
| `collect_condition_assignment_names` (binop.rs) | converted |
| `assigned_names_in_body` (index.rs) | converted |
| `collect_executed_identifiers` pair (misc.rs) | converted + merged |
| `collect_forwarded_calls` pair (misc.rs) | converted + merged |
| RY098 force family (misc.rs, 5 fns) | **left hand-rolled** — its rules are per-child laziness (strict-builtin call args, literal-cond branch choice, first-in-eval-order stop), not subtree skips; documented in place, as #152 sanctioned |
| `vector_intent_parameters` (mod.rs) | converted |
| `r6_rebound_members` (call.rs) | converted |
| `stmt_any`/`expr_any` (collect.rs) | converted onto the shared core |
| `collect_local_bindings` pair (dump.rs) | converted + merged |
| `index_scope_bodies` pair (dump.rs) | converted + merged |
| attachment + dynamic-bindings walkers (ry-workspace) | converted |

Nice confirmation of the knob axes: dump.rs's two walkers hold *opposite* fn-body policies (skip vs. walk); one `fn_bodies` flag expresses both.

## Caught in review, fixed before push (b825060)

The family-by-family equivalence audit found two real traversal regressions where a wildcard `Descend::Skip` arm was one variant too broad: `assigned_names_in_body` stopped walking `Expr::Block`/`Expr::If` in expression position, and `collect_condition_assignment_names` pruned `Stmt::Expr` and non-Ident-target assigns inside condition blocks. Under-collection shapes that byte-identical snapshots cannot catch — exactly why the audit exists. Both restored to base semantics, with 9 new exact-set regression tests (4 proven to fail against the broken version). A third flagged case turned out to be a false positive (`assign_operands` was already `true` via `Walk::ALL`) — now explicit and pinned.

## Gates

`cargo test --workspace` (43 suites, +22 new tests), clippy `-D warnings`, fmt, perf suite (8/8 `--release -- --ignored`), oracle suite with R; snapshots byte-identical throughout, including after the fixes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved code analysis across nested expressions, conditional blocks, assignments, and function bodies.
  - More accurately detects variable bindings and dynamic assignments while respecting function scope.
  - Improved recognition of statically specified packages loaded through `library()` and `require()`, including nested calls.
  - Refined handling of forwarded calls, executed identifiers, vector operations, and rebound members for more consistent inference.
- **Tests**
  - Added coverage for traversal, scoping, package detection, and dynamic-binding behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->