### PR TITLE
refactor: collapse second-wave duplication across cli, config, checker, lsp, workspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,22 @@ suppression actions — and fixes a parser panic plus several editor issues.
 
 ### Changed
 
+- **One shared front half for `ry check` and `ry dump-types`**: both
+  commands resolve their per-package groups, workspace contexts, and
+  checker inputs through one pipeline helper, so their file sets,
+  resolution roots, and degraded-scope notes cannot drift apart.
+  Diagnostics and dump output are unchanged.
+- **Consolidated duplicated helpers across the crates**: `ry rule` and
+  `ry explain rule` share one argument struct; `ry.toml` merging takes a
+  single `CliOverrides` value instead of ten positional flags; the
+  checker's argument matching, condition inference, and plain-assignment
+  binding each have one implementation; the language server partitions
+  open documents per folder once, carries the owning folder through
+  publication, and reads the parse cache under a single lock; workspace
+  resolution caches DESCRIPTION reads per package root. Tests for
+  workspace discovery, `.Rbuildignore` translation, and baselines moved
+  into the crates whose code they exercise. Behavior, diagnostics, and
+  inferred types are unchanged.
 - **`enable` is honored per folder**: a workspace folder whose settings
   set `enable: false` is skipped: the language server publishes no
   diagnostics and returns no inlay hints for it. The setting was

--- a/crates/ry-checker/src/higher_order.rs
+++ b/crates/ry-checker/src/higher_order.rs
@@ -1,17 +1,6 @@
 use super::*;
 use crate::infer::*;
 
-/// `HigherOrderSpec` argument indices name formal slots, never raw call
-/// positions. One ordinary R argument match drives callback, source,
-/// length, and template lookup throughout the higher-order path.
-fn higher_order_argument_match(params: &[ParamSpec], args: &[Arg]) -> ArgumentMatch {
-    let names = params
-        .iter()
-        .map(|parameter| parameter.name.as_str())
-        .collect::<Vec<_>>();
-    match_arguments(&names, args)
-}
-
 fn matched_argument_index(argument_match: &ArgumentMatch, formal_index: usize) -> Option<usize> {
     argument_match
         .param_for_arg
@@ -35,8 +24,9 @@ fn argument_bound_to_formal<'a>(
     matched_argument_index(argument_match, formal_index).and_then(|index| args.get(index))
 }
 
-/// With a `...` formal, every unmatched actual is part of dots (see
-/// `higher_order_argument_match` for the shared match).
+/// With a `...` formal, every unmatched actual is part of dots (one
+/// ordinary R argument match drives callback, source, length, and
+/// template lookup throughout the higher-order path).
 fn arguments_bound_to_dots<'a>(
     arg_types: &'a [RType],
     argument_match: &'a ArgumentMatch,
@@ -68,7 +58,7 @@ impl Checker {
     ) -> Option<RType> {
         let signature = self.resolve_typeshed_sig(name)?;
         let spec = signature.higher_order.as_ref()?;
-        let argument_match = higher_order_argument_match(&signature.params, args);
+        let argument_match = match_params(&signature.params, args);
         Some(self.infer_ho_result(name, spec, args, arg_types, &argument_match, scope, span))
     }
 
@@ -431,13 +421,7 @@ impl Checker {
                 }
                 // Typeshed function?
                 if let Some(sig) = self.resolve_typeshed_sig(name) {
-                    return Some(self.apply_sig(
-                        lookup_name,
-                        &sig,
-                        call_arg_types,
-                        &[],
-                        Span::default(),
-                    ));
+                    return Some(self.apply_sig(&sig, call_arg_types, &[]));
                 }
                 None
             }
@@ -482,9 +466,7 @@ impl Checker {
         if returns.is_empty() {
             return None;
         }
-        let mut iter = returns.into_iter();
-        let first = iter.next().unwrap_or(RType::unknown());
-        let joined = iter.fold(first, |acc, t| acc.join(t));
+        let joined = join_all(returns.into_iter());
         if matches!(joined.mode, Mode::Opaque) {
             return None;
         }
@@ -522,7 +504,7 @@ impl Checker {
         if matches!(spec.result.kind, HigherOrderResultKind::CallbackIdentity) {
             return;
         }
-        let argument_match = higher_order_argument_match(&signature.params, args);
+        let argument_match = match_params(&signature.params, args);
         let elem_types = self.higher_order_callback_types(spec, arg_types, &argument_match);
         let cb = match argument_bound_to_formal(args, &argument_match, spec.callback_position) {
             Some(argument) => &argument.value,
@@ -597,7 +579,7 @@ impl Checker {
                     });
                 }
                 if let Some(sig) = self.typeshed.s3_methods.get(&key).cloned() {
-                    return Some(self.apply_sig(candidate, &sig, arg_types, &[], span));
+                    return Some(self.apply_sig(&sig, arg_types, &[]));
                 }
                 let sig = self.available_package_names().find_map(|pkg| {
                     self.package_typeshed(pkg)
@@ -605,7 +587,7 @@ impl Checker {
                         .cloned()
                 });
                 if let Some(sig) = sig {
-                    return Some(self.apply_sig(candidate, &sig, arg_types, &[], span));
+                    return Some(self.apply_sig(&sig, arg_types, &[]));
                 }
             }
         }

