### PR TITLE
refactor: share test harnesses, diet narration comments, rename suppress.rs to resolve.rs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,17 @@ suppression actions — and fixes a parser panic plus several editor issues.
 
 ### Changed
 
+- **Shared test harnesses, leaner comments, `suppress.rs` renamed to
+  `resolve.rs`**: the checker's inline tests gained `check_with` (parse,
+  configure, check) and a shared `parse_file`, replacing copy-pasted
+  parser/checker scaffolding; the language server's session and protocol
+  tests each extract one copy of their spawn/normalize helpers
+  (`tests/harness/`, `tests/common/`); near-duplicate literal-pair tests
+  are table-driven. Narrating comments that restated the next line were
+  removed. Contributor-facing rename: `crates/ry-checker/src/suppress.rs`
+  is now `crates/ry-checker/src/resolve.rs` (same code; it holds the
+  typeshed/package signature and value resolution plus the checker's
+  emit helpers). No behavior change.
 - **One shared front half for `ry check` and `ry dump-types`**: both
   commands resolve their per-package groups, workspace contexts, and
   checker inputs through one pipeline helper, so their file sets,

--- a/crates/ry-checker/src/collect.rs
+++ b/crates/ry-checker/src/collect.rs
@@ -72,20 +72,8 @@ impl Checker {
                         let _ = self.record_fn(name.to_string(), params, body.clone());
                     }
                     self.collect_forwarded_calls(name, params, body);
-                    // Recurse into the function body so nested
-                    // `inner <- function(...) ...` definitions are
-                    // recorded with a mangled name. The mangled name is
-                    // an internal implementation detail (not user-facing)
-                    // used only so the fixpoint can refine the inner
-                    // function's return type independently. Callers that
-                    // close over the inner function via a captured
-                    // `Function`-typed value go through `fn_sig` on the
-                    // outer function's return type, not through this
-                    // table entry.
                     self.collect_nested_fns_in_body(name, body);
                 }
-                // Non-function assignments: nothing further to record
-                // (the name is already in `known_vars`).
             }
             Stmt::If { then, else_, .. } => {
                 for s in then {
@@ -301,7 +289,9 @@ impl Checker {
     // `<outer>$<inner>`. The mangled name is internal: it exists so
     // the fixpoint can refine the inner function's return type, which
     // `refine_fn_return` reads back when building the outer function's
-    // `fn_sig`. Users never see this name.
+    // `fn_sig`. Callers that close over the inner function via a
+    // captured `Function`-typed value go through that `fn_sig`, not
+    // through the table entry. Users never see the mangled name.
     //
     // Recursion is bounded by the AST's literal nesting (small in
     // practice). The inference depth is separately bounded by

--- a/crates/ry-checker/src/infer/construct.rs
+++ b/crates/ry-checker/src/infer/construct.rs
@@ -52,7 +52,9 @@ impl Checker {
     /// Infer the type of `structure(x, class = "...")`. We model only
     /// the literal class forms; everything else returns the first
     /// argument's type with `ClassVector::unknown()` (so we neither lie
-    /// about a class nor spuriously trigger RY050).
+    /// about a class nor spuriously trigger RY050). The base value is the
+    /// first positional or `x =` argument; later candidates are inferred
+    /// for diagnostics only.
     ///
     /// The base value's column schema is preserved: `RType::with_class`
     /// is `RType { class, ..self }`, so a `structure(list(a = 1L),
@@ -61,9 +63,6 @@ impl Checker {
     /// `$a` resolve correctly on user-defined classes built on top of
     /// a list-shaped payload.
     pub(crate) fn infer_structure_call(&mut self, args: &[Arg], scope: &mut Scope) -> RType {
-        // The base value is the first positional argument (or the
-        // `x = ...` named argument). The first such positional-or-`x`
-        // arg wins; later ones are inferred for diagnostics only.
         let mut base_type = RType::unknown();
         let mut class_expr: Option<&Expr> = None;
         for a in args {
@@ -214,15 +213,12 @@ impl Checker {
         RType::new(if saw_union { Mode::Opaque } else { mode }, length)
     }
 
-    // Infer the type of `list(...)`. The result is always a list whose
-    // length equals the argument count; if at least one argument is
-    // named, we additionally build a column schema from the named
-    // args (positional args get R's auto-generated `[[i]]` names).
-    //
-    // We build the schema even when only some args are named: that
-    // mirrors R's `list(a = 1, "x")` which produces names `c("a", "2")`.
-    // The schema is what powers `df$col` / `df[["col"]]` resolution
-    // downstream.
+    /// Infer the type of `list(...)`: a list whose length equals the
+    /// argument count, plus a column schema from named args (positional
+    /// args get R's auto-generated `[[i]]` names). The schema is built
+    /// even when only some args are named, mirroring R's
+    /// `list(a = 1, "x")` producing names `c("a", "2")`; it is what
+    /// powers `df$col` / `df[["col"]]` resolution downstream.
     pub(crate) fn infer_list(&mut self, arg_types: &[RType], args: &[Arg]) -> RType {
         let length = Length::Known(arg_types.len());
         let base = RType::new(Mode::List, length);
@@ -245,20 +241,14 @@ impl Checker {
         base.with_columns(Arc::new(schema))
     }
 
-    // Infer the type of `data.frame(...)`. Same column-schema logic as
-    // `list(...)`, but:
-    // * The result is classed `"data.frame"`.
-    // * Column lengths are coerced to a common length (R recycles). For
-    //   v1 we take the max of the known lengths (or Unknown if any
-    //   column's length is Unknown), and propagate that length onto
-    //   each column so `df$col` returns a vector of the right length.
-    // * Special arguments like `row.names = ...`, `check.names = ...`
-    //   are NOT columns and are dropped from the schema. We recognize
-    //   the common ones by name.
+    /// Infer the type of `data.frame(...)`: the same column-schema logic
+    /// as `list(...)`, but the result is classed `"data.frame"` and
+    /// column lengths are coerced to a common length (R recycles; v1
+    /// takes the max of the known lengths and propagates it onto each
+    /// column so `df$col` returns a vector of the right length). Known
+    /// metadata arguments (`row.names`, `check.names`, ...) are not
+    /// columns and are dropped from the schema.
     pub(crate) fn infer_data_frame(&mut self, arg_types: &[RType], args: &[Arg]) -> RType {
-        // Filter out non-column named arguments first. Positional args
-        // are kept (they become columns); known metadata args are dropped
-        // so they don't pollute the schema.
         use crate::semantic_lists::METADATA_ARGS;
         let mut filtered_types: Vec<RType> = Vec::with_capacity(arg_types.len());
         let mut filtered_args: Vec<Arg> = Vec::with_capacity(args.len());
@@ -272,10 +262,8 @@ impl Checker {
             filtered_args.push(a.clone());
         }
 
-        // Compute the common column length (max of known lengths).
         let common_len = longest_arg_length(&filtered_types);
 
-        // Build per-column types with the coerced length.
         let coerced_types: Vec<RType> = filtered_types
             .iter()
             .map(|t| RType {
@@ -349,26 +337,15 @@ impl Checker {
         RType::new(mode, length)
     }
 
+    /// Infer `rep(x, times, each)`: length is `length(x) * times * each`
+    /// with unsupplied counts defaulting to 1, keeping `x`'s mode, class,
+    /// and schema. `length.out` takes precedence in R but is not modeled.
+    /// `times`/`each` are read from the raw AST, not the inferred
+    /// `RType`, because the type lattice discards the runtime value (a
+    /// supplied non-literal means `Length::Unknown`). `x` is matched by
+    /// name or first unnamed position, because named `times`/`each` can
+    /// precede it in the call.
     pub(crate) fn infer_rep(&self, args: &[Arg], arg_types: &[RType]) -> RType {
-        // Infer `rep(x, times, each)`: length = `length(x) * times * each`
-        // with `times`/`each` defaulting to 1, and the result keeping
-        // `x`'s mode, class, and schema (so `rep(factor(...), 3)` stays
-        // a factor). `length.out` is not modeled: in R it takes
-        // precedence over `times`, but the length here ignores it.
-        //
-        // `times`/`each` come from the raw AST, not the inferred
-        // `RType`, because the type lattice discards the runtime value:
-        // a supplied non-literal means `Length::Unknown`; an unsupplied
-        // one defaults to 1.
-        //
-        // `find_arg`'s `pos` counts only unnamed args, so
-        // `rep(each = 2, c(1,2,3), 1)` matches `x` at 0 and `times`
-        // at 1 (mirrors `infer_seq`).
-        //
-        // `x` is the first positional arg (pos 0) or a named `x = ...`.
-        // We must look it up by index rather than `arg_types.first()`
-        // because named `times`/`each` args can precede `x` in the
-        // call (e.g. `rep(each = 2, c(1,2,3), 1)`).
         let x_type = find_arg(args, "x", 0)
             .and_then(|i| arg_types.get(i).cloned())
             .unwrap_or(RType::unknown());
@@ -425,18 +402,14 @@ impl Checker {
         RType { length, ..x_type }
     }
 
-    // Infer the result type of `seq(from, to, by)` / `seq.int(...)`.
-    // Two literal forms let us pin the result length exactly:
-    //   * `seq(from, to, by)`: length = `|to - from| / |by| + 1`
-    //     (R rounds to the nearest whole step that stays in range).
-    //   * `seq(from, to, length.out = n)`: length = `n`.
-    //   * `seq(from, to)` (no `by`, no `length.out`): R defaults
-    //     `by` to +/-1, so length = `|to - from| + 1`.
-    //
-    // When `length.out` is present it wins (R documents this as
-    // taking precedence over `by`). When we can't pin the length, we
-    // still report the right mode (integer when the first arg is an
-    // integer literal, else double) with `Length::Unknown`.
+    /// Infer the result type of `seq(from, to, by)` / `seq.int(...)`.
+    /// Literal forms pin the length exactly: `|to - from| / |by| + 1`
+    /// (R rounds to the nearest whole step in range), `length.out = n`
+    /// when supplied (it wins over `by`, as R documents), or
+    /// `|to - from| + 1` when `by` is absent (R defaults it to +/-1).
+    /// Otherwise the mode is still reported — integer when the first
+    /// argument is an integer literal, else double — with
+    /// `Length::Unknown`.
     pub(crate) fn infer_seq(&self, args: &[Arg], arg_types: &[RType]) -> RType {
         // Helper: find (was_supplied, literal_value) for a named or
         // positional argument. Named args win over positional. The

--- a/crates/ry-checker/src/infer/mod.rs
+++ b/crates/ry-checker/src/infer/mod.rs
@@ -122,12 +122,6 @@ fn discarded_value_expression(expression: &Expr) -> bool {
     }
 }
 
-// The T7b "mutually-exclusive branch" loop refinement was removed after two
-// rounds of corpus regressions (it ended up flagging loop iterators inside
-// their own bodies). Loop bodies pre-bind every name assigned anywhere
-// in the body before walking; a use-before-first-assignment inside a loop is
-// statically indistinguishable from a legitimate loop-carried binding.
-
 impl Checker {
     /// The unified statement walker. Handles both diagnostic emission
     /// (gated by `self.discarding`) and return-type collection (when
@@ -725,10 +719,8 @@ impl Checker {
         }
     }
 
-    /// runs the single diagnostic `infer` with `discarding` enabled, so
-    /// the type computation (including the full `Expr::Ident` resolution
-    /// ladder, all `Expr::Call` cases, narrowing, etc.) is shared between
-    /// the pure and the diagnostic walks.
+    /// Run `infer` with emission suppressed so callers needing only the
+    /// type share the full resolution ladder with the diagnostic walk.
     pub(crate) fn infer_discarding(&mut self, e: &Expr, scope: &mut Scope) -> RType {
         let prev = self.discarding;
         self.discarding = true;
@@ -850,8 +842,6 @@ impl Checker {
             return None;
         }
         let joined = join_all(returns.into_iter());
-        // If we couldn't infer anything useful (joined is UNKNOWN),
-        // there's no point attaching an empty signature.
         if matches!(joined.mode, Mode::Opaque) {
             return None;
         }

--- a/crates/ry-checker/src/infer/pipe.rs
+++ b/crates/ry-checker/src/infer/pipe.rs
@@ -205,7 +205,6 @@ impl Checker {
                 self.infer_pipe_call(rhs, &new_args, lhs, lhs_t.clone(), scope, span)
             }
             _ => {
-                // Unknown rhs form: infer rhs for diagnostics, give up on type.
                 let _ = self.infer(rhs, scope);
                 RType::unknown()
             }
@@ -237,7 +236,6 @@ impl Checker {
     /// the value flows through as the LHS.
     pub(crate) fn infer_pipe_tee(&mut self, lhs: &Expr, rhs: &Expr, scope: &mut Scope) -> RType {
         let lhs_t = self.infer(lhs, scope);
-        // Still walk the RHS so any diagnostics on its body fire.
         let _ = self.infer_pipe_with_lhs_type(
             lhs,
             rhs,
@@ -296,11 +294,9 @@ impl Checker {
     /// can't know which branch will execute at runtime). Each
     /// alternative is also walked for diagnostics.
     pub(crate) fn infer_switch_call(&mut self, args: &[Arg], scope: &mut Scope) -> RType {
-        // The first argument is the selector; infer it for diagnostics.
         if let Some(first) = args.first() {
             let _ = self.infer(&first.value, scope);
         }
-        // Join the types of all remaining arguments (the alternatives).
         let mut alt_types: Vec<RType> = Vec::new();
         for a in args.iter().skip(1) {
             alt_types.push(self.infer(&a.value, scope));
@@ -326,20 +322,14 @@ impl Checker {
         let mut types: Vec<RType> = Vec::new();
         for (i, a) in args.iter().enumerate() {
             if i == 0 {
-                // Main expression.
                 types.push(self.infer(&a.value, scope));
             } else if a.name.is_some() {
-                // Named handler: `error = function(e) ...`. Infer the
-                // handler function's return type.
                 if let Some(rt) = self.callback_return_type(&a.value, &[RType::unknown()], scope) {
                     types.push(rt);
                 } else {
-                    // Couldn't infer handler return: infer for
-                    // diagnostics and use opaque.
                     let _ = self.infer(&a.value, scope);
                 }
             } else {
-                // Extra positional arg (rare): infer for diagnostics.
                 let _ = self.infer(&a.value, scope);
             }
         }

--- a/crates/ry-checker/src/lib.rs
+++ b/crates/ry-checker/src/lib.rs
@@ -17,13 +17,10 @@ mod higher_order;
 mod infer;
 mod nse;
 pub mod project;
+mod resolve;
 pub mod rules;
 pub mod semantic_lists;
-mod suppress;
 
-// Re-export `Project` at the crate root so callers (the CLI, integration
-// tests) can write `ry_checker::Project` rather than
-// `ry_checker::project::Project`. Mirrors the ergonomics of `Checker`.
 pub use project::Project;
 // Re-export the diagnostic data types and suppression helpers at the
 // crate root for back-compat (callers and tests reference
@@ -34,9 +31,8 @@ pub use diagnostics::{
     parse_suppressions_from_comments,
 };
 
-// These builders construct a `SeverityFilter`, a checker type, from a
-// config's rule lists. They live here because ry-checker depends on
-// ry-config; the reverse direction would be a cycle.
+// These builders live here, not in ry-config, because ry-checker depends
+// on ry-config and the reverse direction would be a cycle.
 
 /// Build a [`SeverityFilter`] from the `error`, `warn`, and `ignore`
 /// rule lists in a config.

--- a/crates/ry-checker/src/project.rs
+++ b/crates/ry-checker/src/project.rs
@@ -803,12 +803,7 @@ impl Project {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use ry_core::RParser;
-
-    fn parse(path: &str, src: &str) -> SourceFile {
-        let mut p = RParser::new().unwrap();
-        p.parse(path, src).unwrap()
-    }
+    use crate::tests::parse_file;
 
     #[test]
     fn empty_project_has_no_diagnostics() {
@@ -822,7 +817,7 @@ mod tests {
         // Sanity: a single-file Project should behave like a single-file
         // Checker (no surprises from the extra plumbing).
         let src = "f <- function() { \"hello\" }\ny <- f() + 1L\n";
-        let file = parse("a.R", src);
+        let file = parse_file("a.R", src);
 
         let mut project = Project::new();
         project.add_file("a.R".to_string(), file);
@@ -840,7 +835,7 @@ mod tests {
         let mut project = Project::new();
         project.add_file(
             "inst/shiny/src/server/fragment.R".to_string(),
-            parse(
+            parse_file(
                 "inst/shiny/src/server/fragment.R",
                 "output$value <- input$value\nsession$sendCustomMessage('x', list())\n",
             ),
@@ -863,11 +858,11 @@ mod tests {
         let mut project = Project::new();
         project.add_file(
             "function.R".to_string(),
-            parse("function.R", "list.map <- function(.data, expr) expr\n"),
+            parse_file("function.R", "list.map <- function(.data, expr) expr\n"),
         );
         project.add_file(
             "call.R".to_string(),
-            parse("call.R", "r <- list.map(some_list(), . + score)\n"),
+            parse_file("call.R", "r <- list.map(some_list(), . + score)\n"),
         );
         project.set_loaded(std::collections::HashSet::from(["rlist".to_string()]));
         let diagnostics: Vec<_> = project
@@ -895,7 +890,7 @@ mod tests {
         // call site a defaulted formal stays opaque by design.
         let src = "base <- 2L\nouter <- function(x = 1L, y) {\n  local <- x + base\n  inner <- function(z) z + base\n  inner(y)\n}\nouter()\n";
         let mut project = Project::new();
-        project.add_file("a.R".to_string(), parse("a.R", src));
+        project.add_file("a.R".to_string(), parse_file("a.R", src));
         project.enable_scope_capture();
         project.check();
         let records = project.take_scope_records();
@@ -936,7 +931,7 @@ mod tests {
         assert!(outer.scope.get("local").is_some());
         // No capture without opting in.
         let mut plain = Project::new();
-        plain.add_file("a.R".to_string(), parse("a.R", src));
+        plain.add_file("a.R".to_string(), parse_file("a.R", src));
         plain.check();
         assert!(plain.take_scope_records().is_empty());
     }

--- a/crates/ry-checker/src/resolve.rs
+++ b/crates/ry-checker/src/resolve.rs
@@ -1,3 +1,6 @@
+//! Typeshed and package signature/value resolution, plus the checker's
+//! diagnostic emit helpers.
+
 use super::*;
 use crate::infer::json_rtype_to_rtype;
 

--- a/crates/ry-checker/src/tests/data_frames_s3.rs
+++ b/crates/ry-checker/src/tests/data_frames_s3.rs
@@ -55,17 +55,10 @@ fn registered_unexported_s3_method_in_stub_satisfies_dispatch() {
     )
     .unwrap();
     let stubs = Arc::new(ry_typeshed::load_stub_dir(dir.path()).unwrap());
-    let mut parser = RParser::new().unwrap();
-    let file = parser
-        .parse(
-            "registered.R",
-            "x <- structure(list(), class = \"unexported\")\nprint(x)\n",
-        )
-        .unwrap();
-    let mut checker = Checker::new("registered.R");
-    checker.set_user_stubs(stubs);
-    checker.check(&file);
-    let diagnostics = checker.take_diagnostics();
+    let diagnostics = check_with(
+        "x <- structure(list(), class = \"unexported\")\nprint(x)\n",
+        |c| c.set_user_stubs(stubs),
+    );
     assert!(
         diagnostics
             .iter()
@@ -235,13 +228,9 @@ fn structure_call_sets_class() {
     // public `Checker` API by relying on the fact that a missing
     // `Summary.foo` method would emit RY050 only if the class was
     // actually attached.
-    let mut parser = RParser::new().unwrap();
-    let src =
-        "Summary.other <- function(...) 1L\nx <- structure(list(), class = \"foo\")\nSummary(x)\n";
-    let f = parser.parse("test.R", src).unwrap();
-    let mut c = Checker::new("test.R");
-    c.check(&f);
-    let diags = c.take_diagnostics();
+    let diags = check(
+        "Summary.other <- function(...) 1L\nx <- structure(list(), class = \"foo\")\nSummary(x)\n",
+    );
     assert!(
         diags.iter().any(|d| d.code == "RY050"),
         "expected RY050 proving class was attached, got {:?}",

--- a/crates/ry-checker/src/tests/diagnostics.rs
+++ b/crates/ry-checker/src/tests/diagnostics.rs
@@ -2,22 +2,9 @@ use super::*;
 
 // ---- inline suppression comment tests ----
 
-/// Synthesize the comment list for `src` the way the parser collects it:
-/// one `Comment` per line containing a `#`, with the `#` byte column and
-/// the text after it as the body. None of these fixtures puts a `#`
-/// inside a string literal, so a plain line scan reproduces the parser's
-/// output exactly.
 fn scan_comments(src: &str) -> Vec<ry_core::ast::Comment> {
-    src.lines()
-        .enumerate()
-        .filter_map(|(line, text)| {
-            text.find('#').map(|col| ry_core::ast::Comment {
-                line,
-                col,
-                body: text[col + 1..].to_string(),
-            })
-        })
-        .collect()
+    let mut parser = RParser::new().unwrap();
+    parser.parse("test.R", src).unwrap().comments
 }
 
 #[test]
@@ -275,10 +262,7 @@ fn public_check_with_scope_surfaces_ry000_on_broken_file() {
     // Regression: `check_with_scope` used to clear diagnostics
     // AFTER emitting parse errors, wiping the RY000s. It must now
     // surface them.
-    let mut p = RParser::new().unwrap();
-    let f = p.parse("test.R", "f <- function( { 1 }\n").unwrap();
-    let mut c = Checker::new("test.R");
-    let (diags, _scope) = c.check_with_scope(&f);
+    let (diags, _scope) = check_with_scope("f <- function( { 1 }\n");
     assert!(
         diags.iter().any(|d| d.code == "RY000"),
         "check_with_scope must surface RY000 on a broken file, got {:?}",
@@ -288,8 +272,7 @@ fn public_check_with_scope_surfaces_ry000_on_broken_file() {
 
 #[test]
 fn public_check_emits_each_parse_error_once() {
-    let mut parser = RParser::new().unwrap();
-    let file = parser.parse("test.R", "f <- function( { 1 }\n").unwrap();
+    let file = parse_file("test.R", "f <- function( { 1 }\n");
     let expected = file.parse_errors.len();
     assert!(expected > 0, "fixture must contain a parse error");
     let mut checker = Checker::new("test.R");

--- a/crates/ry-checker/src/tests/functions_classes.rs
+++ b/crates/ry-checker/src/tests/functions_classes.rs
@@ -249,19 +249,15 @@ fn inherits_narrows_positive_and_negated_else_branches() {
 
 #[test]
 fn dynlib_prefix_resolves_only_with_nonempty_remainder() {
-    let mut parser = RParser::new().unwrap();
-    let file = parser.parse("test.R", "value <- pkg_call\n").unwrap();
-    let mut checker = Checker::new("test.R");
-    checker.set_external_bindings(HashSet::from(["\0useDynLib:pkg_".to_string()]));
-    checker.check(&file);
-    assert!(checker.take_diagnostics().is_empty());
+    let diags = check_with("value <- pkg_call\n", |c| {
+        c.set_external_bindings(HashSet::from(["\0useDynLib:pkg_".to_string()]));
+    });
+    assert!(diags.is_empty());
 
-    let mut parser = RParser::new().unwrap();
-    let file = parser.parse("test.R", "value <- pkg_\n").unwrap();
-    let mut checker = Checker::new("test.R");
-    checker.set_external_bindings(HashSet::from(["\0useDynLib:pkg_".to_string()]));
-    checker.check(&file);
-    assert!(checker.take_diagnostics().iter().any(|d| d.code == "RY010"));
+    let diags = check_with("value <- pkg_\n", |c| {
+        c.set_external_bindings(HashSet::from(["\0useDynLib:pkg_".to_string()]));
+    });
+    assert!(diags.iter().any(|d| d.code == "RY010"));
 }
 
 /// `call_with_cleanup(native_symbol, ...)` is the cleancall
@@ -273,15 +269,12 @@ fn dynlib_prefix_resolves_only_with_nonempty_remainder() {
 fn call_with_cleanup_symbol_needs_declared_registration() {
     let src = "f <- function(x) call_with_cleanup(map_impl, environment(), x)\n";
 
-    let mut parser = RParser::new().unwrap();
-    let file = parser.parse("test.R", src).unwrap();
-    let mut checker = Checker::new("test.R");
-    checker.set_external_bindings(HashSet::from([
-        ry_workspace::packages::NATIVE_REGISTRATION_SENTINEL.to_string(),
-        "call_with_cleanup".to_string(),
-    ]));
-    checker.check(&file);
-    let diags = checker.take_diagnostics();
+    let diags = check_with(src, |c| {
+        c.set_external_bindings(HashSet::from([
+            ry_workspace::packages::NATIVE_REGISTRATION_SENTINEL.to_string(),
+            "call_with_cleanup".to_string(),
+        ]));
+    });
     assert!(
         !diags.iter().any(|d| d.message.contains("map_impl")),
         "registered native symbol must not be reported unbound: {diags:?}"
@@ -289,14 +282,11 @@ fn call_with_cleanup_symbol_needs_declared_registration() {
 
     // Negative control: the same call in a package that never declared
     // `.registration = TRUE` keeps reporting the unbound symbol.
-    let mut parser = RParser::new().unwrap();
-    let file = parser.parse("test.R", src).unwrap();
-    let mut checker = Checker::new("test.R");
-    checker.set_external_bindings(HashSet::from(["call_with_cleanup".to_string()]));
-    checker.check(&file);
+    let diags = check_with(src, |c| {
+        c.set_external_bindings(HashSet::from(["call_with_cleanup".to_string()]));
+    });
     assert!(
-        checker
-            .take_diagnostics()
+        diags
             .iter()
             .any(|d| d.code == "RY010" && d.message.contains("map_impl")),
         "without .registration the symbol is an ordinary unbound read"
@@ -307,22 +297,17 @@ fn call_with_cleanup_symbol_needs_declared_registration() {
 /// arguments of the same call are still ordinary reads.
 #[test]
 fn call_with_cleanup_still_checks_non_symbol_arguments() {
-    let mut parser = RParser::new().unwrap();
-    let file = parser
-        .parse(
-            "test.R",
-            "f <- function() call_with_cleanup(map_impl, undefined_thing_xyz)\n",
-        )
-        .unwrap();
-    let mut checker = Checker::new("test.R");
-    checker.set_external_bindings(HashSet::from([
-        ry_workspace::packages::NATIVE_REGISTRATION_SENTINEL.to_string(),
-        "call_with_cleanup".to_string(),
-    ]));
-    checker.check(&file);
+    let diags = check_with(
+        "f <- function() call_with_cleanup(map_impl, undefined_thing_xyz)\n",
+        |c| {
+            c.set_external_bindings(HashSet::from([
+                ry_workspace::packages::NATIVE_REGISTRATION_SENTINEL.to_string(),
+                "call_with_cleanup".to_string(),
+            ]));
+        },
+    );
     assert!(
-        checker
-            .take_diagnostics()
+        diags
             .iter()
             .any(|d| d.code == "RY010" && d.message.contains("undefined_thing_xyz")),
         "only the first argument is a native symbol"

--- a/crates/ry-checker/src/tests/mod.rs
+++ b/crates/ry-checker/src/tests/mod.rs
@@ -20,6 +20,18 @@ fn check(src: &str) -> Vec<Diagnostic> {
     c.take_diagnostics()
 }
 
+/// `check` plus a setup step on the `Checker` before the run, for tests
+/// that configure external bindings, loaded packages, imported-from
+/// metadata, or user stubs.
+fn check_with(src: &str, setup: impl FnOnce(&mut Checker)) -> Vec<Diagnostic> {
+    let mut p = RParser::new().unwrap();
+    let f = p.parse("test.R", src).unwrap();
+    let mut c = Checker::new("test.R");
+    setup(&mut c);
+    c.check(&f);
+    c.take_diagnostics()
+}
+
 /// Test-only variant of `check` that also returns the final
 /// top-level scope so tests can assert on the inferred `RType` of a
 /// binding (mode, length, class, columns). Delegates to the public
@@ -32,9 +44,9 @@ fn check_with_scope(src: &str) -> (Vec<Diagnostic>, Scope) {
     c.check_with_scope(&f)
 }
 
-/// Parse helper for project-mode tests, mirroring the one in
-/// `project::tests`.
-fn parse_file(path: &str, src: &str) -> SourceFile {
+/// Parse helper for tests that check a `SourceFile` under a custom path
+/// (project mode, non-`test.R` names). Also used by `project::tests`.
+pub(super) fn parse_file(path: &str, src: &str) -> SourceFile {
     let mut p = RParser::new().unwrap();
     p.parse(path, src).unwrap()
 }

--- a/crates/ry-checker/src/tests/narrowing.rs
+++ b/crates/ry-checker/src/tests/narrowing.rs
@@ -578,25 +578,20 @@ fn reassigned_parameter_can_make_standalone_check_impossible() {
 
 #[test]
 fn project_standalone_checks_do_not_reject_incompatible_parameter_defaults() {
-    let mut parser = RParser::new().unwrap();
     let mut project = Project::new();
     project.add_file(
         "R/check.R".to_string(),
-        parser
-            .parse(
-                "R/check.R",
-                "check_string <- function(x, what = NULL, ..., allow_null = FALSE, allow_na = FALSE, arg = caller_arg(x), call = caller_env()) invisible(NULL)\n",
-            )
-            .unwrap(),
+        parse_file(
+            "R/check.R",
+            "check_string <- function(x, what = NULL, ..., allow_null = FALSE, allow_na = FALSE, arg = caller_arg(x), call = caller_env()) invisible(NULL)\n",
+        ),
     );
     project.add_file(
         "R/bind.R".to_string(),
-        parser
-            .parse(
-                "R/bind.R",
-                "bind <- function(.id = NULL) { check_string(.id) }\n",
-            )
-            .unwrap(),
+        parse_file(
+            "R/bind.R",
+            "bind <- function(.id = NULL) { check_string(.id) }\n",
+        ),
     );
     let diagnostics: Vec<_> = project
         .check()
@@ -797,34 +792,24 @@ fn typeshed_predicate_uses_exact_callee_provenance_and_formal_binding() {
         "a negated schema predicate must narrow its true branch: {diagnostics:?}"
     );
 
-    let mut parser = RParser::new().unwrap();
-    let file = parser
-        .parse(
-            "test.R",
-            "x <- NULL\nif (is_null(x)) stop(\"missing\")\nx()\n",
-        )
-        .unwrap();
-    let mut checker = Checker::new("test.R");
-    checker.set_loaded(HashSet::from(["rlang".to_string()]));
-    checker.check(&file);
+    let diagnostics = check_with("x <- NULL\nif (is_null(x)) stop(\"missing\")\nx()\n", |c| {
+        c.set_loaded(HashSet::from(["rlang".to_string()]))
+    });
     assert!(
-        checker
-            .diagnostics
+        diagnostics
             .iter()
             .all(|diagnostic| diagnostic.code != "RY070"),
         "an attached package predicate must not count the same origin twice: {:?}",
-        checker.diagnostics
+        diagnostics
     );
 
-    let mut checker = Checker::new("test.R");
-    checker.check(&file);
+    let diagnostics = check("x <- NULL\nif (is_null(x)) stop(\"missing\")\nx()\n");
     assert!(
-        checker
-            .diagnostics
+        diagnostics
             .iter()
             .any(|diagnostic| diagnostic.code == "RY070"),
         "an unattached package predicate must not establish bare-call provenance: {:?}",
-        checker.diagnostics
+        diagnostics
     );
 
     for source in [

--- a/crates/ry-checker/src/tests/packages_typeshed.rs
+++ b/crates/ry-checker/src/tests/packages_typeshed.rs
@@ -22,13 +22,10 @@ fn package_loading_calls_have_distinct_return_types() {
 
 #[test]
 fn user_function_argument_rules_wait_for_callable_provenance() {
-    let mut parser = RParser::new().unwrap();
-    let file = parser
-        .parse(
-            "project.R",
-            "f <- function(required) required\nf()\nc <- function(x) x\nc(unrelated = 1L)\n",
-        )
-        .unwrap();
+    let file = parse_file(
+        "project.R",
+        "f <- function(required) required\nf()\nc <- function(x) x\nc(unrelated = 1L)\n",
+    );
     let mut project = Project::new();
     project.add_file("project.R".to_string(), file);
     let diags: Vec<_> = project

--- a/crates/ry-checker/src/tests/quoting_data_mask.rs
+++ b/crates/ry-checker/src/tests/quoting_data_mask.rs
@@ -641,10 +641,7 @@ fn unknown_dot_helper_quotes_its_operands_but_known_dot_evaluates_them() {
 
 #[test]
 fn runtime_stub_defines_package_function_for_checker() {
-    let mut parser = RParser::new().unwrap();
-    let file = parser
-        .parse("runtime.R", "library(foo)\nx <- bar() + 1L\n")
-        .unwrap();
+    let file = parse_file("runtime.R", "library(foo)\nx <- bar() + 1L\n");
 
     let mut without = Checker::new("runtime.R");
     let (without_diags, without_scope) = without.check_with_scope(&file);
@@ -699,7 +696,7 @@ fn runtime_stub_defines_package_function_for_checker() {
     );
     assert_eq!(with_scope.get("x").map(|ty| &ty.mode), Some(&Mode::Integer));
 
-    let base_file = parser.parse("base.R", "x <- custom_base() + 1L\n").unwrap();
+    let base_file = parse_file("base.R", "x <- custom_base() + 1L\n");
     let mut base_checker = Checker::new("base.R");
     base_checker.set_user_stubs(stubs);
     let (base_diags, base_scope) = base_checker.check_with_scope(&base_file);
@@ -712,13 +709,10 @@ fn runtime_stub_defines_package_function_for_checker() {
 
 #[test]
 fn runtime_stub_schema_effect_extends_data_mask_semantics() {
-    let mut parser = RParser::new().unwrap();
-    let file = parser
-        .parse(
-            "runtime_nse.R",
-            "library(fakepkg)\ndf <- data.frame(x = 1L)\nout <- enrich(df, y = x + 1L)\nz <- out$y + 1L\n",
-        )
-        .unwrap();
+    let file = parse_file(
+        "runtime_nse.R",
+        "library(fakepkg)\ndf <- data.frame(x = 1L)\nout <- enrich(df, y = x + 1L)\nz <- out$y + 1L\n",
+    );
     let dir = tempfile::tempdir().unwrap();
     std::fs::write(
         dir.path().join("fakepkg.json"),
@@ -750,15 +744,8 @@ fn runtime_stub_schema_effect_extends_data_mask_semantics() {
 
 #[test]
 fn qualified_base_schema_effect_is_applied() {
-    let mut parser = RParser::new().unwrap();
-    let file = parser
-        .parse(
-            "qualified_base.R",
-            "df <- data.frame(x = 1L)\ny <- base::with(df, x + 1L)\nz <- y + 1L\n",
-        )
-        .unwrap();
-    let mut checker = Checker::new("qualified_base.R");
-    let (diagnostics, scope) = checker.check_with_scope(&file);
+    let (diagnostics, scope) =
+        check_with_scope("df <- data.frame(x = 1L)\ny <- base::with(df, x + 1L)\nz <- y + 1L\n");
     assert!(diagnostics.is_empty(), "{diagnostics:?}");
     assert_eq!(scope.get("z").map(|ty| &ty.mode), Some(&Mode::Integer));
 }
@@ -937,22 +924,16 @@ fn join_normal_arguments_use_the_ordinary_scope() {
 
 #[test]
 fn typeshed_parameter_modes_drive_data_mask_evaluation() {
-    let mut parser = RParser::new().unwrap();
-    let file = parser
-        .parse(
-            "test.R",
-            "x <- as_draws_df(source)\ny <- mutate_variables(x, tau2 = tau^2)\n",
-        )
-        .unwrap();
-    let mut checker = Checker::new("test.R");
-    checker.set_loaded(HashSet::from(["posterior".to_string()]));
-    checker.check(&file);
+    let diagnostics = check_with(
+        "x <- as_draws_df(source)\ny <- mutate_variables(x, tau2 = tau^2)\n",
+        |c| c.set_loaded(HashSet::from(["posterior".to_string()])),
+    );
     assert!(
-        checker.diagnostics.iter().all(|diagnostic| {
+        diagnostics.iter().all(|diagnostic| {
             diagnostic.code != "RY010" || !diagnostic.message.contains("tau")
         }),
         "data-mask metadata should make tau an opaque masked binding: {:?}",
-        checker.diagnostics
+        diagnostics
     );
 }
 
@@ -1060,8 +1041,7 @@ fn lexical_types_are_opaque_under_unknown_data_masks_only() {
 #[test]
 fn exclusively_defused_dots_are_opaque_at_call_sites() {
     let source = "f <- function(...) enquos(...)\ny <- \"a\"\nf(not_a_binding == 1, y / 1L)\n";
-    let mut parser = RParser::new().unwrap();
-    let file = parser.parse("test.R", source).unwrap();
+    let file = parse_file("test.R", source);
     let mut checker = Checker::new("test.R");
     checker.collect_fns(&file.stmts);
     assert!(checker.fn_table.fns["f"].params[0].defused);
@@ -1091,8 +1071,7 @@ fn defuser_cache_reflects_propagated_quoting() {
                     inner\n\
                   }\n\
                   wrapper()\n";
-    let mut parser = RParser::new().unwrap();
-    let file = parser.parse("test.R", source).unwrap();
+    let file = parse_file("test.R", source);
     let mut checker = Checker::new("test.R");
     checker.collect_fns(&file.stmts);
     checker.run_fixpoint();
@@ -1133,8 +1112,7 @@ fn normally_used_dots_remain_eager_at_call_sites() {
 #[test]
 fn embraced_parameters_are_defused_at_call_sites() {
     let source = "library(dplyr)\nwrapper <- function(df, var) select(df, {{ var }})\nwrapper(data.frame(a = 1L), a)\n";
-    let mut parser = RParser::new().unwrap();
-    let file = parser.parse("test.R", source).unwrap();
+    let file = parse_file("test.R", source);
     let mut checker = Checker::new("test.R");
     checker.collect_fns(&file.stmts);
     assert!(checker.fn_table.fns["wrapper"].params[1].defused);

--- a/crates/ry-checker/src/tests/scope_resolution.rs
+++ b/crates/ry-checker/src/tests/scope_resolution.rs
@@ -201,23 +201,18 @@ fn shiny_stub_marks_reactive_code_arguments_as_quoted() {
 
 #[test]
 fn import_from_applies_metadata_only_to_the_imported_binding() {
-    let mut parser = RParser::new().unwrap();
-    let file = parser
-        .parse(
-            "test.R",
-            "df <- data.frame(x = 1L)\nselect(df, x)\nmutate(df, created = missing_name)\n",
-        )
-        .unwrap();
-    let mut checker = Checker::new("test.R");
-    checker.set_external_bindings(HashSet::from(["select".to_string()]));
-    checker.set_imported_from(HashMap::from([("select".to_string(), "dplyr".to_string())]));
-    checker.check(&file);
-
-    assert!(checker.diagnostics.iter().any(|diagnostic| {
+    let diagnostics = check_with(
+        "df <- data.frame(x = 1L)\nselect(df, x)\nmutate(df, created = missing_name)\n",
+        |c| {
+            c.set_external_bindings(HashSet::from(["select".to_string()]));
+            c.set_imported_from(HashMap::from([("select".to_string(), "dplyr".to_string())]));
+        },
+    );
+    assert!(diagnostics.iter().any(|diagnostic| {
         diagnostic.code == "RY010" && diagnostic.message.contains("missing_name")
     }));
     assert!(
-        checker.diagnostics.iter().all(|diagnostic| {
+        diagnostics.iter().all(|diagnostic| {
             diagnostic.code != "RY010" || !diagnostic.message.contains("`x`")
         })
     );
@@ -225,13 +220,10 @@ fn import_from_applies_metadata_only_to_the_imported_binding() {
 
 #[test]
 fn typed_package_constants_are_values_not_functions() {
-    let mut parser = RParser::new().unwrap();
-    let file = parser
-        .parse(
-            "test.R",
-            "value <- na_chr\nbad <- na_chr()\nqualified_bad <- rlang::na_chr()\n",
-        )
-        .unwrap();
+    let file = parse_file(
+        "test.R",
+        "value <- na_chr\nbad <- na_chr()\nqualified_bad <- rlang::na_chr()\n",
+    );
     let mut checker = Checker::new("test.R");
     checker.set_loaded(HashSet::from(["rlang".to_string()]));
     let (diagnostics, scope) = checker.check_with_scope(&file);
@@ -264,8 +256,7 @@ fn local_callable_shadows_typed_package_constant() {
 
 #[test]
 fn import_from_preserves_typed_package_constant() {
-    let mut parser = RParser::new().unwrap();
-    let file = parser.parse("test.R", "value <- na_int\n").unwrap();
+    let file = parse_file("test.R", "value <- na_int\n");
     let mut checker = Checker::new("test.R");
     checker.set_external_bindings(HashSet::from(["na_int".to_string()]));
     checker.set_imported_from(HashMap::from([("na_int".to_string(), "rlang".to_string())]));
@@ -293,13 +284,10 @@ fn unknown_user_infix_quotes_both_operands_and_returns_unknown() {
 
 #[test]
 fn zeallot_destructuring_binds_nested_pattern_symbols() {
-    let mut parser = RParser::new().unwrap();
-    let file = parser
-        .parse(
-            "test.R",
-            "c(first, c(second, third)) %<-% make_value()\nout <- first + second + third\n",
-        )
-        .unwrap();
+    let file = parse_file(
+        "test.R",
+        "c(first, c(second, third)) %<-% make_value()\nout <- first + second + third\n",
+    );
     let mut checker = Checker::new("test.R");
     checker.set_loaded(HashSet::from(["zeallot".to_string()]));
     let (diagnostics, scope) = checker.check_with_scope(&file);
@@ -319,10 +307,7 @@ fn zeallot_destructuring_binds_nested_pattern_symbols() {
 
 #[test]
 fn future_import_enables_mirrored_destructuring() {
-    let mut parser = RParser::new().unwrap();
-    let file = parser
-        .parse("test.R", "make_value() %->% c(left, right)\nleft + right\n")
-        .unwrap();
+    let file = parse_file("test.R", "make_value() %->% c(left, right)\nleft + right\n");
     let mut checker = Checker::new("test.R");
     checker.set_imported_from(HashMap::from([("%->%".to_string(), "future".to_string())]));
     let (diagnostics, scope) = checker.check_with_scope(&file);
@@ -1012,14 +997,11 @@ fn external_unenumerable_marker_suppresses_ry010_for_its_file() {
     // Suggests). It must suppress RY010 for THAT file only — never
     // project-wide. The over-cap fix removed the package-global sysdata route;
     // this is the remaining legitimate, file-local open search path.
-    let mut p = RParser::new().unwrap();
-    let f = p.parse("test.R", "x <- genuinely_unbound_name\n").unwrap();
-    let mut c = Checker::new("test.R");
-    c.set_external_bindings(HashSet::from([
-        ry_core::SERIALIZED_BINDINGS_UNENUMERABLE.to_string()
-    ]));
-    c.check(&f);
-    let diags = c.take_diagnostics();
+    let diags = check_with("x <- genuinely_unbound_name\n", |c| {
+        c.set_external_bindings(HashSet::from([
+            ry_core::SERIALIZED_BINDINGS_UNENUMERABLE.to_string()
+        ]));
+    });
     assert!(
         diags.iter().all(|d| d.code != "RY010"),
         "the unenumerable marker should suppress RY010 for its file: {diags:?}"

--- a/crates/ry-checker/src/tests/type_inference.rs
+++ b/crates/ry-checker/src/tests/type_inference.rs
@@ -658,25 +658,21 @@ fn if_expr_nested() {
 }
 
 #[test]
-fn negative_integer_literal_infers_integer() {
-    // `-1L` is unary minus applied to an integer literal. The result
-    // must be integer (same mode as the operand), length 1, non-NA.
-    let (diags, scope) = check_with_scope("x <- -1L\n");
-    assert!(diags.is_empty(), "got {:?}", diags);
-    let x = scope.get("x").expect("x should be bound");
-    assert_eq!(x.mode, Mode::Integer, "got {:?}", x);
-    assert_eq!(x.length, Length::One, "got {:?}", x);
-}
-
-#[test]
-fn negative_double_literal_infers_double() {
-    // `-3.14` is unary minus applied to a double literal; result is
-    // double, length 1, non-NA.
-    let (diags, scope) = check_with_scope("y <- -3.14\n");
-    assert!(diags.is_empty(), "got {:?}", diags);
-    let y = scope.get("y").expect("y should be bound");
-    assert_eq!(y.mode, Mode::Double, "got {:?}", y);
-    assert_eq!(y.length, Length::One, "got {:?}", y);
+fn negative_literals_infer_operand_mode() {
+    // Unary minus on a numeric literal preserves the operand's mode:
+    // `-1L` stays integer, `-3.14` stays double; length is one.
+    for (src, mode) in [
+        ("x <- -1L\n", Mode::Integer),
+        ("x <- -3.14\n", Mode::Double),
+    ] {
+        let (diags, scope) = check_with_scope(src);
+        assert!(diags.is_empty(), "`{}`: got {:?}", src.trim(), diags);
+        let x = scope
+            .get("x")
+            .unwrap_or_else(|| panic!("`{}`: x should be bound", src.trim()));
+        assert_eq!(x.mode, mode, "`{}`: got {:?}", src.trim(), x);
+        assert_eq!(x.length, Length::One, "`{}`: got {:?}", src.trim(), x);
+    }
 }
 
 #[test]
@@ -897,23 +893,18 @@ fn rep_zero_times_yields_length_zero() {
 }
 
 #[test]
-fn calling_integer_emits_ry070() {
-    let diags = check("x <- 42\ny <- x(10)\n");
-    assert!(
-        diags.iter().any(|d| d.code == "RY070"),
-        "expected RY070 for calling integer, got {:?}",
-        diags
-    );
-}
-
-#[test]
-fn calling_character_emits_ry070() {
-    let diags = check("x <- \"paste\"\ny <- x(1)\n");
-    assert!(
-        diags.iter().any(|d| d.code == "RY070"),
-        "expected RY070 for calling character, got {:?}",
-        diags
-    );
+fn calling_non_function_values_emits_ry070() {
+    for (src, kind) in [
+        ("x <- 42\ny <- x(10)\n", "integer"),
+        ("x <- \"paste\"\ny <- x(1)\n", "character"),
+    ] {
+        let diags = check(src);
+        assert!(
+            diags.iter().any(|d| d.code == "RY070"),
+            "expected RY070 for calling {kind}, got {:?}",
+            diags
+        );
+    }
 }
 
 #[test]
@@ -983,15 +974,21 @@ fn calling_index_expression_stays_silent() {
 }
 
 #[test]
-fn dollar_on_integer_emits_ry061() {
-    let diags = check("x <- 1:10\nval <- x$col\n");
-    assert!(diags.iter().any(|d| d.code == "RY061"), "got {:?}", diags);
-}
-
-#[test]
-fn dollar_on_character_emits_ry061() {
-    let diags = check("x <- c(\"a\", \"b\")\nval <- x$col\n");
-    assert!(diags.iter().any(|d| d.code == "RY061"), "got {:?}", diags);
+fn dollar_on_atomic_vectors_emits_ry061() {
+    // `$` subset assignment only exists for recursive (list-like)
+    // objects; R raises "$ operator is invalid for atomic vectors".
+    for src in [
+        "x <- 1:10\nval <- x$col\n",
+        "x <- c(\"a\", \"b\")\nval <- x$col\n",
+    ] {
+        let diags = check(src);
+        assert!(
+            diags.iter().any(|d| d.code == "RY061"),
+            "`{}`: got {:?}",
+            src.trim(),
+            diags
+        );
+    }
 }
 
 #[test]

--- a/crates/ry-cli/src/dump.rs
+++ b/crates/ry-cli/src/dump.rs
@@ -502,9 +502,8 @@ pub(crate) fn run_dump_types(
     }
     sort_and_deduplicate_paths(&mut all_paths);
 
-    // Parallel parsing through the same thread-local parser pool as
-    // `ry check` (tree-sitter parsers are not Send); see
-    // `pipeline::parse_files`. Input order is preserved.
+    // Parsing goes through the same path as `ry check`; see
+    // `pipeline::parse_files`.
     let parsed = match pipeline::parse_files(&all_paths, dump_parse_failure) {
         Ok(parsed) => parsed,
         Err(failure) => {

--- a/crates/ry-cli/src/main.rs
+++ b/crates/ry-cli/src/main.rs
@@ -287,9 +287,8 @@ fn main() -> Result<ExitCode> {
         None => Cmd::Check(CheckArgs::default()),
     };
 
-    // Subcommand matches are nested under the subcommand's name. We
-    // only need them for `check` (to detect explicit CLI overrides of
-    // scalar fields that the config file can also set).
+    // Kept only for `check`: detecting explicit CLI overrides of scalar
+    // fields the config file can also set.
     let check_matches = matches.subcommand_matches("check");
 
     match cmd {
@@ -560,7 +559,6 @@ fn run_check(
         return Ok(ExitCode::FAILURE);
     }
 
-    // Watch mode: poll for changes and re-check.
     eprintln!(
         "ry: watching {} file(s) for changes (Ctrl+C to stop)...",
         all_paths.len()

--- a/crates/ry-cli/tests/config_e2e.rs
+++ b/crates/ry-cli/tests/config_e2e.rs
@@ -3,8 +3,8 @@
 //! These tests invoke the `ry` binary against temporary project trees
 //! to exercise the full pipeline: discovery, parsing, merging with CLI
 //! flags, and applying the merged settings to diagnostics. They
-//! complement the unit tests in `src/config.rs`, which cover the
-//! individual pieces in isolation.
+//! complement the unit tests in `ry-config`'s `src/config.rs`, which
+//! cover the individual pieces in isolation.
 
 use std::fs;
 use std::process::Command;

--- a/crates/ry-lsp/src/backend.rs
+++ b/crates/ry-lsp/src/backend.rs
@@ -94,9 +94,7 @@ pub(super) struct State {
     /// from `file_config` and the root `folder_settings`.
     ///
     /// A document outside every folder root must be filtered by root-level
-    /// config: `folder_contexts` is sorted by root-path length descending,
-    /// so `.first()` is the most specific *unrelated* root, whose severity
-    /// filter and excludes could drop the diagnostics entirely.
+    /// config.
     root_filter: ry_checker::SeverityFilter,
     root_min_confidence: Option<ry_checker::Confidence>,
     root_excludes: ry_config::Excludes,
@@ -690,8 +688,6 @@ impl LanguageServer for Backend {
 
         self.spawn_background_index().await;
 
-        // Republish diagnostics for every open document so the new
-        // settings take effect immediately.
         self.republish_all_open_documents().await;
     }
 
@@ -868,8 +864,6 @@ impl LanguageServer for Backend {
 
         self.spawn_background_index().await;
 
-        // Republish diagnostics for every open document so the new
-        // config/baseline takes effect immediately.
         self.republish_all_open_documents().await;
     }
 

--- a/crates/ry-lsp/src/util.rs
+++ b/crates/ry-lsp/src/util.rs
@@ -4,10 +4,6 @@
 //! offset. These helpers convert between byte offsets (what tree-sitter
 //! and ry's `Span` use) and LSP `Position`s, counting UTF-16 code units
 //! so non-ASCII (including astral-plane) characters resolve correctly.
-//!
-//! Extracted from `lib.rs` because they
-//! are pure functions with no dependency on the `Backend`/`State` and
-//! are reused across every LSP handler.
 
 use tower_lsp::lsp_types::Position;
 

--- a/crates/ry-lsp/tests/common/mod.rs
+++ b/crates/ry-lsp/tests/common/mod.rs
@@ -1,0 +1,124 @@
+//! Shared helpers for the cross-mode protocol gates.
+//!
+//! One copy of the `Published` normalization and the CLI/LSP comparison
+//! plumbing used by both `protocol.rs` and `protocol_contract.rs`, so the
+//! contract stays "LSP published diagnostics equal `ry check` run
+//! independently in the same root".
+
+// Each test binary uses a different subset of this module.
+#![allow(dead_code)]
+
+use ry_testkit::{ObservedPosition, PositionEncoding, normalize_path, normalize_position};
+use serde_json::Value;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// A diagnostic normalized to file-relative coordinates so CLI and LSP
+/// output can be compared item by item.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Published {
+    pub path: String,
+    pub code: String,
+    pub severity: String,
+    pub message: String,
+    pub line: u32,
+    pub byte_column: u32,
+}
+
+/// The workspace root (this crate's parent's parent), where `target/`
+/// and the cargo invocations live.
+pub fn workspace_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .unwrap()
+}
+
+/// Build the production `ry` binary once per test process and return its
+/// debug path.
+pub fn ry_binary() -> PathBuf {
+    static BINARY: std::sync::OnceLock<PathBuf> = std::sync::OnceLock::new();
+    BINARY
+        .get_or_init(|| {
+            let status = Command::new(env!("CARGO"))
+                .current_dir(workspace_root())
+                .args(["build", "--quiet", "-p", "ry-cli"])
+                .status()
+                .expect("build the production ry binary for the protocol gate");
+            assert!(status.success());
+            workspace_root().join("target/debug/ry")
+        })
+        .clone()
+}
+
+/// Percent-encoded `file://` URI for `path` (the testkit encoder, which
+/// the server itself accepts).
+pub fn file_uri(path: &Path) -> String {
+    ry_testkit::file_uri(path).unwrap()
+}
+
+/// Convert one `ry check --output-format json` entry into a `Published`
+/// with byte columns, relative to `root`.
+pub fn published_from_cli_value(value: &Value, root: &Path) -> Published {
+    let path = value["path"].as_str().unwrap();
+    let relative = normalize_path(Path::new(path), root);
+    let relative = relative.strip_prefix("./").unwrap_or(&relative).to_string();
+    let source = std::fs::read_to_string(root.join(&relative)).unwrap_or_default();
+    let scalar = ObservedPosition {
+        line: value["line"].as_u64().unwrap() as u32 - 1,
+        character: value["column"].as_u64().unwrap() as u32 - 1,
+        encoding: PositionEncoding::UnicodeScalar,
+    };
+    let position = normalize_position(&source, &scalar).unwrap();
+    Published {
+        path: relative,
+        code: value["code"].as_str().unwrap_or("").to_string(),
+        severity: value["severity"].as_str().unwrap_or("").to_string(),
+        message: value["message"].as_str().unwrap_or("").to_string(),
+        line: position.line,
+        byte_column: position.character,
+    }
+}
+
+/// Normalize an LSP `publishDiagnostics` message into sorted `Published`
+/// entries so comparison is order-independent.
+pub fn published_from_lsp(message: &Value, path: &Path, root: &Path) -> Vec<Published> {
+    let relative = normalize_path(path, root);
+    let source = std::fs::read_to_string(path).unwrap_or_default();
+    let mut diags: Vec<_> = message
+        .pointer("/params/diagnostics")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default()
+        .iter()
+        .map(|value| {
+            let start = &value["range"]["start"];
+            let position = normalize_position(
+                &source,
+                &ObservedPosition {
+                    line: start["line"].as_u64().unwrap_or(0) as u32,
+                    character: start["character"].as_u64().unwrap_or(0) as u32,
+                    encoding: PositionEncoding::Utf16,
+                },
+            )
+            .expect("diagnostic start position must normalize");
+            Published {
+                path: relative.clone(),
+                code: value["code"].as_str().unwrap_or("").to_string(),
+                severity: match value["severity"].as_u64() {
+                    Some(1) => "error",
+                    Some(2) => "warning",
+                    Some(3) => "info",
+                    Some(4) => "hint",
+                    _ => "unknown",
+                }
+                .to_string(),
+                message: value["message"].as_str().unwrap_or("").to_string(),
+                line: position.line,
+                byte_column: position.character,
+            }
+        })
+        .collect();
+    diags.sort();
+    diags
+}

--- a/crates/ry-lsp/tests/configuration_refresh.rs
+++ b/crates/ry-lsp/tests/configuration_refresh.rs
@@ -23,13 +23,19 @@ type Session = LspSession<
     tokio::io::WriteHalf<tokio::io::DuplexStream>,
 >;
 
-/// Spawn an LSP server and return a connected session: initialize, then
-/// hand the session to the test. No settle wait for the background
-/// indexer: it never publishes diagnostics itself (its caller
+/// Spawn an LSP server and return a connected session, initialized with
+/// `capabilities` and, unless it is `Null`, `initialization_options`.
+/// Tests using the pull path answer the server's `workspace/configuration`
+/// request themselves right after this returns. No settle wait for the
+/// background indexer: it never publishes diagnostics itself (its caller
 /// republishes, and no document is open here), and open documents shadow
 /// disk files, so each test's `published_diagnostics_after` await (which
 /// has its own timeout) is the only synchronization needed.
-async fn spawn_session(root: &Path) -> (Session, tokio::task::JoinHandle<()>) {
+async fn spawn_session(
+    root: &Path,
+    capabilities: Value,
+    initialization_options: Value,
+) -> (Session, tokio::task::JoinHandle<()>) {
     let (client_stream, server_stream) = tokio::io::duplex(128 * 1024);
     let (client_reader, client_writer) = tokio::io::split(client_stream);
     let (server_reader, server_writer) = tokio::io::split(server_stream);
@@ -37,7 +43,18 @@ async fn spawn_session(root: &Path) -> (Session, tokio::task::JoinHandle<()>) {
         let _ = ry_lsp::run_with(server_reader, server_writer).await;
     });
     let mut session = LspSession::new(client_reader, client_writer);
-    session.initialize(root).await.unwrap();
+    let root_uri = file_uri(root).unwrap();
+    let mut params = json!({
+        "processId": null,
+        "rootUri": root_uri,
+        "capabilities": capabilities,
+        "workspaceFolders": [{"uri": root_uri, "name": "fixture"}]
+    });
+    if initialization_options != Value::Null {
+        params["initializationOptions"] = initialization_options;
+    }
+    session.request("initialize", params).await.unwrap();
+    session.notify("initialized", json!({})).await.unwrap();
     (session, server)
 }
 
@@ -76,7 +93,7 @@ fn did_change_configuration_refreshes_cached_filters() {
             .write_file("R/diag.R", "z <- length(xx = 1L)\n")
             .unwrap();
 
-        let (mut session, _server) = spawn_session(fixture.root()).await;
+        let (mut session, _server) = spawn_session(fixture.root(), json!({}), Value::Null).await;
 
         let diag_uri = file_uri(&fixture.path("R/diag.R")).unwrap();
 
@@ -129,31 +146,6 @@ fn did_change_configuration_refreshes_cached_filters() {
 // context and refresh its cached values.
 // ════════════════════════════════════════════════════════════════════════════
 
-/// Spawn a session whose client advertises `workspace.configuration = true`
-/// (the pull path). The server sends a `workspace/configuration` request
-/// during `initialized`; the harness answers it with default (empty)
-/// settings so the server unblocks and the background indexer runs.
-async fn spawn_pull_session(root: &Path) -> (Session, tokio::task::JoinHandle<()>) {
-    let (client_stream, server_stream) = tokio::io::duplex(128 * 1024);
-    let (client_reader, client_writer) = tokio::io::split(client_stream);
-    let (server_reader, server_writer) = tokio::io::split(server_stream);
-    let server = tokio::spawn(async move {
-        let _ = ry_lsp::run_with(server_reader, server_writer).await;
-    });
-    let mut session = LspSession::new(client_reader, client_writer);
-    session
-        .initialize_with_capabilities(root, json!({ "workspace": { "configuration": true } }))
-        .await
-        .unwrap();
-    // Answer the initial `workspace/configuration` pull during `initialized`
-    // with default settings (one per folder root, then a root-scoped item).
-    session
-        .respond_to_request("workspace/configuration", json!([{}, {}]))
-        .await
-        .unwrap();
-    (session, server)
-}
-
 #[test]
 fn did_change_configuration_pull_applies_per_folder_settings() {
     run(async {
@@ -163,7 +155,19 @@ fn did_change_configuration_pull_applies_per_folder_settings() {
             .write_file("R/diag.R", "z <- length(xx = 1L)\n")
             .unwrap();
 
-        let (mut session, _server) = spawn_pull_session(fixture.root()).await;
+        let (mut session, _server) = spawn_session(
+            fixture.root(),
+            json!({ "workspace": { "configuration": true } }),
+            Value::Null,
+        )
+        .await;
+        // Answer the initial `workspace/configuration` pull during
+        // `initialized` with default settings (one per folder root, then a
+        // root-scoped item).
+        session
+            .respond_to_request("workspace/configuration", json!([{}, {}]))
+            .await
+            .unwrap();
 
         let diag_uri = file_uri(&fixture.path("R/diag.R")).unwrap();
 
@@ -238,7 +242,15 @@ fn enable_false_skips_diagnostics_for_the_folder() {
             .write_file("R/diag.R", "z <- length(xx = 1L)\n")
             .unwrap();
 
-        let (mut session, server) = spawn_disabled_session(fixture.root()).await;
+        let (mut session, server) = spawn_session(
+            fixture.root(),
+            json!({}),
+            json!({
+                "settings": [{"enable": false}],
+                "globalSettings": {}
+            }),
+        )
+        .await;
 
         let diag_uri = file_uri(&fixture.path("R/diag.R")).unwrap();
         let mark = session.publication_mark();
@@ -265,36 +277,6 @@ fn enable_false_skips_diagnostics_for_the_folder() {
     })
 }
 
-/// Spawn a session with `enable: false` for the fixture root.
-async fn spawn_disabled_session(root: &Path) -> (Session, tokio::task::JoinHandle<()>) {
-    let (client_stream, server_stream) = tokio::io::duplex(128 * 1024);
-    let (client_reader, client_writer) = tokio::io::split(client_stream);
-    let (server_reader, server_writer) = tokio::io::split(server_stream);
-    let server = tokio::spawn(async move {
-        let _ = ry_lsp::run_with(server_reader, server_writer).await;
-    });
-    let mut session = LspSession::new(client_reader, client_writer);
-    let root_uri = file_uri(root).unwrap();
-    session
-        .request(
-            "initialize",
-            json!({
-                "processId": null,
-                "rootUri": root_uri,
-                "capabilities": {},
-                "initializationOptions": {
-                    "settings": [{"enable": false}],
-                    "globalSettings": {}
-                },
-                "workspaceFolders": [{"uri": root_uri, "name": "fixture"}]
-            }),
-        )
-        .await
-        .unwrap();
-    session.notify("initialized", json!({})).await.unwrap();
-    (session, server)
-}
-
 #[test]
 fn enable_false_skips_inlay_hints_for_the_folder() {
     run(async {
@@ -303,7 +285,15 @@ fn enable_false_skips_inlay_hints_for_the_folder() {
         // (pinned by `inlay_hint_does_not_cross_workspace_roots`).
         fixture.write_file("R/hint.R", "x <- 1L\n").unwrap();
 
-        let (mut session, server) = spawn_disabled_session(fixture.root()).await;
+        let (mut session, server) = spawn_session(
+            fixture.root(),
+            json!({}),
+            json!({
+                "settings": [{"enable": false}],
+                "globalSettings": {}
+            }),
+        )
+        .await;
 
         let hint_uri = file_uri(&fixture.path("R/hint.R")).unwrap();
         session.open(&hint_uri, 1, "x <- 1L\n").await.unwrap();

--- a/crates/ry-lsp/tests/harness/mod.rs
+++ b/crates/ry-lsp/tests/harness/mod.rs
@@ -1,0 +1,147 @@
+//! Shared session harness for the LSP property tests.
+//!
+//! One copy of the client-session type, the source variants the
+//! properties edit between, and the spawn/quiesce plumbing, used by both
+//! `session.rs` (transcript + convergence property) and
+//! `session_state_machine.rs` (extended operation alphabet).
+
+// Each test binary uses a different subset of this module.
+#![allow(dead_code)]
+
+use ry_testkit::LspSession;
+use serde_json::{Value, json};
+use std::path::Path;
+use std::time::Duration;
+
+pub type ClientSession = LspSession<
+    tokio::io::ReadHalf<tokio::io::DuplexStream>,
+    tokio::io::WriteHalf<tokio::io::DuplexStream>,
+>;
+
+/// Source variants with varying Unicode prefixes so incremental-edit ranges
+/// exercise BMP, combining-mark, and astral-plane UTF-16 positions.  Each
+/// diagnostic variant emits RY090 (partial argument name) and RY091 so the
+/// oracle comparison is meaningful.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum SourceVariant {
+    Clean,
+    AsciiDiagnostic,
+    BmpDiagnostic,
+    AstralDiagnostic,
+}
+
+impl SourceVariant {
+    pub fn text(self) -> &'static str {
+        match self {
+            Self::Clean => "x <- 1L\ny <- 2L\n",
+            Self::AsciiDiagnostic => "z <- length(xx = 1L)\ny <- 2L\n",
+            Self::BmpDiagnostic => "café <- length(xx = 1L)\ny <- 2L\n",
+            Self::AstralDiagnostic => "\u{1f600} <- length(xx = 1L)\ny <- 2L\n",
+        }
+    }
+
+    /// The content of the first line without the trailing newline.  Used as
+    /// the replacement text for an incremental range edit targeting line 0.
+    pub fn first_line(self) -> &'static str {
+        self.text().lines().next().unwrap()
+    }
+}
+
+/// Compute the UTF-16 code-unit length of the first line of `text`.  This is
+/// the LSP character column at the end of line 0.
+pub fn first_line_utf16_len(text: &str) -> u32 {
+    let end = text.find('\n').unwrap_or(text.len());
+    text[..end].encode_utf16().count() as u32
+}
+
+/// Splice the first-line replacement, matching the server's incremental
+/// range-to-byte conversion: replace everything from (0, 0) to
+/// (0, first_line_utf16_len) with the new first line, keeping the rest.
+pub fn apply_incremental_edit(old: &str, source: SourceVariant) -> String {
+    let first_line_end_byte = old.find('\n').unwrap_or(old.len());
+    let mut result = String::with_capacity(old.len() + source.first_line().len());
+    result.push_str(source.first_line());
+    result.push_str(&old[first_line_end_byte..]);
+    result
+}
+
+/// Sort diagnostics for order-independent comparison.
+pub fn sorted_diagnostics(diagnostics: &[Value]) -> Vec<Value> {
+    let mut diags: Vec<Value> = diagnostics.to_vec();
+    diags.sort_by(|a, b| {
+        serde_json::to_string(a)
+            .unwrap_or_default()
+            .cmp(&serde_json::to_string(b).unwrap_or_default())
+    });
+    diags
+}
+
+/// Extract and sort the diagnostics array from a publishDiagnostics
+/// notification so comparison is order-independent.
+pub fn normalize_diagnostics(publish: &Value) -> Vec<Value> {
+    sorted_diagnostics(
+        publish
+            .pointer("/params/diagnostics")
+            .and_then(Value::as_array)
+            .map(Vec::as_slice)
+            .unwrap_or(&[]),
+    )
+}
+
+/// Spawn a fresh server on a duplex pair and initialize the client session
+/// with the given workspace folders (first folder is the root URI).
+pub async fn spawn_session(roots: &[&Path]) -> (ClientSession, tokio::task::JoinHandle<()>) {
+    let (client_stream, server_stream) = tokio::io::duplex(128 * 1024);
+    let (client_reader, client_writer) = tokio::io::split(client_stream);
+    let (server_reader, server_writer) = tokio::io::split(server_stream);
+    let server = tokio::spawn(async move {
+        let _ = ry_lsp::run_with(server_reader, server_writer).await;
+    });
+    let mut session = LspSession::new(client_reader, client_writer);
+    let root_uri = ry_testkit::file_uri(roots[0]).unwrap();
+    let ws_folders: Vec<Value> = roots
+        .iter()
+        .map(|r| {
+            json!({
+                "uri": ry_testkit::file_uri(r).unwrap(),
+                "name": r.file_name().unwrap().to_string_lossy()
+            })
+        })
+        .collect();
+    session
+        .request(
+            "initialize",
+            json!({
+                "processId": null,
+                "rootUri": root_uri,
+                "capabilities": {},
+                "workspaceFolders": ws_folders
+            }),
+        )
+        .await
+        .unwrap();
+    session.notify("initialized", json!({})).await.unwrap();
+    (session, server)
+}
+
+/// Shut down a session and bounded-join its server.
+pub async fn join_session(mut session: ClientSession, server: tokio::task::JoinHandle<()>) {
+    let _ = session.shutdown().await;
+    drop(session);
+    let _ = tokio::time::timeout(Duration::from_secs(3), server).await;
+}
+
+/// Synchronization barrier: a request/response round-trip that drains
+/// leftover publications so the next `publication_mark` captures only
+/// future arrivals. See `LspSession::publication_mark`.
+pub async fn sync_barrier(session: &mut ClientSession, uri: &str) {
+    let _ = session
+        .request(
+            "textDocument/inlayHint",
+            json!({
+                "textDocument": {"uri": uri},
+                "range": {"start": {"line": 0, "character": 0}, "end": {"line": 0, "character": 0}}
+            }),
+        )
+        .await;
+}

--- a/crates/ry-lsp/tests/protocol.rs
+++ b/crates/ry-lsp/tests/protocol.rs
@@ -1,42 +1,10 @@
-use ry_testkit::{
-    AsyncJsonRpcClient, CliProcess, FixtureProject, JsonRpcProcess, ObservedPosition,
-    PositionEncoding, normalize_path, normalize_position,
-};
+use ry_testkit::{AsyncJsonRpcClient, CliProcess, FixtureProject, JsonRpcProcess};
 use serde_json::{Value, json};
-use std::path::{Path, PathBuf};
 use std::process::Command;
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
-struct Published {
-    path: String,
-    code: String,
-    severity: String,
-    message: String,
-    line: u32,
-    byte_column: u32,
-}
+mod common;
 
-fn workspace_root() -> PathBuf {
-    Path::new(env!("CARGO_MANIFEST_DIR"))
-        .join("../..")
-        .canonicalize()
-        .unwrap()
-}
-
-fn ry_binary() -> PathBuf {
-    static BINARY: std::sync::OnceLock<PathBuf> = std::sync::OnceLock::new();
-    BINARY
-        .get_or_init(|| {
-            let status = Command::new(env!("CARGO"))
-                .current_dir(workspace_root())
-                .args(["build", "--quiet", "-p", "ry-cli"])
-                .status()
-                .expect("build the production ry binary for the protocol gate");
-            assert!(status.success());
-            workspace_root().join("target/debug/ry")
-        })
-        .clone()
-}
+use common::{Published, file_uri, published_from_cli_value, published_from_lsp, ry_binary};
 
 fn cli_diagnostics(fixture: &FixtureProject, extra: &[&str]) -> Vec<Published> {
     let output = CliProcess::new(ry_binary())
@@ -56,33 +24,10 @@ fn cli_diagnostics(fixture: &FixtureProject, extra: &[&str]) -> Vec<Published> {
     let values: Vec<Value> = serde_json::from_slice(&output.stdout).unwrap();
     let mut diagnostics: Vec<_> = values
         .into_iter()
-        .map(|value| {
-            let path = value["path"].as_str().unwrap();
-            let relative = normalize_path(Path::new(path), fixture.root());
-            let relative = relative.strip_prefix("./").unwrap_or(&relative).to_string();
-            let source = std::fs::read_to_string(fixture.path(&relative)).unwrap();
-            let scalar = ObservedPosition {
-                line: value["line"].as_u64().unwrap() as u32 - 1,
-                character: value["column"].as_u64().unwrap() as u32 - 1,
-                encoding: PositionEncoding::UnicodeScalar,
-            };
-            let position = normalize_position(&source, &scalar).unwrap();
-            Published {
-                path: relative,
-                code: value["code"].as_str().unwrap().to_string(),
-                severity: value["severity"].as_str().unwrap().to_string(),
-                message: value["message"].as_str().unwrap().to_string(),
-                line: position.line,
-                byte_column: position.character,
-            }
-        })
+        .map(|value| published_from_cli_value(&value, fixture.root()))
         .collect();
     diagnostics.sort();
     diagnostics
-}
-
-fn file_uri(path: &Path) -> String {
-    format!("file://{}", path.display())
 }
 
 async fn run_with_diagnostics(
@@ -140,7 +85,7 @@ async fn run_with_diagnostics(
         )
         .await
         .unwrap();
-    let mut diagnostics = published_from_lsp(&publish, &path, fixture.root());
+    let diagnostics = published_from_lsp(&publish, &path, fixture.root());
 
     let shutdown_id = client.request("shutdown", Value::Null).await.unwrap();
     client
@@ -154,47 +99,7 @@ async fn run_with_diagnostics(
         .unwrap()
         .unwrap()
         .unwrap();
-    diagnostics.sort();
     diagnostics
-}
-
-fn published_from_lsp(message: &Value, path: &Path, root: &Path) -> Vec<Published> {
-    let relative = normalize_path(path, root);
-    let source = std::fs::read_to_string(path).unwrap();
-    message
-        .pointer("/params/diagnostics")
-        .unwrap()
-        .as_array()
-        .unwrap()
-        .iter()
-        .map(|value| {
-            let start = &value["range"]["start"];
-            let position = normalize_position(
-                &source,
-                &ObservedPosition {
-                    line: start["line"].as_u64().unwrap() as u32,
-                    character: start["character"].as_u64().unwrap() as u32,
-                    encoding: PositionEncoding::Utf16,
-                },
-            )
-            .unwrap();
-            Published {
-                path: relative.clone(),
-                code: value["code"].as_str().unwrap().to_string(),
-                severity: match value["severity"].as_u64() {
-                    Some(1) => "error",
-                    Some(2) => "warning",
-                    Some(3) => "info",
-                    Some(4) => "hint",
-                    _ => "unknown",
-                }
-                .to_string(),
-                message: value["message"].as_str().unwrap().to_string(),
-                line: position.line,
-                byte_column: position.character,
-            }
-        })
-        .collect()
 }
 
 fn settings(fixture: &FixtureProject, relative: &str) -> Value {

--- a/crates/ry-lsp/tests/protocol_contract.rs
+++ b/crates/ry-lsp/tests/protocol_contract.rs
@@ -8,59 +8,24 @@
 //!
 //! Shared infrastructure reuses `ry-testkit` (`FixtureProject`,
 //! `LspSession`, `AsyncJsonRpcClient`) and the `ry_lsp::run_with` in-memory
-//! server seam. The CLI comparison helpers mirror `tests/protocol.rs` so the
-//! contract is "LSP published diagnostics equal `ry check` run independently
-//! in the same root."
+//! server seam, plus the `Published` comparison helpers shared with
+//! `tests/protocol.rs` in `tests/common`, so the contract is "LSP published
+//! diagnostics equal `ry check` run independently in the same root."
 //!
 //! No test below adds package-import or filtering differences to `normalise()`.
 
-use ry_testkit::{
-    AsyncJsonRpcClient, FixtureProject, ObservedPosition, PositionEncoding, normalize_path,
-    normalize_position,
-};
+use ry_testkit::{AsyncJsonRpcClient, FixtureProject, normalize_path};
 use serde_json::{Value, json};
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::process::Command;
+
+mod common;
+
+use common::{Published, file_uri, published_from_cli_value, published_from_lsp, ry_binary};
 
 // ──────────────────────────────────────────────────────────────────────────
 // Shared helpers (adapted from tests/protocol.rs for multi-root support)
 // ──────────────────────────────────────────────────────────────────────────
-
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
-struct Published {
-    path: String,
-    code: String,
-    severity: String,
-    message: String,
-    line: u32,
-    byte_column: u32,
-}
-
-fn workspace_root() -> PathBuf {
-    Path::new(env!("CARGO_MANIFEST_DIR"))
-        .join("../..")
-        .canonicalize()
-        .unwrap()
-}
-
-fn ry_binary() -> PathBuf {
-    static BINARY: std::sync::OnceLock<PathBuf> = std::sync::OnceLock::new();
-    BINARY
-        .get_or_init(|| {
-            let status = Command::new(env!("CARGO"))
-                .current_dir(workspace_root())
-                .args(["build", "--quiet", "-p", "ry-cli"])
-                .status()
-                .expect("build the production ry binary for the protocol gate");
-            assert!(status.success());
-            workspace_root().join("target/debug/ry")
-        })
-        .clone()
-}
-
-fn file_uri(path: &Path) -> String {
-    format!("file://{}", path.display())
-}
 
 /// Run `ry check` in `dir` (as the working directory) and return normalized
 /// diagnostics. Each root is checked independently so multi-root parity is
@@ -89,69 +54,6 @@ fn cli_diagnostics_in_dir(dir: &Path, extra: &[&str]) -> Vec<Published> {
         .collect();
     diagnostics.sort();
     diagnostics
-}
-
-fn published_from_cli_value(value: &Value, root: &Path) -> Published {
-    let path = value["path"].as_str().unwrap();
-    let relative = normalize_path(Path::new(path), root);
-    let relative = relative.strip_prefix("./").unwrap_or(&relative).to_string();
-    let source = std::fs::read_to_string(root.join(&relative)).unwrap_or_default();
-    let scalar = ObservedPosition {
-        line: value["line"].as_u64().unwrap() as u32 - 1,
-        character: value["column"].as_u64().unwrap() as u32 - 1,
-        encoding: PositionEncoding::UnicodeScalar,
-    };
-    let position = normalize_position(&source, &scalar).unwrap();
-    Published {
-        path: relative,
-        code: value["code"].as_str().unwrap().to_string(),
-        severity: value["severity"].as_str().unwrap().to_string(),
-        message: value["message"].as_str().unwrap().to_string(),
-        line: position.line,
-        byte_column: position.character,
-    }
-}
-
-/// Normalize an LSP `publishDiagnostics` message into `Published` entries.
-fn published_from_lsp(message: &Value, path: &Path, root: &Path) -> Vec<Published> {
-    let relative = normalize_path(path, root);
-    let source = std::fs::read_to_string(path).unwrap_or_default();
-    let mut diags: Vec<_> = message
-        .pointer("/params/diagnostics")
-        .and_then(Value::as_array)
-        .cloned()
-        .unwrap_or_default()
-        .iter()
-        .map(|value| {
-            let start = &value["range"]["start"];
-            let position = normalize_position(
-                &source,
-                &ObservedPosition {
-                    line: start["line"].as_u64().unwrap_or(0) as u32,
-                    character: start["character"].as_u64().unwrap_or(0) as u32,
-                    encoding: PositionEncoding::Utf16,
-                },
-            )
-            .expect("diagnostic start position must normalize");
-            Published {
-                path: relative.clone(),
-                code: value["code"].as_str().unwrap_or("").to_string(),
-                severity: match value["severity"].as_u64() {
-                    Some(1) => "error",
-                    Some(2) => "warning",
-                    Some(3) => "info",
-                    Some(4) => "hint",
-                    _ => "unknown",
-                }
-                .to_string(),
-                message: value["message"].as_str().unwrap_or("").to_string(),
-                line: position.line,
-                byte_column: position.character,
-            }
-        })
-        .collect();
-    diags.sort();
-    diags
 }
 
 // ──────────────────────────────────────────────────────────────────────────

--- a/crates/ry-lsp/tests/session.rs
+++ b/crates/ry-lsp/tests/session.rs
@@ -1,6 +1,8 @@
 use ry_testkit::{FixtureProject, LspSession, file_uri};
 use serde_json::{Value, json};
 
+mod harness;
+
 const SOURCE: &str = concat!(
     "ascii <- 1L\r\n",
     "frame <- data.frame(column = 1L)\r\n",
@@ -455,30 +457,11 @@ use proptest::prelude::*;
 use proptest::test_runner::TestCaseError;
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::path::Path;
-use std::time::Duration;
 
-type ClientSession = LspSession<
-    tokio::io::ReadHalf<tokio::io::DuplexStream>,
-    tokio::io::WriteHalf<tokio::io::DuplexStream>,
->;
-
-/// Three workspace files exercised by the model.
-const W10_FILES: &[&str] = &["a.R", "b.R", "c.R"];
-
-/// Initial on-disk content for every workspace file.
-const W10_DISK: &str = "x <- 1L\ny <- 2L\n";
-
-/// Source variants with varying Unicode prefixes so incremental-edit ranges
-/// exercise BMP, combining-mark, and astral-plane UTF-16 positions.  Each
-/// diagnostic variant emits RY090 (partial argument name) and RY091 so the
-/// oracle comparison is meaningful.
-#[derive(Clone, Copy, Debug, PartialEq)]
-enum SourceVariant {
-    Clean,
-    AsciiDiagnostic,
-    BmpDiagnostic,
-    AstralDiagnostic,
-}
+use harness::{
+    ClientSession, SourceVariant, apply_incremental_edit, first_line_utf16_len, join_session,
+    normalize_diagnostics, spawn_session, sync_barrier,
+};
 
 impl SourceVariant {
     /// Every variant, ordered for `from_choice`'s residue pick.
@@ -489,27 +472,18 @@ impl SourceVariant {
         Self::AstralDiagnostic,
     ];
 
-    fn text(self) -> &'static str {
-        match self {
-            Self::Clean => "x <- 1L\ny <- 2L\n",
-            Self::AsciiDiagnostic => "z <- length(xx = 1L)\ny <- 2L\n",
-            Self::BmpDiagnostic => "café <- length(xx = 1L)\ny <- 2L\n",
-            Self::AstralDiagnostic => "😀 <- length(xx = 1L)\ny <- 2L\n",
-        }
-    }
-
-    /// The content of the first line without the trailing newline.  Used as
-    /// the replacement text for an incremental range edit targeting line 0.
-    fn first_line(self) -> &'static str {
-        self.text().lines().next().unwrap()
-    }
-
     /// Resolve a raw source byte to a variant.  Deterministic so shrinking
     /// the byte shrinks the resolved operation.
     fn from_choice(source: u8) -> Self {
         Self::ALL[source as usize % Self::ALL.len()]
     }
 }
+
+/// Three workspace files exercised by the model.
+const W10_FILES: &[&str] = &["a.R", "b.R", "c.R"];
+
+/// Initial on-disk content for every workspace file.
+const W10_DISK: &str = "x <- 1L\ny <- 2L\n";
 
 /// The gated operation alphabet.  Versioned operations carry the
 /// exact `textDocument/version` they send, and `Restart` carries the
@@ -761,60 +735,6 @@ impl SessionModel {
     }
 }
 
-/// Compute the UTF-16 code-unit length of the first line of `text`.  This is
-/// the LSP character column at the end of line 0.
-fn first_line_utf16_len(text: &str) -> u32 {
-    let end = text.find('\n').unwrap_or(text.len());
-    text[..end].encode_utf16().count() as u32
-}
-
-/// Splice the first-line replacement, matching the server's incremental
-/// range-to-byte conversion: replace everything from (0, 0) to
-/// (0, first_line_utf16_len) with the new first line, keeping the rest.
-fn apply_incremental_edit(old: &str, source: SourceVariant) -> String {
-    let first_line_end_byte = old.find('\n').unwrap_or(old.len());
-    let mut result = String::with_capacity(old.len() + source.first_line().len());
-    result.push_str(source.first_line());
-    result.push_str(&old[first_line_end_byte..]);
-    result
-}
-
-/// Extract and sort the diagnostics array from a publishDiagnostics
-/// notification so comparison is order-independent.
-fn normalize_diagnostics(publish: &Value) -> Vec<Value> {
-    let mut diags = publish
-        .pointer("/params/diagnostics")
-        .and_then(Value::as_array)
-        .cloned()
-        .unwrap_or_default();
-    diags.sort_by(|a, b| {
-        serde_json::to_string(a)
-            .unwrap_or_default()
-            .cmp(&serde_json::to_string(b).unwrap_or_default())
-    });
-    diags
-}
-
-/// Spawn a fresh server on a duplex pair and initialize the client session.
-async fn spawn_session(root: &Path) -> (ClientSession, tokio::task::JoinHandle<()>) {
-    let (client_stream, server_stream) = tokio::io::duplex(128 * 1024);
-    let (client_reader, client_writer) = tokio::io::split(client_stream);
-    let (server_reader, server_writer) = tokio::io::split(server_stream);
-    let server = tokio::spawn(async move {
-        let _ = ry_lsp::run_with(server_reader, server_writer).await;
-    });
-    let mut session = LspSession::new(client_reader, client_writer);
-    session.initialize(root).await.unwrap();
-    (session, server)
-}
-
-/// Shut down a session and bounded-join its server.
-async fn join_session(mut session: ClientSession, server: tokio::task::JoinHandle<()>) {
-    let _ = session.shutdown().await;
-    drop(session);
-    let _ = tokio::time::timeout(Duration::from_secs(3), server).await;
-}
-
 /// Start a fresh server on the same fixture root, open the supplied
 /// documents, and return the diagnostics published for `target_file`.  This
 /// is the oracle: the live session must converge to this result.
@@ -824,7 +744,7 @@ async fn fresh_server_diagnostics(
     uris: &[String],
     target_file: u8,
 ) -> Value {
-    let (mut session, server) = spawn_session(root).await;
+    let (mut session, server) = spawn_session(&[root]).await;
     // Sync barrier to drain stale publications from the initialize cycle.
     let _ = session
         .request(
@@ -846,21 +766,6 @@ async fn fresh_server_diagnostics(
         .unwrap();
     join_session(session, server).await;
     publish
-}
-
-/// Synchronization barrier: a request/response round-trip that drains
-/// leftover publications so the next `publication_mark` captures only
-/// future arrivals. See the module docs and `LspSession::publication_mark`.
-async fn sync_barrier(live: &mut ClientSession, uri: &str) {
-    let _ = live
-        .request(
-            "textDocument/inlayHint",
-            json!({
-                "textDocument": {"uri": uri},
-                "range": {"start": {"line": 0, "character": 0}, "end": {"line": 0, "character": 0}}
-            }),
-        )
-        .await;
 }
 
 /// Sync, set a fresh mark, quiesce on the debounced diagnostic publication
@@ -1006,7 +911,7 @@ async fn w10_convergence_property(operations: Vec<Operation>) -> Result<(), Test
         .map(|name| file_uri(&fixture.path(name)).unwrap())
         .collect();
 
-    let (mut live, mut live_server) = spawn_session(fixture.root()).await;
+    let (mut live, mut live_server) = spawn_session(&[fixture.root()]).await;
     let mut model = SessionModel::default();
 
     // Every operation was resolved against an identical model at generation
@@ -1145,7 +1050,7 @@ async fn w10_convergence_property(operations: Vec<Operation>) -> Result<(), Test
 
             Operation::Restart { reopens } => {
                 join_session(live, live_server).await;
-                let (new_live, new_server) = spawn_session(fixture.root()).await;
+                let (new_live, new_server) = spawn_session(&[fixture.root()]).await;
                 live = new_live;
                 live_server = new_server;
 
@@ -1195,7 +1100,7 @@ async fn close_reopen_republishes() {
     let fixture = FixtureProject::empty().unwrap();
     fixture.write_file("a.R", W10_DISK).unwrap();
     let uri = file_uri(&fixture.path("a.R")).unwrap();
-    let (mut session, server) = spawn_session(fixture.root()).await;
+    let (mut session, server) = spawn_session(&[fixture.root()]).await;
 
     // Barrier + mark before the open, the same pattern
     // `fresh_server_diagnostics` uses to drain the initialize cycle's

--- a/crates/ry-lsp/tests/session_state_machine.rs
+++ b/crates/ry-lsp/tests/session_state_machine.rs
@@ -36,16 +36,18 @@
 use proptest::collection;
 use proptest::prelude::*;
 use proptest::test_runner::{Config, RngAlgorithm, TestCaseError, TestRng, TestRunner};
-use ry_testkit::{FixtureProject, LspSession, file_uri};
+use ry_testkit::{FixtureProject, file_uri};
 use serde_json::{Value, json};
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
-type ClientSession = LspSession<
-    tokio::io::ReadHalf<tokio::io::DuplexStream>,
-    tokio::io::WriteHalf<tokio::io::DuplexStream>,
->;
+mod harness;
+
+use harness::{
+    ClientSession, SourceVariant, apply_incremental_edit, first_line_utf16_len, join_session,
+    sorted_diagnostics, spawn_session, sync_barrier,
+};
 
 // ──────────────────────────────────────────────────────────────────────────
 // Fixture layout
@@ -69,35 +71,14 @@ const DRAIN_IDLE: Duration = Duration::from_millis(60);
 // Source variants
 // ──────────────────────────────────────────────────────────────────────────
 
-#[derive(Clone, Copy, Debug, PartialEq)]
-enum Source {
-    /// No diagnostics.
-    Clean,
-    /// Triggers RY090 (partial argument name).
-    Diagnostic,
-    /// Triggers RY090 with a Unicode (astral) prefix.
-    Unicode,
-}
+// The variants live in `harness` (`SourceVariant`); the diagnostic
+// variants differ only in the Unicode class of the bound name on line 0.
 
-impl Source {
-    fn text(self) -> &'static str {
-        match self {
-            Self::Clean => "x <- 1L\ny <- 2L\n",
-            Self::Diagnostic => "z <- length(xx = 1L)\nw <- 2L\n",
-            Self::Unicode => "\u{1f600} <- length(xx = 1L)\nw <- 2L\n",
-        }
-    }
-
-    fn first_line(self) -> &'static str {
-        self.text().lines().next().unwrap()
-    }
-}
-
-fn source_strategy() -> impl Strategy<Value = Source> {
+fn source_strategy() -> impl Strategy<Value = SourceVariant> {
     prop_oneof![
-        Just(Source::Clean),
-        Just(Source::Diagnostic),
-        Just(Source::Unicode)
+        Just(SourceVariant::Clean),
+        Just(SourceVariant::AsciiDiagnostic),
+        Just(SourceVariant::AstralDiagnostic)
     ]
 }
 
@@ -110,15 +91,15 @@ enum Operation {
     // Base alphabet
     Open {
         file: u8,
-        source: Source,
+        source: SourceVariant,
     },
     FullEdit {
         file: u8,
-        source: Source,
+        source: SourceVariant,
     },
     IncrementalEdit {
         file: u8,
-        source: Source,
+        source: SourceVariant,
     },
     Close {
         file: u8,
@@ -129,7 +110,7 @@ enum Operation {
     /// Create an on-disk R file (if the slot is empty).
     CreateFile {
         file: u8,
-        source: Source,
+        source: SourceVariant,
     },
     /// Delete an on-disk R file (if the slot has a file).
     DeleteFile {
@@ -162,7 +143,7 @@ enum Operation {
     /// controlled parse completion from an older generation.
     RapidEdit {
         file: u8,
-        source: Source,
+        source: SourceVariant,
     },
     /// Add the secondary workspace folder.
     AddFolder,
@@ -371,30 +352,6 @@ impl SessionModel {
 // Helpers
 // ──────────────────────────────────────────────────────────────────────────
 
-fn first_line_utf16_len(text: &str) -> u32 {
-    let end = text.find('\n').unwrap_or(text.len());
-    text[..end].encode_utf16().count() as u32
-}
-
-fn apply_incremental_edit(old: &str, source: Source) -> String {
-    let first_line_end_byte = old.find('\n').unwrap_or(old.len());
-    let mut result = String::with_capacity(old.len() + source.first_line().len());
-    result.push_str(source.first_line());
-    result.push_str(&old[first_line_end_byte..]);
-    result
-}
-
-/// Sort diagnostics for order-independent comparison.
-fn normalize_diagnostics(diagnostics: &[Value]) -> Vec<Value> {
-    let mut diags: Vec<Value> = diagnostics.to_vec();
-    diags.sort_by(|a, b| {
-        serde_json::to_string(a)
-            .unwrap_or_default()
-            .cmp(&serde_json::to_string(b).unwrap_or_default())
-    });
-    diags
-}
-
 /// Build the fixture: primary root with five R files, `ry.toml`,
 /// `baseline.json`, and a secondary package root for folder ops.
 fn build_fixture() -> FixtureProject {
@@ -452,47 +409,6 @@ fn file_uri_str(fixture: &FixtureProject, slot: u8) -> String {
     file_uri(&file_path(fixture, slot)).unwrap()
 }
 
-/// Spawn a fresh server and initialize with the given roots.
-async fn spawn_session(roots: &[&Path]) -> (ClientSession, tokio::task::JoinHandle<()>) {
-    let (client_stream, server_stream) = tokio::io::duplex(128 * 1024);
-    let (client_reader, client_writer) = tokio::io::split(client_stream);
-    let (server_reader, server_writer) = tokio::io::split(server_stream);
-    let server = tokio::spawn(async move {
-        let _ = ry_lsp::run_with(server_reader, server_writer).await;
-    });
-    let mut session = LspSession::new(client_reader, client_writer);
-    let root_uri = file_uri(roots[0]).unwrap();
-    let ws_folders: Vec<Value> = roots
-        .iter()
-        .map(|r| {
-            json!({
-                "uri": file_uri(r).unwrap(),
-                "name": r.file_name().unwrap().to_string_lossy()
-            })
-        })
-        .collect();
-    session
-        .request(
-            "initialize",
-            json!({
-                "processId": null,
-                "rootUri": root_uri,
-                "capabilities": {},
-                "workspaceFolders": ws_folders
-            }),
-        )
-        .await
-        .unwrap();
-    session.notify("initialized", json!({})).await.unwrap();
-    (session, server)
-}
-
-async fn join_session(mut session: ClientSession, server: tokio::task::JoinHandle<()>) {
-    let _ = session.shutdown().await;
-    drop(session);
-    let _ = tokio::time::timeout(Duration::from_secs(3), server).await;
-}
-
 /// Write the current model's `ry.toml` to disk.
 fn write_config(fixture: &FixtureProject, model: &SessionModel) {
     let mut toml = String::new();
@@ -530,7 +446,7 @@ async fn collect_snapshot(
         .await
         .unwrap_or_default();
     raw.into_iter()
-        .map(|(uri, diags)| (uri, normalize_diagnostics(&diags)))
+        .map(|(uri, diags)| (uri, sorted_diagnostics(&diags)))
         .collect()
 }
 
@@ -570,20 +486,6 @@ async fn fresh_server_snapshot(
     let snapshot = collect_snapshot(&mut session, &target_uri, mark).await;
     join_session(session, server).await;
     snapshot
-}
-
-/// Sync barrier: a request/response round-trip that drains leftover
-/// publications from the previous step's multi-URI broadcast.
-async fn sync_barrier(session: &mut ClientSession, uri: &str) {
-    let _ = session
-        .request(
-            "textDocument/inlayHint",
-            json!({
-                "textDocument": {"uri": uri},
-                "range": {"start": {"line": 0, "character": 0}, "end": {"line": 0, "character": 0}}
-            }),
-        )
-        .await;
 }
 
 // ──────────────────────────────────────────────────────────────────────────
@@ -1107,15 +1009,15 @@ fn catches_issue_53_stale_parse() {
     run_explicit_sequence(vec![
         Operation::Open {
             file: 0,
-            source: Source::Clean,
+            source: SourceVariant::Clean,
         },
         Operation::RapidEdit {
             file: 0,
-            source: Source::Diagnostic,
+            source: SourceVariant::AsciiDiagnostic,
         },
         Operation::IncrementalEdit {
             file: 0,
-            source: Source::Diagnostic,
+            source: SourceVariant::AsciiDiagnostic,
         },
     ]);
 }
@@ -1129,7 +1031,7 @@ fn catches_issue_55_folder_mutation() {
         Operation::RemoveFolder,
         Operation::Open {
             file: 0,
-            source: Source::Diagnostic,
+            source: SourceVariant::AsciiDiagnostic,
         },
     ]);
 }
@@ -1141,12 +1043,12 @@ fn catches_issue_45_baseline_reload() {
     run_explicit_sequence(vec![
         Operation::Open {
             file: 0,
-            source: Source::Diagnostic,
+            source: SourceVariant::AsciiDiagnostic,
         },
         Operation::EditBaseline { suppress: true },
         Operation::FullEdit {
             file: 0,
-            source: Source::Diagnostic,
+            source: SourceVariant::AsciiDiagnostic,
         },
     ]);
 }
@@ -1160,7 +1062,7 @@ fn catches_issue_48_discovery_caps() {
         Operation::EditDiscoveryCaps { max_files: 2 },
         Operation::Open {
             file: 0,
-            source: Source::Diagnostic,
+            source: SourceVariant::AsciiDiagnostic,
         },
     ]);
 }
@@ -1173,14 +1075,14 @@ fn catches_config_reload() {
     run_explicit_sequence(vec![
         Operation::Open {
             file: 0,
-            source: Source::Diagnostic,
+            source: SourceVariant::AsciiDiagnostic,
         },
         Operation::EditConfig {
             ignore_diagnostic: true,
         },
         Operation::FullEdit {
             file: 0,
-            source: Source::Diagnostic,
+            source: SourceVariant::AsciiDiagnostic,
         },
     ]);
 }
@@ -1192,11 +1094,11 @@ fn catches_disk_file_lifecycle() {
         Operation::DeleteFile { file: 4 },
         Operation::Open {
             file: 0,
-            source: Source::Diagnostic,
+            source: SourceVariant::AsciiDiagnostic,
         },
         Operation::CreateFile {
             file: 4,
-            source: Source::Diagnostic,
+            source: SourceVariant::AsciiDiagnostic,
         },
         Operation::RenameFile { from: 4, to: 3 },
     ]);
@@ -1208,12 +1110,12 @@ fn catches_restart_convergence() {
     run_explicit_sequence(vec![
         Operation::Open {
             file: 0,
-            source: Source::Diagnostic,
+            source: SourceVariant::AsciiDiagnostic,
         },
         Operation::Restart,
         Operation::IncrementalEdit {
             file: 0,
-            source: Source::Unicode,
+            source: SourceVariant::AstralDiagnostic,
         },
     ]);
 }
@@ -1228,14 +1130,14 @@ fn metadata_edits_converge() {
         Operation::AddFolder,
         Operation::Open {
             file: 0,
-            source: Source::Clean,
+            source: SourceVariant::Clean,
         },
         Operation::EditNamespace,
         Operation::EditDescription,
         Operation::EditTypeshed,
         Operation::IncrementalEdit {
             file: 0,
-            source: Source::Diagnostic,
+            source: SourceVariant::AsciiDiagnostic,
         },
     ]);
 }

--- a/crates/ry-lsp/tests/testkit.rs
+++ b/crates/ry-lsp/tests/testkit.rs
@@ -5,6 +5,10 @@ use ry_testkit::{
 use serde_json::{Value, json};
 use std::path::Path;
 
+mod common;
+
+use common::file_uri;
+
 struct RunWithDriver;
 
 impl Driver for RunWithDriver {
@@ -144,10 +148,6 @@ fn lsp_position(value: &Value) -> Result<ObservedPosition, DriverError> {
             .ok_or("position has no character")? as u32,
         encoding: PositionEncoding::Utf16,
     })
-}
-
-fn file_uri(path: &Path) -> String {
-    format!("file://{}", path.display())
 }
 
 #[test]

--- a/crates/ry-workspace/src/lib.rs
+++ b/crates/ry-workspace/src/lib.rs
@@ -1801,31 +1801,6 @@ mod shared_tests {
 
     #[test]
     fn discovery_includes_all_r_source_extensions() {
-        let dir = tempfile::tempdir().unwrap();
-        for ext in &["R", "r", "S", "s", "q"] {
-            std::fs::write(
-                dir.path().join(format!("source.{ext}")),
-                "value <- 1
-",
-            )
-            .unwrap();
-        }
-        std::fs::write(
-            dir.path().join("source.txt"),
-            "not R
-",
-        )
-        .unwrap();
-        let result = discover_r_files(dir.path(), None, &ry_config::Config::default(), false);
-        assert_eq!(
-            result.files.len(),
-            5,
-            "R, r, S, s, q discovered; .txt excluded"
-        );
-    }
-
-    #[test]
-    fn collection_includes_all_supported_r_source_extensions() {
         let temp = tempfile::tempdir().unwrap();
         let root = temp.path();
         for extension in ["R", "r", "S", "s", "q"] {


### PR DESCRIPTION
Third wave of the cleanup review: test-harness consolidation, a comment
diet restricted to an explicit list, and one module rename. Builds on
#173 and #175 (stacked; merge those first). Net **-307 LOC**, no
production behavior change (one test fixture's inert second line was
unified with the shared source-variant enum).

## Shared test harnesses

- **ry-lsp session tests**: `tests/harness/mod.rs` now holds the single
  copy of seven helpers that were duplicated verbatim between
  `session.rs` and `session_state_machine.rs` (`ClientSession`,
  `first_line_utf16_len`, `apply_incremental_edit`,
  `normalize_diagnostics`, `spawn_session`, `join_session`,
  `sync_barrier`) plus one shared source-variant type replacing the two
  parallel enums. The `w10` convergence property and resolver
  self-check are untouched — dropping them is a separate decision
  (#171).
- **ry-lsp protocol tests**: `tests/common/mod.rs` holds the single
  copy of `Published`, `workspace_root`, `ry_binary`, the CLI-JSON
  conversion, and `published_from_lsp` that protocol.rs and
  protocol_contract.rs each carried ("adapted from" per the old
  header). The three local `format!`-based `file_uri` builders are
  replaced by `ry_testkit::file_uri` (canonicalize + percent-encoding
  — the local copies broke on paths with spaces).
- **configuration_refresh.rs**: three spawn helpers collapsed to one
  parameterized on capabilities + initializationOptions (wire format
  preserved: init options omitted when null).
- **checker tests**: a `check_with(src, setup)` helper plus the
  existing `parse_file` collapse 25 copy-pasted parse+configure+check
  blocks; 13 sites keep their explicit shape because they need the
  scope, a Project, or mid-run introspection back. `project.rs`'s
  private `parse` twin is deleted. `scan_comments` calls the real
  parser instead of re-implementing comment collection with a "holds
  by luck" caveat. Three copy-pasted literal-family test pairs are
  table-driven; two truly redundant discovery-extension tests merged
  into the stronger one.

## Comment diet (the reviewed list, nothing else)

Deleted or rewrote ~60 lines of comments that narrated the next line or
argued at a reviewer: the T7b archaeology block, pipe-desugar narration,
the "no point attaching an empty signature" if-restatement, five
construct.rs functions' `//` blocks converted to concise `///` docs,
the Project re-export ergonomics comment, the clap-subcommand narration,
the stale `root_filter` `.first()` paragraph, duplicated republish
comments, and the util.rs extraction-history note. All R-semantics and
design-constraint comments were left in place.

## Rename

`suppress.rs` -> `resolve.rs`: the module contains typeshed/package
signature and value resolution (plus the emit helpers), while every
suppression feature lives in diagnostics.rs — the old name misled
reviews. Pure `git mv` + module declaration + header doc; no functions
moved, no logic changed.

## Verification

`cargo fmt --all --check`, `cargo clippy --workspace --all-targets --
-D warnings`, `cargo test --workspace` (all suites green, 437 checker
lib tests, full LSP session/protocol/state-machine suites).