--- a/crates/ry-checker/src/infer/call.rs
+++ b/crates/ry-checker/src/infer/call.rs
@@ -94,18 +94,18 @@ impl Checker {
 
         // `switch(EXPR, ...)`: the join of all alternatives.
         if semantic_name == "switch" {
-            return self.infer_switch_call(args, scope, span);
+            return self.infer_switch_call(args, scope);
         }
 
         // `tryCatch(expr, ..., handler = fun)`: the join of the main
         // expression and all handler return types.
         if semantic_name == "tryCatch" {
-            return self.infer_trycatch_call(args, scope, span);
+            return self.infer_trycatch_call(args, scope);
         }
 
         // The class-constructor stage: `structure`, `factor`, S4 `new`.
         if let Some(t) =
-            self.infer_class_constructor_call(&semantic_name, &lookup_name, args, scope, span)
+            self.infer_class_constructor_call(&semantic_name, &lookup_name, args, scope)
         {
             return t;
         }
@@ -170,9 +170,7 @@ impl Checker {
 
         // The atomic-constructor stage: `c`, `list`, `data.frame`, `t`,
         // `as.data.frame`.
-        if let Some(t) =
-            self.infer_atomic_constructor_call(&lookup_name, args, &call.arg_types, span)
-        {
+        if let Some(t) = self.infer_atomic_constructor_call(&lookup_name, args, &call.arg_types) {
             return t;
         }
 
@@ -249,7 +247,7 @@ impl Checker {
         // Must run after the FnTable stage above so a user-defined
         // `rep`/`seq` still wins, and before the typeshed stage below so
         // the literal-pinned length beats the conservative stub.
-        if let Some(t) = self.infer_literal_length_call(&lookup_name, args, &call.arg_types, span) {
+        if let Some(t) = self.infer_literal_length_call(&lookup_name, args, &call.arg_types) {
             return t;
         }
 
@@ -257,7 +255,7 @@ impl Checker {
         // against `load_package(pkg)`; an unqualified call falls back
         // from base to loaded packages (reverse load order).
         if let Some(sig) = call.resolved_sig {
-            return self.apply_sig(&lookup_name, &sig, &call.arg_types, args, span);
+            return self.apply_sig(&sig, &call.arg_types, args);
         }
 
         // Unknown function: opaque.
@@ -384,7 +382,7 @@ impl Checker {
             return None;
         }
         let params: Vec<&str> = signature.param_names().collect();
-        let matches = match_arguments(&params, args);
+        let matches = match_params(&signature.params, args);
         // R6 has two evaluation models for method bodies. Under the default
         // (`portable = TRUE`) a method is enclosed by a separate environment
         // in which members are reachable only through `self$` / `private$`,
@@ -402,7 +400,7 @@ impl Checker {
         for (index, argument) in args.iter().enumerate() {
             let parameter = matches.param_for_arg[index].and_then(|index| params.get(index));
             let quoted_expression = matches!(
-                eval_mode_for_arg(&signature, &params, &matches, index),
+                eval_mode_for_arg(&signature, &matches, index),
                 Some(EvalMode::QuotedExpression)
             );
             let specs: Vec<_> = signature
@@ -460,7 +458,7 @@ impl Checker {
             );
         }
         self.check_typeshed_call_arguments(lookup_name, &signature, args, &arg_types, span);
-        Some(self.apply_sig(lookup_name, &signature, &arg_types, args, span))
+        Some(self.apply_sig(&signature, &arg_types, args))
     }
 
     /// `assign("name", ..., envir = asNamespace("pkg"))`: the binding
@@ -787,7 +785,7 @@ impl Checker {
         // the same convention, but they are ordinary redefinable R
         // functions, so they only get this treatment in a package that
         // declares `useDynLib(..., .registration = TRUE)`.
-        if is_ffi_primitive(semantic_name)
+        if ry_core::FFI_PRIMITIVES.contains(&semantic_name)
             || (is_registered_ffi_wrapper(semantic_name) && self.native_registration)
         {
             for (i, a) in args.iter().enumerate() {
@@ -895,34 +893,28 @@ impl Checker {
         });
         // One match for the resolved signature; the loop below used to redo it
         // for every argument.
-        let declared_binding = resolved_sig.as_ref().map(|signature| {
-            let names: Vec<&str> = signature.param_names().collect();
-            let bindings = match_arguments(&names, args);
-            (signature, names, bindings)
-        });
+        let declared_binding = resolved_sig
+            .as_ref()
+            .map(|signature| (signature, match_params(&signature.params, args)));
         let mut arg_types: Vec<RType> = Vec::with_capacity(args.len());
         for (index, a) in args.iter().enumerate() {
-            let declared_mode =
-                declared_binding
-                    .as_ref()
-                    .and_then(|(signature, names, bindings)| {
-                        eval_mode_for_arg(signature, names, bindings, index)
-                    });
+            let declared_mode = declared_binding
+                .as_ref()
+                .and_then(|(signature, bindings)| eval_mode_for_arg(signature, bindings, index));
             let user_dispatch = inherited_s3_metadata
                 || user_function.is_some()
                 || arg_types
                     .first()
                     .is_some_and(|first| self.resolves_user_s3_dispatch(lookup_name, first));
-            let is_defused = user_argument_matches
+            // The user formal this actual bound to (directly or through
+            // `...`), looked up once for both the defusing and quoting
+            // flags below.
+            let user_param = user_argument_matches
                 .as_ref()
                 .and_then(|matches| matches.param_for_arg[index].or(matches.dots))
-                .and_then(|parameter| user_function.as_ref()?.params.get(parameter))
-                .is_some_and(|parameter| parameter.defused);
-            let is_quoting = user_argument_matches
-                .as_ref()
-                .and_then(|matches| matches.param_for_arg[index].or(matches.dots))
-                .and_then(|parameter| user_function.as_ref()?.params.get(parameter))
-                .is_some_and(|parameter| parameter.quoting);
+                .and_then(|parameter| user_function.as_ref()?.params.get(parameter));
+            let is_defused = user_param.is_some_and(|parameter| parameter.defused);
+            let is_quoting = user_param.is_some_and(|parameter| parameter.quoting);
             if is_quoting {
                 // User functions that capture an argument with substitute(),
                 // bquote(), or match.call()-style reflection receive the
@@ -1119,10 +1111,7 @@ impl Checker {
         // once, and only for signatures that actually declare an assertion.
         let assertion_binding = assertion_signature
             .filter(|signature| signature.assertion.is_some())
-            .map(|signature| {
-                let names: Vec<&str> = signature.param_names().collect();
-                (signature, match_arguments(&names, args))
-            });
+            .map(|signature| (signature, match_params(&signature.params, args)));
         if (name.contains("::") || !locally_shadows_stub || resolution.user_function.is_some())
             && let Some((signature, bindings)) = assertion_binding
             && let Some(assertion) = signature.assertion.as_ref()

--- a/crates/ry-checker/src/infer/construct.rs
+++ b/crates/ry-checker/src/infer/construct.rs
@@ -10,7 +10,6 @@ impl Checker {
         lookup_name: &str,
         args: &[Arg],
         scope: &mut Scope,
-        span: Span,
     ) -> Option<RType> {
         // `structure(x, class = "...")` is R's class constructor. We
         // model only the common literal forms:
@@ -19,7 +18,7 @@ impl Checker {
         // Non-literal or unparseable forms fall through to opaque
         // inference with `ClassVector::unknown()` so RY050 stays quiet.
         if semantic_name == "structure" {
-            return Some(self.infer_structure_call(args, scope, span));
+            return Some(self.infer_structure_call(args, scope));
         }
         // `factor(x)` returns an integer vector with class "factor".
         // (And often also "ordered" if `ordered = TRUE`, but we keep v1
@@ -61,12 +60,7 @@ impl Checker {
     /// `[("a", integer<1>)]` and whose class is `["foo"]`. This lets
     /// `$a` resolve correctly on user-defined classes built on top of
     /// a list-shaped payload.
-    pub(crate) fn infer_structure_call(
-        &mut self,
-        args: &[Arg],
-        scope: &mut Scope,
-        _span: Span,
-    ) -> RType {
+    pub(crate) fn infer_structure_call(&mut self, args: &[Arg], scope: &mut Scope) -> RType {
         // The base value is the first positional argument (or the
         // `x = ...` named argument). The first such positional-or-`x`
         // arg wins; later ones are inferred for diagnostics only.
@@ -111,11 +105,10 @@ impl Checker {
         lookup_name: &str,
         args: &[Arg],
         arg_types: &[RType],
-        span: Span,
     ) -> Option<RType> {
         // Built-in: `c(...)` concatenates and produces the common mode.
         if lookup_name == "c" {
-            let result = self.infer_c(args, arg_types, span);
+            let result = self.infer_c(args, arg_types);
             if let Some(schema) = build_named_schema(arg_types, args)
                 .filter(|_| args.iter().any(|argument| argument.name.is_some()))
             {
@@ -124,7 +117,7 @@ impl Checker {
             return Some(result);
         }
         if lookup_name == "list" {
-            return Some(self.infer_list(arg_types, args, span));
+            return Some(self.infer_list(arg_types, args));
         }
         // `data.frame(...)`: a record constructor. Same column-schema
         // logic as `list(...)`, but the result is classed
@@ -142,7 +135,7 @@ impl Checker {
                         .with_columns(schema),
                 );
             }
-            return Some(self.infer_data_frame(arg_types, args, span));
+            return Some(self.infer_data_frame(arg_types, args));
         }
 
         if lookup_name == "t" {
@@ -172,21 +165,20 @@ impl Checker {
         lookup_name: &str,
         args: &[Arg],
         arg_types: &[RType],
-        span: Span,
     ) -> Option<RType> {
         if lookup_name == "vector" {
             return Some(self.infer_vector(args));
         }
         if lookup_name == "rep" {
-            return Some(self.infer_rep(args, arg_types, span));
+            return Some(self.infer_rep(args, arg_types));
         }
         if lookup_name == "seq" || lookup_name == "seq.int" {
-            return Some(self.infer_seq(args, arg_types, span));
+            return Some(self.infer_seq(args, arg_types));
         }
         None
     }
 
-    pub(crate) fn infer_c(&mut self, args: &[Arg], arg_types: &[RType], _span: Span) -> RType {
+    pub(crate) fn infer_c(&mut self, args: &[Arg], arg_types: &[RType]) -> RType {
         if arg_types.is_empty() {
             return RType::new(Mode::Null, Length::Zero);
         }
@@ -207,7 +199,10 @@ impl Checker {
                 Length::One => 1,
                 Length::Known(n) => n,
                 Length::Unknown => {
-                    return RType::new(collapse_c_mode(mode, saw_union), Length::Unknown);
+                    return RType::new(
+                        if saw_union { Mode::Opaque } else { mode },
+                        Length::Unknown,
+                    );
                 }
             });
         }
@@ -216,7 +211,7 @@ impl Checker {
         } else {
             Length::Known(total_len)
         };
-        RType::new(collapse_c_mode(mode, saw_union), length)
+        RType::new(if saw_union { Mode::Opaque } else { mode }, length)
     }
 
     // Infer the type of `list(...)`. The result is always a list whose
@@ -228,7 +223,7 @@ impl Checker {
     // mirrors R's `list(a = 1, "x")` which produces names `c("a", "2")`.
     // The schema is what powers `df$col` / `df[["col"]]` resolution
     // downstream.
-    pub(crate) fn infer_list(&mut self, arg_types: &[RType], args: &[Arg], _span: Span) -> RType {
+    pub(crate) fn infer_list(&mut self, arg_types: &[RType], args: &[Arg]) -> RType {
         let length = Length::Known(arg_types.len());
         let base = RType::new(Mode::List, length);
         let mut schema = build_named_schema(arg_types, args).unwrap_or(ColumnSchema {
@@ -260,12 +255,7 @@ impl Checker {
     // * Special arguments like `row.names = ...`, `check.names = ...`
     //   are NOT columns and are dropped from the schema. We recognize
     //   the common ones by name.
-    pub(crate) fn infer_data_frame(
-        &mut self,
-        arg_types: &[RType],
-        args: &[Arg],
-        _span: Span,
-    ) -> RType {
+    pub(crate) fn infer_data_frame(&mut self, arg_types: &[RType], args: &[Arg]) -> RType {
         // Filter out non-column named arguments first. Positional args
         // are kept (they become columns); known metadata args are dropped
         // so they don't pollute the schema.
@@ -359,7 +349,7 @@ impl Checker {
         RType::new(mode, length)
     }
 
-    pub(crate) fn infer_rep(&self, args: &[Arg], arg_types: &[RType], _span: Span) -> RType {
+    pub(crate) fn infer_rep(&self, args: &[Arg], arg_types: &[RType]) -> RType {
         // Infer `rep(x, times, each)`: length = `length(x) * times * each`
         // with `times`/`each` defaulting to 1, and the result keeping
         // `x`'s mode, class, and schema (so `rep(factor(...), 3)` stays
@@ -447,7 +437,7 @@ impl Checker {
     // taking precedence over `by`). When we can't pin the length, we
     // still report the right mode (integer when the first arg is an
     // integer literal, else double) with `Length::Unknown`.
-    pub(crate) fn infer_seq(&self, args: &[Arg], arg_types: &[RType], _span: Span) -> RType {
+    pub(crate) fn infer_seq(&self, args: &[Arg], arg_types: &[RType]) -> RType {
         // Helper: find (was_supplied, literal_value) for a named or
         // positional argument. Named args win over positional. The
         // `pos` index counts only unnamed args, so `seq(from=1, 10)`
@@ -522,11 +512,9 @@ impl Checker {
 
     pub(crate) fn apply_sig(
         &mut self,
-        _name: &str,
         sig: &FunctionSig,
         arg_types: &[RType],
         args: &[Arg],
-        span: Span,
     ) -> RType {
         // Match named arguments to parameters so that `arg0` refers to
         // the first *parameter* (by name), not the first positional arg.
@@ -550,7 +538,7 @@ impl Checker {
             ReturnSpec::Slot(slot) => {
                 let mut result = match slot {
                     ReturnSlot::Arg0 => first,
-                    ReturnSlot::ConcatOfArgs => self.infer_c(args, arg_types, span),
+                    ReturnSlot::ConcatOfArgs => self.infer_c(args, arg_types),
                 };
                 if let Some(length) =
                     semantic_return_length(sig.return_length.as_ref(), &sig.params, args, arg_types)
@@ -703,13 +691,7 @@ fn semantic_return_length(
     if args.is_empty() && !arg_types.is_empty() {
         return None;
     }
-    let bindings = match_arguments(
-        &signature_params
-            .iter()
-            .map(|param| param.name.as_str())
-            .collect::<Vec<_>>(),
-        args,
-    );
+    let bindings = match_params(signature_params, args);
     let bound_args = |param: &str| {
         signature_params
             .iter()

--- a/crates/ry-checker/src/infer/misc.rs
+++ b/crates/ry-checker/src/infer/misc.rs
@@ -34,28 +34,6 @@ pub(crate) fn equality_list_leaf_type(value: &RType) -> Option<RType> {
     }
 }
 
-pub(crate) fn is_ffi_primitive(name: &str) -> bool {
-    ry_core::FFI_PRIMITIVES.contains(&name)
-}
-
-#[cfg(test)]
-mod ffi_primitives_tests {
-    use super::*;
-
-    /// .Internal must NOT be in FFI_PRIMITIVES: its first argument is a
-    /// call expression, not a bare entry-point symbol. (Every listed
-    /// primitive is trivially "recognized" -- `is_ffi_primitive` is a
-    /// containment check against that very list -- so only non-members
-    /// pin the convention.)
-    #[test]
-    fn internal_is_not_an_ffi_primitive() {
-        assert!(
-            !is_ffi_primitive(".Internal"),
-            ".Internal takes a call, not a symbol; it must not be in FFI_PRIMITIVES"
-        );
-    }
-}
-
 /// Wrappers that forward their first argument to an FFI primitive, so it is
 /// a native routine symbol under the same convention. Unlike the primitives
 /// these are ordinary R functions a user could redefine, so callers gate
@@ -77,14 +55,17 @@ pub(crate) fn modes_compatible(mode: &Mode, target: &Mode) -> bool {
     if matches!(mode, Mode::Opaque | Mode::Union | Mode::Null) {
         return true;
     }
-    fn is_numeric(m: &Mode) -> bool {
-        matches!(m, Mode::Double | Mode::Integer | Mode::Logical)
-    }
     match target {
-        Mode::Double | Mode::Integer | Mode::Logical => is_numeric(mode),
+        Mode::Double | Mode::Integer | Mode::Logical => is_numeric_mode(*mode),
         Mode::Character => matches!(mode, Mode::Character),
         _ => true,
     }
+}
+
+/// R's coercion family: logical, integer, and double values interchange
+/// without a lossy or surprising conversion in the contexts that ask.
+fn is_numeric_mode(mode: Mode) -> bool {
+    matches!(mode, Mode::Double | Mode::Integer | Mode::Logical)
 }
 
 /// Return the R source symbol for a binary operator, for use in
@@ -245,7 +226,7 @@ pub(crate) fn extract_builtin_type_narrowing(cond: &Expr) -> Narrowing {
             lhs,
             rhs,
             ..
-        } if is_zero_literal(rhs) => {
+        } if is_literal_eq(rhs, 0.0) => {
             if let Some(var) = length_guard_var(lhs) {
                 Narrowing::NonNullElse { var }
             } else {
@@ -326,9 +307,9 @@ fn scalar_false_path_fact(expr: &Expr) -> Option<(String, Option<RType>)> {
         else {
             return None;
         };
-        if is_one_literal(rhs) {
+        if is_literal_eq(rhs, 1.0) {
             length_guard_var(lhs)
-        } else if is_one_literal(lhs) {
+        } else if is_literal_eq(lhs, 1.0) {
             length_guard_var(rhs)
         } else {
             None
@@ -371,12 +352,14 @@ fn length_guard_var(expr: &Expr) -> Option<String> {
     first_arg_ident(args)
 }
 
-fn is_zero_literal(expr: &Expr) -> bool {
-    matches!(expr, Expr::Integer(0, _)) || matches!(expr, Expr::Double(value, _) if *value == 0.0)
-}
-
-fn is_one_literal(expr: &Expr) -> bool {
-    matches!(expr, Expr::Integer(1, _)) || matches!(expr, Expr::Double(value, _) if *value == 1.0)
+/// Whether `expr` is the whole-number literal `value` (`0`, `1`, `1.0`),
+/// for the length-guard shapes `length(x) == 0` / `length(x) != 1`.
+fn is_literal_eq(expr: &Expr, value: f64) -> bool {
+    match expr {
+        Expr::Integer(n, _) => *n as f64 == value,
+        Expr::Double(n, _) => *n == value,
+        _ => false,
+    }
 }
 
 /// Return the variable inspected by a simple predicate. `is.na` is included
@@ -1208,6 +1191,41 @@ pub(crate) fn match_arguments(param_names: &[&str], args: &[Arg]) -> ArgumentMat
     result
 }
 
+/// The formal-parameter view RY090/RY091 reporting needs, shared by
+/// typeshed `ParamSpec`s and collected `UserParam`s so one code path
+/// serves stub and user calls.
+trait CallFormal {
+    fn name(&self) -> &str;
+    fn required(&self) -> bool;
+}
+
+impl CallFormal for ParamSpec {
+    fn name(&self) -> &str {
+        &self.name
+    }
+    fn required(&self) -> bool {
+        self.required
+    }
+}
+
+impl CallFormal for UserParam {
+    fn name(&self) -> &str {
+        &self.name
+    }
+    fn required(&self) -> bool {
+        self.required
+    }
+}
+
+/// `match_arguments` over a signature's formal specs: collect the formal
+/// names once and run R's three-pass matching. Callers that need the
+/// names themselves (message text, eval-mode lookup) keep their own
+/// `param_names()` vector.
+pub(crate) fn match_params(params: &[ParamSpec], args: &[Arg]) -> ArgumentMatch {
+    let names: Vec<&str> = params.iter().map(|param| param.name.as_str()).collect();
+    match_arguments(&names, args)
+}
+
 /// Return the actual argument bound to a formal under ordinary R matching.
 /// Semantic metadata must use this rather than raw call positions.
 pub(crate) fn bound_argument_index(
@@ -1215,8 +1233,7 @@ pub(crate) fn bound_argument_index(
     args: &[Arg],
     formal: &str,
 ) -> Option<usize> {
-    let names: Vec<_> = params.iter().map(|param| param.name.as_str()).collect();
-    bound_argument_index_matched(params, &match_arguments(&names, args), formal)
+    bound_argument_index_matched(params, &match_params(params, args), formal)
 }
 
 /// `bound_argument_index` over a match already computed for this call.
@@ -1237,8 +1254,7 @@ pub(crate) fn match_args_to_params(
     args: &[Arg],
     arg_types: &[RType],
 ) -> Vec<RType> {
-    let names: Vec<&str> = sig_params.iter().map(|param| param.name.as_str()).collect();
-    let bindings = match_arguments(&names, args);
+    let bindings = match_params(sig_params, args);
     let mut matched = vec![RType::unknown(); sig_params.len()];
     for (argument_index, parameter_index) in bindings.param_for_arg.iter().enumerate() {
         if let Some(parameter_index) = parameter_index
@@ -1267,9 +1283,7 @@ impl Checker {
         arg_types: &[RType],
         call_span: Span,
     ) {
-        let names: Vec<&str> = signature.param_names().collect();
-        let bindings = match_arguments(&names, args);
-
+        let bindings = match_params(&signature.params, args);
         // `...` accepts every otherwise-unmatched actual argument. Without
         // it, report only named arguments; excess positionals are outside
         // this rule's deliberately narrow scope.
@@ -1277,19 +1291,14 @@ impl Checker {
             .params
             .iter()
             .any(|param| param.required || param.default.is_some() || param.type_.is_some());
-        self.emit_unknown_arguments(
+        self.check_call_arity(
             function_name,
-            &names,
+            &signature.params,
             args,
             &bindings,
             supports_unknown_argument_check,
+            call_span,
         );
-        let required: Vec<bool> = signature
-            .params
-            .iter()
-            .map(|param| param.required)
-            .collect();
-        self.emit_missing_required(function_name, &names, &required, &bindings, call_span);
 
         for (argument_index, parameter_index) in bindings.param_for_arg.iter().enumerate() {
             let Some(parameter_index) = parameter_index else {
@@ -1335,13 +1344,33 @@ impl Checker {
             .map(|parameter| parameter.name.as_str())
             .collect();
         let bindings = match_arguments(&names, args);
-        self.emit_unknown_arguments(function_name, &names, args, &bindings, true);
-        let required: Vec<bool> = function
-            .params
-            .iter()
-            .map(|parameter| parameter.required)
-            .collect();
-        self.emit_missing_required(function_name, &names, &required, &bindings, call_span);
+        self.check_call_arity(
+            function_name,
+            &function.params,
+            args,
+            &bindings,
+            true,
+            call_span,
+        );
+    }
+
+    /// Shared arity reporting over one argument match: RY090 for named
+    /// actuals no formal matched, RY091 for required formals no actual
+    /// bound. The typeshed and user-function checks differ only in their
+    /// formals source and unknown-argument gating.
+    fn check_call_arity<P: CallFormal>(
+        &mut self,
+        function_name: &str,
+        params: &[P],
+        args: &[Arg],
+        bindings: &ArgumentMatch,
+        report_unknown: bool,
+        call_span: Span,
+    ) {
+        let names: Vec<&str> = params.iter().map(|param| param.name()).collect();
+        let required: Vec<bool> = params.iter().map(|param| param.required()).collect();
+        self.emit_unknown_arguments(function_name, &names, args, bindings, report_unknown);
+        self.emit_missing_required(function_name, &names, &required, bindings, call_span);
     }
 
     fn emit_unknown_arguments(
@@ -1542,10 +1571,7 @@ fn known_modes(rtype: &RType) -> Option<Vec<Mode>> {
 }
 
 fn compatible_mode_pair(actual: Mode, expected: Mode) -> bool {
-    fn numeric(mode: Mode) -> bool {
-        matches!(mode, Mode::Logical | Mode::Integer | Mode::Double)
-    }
-    actual == expected || (numeric(actual) && numeric(expected))
+    actual == expected || (is_numeric_mode(actual) && is_numeric_mode(expected))
 }
 
 pub(crate) fn expected_type_label(expected: &RType) -> String {
@@ -1571,17 +1597,18 @@ pub(crate) fn expected_type_label(expected: &RType) -> String {
 
 /// Eval mode declared for the argument at `index`.
 ///
-/// `names` and `bindings` come from one `match_arguments` call shared by the
-/// whole call site, so a loop over arguments does not re-match per argument.
+/// `bindings` comes from one `match_params` call shared by the whole call
+/// site, so a loop over arguments does not re-match per argument.
 pub(crate) fn eval_mode_for_arg(
     sig: &FunctionSig,
-    names: &[&str],
     bindings: &ArgumentMatch,
     index: usize,
 ) -> Option<EvalMode> {
-    bindings.param_for_arg.get(index)?;
-    let parameter = bindings.param_for_arg[index]
-        .and_then(|parameter_index| names.get(parameter_index).copied())
+    let parameter = bindings
+        .param_for_arg
+        .get(index)?
+        .and_then(|parameter_index| sig.params.get(parameter_index))
+        .map(|param| param.name.as_str())
         .unwrap_or("...");
     sig.eval
         .get(parameter)
@@ -1594,8 +1621,7 @@ pub(crate) fn argument_eval_mode(
     args: &[Arg],
     index: usize,
 ) -> Option<EvalMode> {
-    let names: Vec<&str> = sig.param_names().collect();
-    eval_mode_for_arg(sig, &names, &match_arguments(&names, args), index)
+    eval_mode_for_arg(sig, &match_params(&sig.params, args), index)
 }
 
 /// Locate the supplied argument named by a signature's data-mask source.
@@ -1603,36 +1629,20 @@ pub(crate) fn argument_eval_mode(
 /// after mask-evaluated arguments, so callers must not assume argument zero.
 pub(crate) fn data_mask_source_arg(sig: &FunctionSig, args: &[Arg]) -> Option<usize> {
     let source = sig.data_mask_source.as_deref()?;
-    let names: Vec<&str> = sig.param_names().collect();
-    let source_parameter = names.iter().position(|name| *name == source)?;
-    let bindings = match_arguments(&names, args);
+    let bindings = match_params(&sig.params, args);
+    let source_parameter = sig.params.iter().position(|param| param.name == source)?;
     bindings
         .param_for_arg
         .iter()
         .position(|parameter| *parameter == Some(source_parameter))
 }
 
-/// Resolve the resulting mode for `c(...)`. If any argument was a union,
-/// the coerce-rank ladder doesn't apply soundly, so degrade to opaque
-/// rather than emitting a malformed union.
-pub(crate) fn collapse_c_mode(mode: Mode, saw_union: bool) -> Mode {
-    if saw_union { Mode::Opaque } else { mode }
-}
-
 /// If `e` is a literal expression (`42`, `"x"`, `TRUE`, `NULL`, `NA`),
 /// return the mode that calling it would error with.
 /// Non-literal callees return `None` so the caller stays silent.
 pub(crate) fn literal_callee_mode(e: &Expr) -> Option<Mode> {
-    match e {
-        Expr::Logical(_, _) => Some(Mode::Logical),
-        Expr::Integer(_, _) => Some(Mode::Integer),
-        Expr::Double(_, _) => Some(Mode::Double),
-        Expr::String(_, _) => Some(Mode::Character),
-        Expr::Null(_) => Some(Mode::Null),
-        // `NA` carries its own mode (NA, NA_real_, NA_integer_, ...).
-        Expr::Na(t, _) => Some(t.mode),
-        _ => None,
-    }
+    let t = infer_literal_default(e);
+    (!matches!(t.mode, Mode::Opaque)).then_some(t.mode)
 }
 
 /// Compute the longest known length among a slice of argument types.

--- a/crates/ry-checker/src/infer/mod.rs
+++ b/crates/ry-checker/src/infer/mod.rs
@@ -175,22 +175,18 @@ impl Checker {
                 let value_has_list_origin = expression_has_list_origin(value, scope);
                 let vt = self.infer(value, scope);
                 let function_alias = self.function_alias_target(value, scope);
-                if !self.assign_class_attribute(target, value, scope)
-                    && !self.assign_replacement_target(target, scope)
+                if self.try_assign_value(target, value, vt, scope)
+                    && let Some(name) = binding_name(target)
                 {
-                    self.assign_target(target, vt, scope);
-                    if let Some(name) = binding_name(target) {
-                        if value_has_list_origin {
-                            scope.mark_list_origin(name.to_string());
-                        }
-                        if matches!(value, Expr::Function { .. })
-                            && !self.enclosing_formals.is_empty()
-                        {
-                            scope.mark_lexical_function(name.to_string());
-                        }
-                        if let Some(alias) = function_alias {
-                            scope.set_function_alias(name.to_string(), alias);
-                        }
+                    if value_has_list_origin {
+                        scope.mark_list_origin(name.to_string());
+                    }
+                    if matches!(value, Expr::Function { .. }) && !self.enclosing_formals.is_empty()
+                    {
+                        scope.mark_lexical_function(name.to_string());
+                    }
+                    if let Some(alias) = function_alias {
+                        scope.set_function_alias(name.to_string(), alias);
                     }
                 }
                 // Named function bodies (`f <- function(...) body`) must
@@ -252,16 +248,7 @@ impl Checker {
                 cond, then, else_, ..
             } => {
                 // RY103: an `if` condition is a length-1 logical context.
-                self.check_class_equality_operand(cond, scope);
-                let diagnostic_start = self.diagnostics.len();
-                let ct = self.infer(cond, scope);
-                self.emit_condition_diagnostics(
-                    cond,
-                    ct,
-                    scope,
-                    diagnostic_start,
-                    ConditionContext::If,
-                );
+                self.infer_condition(cond, scope, ConditionContext::If);
                 let narrowing = self.extract_type_narrowing(cond, scope);
                 let has_else = else_.is_some();
                 let (mut then_scope, mut else_scope, narrowed) = apply_narrowing(scope, &narrowing);
@@ -322,16 +309,7 @@ impl Checker {
             }
             Stmt::While { cond, body, .. } => {
                 // RY103: a loop condition is a length-1 logical context.
-                self.check_class_equality_operand(cond, scope);
-                let diagnostic_start = self.diagnostics.len();
-                let ct = self.infer(cond, scope);
-                self.emit_condition_diagnostics(
-                    cond,
-                    ct,
-                    scope,
-                    diagnostic_start,
-                    ConditionContext::Loop,
-                );
+                self.infer_condition(cond, scope, ConditionContext::Loop);
                 let mut inner = scope.clone();
                 self.insert_loop_carried_bindings(body, &mut inner);
                 for s in body {
@@ -427,6 +405,21 @@ impl Checker {
         self.record_scope(function_name, span, params, &fn_scope);
         self.enclosing_formals.pop();
         self.deferred_captures.pop();
+    }
+
+    /// Infer a condition in place and emit its condition-diagnostic
+    /// family, in the one order that keeps the rules honest: the RY103
+    /// class-equality operand check runs first, then the condition's own
+    /// inference, and `diagnostic_start` bounds exactly the diagnostics
+    /// that inference produced — which is what lets an RY100 reported
+    /// inside the condition suppress the RY001/RY003/RY002 family. All
+    /// three condition contexts (`if` statements, loop conditions, `if`
+    /// expressions) route through here so they cannot drift apart.
+    fn infer_condition(&mut self, cond: &Expr, scope: &mut Scope, ctx: ConditionContext) {
+        self.check_class_equality_operand(cond, scope);
+        let diagnostic_start = self.diagnostics.len();
+        let ct = self.infer(cond, scope);
+        self.emit_condition_diagnostics(cond, ct, scope, diagnostic_start, ctx);
     }
 
     /// Emit RY001/RY003/RY002 for a condition already inferred as `ct`.
@@ -1011,6 +1004,29 @@ impl Checker {
         })
     }
 
+    /// Run the plain-assignment path: bind `target` (whose value was
+    /// already inferred as `vt`) unless the statement is one of the two
+    /// special assignment forms the checker models separately — a
+    /// class-attribute write (`class(x) <- ...`) or a
+    /// replacement-function mutation (`names(x) <- ...`). Returns
+    /// whether the plain binding ran; the statement walker layers its
+    /// list-origin and function-alias provenance marks on that outcome.
+    fn try_assign_value(
+        &mut self,
+        target: &Expr,
+        value: &Expr,
+        vt: RType,
+        scope: &mut Scope,
+    ) -> bool {
+        if self.assign_class_attribute(target, value, scope)
+            || self.assign_replacement_target(target, scope)
+        {
+            return false;
+        }
+        self.assign_target(target, vt, scope);
+        true
+    }
+
     pub(crate) fn assign_target(&mut self, target: &Expr, vt: RType, scope: &mut Scope) {
         match target {
             Expr::Ident { name, .. } | Expr::String(name, _) => {
@@ -1295,11 +1311,7 @@ impl Checker {
         match stmt {
             Stmt::Assign { target, value, .. } => {
                 let vt = self.infer(value, scope);
-                if !self.assign_class_attribute(target, value, scope)
-                    && !self.assign_replacement_target(target, scope)
-                {
-                    self.assign_target(target, vt.clone(), scope);
-                }
+                self.try_assign_value(target, value, vt.clone(), scope);
                 vt
             }
             Stmt::Expr(e) => self.infer(e, scope),
@@ -1323,7 +1335,7 @@ impl Checker {
                         span: *span,
                     })
                 });
-                self.infer_if_expr(cond, &then_expr, &else_expr, *span, scope)
+                self.infer_if_expr(cond, &then_expr, &else_expr, scope)
             }
             Stmt::For { .. } | Stmt::While { .. } | Stmt::FunctionDef { .. } => {
                 self.walk_stmt(stmt, scope, None);
@@ -1511,11 +1523,7 @@ impl Checker {
                 // value (invisibly).
                 if matches!(*op, BinOpKind::Assign | BinOpKind::SuperAssign) {
                     let rt = self.infer(rhs, scope);
-                    if !self.assign_class_attribute(lhs, rhs, scope)
-                        && !self.assign_replacement_target(lhs, scope)
-                    {
-                        self.assign_target(lhs, rt.clone(), scope);
-                    }
+                    self.try_assign_value(lhs, rhs, rt.clone(), scope);
                     return rt;
                 }
                 // `:` sequence operator: when both operands are
@@ -1569,26 +1577,19 @@ impl Checker {
                 // strip ALL nested `!` operators and only infer the
                 // innermost operand, so RY021 doesn't fire on the
                 // intermediate `!` applied to a list/function.
-                if matches!(op, UnaryOpKind::Not) {
-                    if let Expr::UnaryOp {
-                        op: UnaryOpKind::Not,
-                        ..
-                    } = expr.as_ref()
-                    {
-                        // Strip all consecutive `!` operators to find
-                        // the innermost real expression.
-                        let mut innermost = expr.as_ref();
-                        while let Expr::UnaryOp {
+                if matches!(op, UnaryOpKind::Not)
+                    && matches!(
+                        expr.as_ref(),
+                        Expr::UnaryOp {
                             op: UnaryOpKind::Not,
-                            expr: next,
                             ..
-                        } = innermost
-                        {
-                            innermost = next.as_ref();
                         }
-                        let _ = self.infer(innermost, scope);
-                        return RType::unknown();
-                    }
+                    )
+                {
+                    // Strip all consecutive `!` operators to find
+                    // the innermost real expression.
+                    let _ = self.infer(recall::strip_negation(expr), scope);
+                    return RType::unknown();
                 }
                 let t = self.infer(expr, scope);
                 // Base R's `Math.data.frame`/`Ops.data.frame` apply unary
@@ -1713,11 +1714,8 @@ impl Checker {
                 }
             }
             Expr::If {
-                cond,
-                then,
-                else_,
-                span,
-            } => self.infer_if_expr(cond, then, else_, *span, scope),
+                cond, then, else_, ..
+            } => self.infer_if_expr(cond, then, else_, scope),
             Expr::Unknown(_) => RType::unknown(),
         }
     }

--- a/crates/ry-checker/src/infer/pipe.rs
+++ b/crates/ry-checker/src/infer/pipe.rs
@@ -259,15 +259,11 @@ impl Checker {
         cond: &Expr,
         then: &Expr,
         else_: &Option<Box<Expr>>,
-        _span: Span,
         scope: &mut Scope,
     ) -> RType {
         // RY103: an `if` used in expression position still requires a
         // length-1 logical condition.
-        self.check_class_equality_operand(cond, scope);
-        let diagnostic_start = self.diagnostics.len();
-        let ct = self.infer(cond, scope);
-        self.emit_condition_diagnostics(cond, ct, scope, diagnostic_start, ConditionContext::If);
+        self.infer_condition(cond, scope, ConditionContext::If);
         // Flow-sensitive type narrowing for the expression form too.
         //
         // Limitation: the branch scopes here are clones, and
@@ -299,12 +295,7 @@ impl Checker {
     /// The result type is the join of all alternative types (since we
     /// can't know which branch will execute at runtime). Each
     /// alternative is also walked for diagnostics.
-    pub(crate) fn infer_switch_call(
-        &mut self,
-        args: &[Arg],
-        scope: &mut Scope,
-        _span: Span,
-    ) -> RType {
+    pub(crate) fn infer_switch_call(&mut self, args: &[Arg], scope: &mut Scope) -> RType {
         // The first argument is the selector; infer it for diagnostics.
         if let Some(first) = args.first() {
             let _ = self.infer(&first.value, scope);
@@ -331,12 +322,7 @@ impl Checker {
     /// `callback_return_type` with the condition object as the
     /// callback's argument (opaque, since we don't model the
     /// condition object).
-    pub(crate) fn infer_trycatch_call(
-        &mut self,
-        args: &[Arg],
-        scope: &mut Scope,
-        _span: Span,
-    ) -> RType {
+    pub(crate) fn infer_trycatch_call(&mut self, args: &[Arg], scope: &mut Scope) -> RType {
         let mut types: Vec<RType> = Vec::new();
         for (i, a) in args.iter().enumerate() {
             if i == 0 {

--- a/crates/ry-checker/src/infer/recall.rs
+++ b/crates/ry-checker/src/infer/recall.rs
@@ -79,8 +79,10 @@ fn mistyped_element_name(target: &Expr) -> Option<&str> {
     }
 }
 
-/// Strip any leading unary `!` operators, returning the operand under them.
-fn strip_negation(expr: &Expr) -> &Expr {
+/// Strip any leading unary `!` operators, returning the operand under
+/// them. Also used by the tidyeval `!!`/`!!!` handling in `infer`, which
+/// tree-sitter parses as nested unary `!`.
+pub(crate) fn strip_negation(expr: &Expr) -> &Expr {
     let mut inner = expr;
     while let Expr::UnaryOp {
         op: UnaryOpKind::Not,

--- a/crates/ry-checker/src/lib.rs
+++ b/crates/ry-checker/src/lib.rs
@@ -737,11 +737,7 @@ impl Checker {
         // Emit parse errors after the collection/refinement passes (both
         // run with emission suppressed), so RY000s lead the diagnostic
         // vector rather than being wiped or buried by it.
-        self.emit_parse_errors(file);
-        let mut scope = self.top_level_scope();
-        for s in &file.stmts {
-            self.check_stmt(s, &mut scope);
-        }
+        let scope = self.emit_diagnostics(file);
         (std::mem::take(&mut self.diagnostics), scope)
     }
 
@@ -1213,8 +1209,9 @@ impl Checker {
 
     // Pass 3: emit diagnostics for this file using the refined tables.
     // Diagnostics are appended to `self.diagnostics`; clear that vec
-    // first if you want only this file's diagnostics.
-    pub(crate) fn emit_diagnostics(&mut self, file: &SourceFile) {
+    // first if you want only this file's diagnostics. Returns the final
+    // top-level scope (also what `check_with_scope` hands to the LSP).
+    pub(crate) fn emit_diagnostics(&mut self, file: &SourceFile) -> Scope {
         self.path = file.path.clone();
         self.source.clone_from(&file.source);
         self.emit_parse_errors(file);
@@ -1230,10 +1227,11 @@ impl Checker {
                 name: None,
                 span: whole_file_span(&self.source),
                 params: Vec::new(),
-                scope,
+                scope: scope.clone(),
             };
             self.scope_records.push(record);
         }
+        scope
     }
 
     /// Opt this checker into snapshotting every completed lexical scope

--- a/crates/ry-cli/src/dump.rs
+++ b/crates/ry-cli/src/dump.rs
@@ -520,53 +520,25 @@ pub(crate) fn run_dump_types(
     // rooted at --project-root, else the config root (the directory
     // owning the discovered ry.toml), else the working directory —
     // `run_check_once`'s fallback chain with --project-root overriding.
-    let groups = pipeline::group_by_package_root(parsed.iter().map(|file| file.path.as_str()));
+    let groups = pipeline::resolve_groups(
+        &parsed,
+        &cfg,
+        &user_stubs,
+        &[project_root.as_deref(), config_root.as_deref()],
+    )?;
 
     let mut records_by_path: HashMap<String, Vec<ry_checker::ScopeRecord>> = HashMap::new();
-    for (group_root, indices) in &groups {
-        let resolution_root = group_root
-            .clone()
-            .or_else(|| project_root.clone())
-            .or_else(|| config_root.clone())
-            .unwrap_or_else(|| std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")));
-        let mut package_scope = ry_workspace::resolve_workspace_context(
-            &resolution_root,
-            &cfg,
-            ry_workspace::ResolutionEnvironment {
-                files: indices.iter().map(|index| &parsed[*index].file).collect(),
-                user_stubs: &user_stubs,
-            },
-        )
-        .map_err(|error| miette::miette!(error))?;
-        let analysis_files: Vec<_> = indices
-            .iter()
-            .map(|index| {
-                let parsed_file = &parsed[*index];
-                (
-                    parsed_file.path.clone(),
-                    std::sync::Arc::new(parsed_file.file.clone()),
-                )
-            })
-            .collect();
-        // Split the resolved workspace into checker input (with an empty
-        // `degraded_scopes`) and the notes this command reports itself.
-        let degraded_scopes = std::mem::take(&mut package_scope.degraded_scopes);
-        let workspace = package_scope;
-        let check_input = check::CheckInput {
-            files: analysis_files,
-            user_stubs: std::sync::Arc::clone(&user_stubs),
-            workspace: Some(workspace),
-        };
+    for group in groups {
         // `ry check` prints one summary line per degraded scope; keep the
         // note on stderr here too so a dump over the same project reports
         // the same precision loss without polluting the JSON on stdout.
-        for (path, reason) in &degraded_scopes {
+        for (path, reason) in &group.degraded_scopes {
             eprintln!(
                 "ry: {}: degraded scope ({reason}); serialized data file(s) over the byte cap fell back to file stems",
                 path.display()
             );
         }
-        for (path, records) in check::check_project_with_scope_capture(check_input) {
+        for (path, records) in check::check_project_with_scope_capture(group.check_input) {
             records_by_path.insert(path, records);
         }
     }

--- a/crates/ry-cli/src/main.rs
+++ b/crates/ry-cli/src/main.rs
@@ -220,13 +220,7 @@ enum Cmd {
     /// Explain a rule (or all rules). `ry rule` is an alias (matches
     /// ruff's `ruff rule`).
     #[command(visible_alias = "rule")]
-    ExplainRule {
-        /// Rule code or name. Omit to list all rules.
-        rule: Option<String>,
-        /// Output format: text or json.
-        #[arg(long, value_name = "FORMAT", default_value = "text")]
-        output_format: String,
-    },
+    ExplainRule(ExplainRuleArgs),
     /// Explain analyzer data and configuration.
     Explain {
         #[command(subcommand)]
@@ -244,16 +238,22 @@ enum Cmd {
     },
 }
 
+/// Arguments shared by `ry explain-rule` (alias `ry rule`) and
+/// `ry explain rule`: both spellings select the same rule and output
+/// format, so their flags cannot drift apart.
+#[derive(Debug, Args)]
+struct ExplainRuleArgs {
+    /// Rule code or name. Omit to list all rules.
+    rule: Option<String>,
+    /// Output format: text or json.
+    #[arg(long, value_name = "FORMAT", default_value = "text")]
+    output_format: String,
+}
+
 #[derive(Debug, Subcommand)]
 enum ExplainCmd {
     /// Explain a rule (or all rules).
-    Rule {
-        /// Rule code or name. Omit to list all rules.
-        rule: Option<String>,
-        /// Output format: text or json.
-        #[arg(long, value_name = "FORMAT", default_value = "text")]
-        output_format: String,
-    },
+    Rule(ExplainRuleArgs),
     /// Show vendored and active runtime typeshed packages.
     Typeshed,
 }
@@ -332,15 +332,9 @@ fn main() -> Result<ExitCode> {
             print_version(&output_format);
             Ok(ExitCode::SUCCESS)
         }
-        Cmd::ExplainRule {
-            rule,
-            output_format,
-        } => run_explain_rule(rule, &output_format),
+        Cmd::ExplainRule(args) => run_explain_rule(args.rule, &args.output_format),
         Cmd::Explain { command } => match command {
-            ExplainCmd::Rule {
-                rule,
-                output_format,
-            } => run_explain_rule(rule, &output_format),
+            ExplainCmd::Rule(args) => run_explain_rule(args.rule, &args.output_format),
             ExplainCmd::Typeshed => run_explain_typeshed(),
         },
         Cmd::Typeshed {
@@ -458,26 +452,16 @@ fn run_check(
         min_confidence,
     } = args;
 
-    // Determine the search start directory for config discovery. If the
-    // user passed a path, anchor discovery at the first path's parent
-    // (for files) or at the path itself (for directories). With no
-    // paths, discovery starts from the current working directory.
-    // `dump-types` anchors at the first input itself instead; see
-    // `run_dump_types`.
-    let search_start: PathBuf = paths
+    // Config discovery is anchored at the first input path (itself for a
+    // directory, its parent for a file — `Config::discover` applies that
+    // rule) or at the working directory when no paths were given, the
+    // same anchor `ry dump-types` uses.
+    let search_start = paths
         .first()
-        .map(|p| {
-            if p.is_dir() {
-                p.clone()
-            } else {
-                p.parent()
-                    .map(|p| p.to_path_buf())
-                    .unwrap_or_else(|| PathBuf::from("."))
-            }
-        })
-        .unwrap_or_else(|| PathBuf::from("."));
+        .map(|p| p.as_path())
+        .unwrap_or_else(|| std::path::Path::new("."));
 
-    let (config_root, base_cfg) = match pipeline::discover_config(&search_start) {
+    let (config_root, base_cfg) = match pipeline::discover_config(search_start) {
         Ok(found) => found,
         Err(code) => return Ok(code),
     };
@@ -485,23 +469,20 @@ fn run_check(
     // Forward `None` for scalars the CLI did not set explicitly, so the
     // config file's value wins.
     let m = check_matches;
-    let cli_error_on_warning = flag_set(m, "error_on_warning").then_some(error_on_warning);
-    let cli_exit_zero = flag_set(m, "exit_zero").then_some(exit_zero);
-    let cli_output_format = flag_set(m, "output_format").then_some(output_format.to_string());
     let baseline_from_cli = flag_set(m, "baseline");
 
-    let cfg = base_cfg.merge_cli(
+    let cfg = base_cfg.merge_cli(config::CliOverrides {
         error,
         warn,
         ignore,
         typeshed,
         baseline,
-        cli_error_on_warning,
-        cli_exit_zero,
-        cli_output_format,
-        cli_verbose,
-        cli_quiet,
-    );
+        error_on_warning: flag_set(m, "error_on_warning").then_some(error_on_warning),
+        exit_zero: flag_set(m, "exit_zero").then_some(exit_zero),
+        output_format: flag_set(m, "output_format").then_some(output_format.to_string()),
+        verbose: cli_verbose,
+        quiet: cli_quiet,
+    });
 
     let baseline = match cfg.baseline.as_deref() {
         Some(path) => match config::load_baseline(path) {
@@ -797,6 +778,7 @@ fn run_check_once(paths: &[PathBuf], ctx: &CheckContext) -> Result<CheckResult> 
         .filter(|parsed_file| {
             file_count += 1;
             srcs.insert(parsed_file.path.clone(), parsed_file.src.clone());
+            comments.insert(parsed_file.path.clone(), parsed_file.file.comments.clone());
             if is_probably_not_r_source(&parsed_file.file) {
                 not_r_diagnostics.push(ry_checker::Diagnostic::new(
                     ry_checker::Severity::Info,
@@ -812,49 +794,21 @@ fn run_check_once(paths: &[PathBuf], ctx: &CheckContext) -> Result<CheckResult> 
         })
         .collect();
 
-    // Same per-package grouping as `ry dump-types` (see
-    // `pipeline::group_by_package_root`).
-    let groups = pipeline::group_by_package_root(parsed.iter().map(|file| file.path.as_str()));
+    // Same per-package grouping as `ry dump-types`; check's fallback
+    // resolution root for non-package files is the config root (check has
+    // no --project-root flag), else the working directory.
+    let groups = pipeline::resolve_groups(
+        &parsed,
+        ctx.resolution_config,
+        &ctx.user_stubs,
+        &[ctx.repo_root],
+    )?;
 
     let mut per_file_diagnostics = Vec::new();
-    for (group_root, indices) in &groups {
-        // Non-package files resolve against the config root, else the
-        // working directory. (`dump-types` offers --project-root as an
-        // extra override here; check has no such flag.)
-        let resolution_root = group_root
-            .clone()
-            .or_else(|| ctx.repo_root.map(PathBuf::from))
-            .unwrap_or_else(|| std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")));
-        let mut package_scope = ry_workspace::resolve_workspace_context(
-            &resolution_root,
-            ctx.resolution_config,
-            ry_workspace::ResolutionEnvironment {
-                files: indices.iter().map(|index| &parsed[*index].file).collect(),
-                user_stubs: &ctx.user_stubs,
-            },
-        )
-        .map_err(|error| miette::miette!(error))?;
-        let mut analysis_files = Vec::new();
-        for index in indices {
-            let parsed_file = &parsed[*index];
-            analysis_files.push((
-                parsed_file.path.clone(),
-                std::sync::Arc::new(parsed_file.file.clone()),
-            ));
-            comments.insert(parsed_file.path.clone(), parsed_file.file.comments.clone());
-        }
-        // Split the resolved workspace into checker input (with an empty
-        // `degraded_scopes`) and the notes this command reports itself.
-        let degraded_scopes = std::mem::take(&mut package_scope.degraded_scopes);
-        let workspace = package_scope;
-        let check_input = check::CheckInput {
-            files: analysis_files,
-            user_stubs: Arc::clone(&ctx.user_stubs),
-            workspace: Some(workspace),
-        };
-        let check_output = check::check_project(check_input);
+    for group in groups {
+        let check_output = check::check_project(group.check_input);
         per_file_diagnostics.extend(check_output.diagnostics);
-        for (path, reason) in degraded_scopes {
+        for (path, reason) in group.degraded_scopes {
             degraded.insert(format!("{} ({})", path.display(), reason));
         }
     }
@@ -1088,21 +1042,6 @@ fn run_shell_completion(shell: &str) -> Result<ExitCode> {
     Ok(ExitCode::SUCCESS)
 }
 
-/// Test-compatible wrapper around the shared bounded discovery module.
-/// Production code calls [`ry_workspace::discover_r_files`] directly with
-/// the effective folder config so CLI and LSP use identical discovery
-/// rules (issue #48).
-#[cfg(test)]
-fn collect_r_files(path: &std::path::Path, out: &mut Vec<PathBuf>, check_test_fixtures: bool) {
-    let result = ry_workspace::discover_r_files(
-        path,
-        None,
-        &ry_config::Config::default(),
-        check_test_fixtures,
-    );
-    out.extend(result.files);
-}
-
 /// Surface a discovery cap hit to the user. A cap hit is never
 /// silent: the CLI prints one warning per root when any limit is reached.
 fn report_truncation(report: &ry_workspace::TruncationReport, root: &std::path::Path) {
@@ -1172,12 +1111,9 @@ fn sync_stamps(paths: &[PathBuf], stamps: &mut HashMap<PathBuf, std::time::Syste
 
 #[cfg(test)]
 mod tests {
-    use super::config::{
-        Baseline, BaselineEntry, load_baseline, subtract_baseline, write_baseline_file,
-    };
     use super::{
-        CheckContext, CheckResult, ColorChoice, collect_r_files, demote_non_source_paths,
-        run_check_once, sort_and_deduplicate_diagnostics,
+        CheckContext, CheckResult, ColorChoice, demote_non_source_paths, run_check_once,
+        sort_and_deduplicate_diagnostics,
     };
     use ry_checker::format::OutputFormat;
     use ry_checker::{Diagnostic, Severity};
@@ -1200,7 +1136,7 @@ mod tests {
     /// root; anything else they vary themselves.
     fn check_files(paths: &[PathBuf], repo_root: Option<&std::path::Path>) -> CheckResult {
         let filter = ry_checker::SeverityFilter::default();
-        let resolution_config = ry_config::Config::defaults();
+        let resolution_config = ry_config::Config::default();
         run_check_once(
             paths,
             &CheckContext {
@@ -1215,35 +1151,6 @@ mod tests {
             },
         )
         .unwrap()
-    }
-
-    #[test]
-    fn rbuildignore_trailing_dollar_respects_escape_parity() {
-        assert!(
-            ry_workspace::rbuildignore_pattern("^file$")
-                .unwrap()
-                .matches("file")
-        );
-        assert!(
-            !ry_workspace::rbuildignore_pattern("^file$")
-                .unwrap()
-                .matches("filex")
-        );
-        assert!(
-            ry_workspace::rbuildignore_pattern(r"^file\$")
-                .unwrap()
-                .matches("file$")
-        );
-        assert!(
-            ry_workspace::rbuildignore_pattern(r"^file\\$")
-                .unwrap()
-                .matches(r"file\")
-        );
-        assert!(
-            !ry_workspace::rbuildignore_pattern(r"^file\\$")
-                .unwrap()
-                .matches(r"file\x")
-        );
     }
 
     #[test]
@@ -1269,39 +1176,6 @@ mod tests {
                 ("b.R", 1, 0, "RY010"),
             ]
         );
-    }
-
-    #[test]
-    fn baseline_round_trip_suppresses_existing_but_not_new_diagnostics() {
-        let temp = tempfile::tempdir().unwrap();
-        let path = temp.path().join("baseline.json");
-        let existing = diag("a.R", 1, 0, "RY010");
-        write_baseline_file(&path, std::slice::from_ref(&existing), Some(temp.path())).unwrap();
-        let baseline = load_baseline(&path).unwrap();
-        let mut diagnostics = vec![existing, diag("a.R", 2, 0, "RY030")];
-        subtract_baseline(&mut diagnostics, &baseline, Some(temp.path()));
-        assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].code, "RY030");
-    }
-
-    #[test]
-    fn baseline_counts_absorb_only_the_recorded_occurrences() {
-        let baseline = Baseline {
-            version: 1,
-            entries: vec![BaselineEntry {
-                path: "a.R".to_string(),
-                code: "RY010".to_string(),
-                message: "same message".to_string(),
-                count: 2,
-            }],
-        };
-        let mut diagnostics = vec![
-            diag("a.R", 1, 0, "RY010"),
-            diag("a.R", 2, 0, "RY010"),
-            diag("a.R", 3, 0, "RY010"),
-        ];
-        subtract_baseline(&mut diagnostics, &baseline, None);
-        assert_eq!(diagnostics.len(), 1);
     }
 
     #[test]
@@ -1349,8 +1223,9 @@ mod tests {
         std::fs::write(first.join("R/first.R"), "only_in_first <- 1L\n").unwrap();
         std::fs::write(second.join("R/second.R"), "value <- only_in_first\n").unwrap();
 
-        let mut paths = Vec::new();
-        collect_r_files(temp.path(), &mut paths, false);
+        let mut paths =
+            ry_workspace::discover_r_files(temp.path(), None, &ry_config::Config::default(), false)
+                .files;
         paths.sort();
         let result = check_files(&paths, Some(temp.path()));
         assert!(result.diagnostics.iter().any(|diagnostic| {
@@ -1358,103 +1233,6 @@ mod tests {
                 && diagnostic.path.contains("second")
                 && diagnostic.message.contains("only_in_first")
         }));
-    }
-
-    #[test]
-    fn package_scan_skips_test_fixtures_but_keeps_executable_test_code() {
-        let temp = tempfile::tempdir().unwrap();
-        let root = temp.path();
-        std::fs::write(root.join("DESCRIPTION"), "Package: example\n").unwrap();
-        for directory in [
-            "R",
-            "tests/testthat",
-            "tests/testthat/fixtures",
-            "tests/testthat/_snaps",
-            "tests/manual",
-            "revdep/other/R",
-            "src/ratfor",
-        ] {
-            std::fs::create_dir_all(root.join(directory)).unwrap();
-        }
-        for file in [
-            "R/package.R",
-            "tests/testthat.R",
-            "tests/testthat/test-package.R",
-            "tests/testthat/helper-package.R",
-            "tests/testthat/setup-package.R",
-            "tests/testthat/teardown-package.R",
-            "tests/testthat/fixtures/input.R",
-            "tests/testthat/data.R",
-            "tests/testthat/_snaps/output.R",
-            "tests/manual/example.R",
-            "revdep/other/R/other.R",
-            "src/ratfor/program.r",
-        ] {
-            std::fs::write(root.join(file), "").unwrap();
-        }
-
-        let mut paths = Vec::new();
-        collect_r_files(root, &mut paths, false);
-        paths.sort();
-
-        assert_eq!(
-            paths,
-            vec![
-                root.join("R/package.R"),
-                root.join("tests/testthat/helper-package.R"),
-                root.join("tests/testthat/setup-package.R"),
-                root.join("tests/testthat/teardown-package.R"),
-                root.join("tests/testthat/test-package.R"),
-                root.join("tests/testthat.R"),
-            ]
-        );
-    }
-
-    #[test]
-    fn package_scan_can_opt_into_test_fixtures() {
-        let temp = tempfile::tempdir().unwrap();
-        let root = temp.path();
-        std::fs::write(root.join("DESCRIPTION"), "Package: example\n").unwrap();
-        std::fs::create_dir_all(root.join("tests/testthat/fixtures")).unwrap();
-        let fixture = root.join("tests/testthat/fixtures/input.R");
-        std::fs::write(&fixture, "missing_name\n").unwrap();
-
-        let mut paths = Vec::new();
-        collect_r_files(root, &mut paths, true);
-
-        assert_eq!(paths, vec![fixture]);
-    }
-
-    #[test]
-    fn package_scan_keeps_inst_sources() {
-        let temp = tempfile::tempdir().unwrap();
-        let root = temp.path();
-        std::fs::write(root.join("DESCRIPTION"), "Package: example\n").unwrap();
-        std::fs::create_dir_all(root.join("inst/resources")).unwrap();
-        let installed = root.join("inst/resources/activate.R");
-        std::fs::write(&installed, "missing_name\n").unwrap();
-
-        let mut paths = Vec::new();
-        collect_r_files(root, &mut paths, false);
-
-        assert_eq!(paths, vec![installed]);
-    }
-
-    #[test]
-    fn package_scan_skips_vendored_renv_bootstrap() {
-        let temp = tempfile::tempdir().unwrap();
-        let root = temp.path();
-        std::fs::write(root.join("DESCRIPTION"), "Package: example\n").unwrap();
-        std::fs::create_dir_all(root.join("R")).unwrap();
-        std::fs::create_dir_all(root.join("renv")).unwrap();
-        let source = root.join("R/package.R");
-        std::fs::write(&source, "value <- 1L\n").unwrap();
-        std::fs::write(root.join("renv/activate.R"), "bootstrap_missing\n").unwrap();
-
-        let mut paths = Vec::new();
-        collect_r_files(root, &mut paths, false);
-
-        assert_eq!(paths, vec![source]);
     }
 
     #[test]
@@ -1466,8 +1244,8 @@ mod tests {
         std::fs::write(&source, "source_missing\n").unwrap();
         std::fs::write(root.join("example.Rcheck/R/copied.R"), "copied_missing\n").unwrap();
 
-        let mut paths = Vec::new();
-        collect_r_files(root, &mut paths, false);
+        let paths =
+            ry_workspace::discover_r_files(root, None, &ry_config::Config::default(), false).files;
 
         assert_eq!(paths, vec![source.clone()]);
 
@@ -1483,84 +1261,6 @@ mod tests {
                 .diagnostics
                 .iter()
                 .all(|diagnostic| diagnostic.path == source.to_string_lossy().as_ref())
-        );
-    }
-
-    #[test]
-    fn collection_includes_all_supported_r_source_extensions() {
-        let temp = tempfile::tempdir().unwrap();
-        let root = temp.path();
-        for extension in ["R", "r", "S", "s", "q"] {
-            std::fs::write(root.join(format!("source.{extension}")), "value <- 1L\n").unwrap();
-        }
-        std::fs::write(root.join("source.txt"), "not R\n").unwrap();
-
-        let mut paths = Vec::new();
-        collect_r_files(root, &mut paths, false);
-        paths.sort();
-
-        let mut expected = ["R", "r", "S", "s", "q"]
-            .map(|extension| root.join(format!("source.{extension}")))
-            .into_iter()
-            .collect::<Vec<_>>();
-        expected.sort();
-        assert_eq!(paths, expected);
-    }
-
-    #[test]
-    fn explicitly_selected_file_is_not_package_excluded() {
-        let temp = tempfile::tempdir().unwrap();
-        let root = temp.path();
-        std::fs::write(root.join("DESCRIPTION"), "Package: example\n").unwrap();
-        std::fs::create_dir(root.join("src")).unwrap();
-        let file = root.join("src/ratfor.r");
-        std::fs::write(&file, "").unwrap();
-
-        let mut paths = Vec::new();
-        collect_r_files(&file, &mut paths, false);
-
-        assert_eq!(paths, vec![file]);
-    }
-
-    #[test]
-    fn explicitly_selected_q_file_is_collected() {
-        let temp = tempfile::tempdir().unwrap();
-        let file = temp.path().join("source.q");
-        std::fs::write(&file, "value <- 1L\n").unwrap();
-
-        let mut paths = Vec::new();
-        collect_r_files(&file, &mut paths, false);
-
-        assert_eq!(paths, vec![file]);
-    }
-
-    #[test]
-    fn package_scan_honors_rbuildignore_except_r_and_tests() {
-        let temp = tempfile::tempdir().unwrap();
-        let root = temp.path();
-        std::fs::write(root.join("DESCRIPTION"), "Package: example\n").unwrap();
-        std::fs::write(root.join(".Rbuildignore"), "^ignored\\.R$\n^R/\n^tests/\n").unwrap();
-        std::fs::create_dir_all(root.join("R")).unwrap();
-        std::fs::create_dir_all(root.join("tests/testthat")).unwrap();
-        for file in [
-            "ignored.R",
-            "kept.R",
-            "R/package.R",
-            "tests/testthat/test-package.R",
-        ] {
-            std::fs::write(root.join(file), "").unwrap();
-        }
-
-        let mut paths = Vec::new();
-        collect_r_files(root, &mut paths, false);
-        paths.sort();
-        assert_eq!(
-            paths,
-            vec![
-                root.join("R/package.R"),
-                root.join("kept.R"),
-                root.join("tests/testthat/test-package.R"),
-            ]
         );
     }
 
@@ -1593,8 +1293,8 @@ mod tests {
         .unwrap();
         std::fs::write(root.join("data-raw/build.R"), "Surv\n").unwrap();
 
-        let mut paths = Vec::new();
-        collect_r_files(root, &mut paths, false);
+        let mut paths =
+            ry_workspace::discover_r_files(root, None, &ry_config::Config::default(), false).files;
         paths.sort();
         let result = check_files(&paths, Some(root));
         let unresolved: Vec<_> = result
@@ -1630,8 +1330,8 @@ mod tests {
         )
         .unwrap();
 
-        let mut paths = Vec::new();
-        collect_r_files(root, &mut paths, false);
+        let mut paths =
+            ry_workspace::discover_r_files(root, None, &ry_config::Config::default(), false).files;
         paths.sort();
         let result = check_files(&paths, Some(root));
         let unresolved: Vec<_> = result

--- a/crates/ry-cli/src/pipeline.rs
+++ b/crates/ry-cli/src/pipeline.rs
@@ -7,6 +7,7 @@
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
+use std::sync::Arc;
 
 use ry_config as config;
 
@@ -24,7 +25,7 @@ pub(crate) fn discover_config(
             tracing::debug!(config = %path.display(), "loaded ry.toml");
             Ok((path.parent().map(PathBuf::from), cfg))
         }
-        Ok(None) => Ok((None, config::Config::defaults())),
+        Ok(None) => Ok((None, config::Config::default())),
         Err(e) => {
             eprintln!("ry: {}", e);
             Err(ExitCode::FAILURE)
@@ -202,4 +203,75 @@ where
             .push(index);
     }
     groups
+}
+
+/// One per-package group, ready for the checker: the group's files and
+/// workspace context wrapped as a `CheckInput`, plus the degraded-scope
+/// notes the command reports in its own voice.
+pub(crate) struct ResolvedGroup {
+    pub check_input: crate::check::CheckInput,
+    pub degraded_scopes: Vec<(PathBuf, &'static str)>,
+}
+
+/// Resolve parsed files into per-package checker inputs, shared by
+/// `ry check` and `ry dump-types` so the two commands can never disagree
+/// about library scoping or resolution roots.
+///
+/// Each DESCRIPTION root becomes its own group (see
+/// [`group_by_package_root`]). A group without a package root resolves
+/// against the first entry of `fallback_roots` that is set — `ry check`
+/// passes the config root, `dump-types` passes `--project-root` and then
+/// the config root — and finally against the working directory. The
+/// workspace context's `degraded_scopes` are split out of the
+/// `CheckInput` because each command reports the precision loss
+/// differently: check summarizes them in its summary line, dump-types
+/// prints one note per scope on stderr to keep stdout's JSON clean.
+pub(crate) fn resolve_groups(
+    parsed: &[ParsedFile],
+    cfg: &config::Config,
+    user_stubs: &Arc<BTreeMap<String, ry_typeshed::Typeshed>>,
+    fallback_roots: &[Option<&Path>],
+) -> miette::Result<Vec<ResolvedGroup>> {
+    let groups = group_by_package_root(parsed.iter().map(|file| file.path.as_str()));
+    let mut resolved = Vec::with_capacity(groups.len());
+    for (group_root, indices) in &groups {
+        let resolution_root = group_root
+            .clone()
+            .or_else(|| {
+                fallback_roots
+                    .iter()
+                    .flatten()
+                    .copied()
+                    .next()
+                    .map(PathBuf::from)
+            })
+            .unwrap_or_else(|| std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")));
+        let mut package_scope = ry_workspace::resolve_workspace_context(
+            &resolution_root,
+            cfg,
+            ry_workspace::ResolutionEnvironment {
+                files: indices.iter().map(|index| &parsed[*index].file).collect(),
+                user_stubs,
+            },
+        )
+        .map_err(|error| miette::miette!(error))?;
+        let analysis_files = indices
+            .iter()
+            .map(|index| {
+                let parsed_file = &parsed[*index];
+                (parsed_file.path.clone(), Arc::new(parsed_file.file.clone()))
+            })
+            .collect();
+        let degraded_scopes = std::mem::take(&mut package_scope.degraded_scopes);
+        let workspace = package_scope;
+        resolved.push(ResolvedGroup {
+            check_input: crate::check::CheckInput {
+                files: analysis_files,
+                user_stubs: Arc::clone(user_stubs),
+                workspace: Some(workspace),
+            },
+            degraded_scopes,
+        });
+    }
+    Ok(resolved)
 }

--- a/crates/ry-cli/tests/lsp_testkit.rs
+++ b/crates/ry-cli/tests/lsp_testkit.rs
@@ -1,6 +1,6 @@
 use ry_testkit::{
     Driver, DriverError, FixtureProject, JsonRpcProcess, ObservedDiagnostic, ObservedPosition,
-    ObservedRange, PositionEncoding, normalize_path,
+    ObservedRange, PositionEncoding, file_uri, normalize_path,
 };
 use serde_json::{Value, json};
 use std::path::Path;
@@ -16,7 +16,7 @@ impl Driver for LspSubprocessDriver {
         let mut command = Command::new(env!("CARGO_BIN_EXE_ry"));
         command.arg("server").current_dir(fixture.root());
         let mut client = JsonRpcProcess::spawn(&mut command)?;
-        let root_uri = file_uri(fixture.root());
+        let root_uri = file_uri(fixture.root())?;
         let initialize_id = client.request(
             "initialize",
             json!({
@@ -33,7 +33,7 @@ impl Driver for LspSubprocessDriver {
         client.notify("initialized", json!({}))?;
 
         let path = fixture.path("R/diagnostic.R");
-        let uri = file_uri(&path);
+        let uri = file_uri(&path)?;
         let text = std::fs::read_to_string(&path)?;
         client.notify(
             "textDocument/didOpen",
@@ -119,10 +119,6 @@ fn lsp_position(value: &Value) -> Result<ObservedPosition, DriverError> {
             .ok_or("position has no character")? as u32,
         encoding: PositionEncoding::Utf16,
     })
-}
-
-fn file_uri(path: &Path) -> String {
-    format!("file://{}", path.display())
 }
 
 #[test]

--- a/crates/ry-config/src/baseline.rs
+++ b/crates/ry-config/src/baseline.rs
@@ -119,28 +119,36 @@ pub fn subtract_baseline<D: BaselineDiagnostic>(
 mod tests {
     use super::*;
 
+    /// Minimal `BaselineDiagnostic` carrier; baseline logic keys on
+    /// (path, code, message) only, so spans are unnecessary here.
+    struct TestDiag {
+        path: String,
+        code: String,
+        message: String,
+    }
+
+    impl BaselineDiagnostic for TestDiag {
+        fn path(&self) -> &str {
+            &self.path
+        }
+        fn code(&self) -> &str {
+            &self.code
+        }
+        fn message(&self) -> &str {
+            &self.message
+        }
+    }
+
+    fn diag(path: &str, code: &str) -> TestDiag {
+        TestDiag {
+            path: path.to_string(),
+            code: code.to_string(),
+            message: "same message".to_string(),
+        }
+    }
+
     #[test]
     fn baseline_subtract_removes_matching_entries() {
-        use ry_core::BaselineDiagnostic;
-
-        struct TestDiag {
-            path: String,
-            code: String,
-            message: String,
-        }
-
-        impl BaselineDiagnostic for TestDiag {
-            fn path(&self) -> &str {
-                &self.path
-            }
-            fn code(&self) -> &str {
-                &self.code
-            }
-            fn message(&self) -> &str {
-                &self.message
-            }
-        }
-
         let baseline = Baseline {
             version: 1,
             entries: vec![BaselineEntry {
@@ -159,5 +167,38 @@ mod tests {
 
         subtract_baseline(&mut diags, &baseline, None);
         assert!(diags.is_empty(), "baseline should remove the diagnostic");
+    }
+
+    #[test]
+    fn baseline_round_trip_suppresses_existing_but_not_new_diagnostics() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("baseline.json");
+        let existing = diag("a.R", "RY010");
+        write_baseline_file(&path, std::slice::from_ref(&existing), Some(temp.path())).unwrap();
+        let baseline = load_baseline(&path).unwrap();
+        let mut diagnostics = vec![existing, diag("a.R", "RY030")];
+        subtract_baseline(&mut diagnostics, &baseline, Some(temp.path()));
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].code, "RY030");
+    }
+
+    #[test]
+    fn baseline_counts_absorb_only_the_recorded_occurrences() {
+        let baseline = Baseline {
+            version: 1,
+            entries: vec![BaselineEntry {
+                path: "a.R".to_string(),
+                code: "RY010".to_string(),
+                message: "same message".to_string(),
+                count: 2,
+            }],
+        };
+        let mut diagnostics = vec![
+            diag("a.R", "RY010"),
+            diag("a.R", "RY010"),
+            diag("a.R", "RY010"),
+        ];
+        subtract_baseline(&mut diagnostics, &baseline, None);
+        assert_eq!(diagnostics.len(), 1);
     }
 }

--- a/crates/ry-config/src/config.rs
+++ b/crates/ry-config/src/config.rs
@@ -143,24 +143,8 @@ pub struct Config {
 }
 
 impl Default for Config {
-    /// Same as [`Config::defaults`].
-    fn default() -> Self {
-        Self::defaults()
-    }
-}
-
-/// serde default for `Config::output_format`. Kept as a free function
-/// because `#[serde(default = "...")]` requires a path, not a closure.
-/// Without this, the struct-level `#[serde(default)]` would fill a
-/// missing `output-format` with the `String` default (empty string)
-/// rather than `"full"`.
-fn default_output_format() -> String {
-    DEFAULT_OUTPUT_FORMAT.to_string()
-}
-
-impl Config {
     /// Built-in defaults, as if no config file were present.
-    pub fn defaults() -> Self {
+    fn default() -> Self {
         Self {
             error_on_warning: false,
             exit_zero: false,
@@ -183,7 +167,18 @@ impl Config {
             index: IndexConfig::default(),
         }
     }
+}
 
+/// serde default for `Config::output_format`. Kept as a free function
+/// because `#[serde(default = "...")]` requires a path, not a closure.
+/// Without this, the struct-level `#[serde(default)]` would fill a
+/// missing `output-format` with the `String` default (empty string)
+/// rather than `"full"`.
+fn default_output_format() -> String {
+    DEFAULT_OUTPUT_FORMAT.to_string()
+}
+
+impl Config {
     /// Try to load a `ry.toml` from the given directory.
     ///
     /// Returns `Ok(Some(config))` if the file exists and parses
@@ -287,7 +282,39 @@ impl Config {
             }
         }
     }
+}
 
+/// CLI flag values that override (or extend) a loaded `ry.toml`.
+///
+/// Every field is empty/unset by default, which means "the CLI did not
+/// touch this; keep the config value". The list fields append to the
+/// config's lists; the scalar fields install only when `Some`; the
+/// verbosity counts add on top of the config's.
+#[derive(Debug, Default)]
+pub struct CliOverrides {
+    /// Rules to treat as errors (`--error`).
+    pub error: Vec<String>,
+    /// Rules to treat as warnings (`--warn`).
+    pub warn: Vec<String>,
+    /// Rules to disable (`--ignore`).
+    pub ignore: Vec<String>,
+    /// Extra typeshed directories (`--typeshed`).
+    pub typeshed: Vec<PathBuf>,
+    /// Baseline file (`--baseline`); wins over a config `baseline`.
+    pub baseline: Option<PathBuf>,
+    /// `--error-on-warning`, when the flag was passed explicitly.
+    pub error_on_warning: Option<bool>,
+    /// `--exit-zero`, when the flag was passed explicitly.
+    pub exit_zero: Option<bool>,
+    /// `--output-format`, when the flag was passed explicitly.
+    pub output_format: Option<String>,
+    /// `-v` count; added to the config's `verbose`.
+    pub verbose: u8,
+    /// `-q` count; added to the config's `quiet`.
+    pub quiet: u8,
+}
+
+impl Config {
     /// Merge CLI overrides into this config, returning a new `Config`.
     ///
     /// List fields (`error`, `warn`, `ignore`) have the CLI values
@@ -299,35 +326,22 @@ impl Config {
     /// `verbose` and `quiet` are additive: the CLI count is added on
     /// top of the config count, so `verbose = 1` in `ry.toml` plus a
     /// single `-v` flag yields a final count of 2.
-    #[allow(clippy::too_many_arguments)]
-    pub fn merge_cli(
-        self,
-        cli_errors: Vec<String>,
-        cli_warns: Vec<String>,
-        cli_ignores: Vec<String>,
-        cli_typeshed: Vec<PathBuf>,
-        cli_baseline: Option<PathBuf>,
-        cli_error_on_warning: Option<bool>,
-        cli_exit_zero: Option<bool>,
-        cli_output_format: Option<String>,
-        cli_verbose: u8,
-        cli_quiet: u8,
-    ) -> Self {
+    pub fn merge_cli(self, cli: CliOverrides) -> Self {
         let mut errors = self.error;
-        errors.extend(cli_errors);
+        errors.extend(cli.error);
         let mut warns = self.warn;
-        warns.extend(cli_warns);
+        warns.extend(cli.warn);
         let mut ignores = self.ignore;
-        ignores.extend(cli_ignores);
+        ignores.extend(cli.ignore);
         let mut typeshed = self.typeshed;
-        typeshed.extend(cli_typeshed);
+        typeshed.extend(cli.typeshed);
 
-        let output_format = cli_output_format.unwrap_or(self.output_format);
-        let baseline = cli_baseline.or(self.baseline);
+        let output_format = cli.output_format.unwrap_or(self.output_format);
+        let baseline = cli.baseline.or(self.baseline);
 
         Self {
-            error_on_warning: cli_error_on_warning.unwrap_or(self.error_on_warning),
-            exit_zero: cli_exit_zero.unwrap_or(self.exit_zero),
+            error_on_warning: cli.error_on_warning.unwrap_or(self.error_on_warning),
+            exit_zero: cli.exit_zero.unwrap_or(self.exit_zero),
             error: errors,
             warn: warns,
             ignore: ignores,
@@ -338,8 +352,8 @@ impl Config {
             output_format,
             // Saturating add so a config value of 255 plus a CLI flag
             // stays within u8 rather than panicking on overflow.
-            verbose: self.verbose.saturating_add(cli_verbose),
-            quiet: self.quiet.saturating_add(cli_quiet),
+            verbose: self.verbose.saturating_add(cli.verbose),
+            quiet: self.quiet.saturating_add(cli.quiet),
             // Config-only (no CLI flag): passes through unchanged.
             packages: self.packages,
             globals: self.globals,
@@ -430,7 +444,7 @@ mod tests {
 
     #[test]
     fn defaults_match_expectations() {
-        let d = Config::defaults();
+        let d = Config::default();
         assert!(!d.error_on_warning);
         assert!(!d.exit_zero);
         assert!(d.error.is_empty());
@@ -539,20 +553,13 @@ paths = ["inst/shiny/**"]
         let cfg = Config {
             typeshed: vec![PathBuf::from("config-stubs")],
             baseline: Some(PathBuf::from("config-baseline.json")),
-            ..Config::defaults()
+            ..Config::default()
         };
-        let merged = cfg.merge_cli(
-            Vec::new(),
-            Vec::new(),
-            Vec::new(),
-            vec![PathBuf::from("cli-stubs")],
-            Some(PathBuf::from("cli-baseline.json")),
-            None,
-            None,
-            None,
-            0,
-            0,
-        );
+        let merged = cfg.merge_cli(CliOverrides {
+            typeshed: vec![PathBuf::from("cli-stubs")],
+            baseline: Some(PathBuf::from("cli-baseline.json")),
+            ..CliOverrides::default()
+        });
         // Typeshed appends config and CLI entries.
         assert_eq!(
             merged.typeshed,
@@ -568,20 +575,13 @@ paths = ["inst/shiny/**"]
             error: vec!["RY001".to_string()],
             warn: vec!["RY002".to_string()],
             ignore: vec!["RY010".to_string()],
-            ..Config::defaults()
+            ..Config::default()
         };
-        let merged = cfg.merge_cli(
-            vec!["RY040".to_string()],
-            vec![],
-            vec!["RY050".to_string()],
-            Vec::new(),
-            None,
-            None,
-            None,
-            None,
-            0,
-            0,
-        );
+        let merged = cfg.merge_cli(CliOverrides {
+            error: vec!["RY040".to_string()],
+            ignore: vec!["RY050".to_string()],
+            ..CliOverrides::default()
+        });
         assert_eq!(merged.error, vec!["RY001", "RY040"]);
         assert_eq!(merged.warn, vec!["RY002"]);
         assert_eq!(merged.ignore, vec!["RY010", "RY050"]);
@@ -593,20 +593,14 @@ paths = ["inst/shiny/**"]
             error_on_warning: false,
             exit_zero: false,
             output_format: "concise".to_string(),
-            ..Config::defaults()
+            ..Config::default()
         };
-        let merged = cfg.merge_cli(
-            Vec::new(),
-            Vec::new(),
-            Vec::new(),
-            Vec::new(),
-            None,
-            Some(true),
-            Some(true),
-            Some("json".to_string()),
-            0,
-            0,
-        );
+        let merged = cfg.merge_cli(CliOverrides {
+            error_on_warning: Some(true),
+            exit_zero: Some(true),
+            output_format: Some("json".to_string()),
+            ..CliOverrides::default()
+        });
         assert!(merged.error_on_warning);
         assert!(merged.exit_zero);
         assert_eq!(merged.output_format, "json");
@@ -622,20 +616,9 @@ paths = ["inst/shiny/**"]
             output_format: "json".to_string(),
             verbose: 2,
             quiet: 1,
-            ..Config::defaults()
+            ..Config::default()
         };
-        let merged = cfg.merge_cli(
-            Vec::new(),
-            Vec::new(),
-            Vec::new(),
-            Vec::new(),
-            None,
-            None,
-            None,
-            None,
-            0,
-            0,
-        );
+        let merged = cfg.merge_cli(CliOverrides::default());
         assert!(merged.error_on_warning);
         assert!(merged.exit_zero);
         assert_eq!(merged.output_format, "json");
@@ -648,20 +631,13 @@ paths = ["inst/shiny/**"]
         let cfg = Config {
             verbose: 1,
             quiet: 1,
-            ..Config::defaults()
+            ..Config::default()
         };
-        let merged = cfg.merge_cli(
-            Vec::new(),
-            Vec::new(),
-            Vec::new(),
-            Vec::new(),
-            None,
-            None,
-            None,
-            None,
-            2,
-            3,
-        );
+        let merged = cfg.merge_cli(CliOverrides {
+            verbose: 2,
+            quiet: 3,
+            ..CliOverrides::default()
+        });
         assert_eq!(merged.verbose, 3);
         assert_eq!(merged.quiet, 4);
     }
@@ -670,20 +646,12 @@ paths = ["inst/shiny/**"]
     fn merge_cli_verbose_saturates() {
         let cfg = Config {
             verbose: 250,
-            ..Config::defaults()
+            ..Config::default()
         };
-        let merged = cfg.merge_cli(
-            Vec::new(),
-            Vec::new(),
-            Vec::new(),
-            Vec::new(),
-            None,
-            None,
-            None,
-            None,
-            10,
-            0,
-        );
+        let merged = cfg.merge_cli(CliOverrides {
+            verbose: 10,
+            ..CliOverrides::default()
+        });
         assert_eq!(merged.verbose, 255);
     }
 
@@ -797,7 +765,7 @@ paths = ["inst/shiny/**"]
                 "tests/fixtures/**".to_string(),
                 "**/_snapshots/**".to_string(),
             ],
-            ..Config::defaults()
+            ..Config::default()
         };
         let ex = Excludes::from_config(&cfg);
         assert!(!ex.is_empty());
@@ -814,7 +782,7 @@ paths = ["inst/shiny/**"]
         // required form. This test records that constraint.
         let ex = Excludes::from_config(&Config {
             exclude: vec!["tests/fixtures".to_string()],
-            ..Config::defaults()
+            ..Config::default()
         });
         assert!(ex.matches("tests/fixtures"));
         assert!(!ex.matches("tests/fixtures/a.R"));
@@ -826,7 +794,7 @@ paths = ["inst/shiny/**"]
         // rather than panic. The matcher ends up with zero patterns.
         let ex = Excludes::from_config(&Config {
             exclude: vec!["[unclosed".to_string()],
-            ..Config::defaults()
+            ..Config::default()
         });
         assert!(ex.is_empty());
         assert!(!ex.matches("anything"));

--- a/crates/ry-core/src/diagnostic.rs
+++ b/crates/ry-core/src/diagnostic.rs
@@ -72,4 +72,6 @@ pub const SERIALIZED_BINDINGS_UNENUMERABLE: &str = "\0serialized:unenumerable";
 
 /// R foreign-function-interface primitives.
 /// Their first argument is a native routine entry-point symbol, not a variable.
+/// `.Internal` is deliberately absent: its first argument is a call
+/// expression, not a bare entry-point symbol.
 pub const FFI_PRIMITIVES: &[&str] = &[".Call", ".C", ".Fortran", ".External", ".External2"];

--- a/crates/ry-core/src/diagnostic.rs
+++ b/crates/ry-core/src/diagnostic.rs
@@ -75,3 +75,15 @@ pub const SERIALIZED_BINDINGS_UNENUMERABLE: &str = "\0serialized:unenumerable";
 /// `.Internal` is deliberately absent: its first argument is a call
 /// expression, not a bare entry-point symbol.
 pub const FFI_PRIMITIVES: &[&str] = &[".Call", ".C", ".Fortran", ".External", ".External2"];
+
+#[cfg(test)]
+mod tests {
+    use super::FFI_PRIMITIVES;
+
+    /// Only a non-member pins the convention: containment against the
+    /// list itself would be a tautology for every listed member.
+    #[test]
+    fn internal_is_not_an_ffi_primitive() {
+        assert!(!FFI_PRIMITIVES.contains(&".Internal"));
+    }
+}

--- a/crates/ry-lsp/src/backend.rs
+++ b/crates/ry-lsp/src/backend.rs
@@ -10,7 +10,8 @@ use crate::diagnostics::{
 };
 use crate::hints::collect_inlay_hints;
 use crate::settings::{FolderSettings, ServerSettings};
-use crate::util::position_to_byte_offset_pos;
+use crate::util::position_to_byte_offset;
+
 use ry_checker::Project;
 use ry_core::{RParser, SourceFile};
 use std::collections::HashMap;
@@ -455,19 +456,6 @@ impl State {
             _ => true,
         }
     }
-
-    /// Return the cached effective baseline for a document path (pure
-    /// cache read — no disk access). Editor setting took precedence over
-    /// `ry.toml`, resolved relative to the owning folder root at load time.
-    pub(super) fn effective_baseline_for_path(
-        &self,
-        doc_path: &str,
-    ) -> Option<ry_config::Baseline> {
-        if let Some(ctx) = self.folder_context_for_path(doc_path) {
-            return ctx.baseline.clone();
-        }
-        self.root_baseline.clone()
-    }
 }
 
 #[tower_lsp::async_trait]
@@ -838,7 +826,10 @@ impl LanguageServer for Backend {
             let old_contexts_for_task = old_contexts.clone();
             // spawn_blocking keeps every disk read off the async runtime.
             let new_contexts = match tokio::task::spawn_blocking(move || {
-                rebuild_folder_contexts(&old_contexts_for_task)
+                old_contexts_for_task
+                    .iter()
+                    .map(rebuild_folder_context)
+                    .collect::<Vec<_>>()
             })
             .await
             {
@@ -1092,30 +1083,26 @@ impl Backend {
     /// path is not an open document or parsing fails.
     async fn parsed_file(&self, path: &str) -> Option<(Arc<SourceFile>, String)> {
         loop {
-            // Fast path: version-matched cache hit.
-            {
+            // One guard reads the parse cache, the document text/version,
+            // and the old tree as one snapshot; only the parse itself
+            // (the non-`Send` `RParser`) happens outside the lock. The
+            // old tree is only cloned on the miss path — a cache hit must
+            // not pay for a tree copy it never hands to the parser.
+            let (text, version, old_tree) = {
                 let state = self.state.lock().await;
-                if let Some(file) = state.cached_parse(path) {
-                    let text = state.docs.get(path).cloned()?;
-                    return Some((file, text));
+                if let (Some(text), Some(version)) =
+                    (state.docs.get(path), state.versions.get(path))
+                {
+                    // Fast path: version-matched cache hit.
+                    if let Some(file) = state.cached_parse(path) {
+                        return Some((file, text.clone()));
+                    }
+                    (text.clone(), *version, state.tree_for(path))
+                } else {
+                    return None;
                 }
-            }
-            let (text, version) = {
-                let state = self.state.lock().await;
-                (
-                    state.docs.get(path).cloned(),
-                    state.versions.get(path).copied(),
-                )
-            };
-            let (text, version) = match (text, version) {
-                (Some(t), Some(v)) => (t, v),
-                _ => return None,
             };
             // Incremental reparse when a version-matched old tree exists.
-            let old_tree = {
-                let state = self.state.lock().await;
-                state.tree_for(path)
-            };
             // Test-only scheduling barrier: when armed, the parse pauses
             // here — after reading text/version/tree, before parsing — so a
             // test can force the interleaving:
@@ -1247,14 +1234,14 @@ impl Backend {
     /// open document. Publishing all files is required because an edit to a
     /// function definition can change diagnostics in its cross-file callers.
     async fn publish_diagnostics(&self, uri: Url, generation: u64) {
-        // Snapshot the open docs under the lock, then drop it before
-        // checking so a slow check doesn't block other LSP requests
-        // (e.g. didOpen of a second file). Only eligible documents'
-        // versions are snapshotted.
-        let (path, doc_versions) = {
+        let path = uri_to_path(&uri);
+        // Snapshot the open docs and the requested file's eligibility under
+        // the lock, then drop it before checking so a slow check doesn't
+        // block other LSP requests (e.g. didOpen of a second file). Only
+        // eligible documents' versions are snapshotted.
+        let (doc_versions, requested_is_eligible) = {
             let state = self.state.lock().await;
             (
-                uri_to_path(&uri),
                 state
                     .docs
                     .keys()
@@ -1267,11 +1254,8 @@ impl Backend {
                             .map(|version| (p.clone(), version))
                     })
                     .collect::<Vec<_>>(),
+                state.eligibility_for_path(&path),
             )
-        };
-        let requested_is_eligible = {
-            let state = self.state.lock().await;
-            state.eligibility_for_path(&path)
         };
         if !requested_is_eligible {
             self.client
@@ -1303,43 +1287,63 @@ impl Backend {
         project_files.extend(disk_entries);
 
         // Check each folder partition independently through its own
-        // ProjectCache, stubs, and workspace context.
-        let (folder_contexts, root_project, user_stubs) = {
+        // ProjectCache, stubs, and workspace context. The root-level
+        // filter, confidence, exclude, baseline, and root state rides
+        // along for the files no folder owns.
+        let (
+            folder_contexts,
+            root_project,
+            user_stubs,
+            root_filter,
+            root_min_confidence,
+            root_excludes,
+            root_baseline,
+            root,
+        ) = {
             let state = self.state.lock().await;
             (
                 state.folder_contexts.clone(),
                 Arc::clone(&state.project),
                 Arc::clone(&state.user_stubs),
+                state.root_filter.clone(),
+                state.root_min_confidence,
+                state.root_excludes.clone(),
+                state.root_baseline.clone(),
+                state.root.clone(),
             )
         };
 
-        // Partition project_files by folder root (longest-prefix ownership).
-        // Files not owned by any folder go to the root project.
-        use std::collections::BTreeMap;
-        let mut per_folder: BTreeMap<String, FolderPartition> = BTreeMap::new();
+        // Partition project_files by folder root: each file goes to the
+        // first folder context whose root contains it (the same ownership
+        // rule as `folder_context_for_path`); files no folder owns go to
+        // the root project. The contexts are already clones, so every
+        // partition carries its owning context instead of a map key
+        // nobody reads.
+        let mut partitions: Vec<FolderPartition> = Vec::new();
+        let mut root_files: Vec<(String, i32, Arc<SourceFile>)> = Vec::new();
         for (fp, ver, file) in project_files {
             if let Some(ctx) = folder_contexts
                 .iter()
                 .find(|c| std::path::Path::new(&fp).starts_with(&c.root))
             {
-                let key = ctx.root.to_string_lossy().to_string();
-                per_folder
-                    .entry(key)
-                    .or_insert_with(|| (Some(ctx.clone()), Vec::new()))
-                    .1
-                    .push((fp, ver, file));
+                let partition = partitions
+                    .iter_mut()
+                    .find(|(owned, _)| owned.as_ref().is_some_and(|c| c.root == ctx.root));
+                match partition {
+                    Some((_, files)) => files.push((fp, ver, file)),
+                    None => partitions.push((Some(ctx.clone()), vec![(fp, ver, file)])),
+                }
             } else {
-                per_folder
-                    .entry("__root__".to_string())
-                    .or_insert_with(|| (None, Vec::new()))
-                    .1
-                    .push((fp, ver, file));
+                root_files.push((fp, ver, file));
             }
         }
+        if !root_files.is_empty() {
+            partitions.push((None, root_files));
+        }
 
-        let mut all_results: Vec<ProjectCheckResult> = Vec::new();
-        for (_key, (ctx_opt, files)) in per_folder {
-            let (stubs, workspace_context, project_handle) = match ctx_opt {
+        let mut all_results: Vec<(Option<FolderAnalysisContext>, ProjectCheckResult)> = Vec::new();
+        for (ctx, files) in partitions {
+            let (stubs, workspace_context, project_handle) = match &ctx {
                 Some(ctx) => (
                     Arc::clone(&ctx.stubs),
                     ctx.workspace_context.clone(),
@@ -1349,7 +1353,7 @@ impl Backend {
             };
             let mut project = project_handle.lock().await;
             let result = project.check_with_workspace(files, stubs, workspace_context.as_ref());
-            all_results.push(result);
+            all_results.push((ctx, result));
         }
 
         // An edit that arrived while parsing/checking invalidates this whole
@@ -1362,34 +1366,32 @@ impl Backend {
         }
 
         // Publish per-file diagnostics through the folder's
-        // filter/confidence/exclude/baseline state.
-        for result in all_results {
+        // filter/confidence/exclude/baseline state. The partition carried
+        // the owning context through the check, so publication uses the
+        // same snapshot the check ran under; files no folder owns use the
+        // snapshotted root-level values.
+        for (ctx, result) in all_results {
             let ProjectCheckResult {
                 diagnostics: per_file,
                 files: checked_files,
             } = result;
+            let (filter, min_confidence, excludes, baseline, folder_root) = match ctx.as_ref() {
+                Some(ctx) => (
+                    ctx.filter.clone(),
+                    ctx.min_confidence,
+                    ctx.excludes.clone(),
+                    ctx.baseline.clone(),
+                    Some(ctx.root.clone()),
+                ),
+                None => (
+                    root_filter.clone(),
+                    root_min_confidence,
+                    root_excludes.clone(),
+                    root_baseline.clone(),
+                    root.clone(),
+                ),
+            };
             for (diagnostic_path, mut diagnostics) in per_file {
-                let (filter, min_confidence, excludes, baseline, folder_root) = {
-                    let state = self.state.lock().await;
-                    let ctx = state.folder_context_for_path(&diagnostic_path);
-                    let (filter, min_confidence, excludes) = match ctx {
-                        Some(c) => (c.filter.clone(), c.min_confidence, c.excludes.clone()),
-                        None => {
-                            // Files outside every folder root use the
-                            // precomputed root-level values.
-                            (
-                                state.root_filter.clone(),
-                                state.root_min_confidence,
-                                state.root_excludes.clone(),
-                            )
-                        }
-                    };
-                    let baseline = state.effective_baseline_for_path(&diagnostic_path);
-                    let folder_root = ctx
-                        .map(|c| Some(c.root.clone()))
-                        .unwrap_or_else(|| state.root.clone());
-                    (filter, min_confidence, excludes, baseline, folder_root)
-                };
                 ry_checker::apply_filter_to_diagnostics(&mut diagnostics, &filter);
 
                 if let Some(min) = min_confidence {
@@ -1863,14 +1865,6 @@ fn rebuild_folder_context(old: &FolderAnalysisContext) -> FolderAnalysisContext 
     }
 }
 
-/// Rebuild every folder's analysis context from disk, returning a
-/// replacement `Vec` in the same order as `old`. Used by the
-/// watched-files handler to rebuild outside the write lock and then swap
-/// atomically; each folder is rebuilt independently.
-fn rebuild_folder_contexts(old: &[FolderAnalysisContext]) -> Vec<FolderAnalysisContext> {
-    old.iter().map(rebuild_folder_context).collect()
-}
-
 /// Convert a document's path string (the key used in `State::docs`)
 /// back into an LSP `Url`. Filesystem paths round-trip via
 /// `Url::from_file_path`; non-file URIs (e.g. `untitled:`) fall back to
@@ -1893,8 +1887,8 @@ pub(crate) fn uri_to_path(uri: &Url) -> String {
 /// Convert an LSP range (0-based line/character, UTF-16 code units) in
 /// `old_text` to a byte-offset span for splicing.
 fn range_byte_span(old_text: &str, range: Range) -> Option<(usize, usize)> {
-    let start_byte = position_to_byte_offset_pos(old_text, range.start)?;
-    let end_byte = position_to_byte_offset_pos(old_text, range.end)?;
+    let start_byte = position_to_byte_offset(old_text, range.start.line, range.start.character)?;
+    let end_byte = position_to_byte_offset(old_text, range.end.line, range.end.character)?;
     (start_byte <= end_byte).then_some((start_byte, end_byte))
 }
 

--- a/crates/ry-lsp/src/util.rs
+++ b/crates/ry-lsp/src/util.rs
@@ -46,7 +46,7 @@ pub(crate) fn byte_offset_to_position(text: &str, byte_offset: usize) -> Positio
 /// Number of UTF-16 code units a Unicode scalar value encodes to: 1 for
 /// the Basic Multilingual Plane, 2 for astral-plane characters (which
 /// become a surrogate pair).
-pub(crate) fn utf16_len(ch: char) -> usize {
+fn utf16_len(ch: char) -> usize {
     if (ch as u32) >= 0x10000 { 2 } else { 1 }
 }
 
@@ -84,13 +84,4 @@ pub(crate) fn position_to_byte_offset(text: &str, line: u32, utf16_col: u32) -> 
     } else {
         None
     }
-}
-
-/// Map an LSP `Position` to a byte offset. Wrapper over the line/col
-/// variant for callers that hold a `Position`. Returns `None` when the
-/// position does not fall inside the text (line past the end of the
-/// file, or a column past the end of its line), so callers can report
-/// "no result" instead of silently resolving against the last byte.
-pub(crate) fn position_to_byte_offset_pos(text: &str, position: Position) -> Option<usize> {
-    position_to_byte_offset(text, position.line, position.character)
 }

--- a/crates/ry-workspace/src/lib.rs
+++ b/crates/ry-workspace/src/lib.rs
@@ -117,6 +117,9 @@ pub fn resolve_workspace_context<'a>(
     let mut export_cache: HashMap<String, HashSet<String>> = HashMap::new();
     let mut dataset_cache: HashMap<PathBuf, DataInventory> = HashMap::new();
     let mut source_binding_cache: HashMap<PathBuf, SourceBindings> = HashMap::new();
+    // A package root is visited once per file in it, so cache the
+    // DESCRIPTION read like the sibling namespace/dataset caches.
+    let mut description_cache: HashMap<PathBuf, DescriptionPackages> = HashMap::new();
     let mut attached = HashSet::new();
     let mut bare_attached = HashMap::new();
     let mut bindings = HashMap::new();
@@ -201,7 +204,13 @@ pub fn resolve_workspace_context<'a>(
                 // Packages that rely on DESCRIPTION Depends may omit a
                 // NAMESPACE (Quarto/Shiny projects commonly do). Depends are
                 // attached before package code runs, unlike Imports.
-                file_attached.extend(read_description_packages(&root).depends);
+                file_attached.extend(
+                    description_cache
+                        .entry(root.clone())
+                        .or_insert_with(|| read_description_packages(&root))
+                        .depends
+                        .clone(),
+                );
             }
             if source_package_lazy_data(&root) {
                 let datasets = dataset_cache
@@ -237,7 +246,10 @@ pub fn resolve_workspace_context<'a>(
                 // DESCRIPTION Suggests as their working set. Imports remain
                 // excluded: they only provide bare names through explicit
                 // NAMESPACE directives.
-                let dependencies = read_description_packages(&root);
+                let dependencies = description_cache
+                    .entry(root.clone())
+                    .or_insert_with(|| read_description_packages(&root))
+                    .clone();
                 let test_dependencies = dependencies
                     .depends
                     .into_iter()
@@ -442,7 +454,7 @@ fn collect_dynamic_bindings_stmts(stmts: &[Stmt], found: &mut SourceBindings) {
     });
 }
 
-#[derive(Default)]
+#[derive(Default, Clone)]
 struct DescriptionPackages {
     depends: HashSet<String>,
     suggests: HashSet<String>,
@@ -1809,6 +1821,185 @@ mod shared_tests {
             result.files.len(),
             5,
             "R, r, S, s, q discovered; .txt excluded"
+        );
+    }
+
+    #[test]
+    fn collection_includes_all_supported_r_source_extensions() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path();
+        for extension in ["R", "r", "S", "s", "q"] {
+            std::fs::write(root.join(format!("source.{extension}")), "value <- 1L\n").unwrap();
+        }
+        std::fs::write(root.join("source.txt"), "not R\n").unwrap();
+
+        let mut paths = discover_r_files(root, None, &ry_config::Config::default(), false).files;
+        paths.sort();
+
+        let mut expected = ["R", "r", "S", "s", "q"]
+            .map(|extension| root.join(format!("source.{extension}")))
+            .into_iter()
+            .collect::<Vec<_>>();
+        expected.sort();
+        assert_eq!(paths, expected);
+    }
+
+    #[test]
+    fn package_scan_skips_test_fixtures_but_keeps_executable_test_code() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path();
+        std::fs::write(root.join("DESCRIPTION"), "Package: example\n").unwrap();
+        for directory in [
+            "R",
+            "tests/testthat",
+            "tests/testthat/fixtures",
+            "tests/testthat/_snaps",
+            "tests/manual",
+            "revdep/other/R",
+            "src/ratfor",
+        ] {
+            std::fs::create_dir_all(root.join(directory)).unwrap();
+        }
+        for file in [
+            "R/package.R",
+            "tests/testthat.R",
+            "tests/testthat/test-package.R",
+            "tests/testthat/helper-package.R",
+            "tests/testthat/setup-package.R",
+            "tests/testthat/teardown-package.R",
+            "tests/testthat/fixtures/input.R",
+            "tests/testthat/data.R",
+            "tests/testthat/_snaps/output.R",
+            "tests/manual/example.R",
+            "revdep/other/R/other.R",
+            "src/ratfor/program.r",
+        ] {
+            std::fs::write(root.join(file), "").unwrap();
+        }
+
+        let paths = discover_r_files(root, None, &ry_config::Config::default(), false).files;
+
+        assert_eq!(
+            paths,
+            vec![
+                root.join("R/package.R"),
+                root.join("tests/testthat/helper-package.R"),
+                root.join("tests/testthat/setup-package.R"),
+                root.join("tests/testthat/teardown-package.R"),
+                root.join("tests/testthat/test-package.R"),
+                root.join("tests/testthat.R"),
+            ]
+        );
+    }
+
+    #[test]
+    fn package_scan_can_opt_into_test_fixtures() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path();
+        std::fs::write(root.join("DESCRIPTION"), "Package: example\n").unwrap();
+        std::fs::create_dir_all(root.join("tests/testthat/fixtures")).unwrap();
+        let fixture = root.join("tests/testthat/fixtures/input.R");
+        std::fs::write(&fixture, "missing_name\n").unwrap();
+
+        let paths = discover_r_files(root, None, &ry_config::Config::default(), true).files;
+
+        assert_eq!(paths, vec![fixture]);
+    }
+
+    #[test]
+    fn package_scan_keeps_inst_sources() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path();
+        std::fs::write(root.join("DESCRIPTION"), "Package: example\n").unwrap();
+        std::fs::create_dir_all(root.join("inst/resources")).unwrap();
+        let installed = root.join("inst/resources/activate.R");
+        std::fs::write(&installed, "missing_name\n").unwrap();
+
+        let paths = discover_r_files(root, None, &ry_config::Config::default(), false).files;
+
+        assert_eq!(paths, vec![installed]);
+    }
+
+    #[test]
+    fn package_scan_skips_vendored_renv_bootstrap() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path();
+        std::fs::write(root.join("DESCRIPTION"), "Package: example\n").unwrap();
+        std::fs::create_dir_all(root.join("R")).unwrap();
+        std::fs::create_dir_all(root.join("renv")).unwrap();
+        let source = root.join("R/package.R");
+        std::fs::write(&source, "value <- 1L\n").unwrap();
+        std::fs::write(root.join("renv/activate.R"), "bootstrap_missing\n").unwrap();
+
+        let paths = discover_r_files(root, None, &ry_config::Config::default(), false).files;
+
+        assert_eq!(paths, vec![source]);
+    }
+
+    #[test]
+    fn explicitly_selected_file_is_not_package_excluded() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path();
+        std::fs::write(root.join("DESCRIPTION"), "Package: example\n").unwrap();
+        std::fs::create_dir(root.join("src")).unwrap();
+        let file = root.join("src/ratfor.r");
+        std::fs::write(&file, "").unwrap();
+
+        let paths = discover_r_files(&file, None, &ry_config::Config::default(), false).files;
+
+        assert_eq!(paths, vec![file]);
+    }
+
+    #[test]
+    fn explicitly_selected_q_file_is_collected() {
+        let temp = tempfile::tempdir().unwrap();
+        let file = temp.path().join("source.q");
+        std::fs::write(&file, "value <- 1L\n").unwrap();
+
+        let paths = discover_r_files(&file, None, &ry_config::Config::default(), false).files;
+
+        assert_eq!(paths, vec![file]);
+    }
+
+    #[test]
+    fn package_scan_honors_rbuildignore_except_r_and_tests() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path();
+        std::fs::write(root.join("DESCRIPTION"), "Package: example\n").unwrap();
+        std::fs::write(root.join(".Rbuildignore"), "^ignored\\.R$\n^R/\n^tests/\n").unwrap();
+        std::fs::create_dir_all(root.join("R")).unwrap();
+        std::fs::create_dir_all(root.join("tests/testthat")).unwrap();
+        for file in [
+            "ignored.R",
+            "kept.R",
+            "R/package.R",
+            "tests/testthat/test-package.R",
+        ] {
+            std::fs::write(root.join(file), "").unwrap();
+        }
+
+        let mut paths = discover_r_files(root, None, &ry_config::Config::default(), false).files;
+        paths.sort();
+        assert_eq!(
+            paths,
+            vec![
+                root.join("R/package.R"),
+                root.join("kept.R"),
+                root.join("tests/testthat/test-package.R"),
+            ]
+        );
+    }
+
+    #[test]
+    fn rbuildignore_trailing_dollar_respects_escape_parity() {
+        assert!(rbuildignore_pattern("^file$").unwrap().matches("file"));
+        assert!(!rbuildignore_pattern("^file$").unwrap().matches("filex"));
+        assert!(rbuildignore_pattern(r"^file\$").unwrap().matches("file$"));
+        assert!(rbuildignore_pattern(r"^file\\$").unwrap().matches(r"file\"));
+        assert!(
+            !rbuildignore_pattern(r"^file\\$")
+                .unwrap()
+                .matches(r"file\x")
         );
     }
 }


### PR DESCRIPTION
Replaces #175, which GitHub closed (and refuses to reopen) when its base
branch was deleted during the stacked merge of #173. Same branch,
rebased onto main: the diff is identical to what was reviewed and
CI-green in #175, now based directly on 7a1b200.

Review ledger carried over from #175:

- pullfrog flagged that inlining `is_ffi_primitive` deleted the only
  executable pin of the `.Internal` exclusion; the pin was restored
  beside `FFI_PRIMITIVES` and pullfrog's re-review confirmed it
  ("a genuine pin rather than theatre", mutation-verified on their side
  too).
- pullfrog's final review of the content: "No new issues found."

Original description follows.

---

Second wave of dedupe from the cleanup review, all behavior-preserving.
Builds on #173. Net **-110 LOC** plus fewer lock round-trips per publish
and per parse.

## CLI: one resolution path for check and dump-types

`ry check` and `ry dump-types` copy-pasted the same ~45-line per-package
resolution front half — comments included — and had already drifted on
which fallback roots apply. Both now call `pipeline::resolve_groups`,
parameterized by the fallback roots (check: config root; dump-types:
`--project-root`, then config root), so the two commands cannot disagree
about library scoping. `run_check`'s hand-rolled `search_start` block
(12 lines re-implementing `Config::discover`'s dir/file rule) is gone.
`explain-rule`/`rule` share one `ExplainRuleArgs` flatten; help output
verified byte-identical.

## Tests live in the crates they test

The rbuildignore escape-parity test and eight pure discovery tests moved
from ry-cli's main.rs to ry-workspace's shared tests (calling
`discover_r_files` directly; the `collect_r_files` shim is deleted), and
the two baseline tests moved to ry-config beside the existing baseline
test. Tests that exercise CLI end-to-end behavior stay.

## ry-config

`Config::defaults()` and `Default::default()` were the same constructor
with two names; one definition remains. `merge_cli` took 10 positional
parameters behind a clippy allow, with six tests dominated by
`Vec::new(), Vec::new(), None, None, 0, 0` filler; it now takes a
`#[derive(Default)] CliOverrides` struct.

## checker infer/

- `match_params`: the `param_names().collect() + match_arguments`
  two-liner appeared ~10 times; one helper now serves all sites
  (`higher_order_argument_match` deleted). `check_typeshed_call_arguments`
  and `check_user_call_arguments` share their arity prefix via
  `check_call_arity` over a two-method `CallFormal` view.
- `infer_condition`: the RY103-before-infer / RY100-window quad appeared
  in `if`, `while`, and pipe's `if` expression; it lives in one place
  now, parameterized by the context noun.
- `try_assign_value`: the assignment guard triple (class attribute ->
  replacement target -> plain assign) is one function.
- `literal_callee_mode` delegates to `infer_literal_default`;
  `strip_negation` is shared instead of re-implemented; the double
  user-parameter lookup in `infer_argument_types` computes once;
  `callback_literal_return` uses `join_all`; the `is_numeric` twins
  hoisted; `is_zero/one_literal` merged; `collapse_c_mode` and
  `is_ffi_primitive` inlined at their sole call sites (the `.Internal`
  rationale moved to `FFI_PRIMITIVES`' docs).
- Ten dead `_span`/`_name` parameters removed (four more became dead as
  a consequence and went too).
- `check_with_scope` re-uses `emit_diagnostics` instead of inlining its
  walk loop.

## ry-lsp backend hygiene

`publish_diagnostics`: the redundant second lock folds into the snapshot
block; the `BTreeMap<String, _>` partition keyed by a lossy string with
a `"__root__"` magic sentinel becomes a `Vec<FolderPartition>` built
from the already-cloned contexts (root last, matching the old sort
position); the per-file publish loop no longer re-locks and re-resolves
the owning folder per diagnostic file — the partition's snapshot rides
along. `parsed_file` reads cache, text, version, and old tree under one
guard, cloning the tree only on the miss path. Two single-use wrappers
inlined.

## ry-workspace

`read_description_packages` was re-read and re-parsed from disk once or
twice per source file while every sibling lookup was cached per package
root; it now has the same `entry().or_insert_with()` cache.

## Verification

`cargo fmt --all --check`, `cargo clippy --workspace --all-targets --
-D warnings`, `cargo test --workspace` (43 suites, 947 passed, 0
failed, oracle ran with R installed).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - `ry check` and `ry dump-types` now use consistent package grouping, workspace resolution, and file selection.
  - Workspace analysis is more efficient when reading package metadata.
  - Language server diagnostics and document parsing are more efficient, with consistent per-folder analysis.

- **Bug Fixes**
  - Improved workspace file discovery, including `.Rbuildignore`, test fixtures, package sources, and explicit-file selection.
  - Baseline handling now correctly suppresses recorded diagnostics while retaining new or excess occurrences.

- **Refactor**
  - Consolidated shared command, configuration, type-checking, and diagnostic logic without changing reported diagnostics or inferred types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->