### PR TITLE
cleanup(checker): unify closure, mode, argument, and parser helpers

### DIFF
--- a/crates/ry-checker/src/collect.rs
+++ b/crates/ry-checker/src/collect.rs
@@ -1028,11 +1028,9 @@ fn expression_must_force(expression: &Expr, name: &str) -> bool {
 #[cfg(test)]
 mod collect_walker_tests {
     use super::*;
-    use ry_core::RParser;
 
     fn parse_stmts(src: &str) -> Vec<Stmt> {
-        let mut parser = RParser::new().unwrap();
-        parser.parse("collect_walker_test.R", src).unwrap().stmts
+        crate::tests::parse_snippet("collect_walker_test.R", src).stmts
     }
 
     fn parameter_uses(src: &str, parameter: &str) -> ParameterUses {
@@ -1050,8 +1048,7 @@ mod collect_walker_tests {
     }
 
     fn collect(src: &str) -> Checker {
-        let mut parser = RParser::new().unwrap();
-        let file = parser.parse("collect_walker_test.R", src).unwrap();
+        let file = crate::tests::parse_snippet("collect_walker_test.R", src);
         let mut checker = Checker::new("collect_walker_test.R");
         checker.collect_file_fns(&file);
         checker

--- a/crates/ry-checker/src/higher_order.rs
+++ b/crates/ry-checker/src/higher_order.rs
@@ -426,12 +426,10 @@ impl Checker {
     }
 
     /// Walk an anonymous function literal's body to infer its return
-    /// type, given the argument types the caller will pass. The shared
-    /// walk is [`Checker::walk_literal_returns`]; this layers the
-    /// callback's params, bound to the call-site argument types, on the
-    /// captured scope (whereas `build_function_signature` binds them
-    /// from declared defaults). Used by `callback_return_type` for the
-    /// inline-literal case.
+    /// type, given the argument types the caller will pass: the shared
+    /// [`Checker::walk_literal_returns`] walk with params bound from
+    /// the call-site argument types instead of declared defaults.
+    /// Used by `callback_return_type` for the inline-literal case.
     pub(crate) fn callback_literal_return(
         &mut self,
         params: &[Param],
@@ -440,7 +438,7 @@ impl Checker {
         captured_scope: &Scope,
         depth: usize,
     ) -> Option<RType> {
-        if body.is_empty() || depth >= MAX_CLOSURE_DEPTH {
+        if depth >= MAX_CLOSURE_DEPTH {
             return None;
         }
         self.walk_literal_returns(body, captured_scope, depth, |scope| {

--- a/crates/ry-checker/src/higher_order.rs
+++ b/crates/ry-checker/src/higher_order.rs
@@ -430,10 +430,12 @@ impl Checker {
     }
 
     /// Walk an anonymous function literal's body to infer its return
-    /// type, given the argument types the caller will pass. Similar to
-    /// `build_function_signature` but takes explicit argument
-    /// types rather than inferring from defaults. Used by
-    /// `callback_return_type` for the inline-literal case.
+    /// type, given the argument types the caller will pass. The shared
+    /// walk is [`Checker::walk_literal_returns`]; this layers the
+    /// callback's params, bound to the call-site argument types, on the
+    /// captured scope (whereas `build_function_signature` binds them
+    /// from declared defaults). Used by `callback_return_type` for the
+    /// inline-literal case.
     pub(crate) fn callback_literal_return(
         &mut self,
         params: &[Param],
@@ -445,32 +447,12 @@ impl Checker {
         if body.is_empty() || depth >= MAX_CLOSURE_DEPTH {
             return None;
         }
-        // Pure return-type computation: force discarding so this does not
-        // double-emit diagnostics (the callback body's diagnostics come
-        // from walk_callback_for_diagnostics in pass 3).
-        let prev_discarding = self.discarding;
-        self.discarding = true;
-        let mut scope = captured_scope.clone();
-        for (i, p) in params.iter().enumerate() {
-            let t = call_arg_types.get(i).cloned().unwrap_or(RType::unknown());
-            scope.insert(p.name.clone(), t);
-        }
-        let mut returns: Vec<RType> = Vec::new();
-        for s in body {
-            self.walk_stmt(s, &mut scope, Some(&mut returns));
-        }
-        if let Some(t) = self.trailing_return_type(body, &mut scope, depth + 1) {
-            returns.push(t);
-        }
-        self.discarding = prev_discarding;
-        if returns.is_empty() {
-            return None;
-        }
-        let joined = join_all(returns.into_iter());
-        if matches!(joined.mode, Mode::Opaque) {
-            return None;
-        }
-        Some(joined)
+        self.walk_literal_returns(body, captured_scope, depth, |scope| {
+            for (i, p) in params.iter().enumerate() {
+                let t = call_arg_types.get(i).cloned().unwrap_or(RType::unknown());
+                scope.insert(p.name.clone(), t);
+            }
+        })
     }
 
     /// Walk the callback body of a higher-order function call for

--- a/crates/ry-checker/src/higher_order.rs
+++ b/crates/ry-checker/src/higher_order.rs
@@ -32,9 +32,8 @@ fn arguments_bound_to_dots<'a>(
         .iter()
         .enumerate()
         .filter_map(|(index, argument_type)| {
-            // With a `...` formal, every unmatched actual is part of dots.
-            // Preserve actual call order because Map/mapply pass that order
-            // on to the callback.
+            // Preserve actual call order because Map/mapply pass that
+            // order on to the callback.
             (argument_match.dots.is_some()
                 && argument_match
                     .param_for_arg

--- a/crates/ry-checker/src/higher_order.rs
+++ b/crates/ry-checker/src/higher_order.rs
@@ -1,19 +1,14 @@
 use super::*;
 use crate::infer::*;
 
-fn matched_argument_index(argument_match: &ArgumentMatch, formal_index: usize) -> Option<usize> {
-    argument_match
-        .param_for_arg
-        .iter()
-        .position(|matched| *matched == Some(formal_index))
-}
-
 fn matched_argument_type<'a>(
     arg_types: &'a [RType],
     argument_match: &ArgumentMatch,
     formal_index: usize,
 ) -> Option<&'a RType> {
-    matched_argument_index(argument_match, formal_index).and_then(|index| arg_types.get(index))
+    argument_match
+        .arg_for_param(formal_index)
+        .and_then(|index| arg_types.get(index))
 }
 
 fn argument_bound_to_formal<'a>(
@@ -21,7 +16,9 @@ fn argument_bound_to_formal<'a>(
     argument_match: &ArgumentMatch,
     formal_index: usize,
 ) -> Option<&'a Arg> {
-    matched_argument_index(argument_match, formal_index).and_then(|index| args.get(index))
+    argument_match
+        .arg_for_param(formal_index)
+        .and_then(|index| args.get(index))
 }
 
 /// With a `...` formal, every unmatched actual is part of dots (one

--- a/crates/ry-checker/src/infer/binop.rs
+++ b/crates/ry-checker/src/infer/binop.rs
@@ -538,17 +538,13 @@ fn collect_condition_assignment_names(expr: &Expr, names: &mut HashSet<String>) 
 #[cfg(test)]
 mod collect_condition_assignment_names_tests {
     use super::*;
-    use ry_core::RParser;
     use std::collections::HashSet;
 
     /// Collects the names bound in the RHS operand of a `flag && ...`
     /// expression -- the position `merge_condition_assignments` scans.
     fn collected(operand_src: &str) -> HashSet<String> {
         let src = format!("flag && {operand_src}\n");
-        let file = RParser::new()
-            .expect("parser")
-            .parse("cond_assign_test.R", &src)
-            .expect("parse");
+        let file = crate::tests::parse_snippet("cond_assign_test.R", &src);
         let [Stmt::Expr(Expr::BinOp { rhs, .. })] = file.stmts.as_slice() else {
             panic!("test source must be a single `flag && ...` expression");
         };

--- a/crates/ry-checker/src/infer/call.rs
+++ b/crates/ry-checker/src/infer/call.rs
@@ -1101,14 +1101,6 @@ impl Checker {
         let assertion_binding = assertion_signature
             .filter(|signature| signature.assertion.is_some())
             .map(|signature| (signature, match_params(&signature.params, args)));
-        // Name -> formal -> actual, against the prebuilt match.
-        let bound_actual = |signature: &FunctionSig, bindings: &ArgumentMatch, name: &str| {
-            signature
-                .params
-                .iter()
-                .position(|param| param.name == name)
-                .and_then(|formal_index| bindings.arg_for_param(formal_index))
-        };
         if (name.contains("::") || !locally_shadows_stub || resolution.user_function.is_some())
             && let Some((signature, bindings)) = assertion_binding
             && let Some(assertion) = signature.assertion.as_ref()
@@ -1126,7 +1118,7 @@ impl Checker {
                     })
             })
             && let Some(subject_index) =
-                bound_actual(signature, &bindings, &assertion.subject_param)
+                bound_argument_index_matched(&signature.params, &bindings, &assertion.subject_param)
             && let Some(Expr::Ident { name: var, .. }) =
                 args.get(subject_index).map(|arg| &arg.value)
         {
@@ -1143,7 +1135,7 @@ impl Checker {
                 ),
             ] {
                 if let (Some(param), Some(weakening)) = (param, null_target)
-                    && bound_actual(signature, &bindings, param)
+                    && bound_argument_index_matched(&signature.params, &bindings, param)
                         .is_some_and(|index| !matches!(args[index].value, Expr::Logical(false, _)))
                 {
                     target = target.join(weakening);

--- a/crates/ry-checker/src/infer/call.rs
+++ b/crates/ry-checker/src/infer/call.rs
@@ -1117,8 +1117,11 @@ impl Checker {
                             .any(|param| param.name == *fingerprint)
                     })
             })
-            && let Some(subject_index) =
-                bound_argument_index_matched(&signature.params, &bindings, &assertion.subject_param)
+            && let Some(subject_index) = signature
+                .params
+                .iter()
+                .position(|param| param.name == assertion.subject_param)
+                .and_then(|formal_index| bindings.arg_for_param(formal_index))
             && let Some(Expr::Ident { name: var, .. }) =
                 args.get(subject_index).map(|arg| &arg.value)
         {
@@ -1135,7 +1138,11 @@ impl Checker {
                 ),
             ] {
                 if let (Some(param), Some(weakening)) = (param, null_target)
-                    && bound_argument_index_matched(&signature.params, &bindings, param)
+                    && signature
+                        .params
+                        .iter()
+                        .position(|candidate| candidate.name == param)
+                        .and_then(|formal_index| bindings.arg_for_param(formal_index))
                         .is_some_and(|index| !matches!(args[index].value, Expr::Logical(false, _)))
                 {
                     target = target.join(weakening);

--- a/crates/ry-checker/src/infer/call.rs
+++ b/crates/ry-checker/src/infer/call.rs
@@ -1101,6 +1101,14 @@ impl Checker {
         let assertion_binding = assertion_signature
             .filter(|signature| signature.assertion.is_some())
             .map(|signature| (signature, match_params(&signature.params, args)));
+        // Name -> formal -> actual, against the prebuilt match.
+        let bound_actual = |signature: &FunctionSig, bindings: &ArgumentMatch, name: &str| {
+            signature
+                .params
+                .iter()
+                .position(|param| param.name == name)
+                .and_then(|formal_index| bindings.arg_for_param(formal_index))
+        };
         if (name.contains("::") || !locally_shadows_stub || resolution.user_function.is_some())
             && let Some((signature, bindings)) = assertion_binding
             && let Some(assertion) = signature.assertion.as_ref()
@@ -1117,11 +1125,8 @@ impl Checker {
                             .any(|param| param.name == *fingerprint)
                     })
             })
-            && let Some(subject_index) = signature
-                .params
-                .iter()
-                .position(|param| param.name == assertion.subject_param)
-                .and_then(|formal_index| bindings.arg_for_param(formal_index))
+            && let Some(subject_index) =
+                bound_actual(signature, &bindings, &assertion.subject_param)
             && let Some(Expr::Ident { name: var, .. }) =
                 args.get(subject_index).map(|arg| &arg.value)
         {
@@ -1138,11 +1143,7 @@ impl Checker {
                 ),
             ] {
                 if let (Some(param), Some(weakening)) = (param, null_target)
-                    && signature
-                        .params
-                        .iter()
-                        .position(|candidate| candidate.name == param)
-                        .and_then(|formal_index| bindings.arg_for_param(formal_index))
+                    && bound_actual(signature, &bindings, param)
                         .is_some_and(|index| !matches!(args[index].value, Expr::Logical(false, _)))
                 {
                     target = target.join(weakening);

--- a/crates/ry-checker/src/infer/index.rs
+++ b/crates/ry-checker/src/infer/index.rs
@@ -737,17 +737,13 @@ pub(crate) fn assigned_names_in_body(body: &[Stmt]) -> HashSet<String> {
 #[cfg(test)]
 mod assigned_names_in_body_tests {
     use super::*;
-    use ry_core::RParser;
     use std::collections::HashSet;
 
     /// The collection runs on a function body (its callers extract the
     /// body from the literal first), so wrap the test source in one.
     fn assigned(body_src: &str) -> HashSet<String> {
         let src = format!("f <- function() {{\n{body_src}\n}}\n");
-        let file = RParser::new()
-            .expect("parser")
-            .parse("assigned_names_test.R", &src)
-            .expect("parse");
+        let file = crate::tests::parse_snippet("assigned_names_test.R", &src);
         let [
             Stmt::Assign {
                 value: Expr::Function { body, .. },

--- a/crates/ry-checker/src/infer/misc.rs
+++ b/crates/ry-checker/src/infer/misc.rs
@@ -1167,6 +1167,19 @@ pub(crate) struct ArgumentMatch {
     pub(crate) dots: Option<usize>,
 }
 
+impl ArgumentMatch {
+    /// The actual argument bound to formal parameter `formal_index`
+    /// under ordinary R matching, if any: the reverse of
+    /// `param_for_arg` (each formal binds at most one actual).
+    /// Semantic metadata must go through this rather than raw call
+    /// positions.
+    pub(crate) fn arg_for_param(&self, formal_index: usize) -> Option<usize> {
+        self.param_for_arg
+            .iter()
+            .position(|bound| *bound == Some(formal_index))
+    }
+}
+
 /// Match R call arguments in the same three passes as `match.call`: exact
 /// names, unambiguous partial names, then unnamed arguments positionally.
 /// Partial and positional matching stop at `...`; exact names may still bind
@@ -1282,20 +1295,8 @@ pub(crate) fn bound_argument_index(
     args: &[Arg],
     formal: &str,
 ) -> Option<usize> {
-    bound_argument_index_matched(params, &match_params(params, args), formal)
-}
-
-/// `bound_argument_index` over a match already computed for this call.
-pub(crate) fn bound_argument_index_matched(
-    params: &[ParamSpec],
-    bindings: &ArgumentMatch,
-    formal: &str,
-) -> Option<usize> {
     let formal_index = params.iter().position(|param| param.name == formal)?;
-    bindings
-        .param_for_arg
-        .iter()
-        .position(|bound| *bound == Some(formal_index))
+    match_params(params, args).arg_for_param(formal_index)
 }
 
 pub(crate) fn match_args_to_params(
@@ -1305,11 +1306,12 @@ pub(crate) fn match_args_to_params(
 ) -> Vec<RType> {
     let bindings = match_params(sig_params, args);
     let mut matched = vec![RType::unknown(); sig_params.len()];
-    for (argument_index, parameter_index) in bindings.param_for_arg.iter().enumerate() {
-        if let Some(parameter_index) = parameter_index
-            && let Some(argument_type) = arg_types.get(argument_index)
+    for (formal_index, slot) in matched.iter_mut().enumerate() {
+        if let Some(argument_type) = bindings
+            .arg_for_param(formal_index)
+            .and_then(|argument_index| arg_types.get(argument_index))
         {
-            matched[*parameter_index] = argument_type.clone();
+            *slot = argument_type.clone();
         }
     }
     matched
@@ -1675,10 +1677,7 @@ pub(crate) fn data_mask_source_arg(sig: &FunctionSig, args: &[Arg]) -> Option<us
     let source = sig.data_mask_source.as_deref()?;
     let bindings = match_params(&sig.params, args);
     let source_parameter = sig.params.iter().position(|param| param.name == source)?;
-    bindings
-        .param_for_arg
-        .iter()
-        .position(|parameter| *parameter == Some(source_parameter))
+    bindings.arg_for_param(source_parameter)
 }
 
 /// If `e` is a literal expression (`42`, `"x"`, `TRUE`, `NULL`, `NA`),

--- a/crates/ry-checker/src/infer/misc.rs
+++ b/crates/ry-checker/src/infer/misc.rs
@@ -110,12 +110,10 @@ fn modes_of(ty: &RType) -> Vec<Mode> {
 ///
 /// `None` is a *proof barrier*, not a mode and not emptiness: callers
 /// that must prove something (incompatibility, a label) treat it as
-/// "cannot decide", never as evidence of a mismatch. These two views
-/// replace the per-helper drift the former union-flattening sites
-/// encoded (`known_modes`, the `modes` closure in `types_intersect`,
-/// and the member walk in `standalone_check_provably_rejects`, which
-/// keeps full `RType`s for per-member length/class checks and so
-/// mirrors `modes_of` rather than calling it).
+/// "cannot decide", never as evidence of a mismatch. A site that needs
+/// the full `RType` of each union member for per-member length/class
+/// checks walks the members itself (`standalone_check_provably_rejects`)
+/// and so mirrors `modes_of` rather than calling this.
 fn mode_set(ty: &RType) -> Option<Vec<Mode>> {
     let modes = modes_of(ty);
     (!modes.is_empty() && !modes.contains(&Mode::Opaque)).then_some(modes)
@@ -1170,9 +1168,11 @@ pub(crate) struct ArgumentMatch {
 impl ArgumentMatch {
     /// The actual argument bound to formal parameter `formal_index`
     /// under ordinary R matching, if any: the reverse of
-    /// `param_for_arg` (each formal binds at most one actual).
-    /// Semantic metadata must go through this rather than raw call
-    /// positions.
+    /// `param_for_arg`. For valid R each formal binds at most one
+    /// actual; a call that repeats a name (`f(x = 1, x = 2)`) is a
+    /// runtime error in R and is not rejected here, and this lookup
+    /// picks the first such actual. Semantic metadata must go through
+    /// this rather than raw call positions.
     pub(crate) fn arg_for_param(&self, formal_index: usize) -> Option<usize> {
         self.param_for_arg
             .iter()

--- a/crates/ry-checker/src/infer/misc.rs
+++ b/crates/ry-checker/src/infer/misc.rs
@@ -56,16 +56,69 @@ pub(crate) fn modes_compatible(mode: &Mode, target: &Mode) -> bool {
         return true;
     }
     match target {
-        Mode::Double | Mode::Integer | Mode::Logical => is_numeric_mode(*mode),
+        Mode::Double | Mode::Integer | Mode::Logical => numeric_family(*mode),
         Mode::Character => matches!(mode, Mode::Character),
         _ => true,
     }
 }
 
-/// R's coercion family: logical, integer, and double values interchange
-/// without a lossy or surprising conversion in the contexts that ask.
-fn is_numeric_mode(mode: Mode) -> bool {
+/// R's silent-coercion numeric family (issue #169): logical, integer,
+/// and double values interchange without a lossy or surprising
+/// conversion in every context modeled here (arithmetic operands, `if`
+/// conditions, purrr typed-map callbacks, stub-argument checking).
+///
+/// Membership decisions, unified across all callers instead of
+/// preserving per-callsite drift:
+/// * Logical IS a member: R coerces `if (1L)` and `1L + 1L` silently.
+/// * Complex is NOT a member: R coerces complex into the double family
+///   only by discarding imaginary parts with a warning, and base R's
+///   `is.numeric()` excludes complex. A complex value meeting a numeric
+///   expectation is therefore a genuine mismatch for compatibility
+///   questions.
+///
+/// One documented, genuine exception: `expected_type_label`'s
+/// "numeric" shorthand covers the wider logical..complex arithmetic
+/// ladder, because it is message wording for unions that R's own
+/// documentation calls numeric (`mean` accepts complex with no warning
+/// at all) — not a coercion promise.
+fn numeric_family(mode: Mode) -> bool {
     matches!(mode, Mode::Double | Mode::Integer | Mode::Logical)
+}
+
+/// Every storage mode a type may hold, with unions flattened
+/// recursively (issue #169). This is the *permissive* view: opaque
+/// contributes `Mode::Opaque` like any other member, so pairwise mode
+/// comparison (`types_intersect`) treats opacity as a mode that only
+/// matches itself. A union that carries no member list (a state
+/// `RType::union`'s contract forbids) yields nothing, overlapping with
+/// no mode. The strict view over the same walk is `mode_set`.
+fn modes_of(ty: &RType) -> Vec<Mode> {
+    match ty.mode {
+        Mode::Union => ty
+            .members
+            .as_ref()
+            .map(|members| members.iter().flat_map(modes_of).collect())
+            .unwrap_or_default(),
+        mode => vec![mode],
+    }
+}
+
+/// The set of storage modes a type may hold when that set is fully
+/// knowable (the *strict* view over `modes_of`): `None` when the type
+/// is opaque, any union member at any depth is opaque, or a union
+/// carries no member list.
+///
+/// `None` is a *proof barrier*, not a mode and not emptiness: callers
+/// that must prove something (incompatibility, a label) treat it as
+/// "cannot decide", never as evidence of a mismatch. These two views
+/// replace the per-helper drift the former union-flattening sites
+/// encoded (`known_modes`, the `modes` closure in `types_intersect`,
+/// and the member walk in `standalone_check_provably_rejects`, which
+/// keeps full `RType`s for per-member length/class checks and so
+/// mirrors `modes_of` rather than calling it).
+fn mode_set(ty: &RType) -> Option<Vec<Mode>> {
+    let modes = modes_of(ty);
+    (!modes.is_empty() && !modes.contains(&Mode::Opaque)).then_some(modes)
 }
 
 /// Return the R source symbol for a binary operator, for use in
@@ -642,19 +695,15 @@ fn install_positive_narrowing(
 /// This deliberately ignores length and class metadata: a guard such as
 /// `is.list(x)` is about storage mode, and a default value's length/class
 /// says nothing about values supplied by callers.
+///
+/// Uses `modes_of` (the permissive view): opaque matches only itself,
+/// so an opaque-bearing default against a concrete predicate target is
+/// "disjoint", which is exactly what lets the narrowing call sites
+/// replace such a default with the predicate's type in the guarded
+/// branch.
 fn types_intersect(left: &RType, right: &RType) -> bool {
-    fn modes(ty: &RType) -> Vec<Mode> {
-        if ty.mode == Mode::Union {
-            ty.members
-                .as_ref()
-                .map(|members| members.iter().flat_map(modes).collect())
-                .unwrap_or_default()
-        } else {
-            vec![ty.mode]
-        }
-    }
-    let left = modes(left);
-    let right = modes(right);
+    let left = modes_of(left);
+    let right = modes_of(right);
     left.iter().any(|mode| right.contains(mode))
 }
 
@@ -1464,10 +1513,10 @@ fn edit_distance(left: &str, right: &str) -> usize {
 }
 
 pub(crate) fn types_provably_incompatible(actual: &RType, expected: &RType) -> bool {
-    let Some(actual_modes) = known_modes(actual) else {
+    let Some(actual_modes) = mode_set(actual) else {
         return false;
     };
-    let Some(expected_modes) = known_modes(expected) else {
+    let Some(expected_modes) = mode_set(expected) else {
         return false;
     };
     !actual_modes.iter().any(|actual_mode| {
@@ -1482,13 +1531,20 @@ pub(crate) fn types_provably_incompatible(actual: &RType, expected: &RType) -> b
 /// standalone checks are exact assertions: their length and class constraints
 /// are runtime preconditions, and numeric modes are not interchangeable.
 pub(crate) fn standalone_check_provably_rejects(actual: &RType, expected: &RType) -> bool {
+    /// The per-member view of a type for standalone checks: unions
+    /// flattened recursively, mirroring `mode_set`'s walk, with a bare
+    /// type as itself. Unlike `mode_set` these keep the full `RType` --
+    /// standalone assertions are exact, so each member's length and
+    /// class are runtime preconditions too. A union that carries no
+    /// member list (a state `RType::union`'s contract forbids) degrades
+    /// to the union itself: one unknowable member, like `mode_set`'s
+    /// `None`.
     fn members(rtype: &RType) -> Vec<&RType> {
         if rtype.mode == Mode::Union {
-            rtype
-                .members
-                .as_deref()
-                .map(|members| members.iter().collect())
-                .unwrap_or_else(|| vec![rtype])
+            match rtype.members.as_deref() {
+                Some(union_members) => union_members.iter().flat_map(|m| members(m)).collect(),
+                None => vec![rtype],
+            }
         } else {
             vec![rtype]
         }
@@ -1555,36 +1611,24 @@ fn generic_argument_may_dispatch(
     generic && (actual.class.has_known_class() || actual.mode == Mode::Null)
 }
 
-fn known_modes(rtype: &RType) -> Option<Vec<Mode>> {
-    match rtype.mode {
-        Mode::Opaque => None,
-        Mode::Union => {
-            let members = rtype.members.as_ref()?;
-            if members.iter().any(|member| member.mode == Mode::Opaque) {
-                None
-            } else {
-                Some(members.iter().map(|member| member.mode).collect())
-            }
-        }
-        mode => Some(vec![mode]),
-    }
-}
-
 fn compatible_mode_pair(actual: Mode, expected: Mode) -> bool {
-    actual == expected || (is_numeric_mode(actual) && is_numeric_mode(expected))
+    actual == expected || (numeric_family(actual) && numeric_family(expected))
 }
 
 pub(crate) fn expected_type_label(expected: &RType) -> String {
-    let Some(modes) = known_modes(expected) else {
+    let Some(modes) = mode_set(expected) else {
         return "unknown".to_string();
     };
+    // The "numeric" shorthand deliberately covers the wider arithmetic
+    // ladder than `numeric_family` (complex included): this is message
+    // wording for unions R's own documentation calls numeric (`mean`
+    // accepts complex with no warning), not a coercion promise, so the
+    // difference from the compatibility family is genuine and kept on
+    // purpose (see `numeric_family`).
     if modes.len() >= 3
-        && modes.iter().all(|mode| {
-            matches!(
-                mode,
-                Mode::Logical | Mode::Integer | Mode::Double | Mode::Complex
-            )
-        })
+        && modes
+            .iter()
+            .all(|mode| numeric_family(*mode) || matches!(mode, Mode::Complex))
     {
         return "numeric".to_string();
     }
@@ -1990,5 +2034,224 @@ mod argument_matching_tests {
             Some("length")
         );
         assert_eq!(closest_parameter("unrelated", &["length", "x"]), None);
+    }
+}
+
+/// Pins for the mode/union-set helpers unified in issue #169:
+/// `modes_compatible`, `types_intersect`,
+/// `types_provably_incompatible`/`expected_type_label`, and
+/// `standalone_check_provably_rejects`. Each block records the behavior
+/// its call sites rely on, so the `mode_set`/`numeric_family`
+/// unification can only change a pin through an explicitly documented
+/// decision (commented at the assert that moved).
+#[cfg(test)]
+mod mode_union_set_pins {
+    use super::*;
+
+    fn union(members: Vec<RType>) -> RType {
+        RType::union(Arc::from(members))
+    }
+
+    // ---- modes_compatible (RY080 purrr typed-map coercion) ----
+    #[test]
+    fn modes_compatible_pins_the_coercion_view() {
+        // No evidence: opaque/union/null callback returns stay compatible.
+        assert!(modes_compatible(&Mode::Opaque, &Mode::Double));
+        assert!(modes_compatible(&Mode::Union, &Mode::Double));
+        assert!(modes_compatible(&Mode::Null, &Mode::Double));
+        // The silent-coercion family interchanges freely.
+        assert!(modes_compatible(&Mode::Logical, &Mode::Double));
+        assert!(modes_compatible(&Mode::Integer, &Mode::Logical));
+        assert!(modes_compatible(&Mode::Double, &Mode::Integer));
+        // The footguns RY080 exists for.
+        assert!(!modes_compatible(&Mode::Character, &Mode::Double));
+        assert!(!modes_compatible(&Mode::Double, &Mode::Character));
+        // Complex into a numeric target discards imaginary parts with a
+        // warning, so it is not silently compatible.
+        assert!(!modes_compatible(&Mode::Complex, &Mode::Double));
+        // Unmodeled targets stay permissive.
+        assert!(modes_compatible(&Mode::Double, &Mode::Complex));
+        assert!(modes_compatible(&Mode::Character, &Mode::List));
+    }
+
+    // ---- types_intersect (parameter-default narrowing compatibility) ----
+    #[test]
+    fn types_intersect_pins_narrowing_mode_overlap() {
+        let double = RType::scalar(Mode::Double);
+        let character = RType::scalar(Mode::Character);
+        let numeric_union = union(vec![RType::scalar(Mode::Integer), double.clone()]);
+        assert!(types_intersect(&double, &double));
+        assert!(!types_intersect(&character, &double));
+        assert!(types_intersect(&numeric_union, &double));
+        assert!(types_intersect(&double, &numeric_union));
+        assert!(!types_intersect(&numeric_union, &character));
+    }
+
+    #[test]
+    fn types_intersect_treats_opaque_as_a_mode_matching_only_itself() {
+        let double = RType::scalar(Mode::Double);
+        let character = RType::scalar(Mode::Character);
+        let opaque_member_union = union(vec![character.clone(), RType::unknown()]);
+        // The permissive view (`modes_of`): opaque participates as an
+        // ordinary mode. Opaque-vs-double is therefore disjoint, which
+        // is what lets a guarded default parameter be replaced by the
+        // predicate's type (see `types_intersect`). An opaque-bearing
+        // union still intersects through its knowable members.
+        assert!(!types_intersect(&RType::unknown(), &double));
+        assert!(!types_intersect(&double, &RType::unknown()));
+        assert!(types_intersect(&RType::unknown(), &RType::unknown()));
+        assert!(!types_intersect(&opaque_member_union, &double));
+        assert!(types_intersect(&opaque_member_union, &character));
+    }
+
+    // ---- types_provably_incompatible / expected_type_label (RY092) ----
+    #[test]
+    fn types_provably_incompatible_pins_argument_checking() {
+        let double = RType::scalar(Mode::Double);
+        let character = RType::scalar(Mode::Character);
+        assert!(types_provably_incompatible(&character, &double));
+        assert!(!types_provably_incompatible(
+            &RType::scalar(Mode::Integer),
+            &double
+        ));
+        assert!(!types_provably_incompatible(
+            &double,
+            &RType::scalar(Mode::Logical)
+        ));
+        // Complex is outside the silent-coercion family (see
+        // `numeric_family`), so complex-vs-double is provably
+        // incompatible.
+        assert!(types_provably_incompatible(
+            &RType::scalar(Mode::Complex),
+            &double
+        ));
+        // Opaque anywhere means "cannot decide", never incompatible.
+        assert!(!types_provably_incompatible(&RType::unknown(), &double));
+        assert!(!types_provably_incompatible(&double, &RType::unknown()));
+        let opaque_member = union(vec![double.clone(), RType::unknown()]);
+        assert!(!types_provably_incompatible(&opaque_member, &character));
+        // A union with any compatible member passes.
+        let mixed = union(vec![character.clone(), double.clone()]);
+        assert!(!types_provably_incompatible(&mixed, &double));
+        assert!(types_provably_incompatible(
+            &RType::scalar(Mode::List),
+            &double
+        ));
+    }
+
+    #[test]
+    fn expected_type_label_pins_message_text() {
+        assert_eq!(expected_type_label(&RType::scalar(Mode::Double)), "double");
+        assert_eq!(expected_type_label(&RType::unknown()), "unknown");
+        let numeric = union(vec![
+            RType::scalar(Mode::Logical),
+            RType::scalar(Mode::Integer),
+            RType::scalar(Mode::Double),
+        ]);
+        assert_eq!(expected_type_label(&numeric), "numeric");
+        // Documented genuine difference from `numeric_family`: the
+        // "numeric" shorthand covers the wider logical..complex
+        // arithmetic ladder, because it is message wording for unions
+        // R's own documentation calls numeric (`mean` accepts complex
+        // with no warning), not a coercion promise.
+        let with_complex = union(vec![
+            RType::scalar(Mode::Integer),
+            RType::scalar(Mode::Double),
+            RType::scalar(Mode::Complex),
+        ]);
+        assert_eq!(expected_type_label(&with_complex), "numeric");
+    }
+
+    // ---- standalone_check_provably_rejects (exact assertions) ----
+    #[test]
+    fn standalone_check_pins_exact_assertions() {
+        let double = RType::scalar(Mode::Double);
+        let character = RType::scalar(Mode::Character);
+        let double2 = RType::new(Mode::Double, Length::Known(2));
+        assert!(standalone_check_provably_rejects(&character, &double));
+        assert!(!standalone_check_provably_rejects(&double, &double));
+        // Standalone checks are exact assertions: numeric modes are not
+        // interchangeable here, unlike ordinary argument compatibility.
+        assert!(standalone_check_provably_rejects(
+            &RType::scalar(Mode::Integer),
+            &double
+        ));
+        // Length is a runtime precondition, and opaque never rejects.
+        assert!(standalone_check_provably_rejects(&double, &double2));
+        assert!(!standalone_check_provably_rejects(
+            &double,
+            &RType::new(Mode::Double, Length::Unknown)
+        ));
+        assert!(!standalone_check_provably_rejects(
+            &RType::unknown(),
+            &double
+        ));
+        // A union expectation with any overlapping member passes.
+        let nullable_character = union(vec![
+            RType::new(Mode::Null, Length::Zero),
+            character.clone(),
+        ]);
+        assert!(!standalone_check_provably_rejects(
+            &character,
+            &nullable_character
+        ));
+        assert!(standalone_check_provably_rejects(
+            &double,
+            &nullable_character
+        ));
+    }
+
+    // ---- apply_narrowing call sites (types_intersect consumers) ----
+    //
+    // These pin installed-narrowing outcomes rather than the
+    // compatibility flag itself, proving the `mode_set` unification
+    // (opaque sides are "unprovable", not "disjoint") cannot change
+    // what a guard installs.
+    #[test]
+    fn opaque_bearing_default_parameters_still_narrow() {
+        let target = RType::scalar(Mode::Double);
+        for existing in [
+            RType::unknown(),
+            union(vec![RType::scalar(Mode::Character), RType::unknown()]),
+        ] {
+            let mut base = Scope::default();
+            base.insert_parameter_default("x", existing);
+            let (then_scope, ..) = apply_narrowing(
+                &base,
+                &Narrowing::Positive {
+                    var: "x".to_string(),
+                    target: target.clone(),
+                },
+            );
+            assert_eq!(
+                then_scope.get("x").map(|t| t.mode),
+                Some(Mode::Double),
+                "an is.double guard must install over an opaque-bearing default"
+            );
+        }
+    }
+
+    #[test]
+    fn knowable_unions_narrow_to_the_confirmed_member() {
+        let mut base = Scope::default();
+        base.insert(
+            "x",
+            union(vec![
+                RType::scalar(Mode::Integer),
+                RType::scalar(Mode::Double),
+            ]),
+        );
+        let (then_scope, ..) = apply_narrowing(
+            &base,
+            &Narrowing::Positive {
+                var: "x".to_string(),
+                target: RType::scalar(Mode::Double),
+            },
+        );
+        assert_eq!(
+            then_scope.get("x").map(|t| t.mode),
+            Some(Mode::Double),
+            "a predicate confirming one union member narrows to it"
+        );
     }
 }

--- a/crates/ry-checker/src/infer/misc.rs
+++ b/crates/ry-checker/src/infer/misc.rs
@@ -62,36 +62,20 @@ pub(crate) fn modes_compatible(mode: &Mode, target: &Mode) -> bool {
     }
 }
 
-/// R's silent-coercion numeric family (issue #169): logical, integer,
-/// and double values interchange without a lossy or surprising
-/// conversion in every context modeled here (arithmetic operands, `if`
-/// conditions, purrr typed-map callbacks, stub-argument checking).
-///
-/// Membership decisions, unified across all callers instead of
-/// preserving per-callsite drift:
-/// * Logical IS a member: R coerces `if (1L)` and `1L + 1L` silently.
-/// * Complex is NOT a member: R coerces complex into the double family
-///   only by discarding imaginary parts with a warning, and base R's
-///   `is.numeric()` excludes complex. A complex value meeting a numeric
-///   expectation is therefore a genuine mismatch for compatibility
-///   questions.
-///
-/// One documented, genuine exception: `expected_type_label`'s
-/// "numeric" shorthand covers the wider logical..complex arithmetic
-/// ladder, because it is message wording for unions that R's own
-/// documentation calls numeric (`mean` accepts complex with no warning
-/// at all) — not a coercion promise.
+/// R's silent-coercion numeric family (#169): logical, integer, and
+/// double interchange losslessly, so compatibility questions treat
+/// them as one family. Complex is excluded: coercing it into the
+/// family discards imaginary parts with a warning, and base R's
+/// `is.numeric()` says no. The one deliberate exception is
+/// `expected_type_label`'s "numeric" wording, which covers complex.
 fn numeric_family(mode: Mode) -> bool {
     matches!(mode, Mode::Double | Mode::Integer | Mode::Logical)
 }
 
-/// Every storage mode a type may hold, with unions flattened
-/// recursively (issue #169). This is the *permissive* view: opaque
-/// contributes `Mode::Opaque` like any other member, so pairwise mode
-/// comparison (`types_intersect`) treats opacity as a mode that only
-/// matches itself. A union that carries no member list (a state
-/// `RType::union`'s contract forbids) yields nothing, overlapping with
-/// no mode. The strict view over the same walk is `mode_set`.
+/// Every storage mode a type may hold, unions flattened recursively.
+/// Opaque participates as an ordinary mode (the permissive view used by
+/// `types_intersect`); a union without a member list -- a state
+/// `RType::union`'s contract forbids -- yields none.
 fn modes_of(ty: &RType) -> Vec<Mode> {
     match ty.mode {
         Mode::Union => ty
@@ -103,17 +87,10 @@ fn modes_of(ty: &RType) -> Vec<Mode> {
     }
 }
 
-/// The set of storage modes a type may hold when that set is fully
-/// knowable (the *strict* view over `modes_of`): `None` when the type
-/// is opaque, any union member at any depth is opaque, or a union
-/// carries no member list.
-///
-/// `None` is a *proof barrier*, not a mode and not emptiness: callers
-/// that must prove something (incompatibility, a label) treat it as
-/// "cannot decide", never as evidence of a mismatch. A site that needs
-/// the full `RType` of each union member for per-member length/class
-/// checks walks the members itself (`standalone_check_provably_rejects`)
-/// and so mirrors `modes_of` rather than calling this.
+/// `modes_of` restricted to fully knowable sets: `None` when the type,
+/// any union member at any depth, or a member-less union is opaque.
+/// `None` is a proof barrier -- callers treat it as "cannot decide",
+/// never as evidence of a mismatch.
 fn mode_set(ty: &RType) -> Option<Vec<Mode>> {
     let modes = modes_of(ty);
     (!modes.is_empty() && !modes.contains(&Mode::Opaque)).then_some(modes)
@@ -693,12 +670,6 @@ fn install_positive_narrowing(
 /// This deliberately ignores length and class metadata: a guard such as
 /// `is.list(x)` is about storage mode, and a default value's length/class
 /// says nothing about values supplied by callers.
-///
-/// Uses `modes_of` (the permissive view): opaque matches only itself,
-/// so an opaque-bearing default against a concrete predicate target is
-/// "disjoint", which is exactly what lets the narrowing call sites
-/// replace such a default with the predicate's type in the guarded
-/// branch.
 fn types_intersect(left: &RType, right: &RType) -> bool {
     let left = modes_of(left);
     let right = modes_of(right);
@@ -1166,13 +1137,9 @@ pub(crate) struct ArgumentMatch {
 }
 
 impl ArgumentMatch {
-    /// The actual argument bound to formal parameter `formal_index`
-    /// under ordinary R matching, if any: the reverse of
-    /// `param_for_arg`. For valid R each formal binds at most one
-    /// actual; a call that repeats a name (`f(x = 1, x = 2)`) is a
-    /// runtime error in R and is not rejected here, and this lookup
-    /// picks the first such actual. Semantic metadata must go through
-    /// this rather than raw call positions.
+    /// The actual argument bound to formal parameter `formal_index`,
+    /// if any: the reverse of `param_for_arg`. Repeated names
+    /// (`f(x = 1, x = 2)`, a runtime error in R) bind the first actual.
     pub(crate) fn arg_for_param(&self, formal_index: usize) -> Option<usize> {
         self.param_for_arg
             .iter()
@@ -1295,8 +1262,17 @@ pub(crate) fn bound_argument_index(
     args: &[Arg],
     formal: &str,
 ) -> Option<usize> {
-    let formal_index = params.iter().position(|param| param.name == formal)?;
-    match_params(params, args).arg_for_param(formal_index)
+    bound_argument_index_matched(params, &match_params(params, args), formal)
+}
+
+/// `bound_argument_index` over an argument match already computed for
+/// this call, so a site that consults several formals matches once.
+pub(crate) fn bound_argument_index_matched(
+    params: &[ParamSpec],
+    bindings: &ArgumentMatch,
+    formal: &str,
+) -> Option<usize> {
+    bindings.arg_for_param(params.iter().position(|param| param.name == formal)?)
 }
 
 pub(crate) fn match_args_to_params(
@@ -1533,14 +1509,9 @@ pub(crate) fn types_provably_incompatible(actual: &RType, expected: &RType) -> b
 /// standalone checks are exact assertions: their length and class constraints
 /// are runtime preconditions, and numeric modes are not interchangeable.
 pub(crate) fn standalone_check_provably_rejects(actual: &RType, expected: &RType) -> bool {
-    /// The per-member view of a type for standalone checks: unions
-    /// flattened recursively, mirroring `mode_set`'s walk, with a bare
-    /// type as itself. Unlike `mode_set` these keep the full `RType` --
-    /// standalone assertions are exact, so each member's length and
-    /// class are runtime preconditions too. A union that carries no
-    /// member list (a state `RType::union`'s contract forbids) degrades
-    /// to the union itself: one unknowable member, like `mode_set`'s
-    /// `None`.
+    /// `modes_of`'s walk keeping full `RType`s: standalone assertions
+    /// are exact, so each member's length and class are preconditions
+    /// too. A member-less union degrades to the union itself.
     fn members(rtype: &RType) -> Vec<&RType> {
         if rtype.mode == Mode::Union {
             match rtype.members.as_deref() {
@@ -1621,12 +1592,9 @@ pub(crate) fn expected_type_label(expected: &RType) -> String {
     let Some(modes) = mode_set(expected) else {
         return "unknown".to_string();
     };
-    // The "numeric" shorthand deliberately covers the wider arithmetic
-    // ladder than `numeric_family` (complex included): this is message
-    // wording for unions R's own documentation calls numeric (`mean`
-    // accepts complex with no warning), not a coercion promise, so the
-    // difference from the compatibility family is genuine and kept on
-    // purpose (see `numeric_family`).
+    // "numeric" is message wording, not a coercion promise: it covers
+    // the wider logical..complex ladder R's own docs call numeric (see
+    // `numeric_family`).
     if modes.len() >= 3
         && modes
             .iter()
@@ -1676,8 +1644,7 @@ pub(crate) fn argument_eval_mode(
 pub(crate) fn data_mask_source_arg(sig: &FunctionSig, args: &[Arg]) -> Option<usize> {
     let source = sig.data_mask_source.as_deref()?;
     let bindings = match_params(&sig.params, args);
-    let source_parameter = sig.params.iter().position(|param| param.name == source)?;
-    bindings.arg_for_param(source_parameter)
+    bound_argument_index_matched(&sig.params, &bindings, source)
 }
 
 /// If `e` is a literal expression (`42`, `"x"`, `TRUE`, `NULL`, `NA`),
@@ -2038,183 +2005,188 @@ mod argument_matching_tests {
 
 /// Pins for the mode/union-set helpers unified in issue #169:
 /// `modes_compatible`, `types_intersect`,
-/// `types_provably_incompatible`/`expected_type_label`, and
-/// `standalone_check_provably_rejects`. Each block records the behavior
-/// its call sites rely on, so the `mode_set`/`numeric_family`
-/// unification can only change a pin through an explicitly documented
-/// decision (commented at the assert that moved).
+/// `types_provably_incompatible`/`expected_type_label`,
+/// `standalone_check_provably_rejects`, and the narrowing call sites.
+/// Each row is a decision a call site relies on.
 #[cfg(test)]
 mod mode_union_set_pins {
     use super::*;
 
-    fn union(members: Vec<RType>) -> RType {
-        RType::union(Arc::from(members))
+    /// Test-only union of mode-only scalars (length One, no class); must not be used where length/class matter (standalone/narrowing cases keep bespoke constructions).
+    fn union(modes: &[Mode]) -> RType {
+        RType::union(Arc::from_iter(
+            modes.iter().map(|mode| RType::scalar(*mode)),
+        ))
     }
 
-    // ---- modes_compatible (RY080 purrr typed-map coercion) ----
     #[test]
     fn modes_compatible_pins_the_coercion_view() {
-        // No evidence: opaque/union/null callback returns stay compatible.
-        assert!(modes_compatible(&Mode::Opaque, &Mode::Double));
-        assert!(modes_compatible(&Mode::Union, &Mode::Double));
-        assert!(modes_compatible(&Mode::Null, &Mode::Double));
-        // The silent-coercion family interchanges freely.
-        assert!(modes_compatible(&Mode::Logical, &Mode::Double));
-        assert!(modes_compatible(&Mode::Integer, &Mode::Logical));
-        assert!(modes_compatible(&Mode::Double, &Mode::Integer));
-        // The footguns RY080 exists for.
-        assert!(!modes_compatible(&Mode::Character, &Mode::Double));
-        assert!(!modes_compatible(&Mode::Double, &Mode::Character));
-        // Complex into a numeric target discards imaginary parts with a
-        // warning, so it is not silently compatible.
-        assert!(!modes_compatible(&Mode::Complex, &Mode::Double));
-        // Unmodeled targets stay permissive.
-        assert!(modes_compatible(&Mode::Double, &Mode::Complex));
-        assert!(modes_compatible(&Mode::Character, &Mode::List));
-    }
-
-    // ---- types_intersect (parameter-default narrowing compatibility) ----
-    #[test]
-    fn types_intersect_pins_narrowing_mode_overlap() {
-        let double = RType::scalar(Mode::Double);
-        let character = RType::scalar(Mode::Character);
-        let numeric_union = union(vec![RType::scalar(Mode::Integer), double.clone()]);
-        assert!(types_intersect(&double, &double));
-        assert!(!types_intersect(&character, &double));
-        assert!(types_intersect(&numeric_union, &double));
-        assert!(types_intersect(&double, &numeric_union));
-        assert!(!types_intersect(&numeric_union, &character));
+        for (actual, target, compatible) in [
+            // No evidence: opaque/union/null callback returns stay compatible.
+            (Mode::Opaque, Mode::Double, true),
+            (Mode::Union, Mode::Double, true),
+            (Mode::Null, Mode::Double, true),
+            // The silent-coercion family interchanges freely.
+            (Mode::Logical, Mode::Double, true),
+            (Mode::Integer, Mode::Logical, true),
+            (Mode::Double, Mode::Integer, true),
+            // The footguns RY080 exists for.
+            (Mode::Character, Mode::Double, false),
+            (Mode::Double, Mode::Character, false),
+            // Complex into a numeric target discards imaginary parts with
+            // a warning, so it is not silently compatible; unmodeled
+            // targets stay permissive.
+            (Mode::Complex, Mode::Double, false),
+            (Mode::Double, Mode::Complex, true),
+        ] {
+            assert_eq!(
+                modes_compatible(&actual, &target),
+                compatible,
+                "{actual:?} into {target:?}"
+            );
+        }
     }
 
     #[test]
-    fn types_intersect_treats_opaque_as_a_mode_matching_only_itself() {
+    fn types_intersect_pins_mode_overlap() {
         let double = RType::scalar(Mode::Double);
         let character = RType::scalar(Mode::Character);
-        let opaque_member_union = union(vec![character.clone(), RType::unknown()]);
-        // The permissive view (`modes_of`): opaque participates as an
-        // ordinary mode. Opaque-vs-double is therefore disjoint, which
-        // is what lets a guarded default parameter be replaced by the
-        // predicate's type (see `types_intersect`). An opaque-bearing
-        // union still intersects through its knowable members.
-        assert!(!types_intersect(&RType::unknown(), &double));
-        assert!(!types_intersect(&double, &RType::unknown()));
-        assert!(types_intersect(&RType::unknown(), &RType::unknown()));
-        assert!(!types_intersect(&opaque_member_union, &double));
-        assert!(types_intersect(&opaque_member_union, &character));
+        let numeric_union = union(&[Mode::Integer, Mode::Double]);
+        let opaque_member_union = union(&[Mode::Character, Mode::Opaque]);
+        for (left, right, overlap) in [
+            (&double, &double, true),
+            (&character, &double, false),
+            (&numeric_union, &double, true),
+            (&double, &numeric_union, true),
+            (&numeric_union, &character, false),
+            // Opaque is a mode matching only itself: opaque-vs-double is
+            // disjoint -- what lets a guarded default parameter be replaced
+            // by the predicate's type -- and an opaque-bearing union still
+            // intersects through its knowable members.
+            (&RType::unknown(), &double, false),
+            (&double, &RType::unknown(), false),
+            (&RType::unknown(), &RType::unknown(), true),
+            (&opaque_member_union, &double, false),
+            (&opaque_member_union, &character, true),
+        ] {
+            assert_eq!(
+                types_intersect(left, right),
+                overlap,
+                "{left:?} vs {right:?}"
+            );
+        }
     }
 
-    // ---- types_provably_incompatible / expected_type_label (RY092) ----
     #[test]
     fn types_provably_incompatible_pins_argument_checking() {
         let double = RType::scalar(Mode::Double);
         let character = RType::scalar(Mode::Character);
-        assert!(types_provably_incompatible(&character, &double));
-        assert!(!types_provably_incompatible(
-            &RType::scalar(Mode::Integer),
-            &double
-        ));
-        assert!(!types_provably_incompatible(
-            &double,
-            &RType::scalar(Mode::Logical)
-        ));
-        // Complex is outside the silent-coercion family (see
-        // `numeric_family`), so complex-vs-double is provably
-        // incompatible.
-        assert!(types_provably_incompatible(
-            &RType::scalar(Mode::Complex),
-            &double
-        ));
-        // Opaque anywhere means "cannot decide", never incompatible.
-        assert!(!types_provably_incompatible(&RType::unknown(), &double));
-        assert!(!types_provably_incompatible(&double, &RType::unknown()));
-        let opaque_member = union(vec![double.clone(), RType::unknown()]);
-        assert!(!types_provably_incompatible(&opaque_member, &character));
-        // A union with any compatible member passes.
-        let mixed = union(vec![character.clone(), double.clone()]);
-        assert!(!types_provably_incompatible(&mixed, &double));
-        assert!(types_provably_incompatible(
-            &RType::scalar(Mode::List),
-            &double
-        ));
+        for (actual, expected, incompatible) in [
+            (&character, &double, true),
+            (&RType::scalar(Mode::Integer), &double, false),
+            (&double, &RType::scalar(Mode::Logical), false),
+            // Complex is outside the silent-coercion family.
+            (&RType::scalar(Mode::Complex), &double, true),
+            // Opaque anywhere means "cannot decide", never a mismatch.
+            (&RType::unknown(), &double, false),
+            (&double, &RType::unknown(), false),
+            (&union(&[Mode::Double, Mode::Opaque]), &character, false),
+            // A union with any compatible member passes.
+            (&union(&[Mode::Character, Mode::Double]), &double, false),
+            (&RType::scalar(Mode::List), &double, true),
+        ] {
+            assert_eq!(
+                types_provably_incompatible(actual, expected),
+                incompatible,
+                "{actual:?} vs {expected:?}"
+            );
+        }
     }
 
     #[test]
     fn expected_type_label_pins_message_text() {
-        assert_eq!(expected_type_label(&RType::scalar(Mode::Double)), "double");
-        assert_eq!(expected_type_label(&RType::unknown()), "unknown");
-        let numeric = union(vec![
-            RType::scalar(Mode::Logical),
-            RType::scalar(Mode::Integer),
-            RType::scalar(Mode::Double),
-        ]);
-        assert_eq!(expected_type_label(&numeric), "numeric");
-        // Documented genuine difference from `numeric_family`: the
-        // "numeric" shorthand covers the wider logical..complex
-        // arithmetic ladder, because it is message wording for unions
-        // R's own documentation calls numeric (`mean` accepts complex
-        // with no warning), not a coercion promise.
-        let with_complex = union(vec![
-            RType::scalar(Mode::Integer),
-            RType::scalar(Mode::Double),
-            RType::scalar(Mode::Complex),
-        ]);
-        assert_eq!(expected_type_label(&with_complex), "numeric");
+        for (expected, label) in [
+            (&RType::scalar(Mode::Double), "double"),
+            (&RType::unknown(), "unknown"),
+            (
+                &union(&[Mode::Logical, Mode::Integer, Mode::Double]),
+                "numeric",
+            ),
+            // The label's one deliberate divergence from `numeric_family`:
+            // "numeric" is wording for unions R's own documentation calls
+            // numeric, so complex is included.
+            (
+                &union(&[Mode::Integer, Mode::Double, Mode::Complex]),
+                "numeric",
+            ),
+        ] {
+            assert_eq!(expected_type_label(expected), label, "{expected:?}");
+        }
     }
 
-    // ---- standalone_check_provably_rejects (exact assertions) ----
     #[test]
     fn standalone_check_pins_exact_assertions() {
         let double = RType::scalar(Mode::Double);
         let character = RType::scalar(Mode::Character);
-        let double2 = RType::new(Mode::Double, Length::Known(2));
-        assert!(standalone_check_provably_rejects(&character, &double));
-        assert!(!standalone_check_provably_rejects(&double, &double));
-        // Standalone checks are exact assertions: numeric modes are not
-        // interchangeable here, unlike ordinary argument compatibility.
-        assert!(standalone_check_provably_rejects(
-            &RType::scalar(Mode::Integer),
-            &double
-        ));
-        // Length is a runtime precondition, and opaque never rejects.
-        assert!(standalone_check_provably_rejects(&double, &double2));
-        assert!(!standalone_check_provably_rejects(
-            &double,
-            &RType::new(Mode::Double, Length::Unknown)
-        ));
-        assert!(!standalone_check_provably_rejects(
-            &RType::unknown(),
-            &double
-        ));
-        // A union expectation with any overlapping member passes.
-        let nullable_character = union(vec![
+        let nullable_character = RType::union(Arc::from(vec![
             RType::new(Mode::Null, Length::Zero),
             character.clone(),
-        ]);
-        assert!(!standalone_check_provably_rejects(
-            &character,
-            &nullable_character
-        ));
-        assert!(standalone_check_provably_rejects(
-            &double,
-            &nullable_character
-        ));
+        ]));
+        for (actual, expected, rejects) in [
+            // Exact assertions: numeric modes are not interchangeable
+            // (unlike ordinary argument compatibility), and length is a
+            // runtime precondition. Opaque never rejects.
+            (&character, &double, true),
+            (&double, &double, false),
+            (&RType::scalar(Mode::Integer), &double, true),
+            (&double, &RType::new(Mode::Double, Length::Known(2)), true),
+            (&double, &RType::new(Mode::Double, Length::Unknown), false),
+            (&RType::unknown(), &double, false),
+            // A union expectation with any overlapping member passes.
+            (&character, &nullable_character, false),
+            (&double, &nullable_character, true),
+        ] {
+            assert_eq!(
+                standalone_check_provably_rejects(actual, expected),
+                rejects,
+                "{actual:?} vs {expected:?}"
+            );
+        }
     }
 
-    // ---- apply_narrowing call sites (types_intersect consumers) ----
-    //
-    // These pin installed-narrowing outcomes rather than the
-    // compatibility flag itself, proving the `mode_set` unification
-    // (opaque sides are "unprovable", not "disjoint") cannot change
-    // what a guard installs.
+    // Pins installed-narrowing outcomes rather than the compatibility
+    // flag itself: the opaque-default arms are disjoint from the guard
+    // (not merely "unprovable"), pinning the disjoint-default install
+    // path, and a plain union binding narrows to the confirmed member.
     #[test]
-    fn opaque_bearing_default_parameters_still_narrow() {
+    fn guards_install_over_opaque_defaults_and_confirmed_members() {
         let target = RType::scalar(Mode::Double);
-        for existing in [
-            RType::unknown(),
-            union(vec![RType::scalar(Mode::Character), RType::unknown()]),
+        for (as_default, existing) in [
+            (true, RType::unknown()),
+            (true, union(&[Mode::Character, Mode::Opaque])),
+            (false, union(&[Mode::Integer, Mode::Double])),
         ] {
+            // Discriminate the disjointness claim: the opaque-default arms
+            // are disjoint from the guard (opaque matches only itself),
+            // while the confirmed-member arm overlaps through Double.
+            if as_default {
+                assert!(
+                    !types_intersect(&existing, &target),
+                    "opaque default must be disjoint from the guard: {existing:?}"
+                );
+            } else {
+                assert!(
+                    types_intersect(&existing, &target),
+                    "confirmed-member union must overlap the guard: {existing:?}"
+                );
+            }
+            let note = format!("guard must install its type over {existing:?}");
             let mut base = Scope::default();
-            base.insert_parameter_default("x", existing);
+            if as_default {
+                base.insert_parameter_default("x", existing);
+            } else {
+                base.insert("x", existing);
+            }
             let (then_scope, ..) = apply_narrowing(
                 &base,
                 &Narrowing::Positive {
@@ -2225,32 +2197,8 @@ mod mode_union_set_pins {
             assert_eq!(
                 then_scope.get("x").map(|t| t.mode),
                 Some(Mode::Double),
-                "an is.double guard must install over an opaque-bearing default"
+                "{note}"
             );
         }
-    }
-
-    #[test]
-    fn knowable_unions_narrow_to_the_confirmed_member() {
-        let mut base = Scope::default();
-        base.insert(
-            "x",
-            union(vec![
-                RType::scalar(Mode::Integer),
-                RType::scalar(Mode::Double),
-            ]),
-        );
-        let (then_scope, ..) = apply_narrowing(
-            &base,
-            &Narrowing::Positive {
-                var: "x".to_string(),
-                target: RType::scalar(Mode::Double),
-            },
-        );
-        assert_eq!(
-            then_scope.get("x").map(|t| t.mode),
-            Some(Mode::Double),
-            "a predicate confirming one union member narrows to it"
-        );
     }
 }

--- a/crates/ry-checker/src/infer/misc.rs
+++ b/crates/ry-checker/src/infer/misc.rs
@@ -2012,7 +2012,7 @@ mod argument_matching_tests {
 mod mode_union_set_pins {
     use super::*;
 
-    /// Test-only union of mode-only scalars (length One, no class); must not be used where length/class matter (standalone/narrowing cases keep bespoke constructions).
+    /// Test-only union of mode-only scalars (length One, no class); must not be used where length/class matter (the standalone pins keep bespoke constructions).
     fn union(modes: &[Mode]) -> RType {
         RType::union(Arc::from_iter(
             modes.iter().map(|mode| RType::scalar(*mode)),

--- a/crates/ry-checker/src/infer/mod.rs
+++ b/crates/ry-checker/src/infer/mod.rs
@@ -774,14 +774,10 @@ impl Checker {
         captured_scope: &Scope,
         depth: usize,
     ) -> Option<Arc<FunctionSignature>> {
-        if body.is_empty() {
-            return None;
-        }
-        // Layer the inner function's params on top of the captured
-        // scope: each param's type comes from its default literal
-        // (`x = 1L` -> integer) or is unknown, and a defaulted param
-        // keeps its default-marker binding so narrowing can treat it
-        // as caller-replaceable.
+        // Each param's type comes from its default literal (`x = 1L` ->
+        // integer) or is unknown; a defaulted param keeps its
+        // default-marker binding so narrowing treats it as
+        // caller-replaceable.
         let mut param_types: Vec<RType> = Vec::with_capacity(params.len());
         let return_type = self.walk_literal_returns(body, captured_scope, depth, |scope| {
             for p in params {
@@ -803,22 +799,15 @@ impl Checker {
         }))
     }
 
-    /// The closure-return inference walk shared by signature building
+    /// The closure-return walk shared by signature building
     /// ([`build_function_signature`]) and higher-order callback
-    /// inference ([`crate::higher_order`]'s `callback_literal_return`):
-    /// clone the captured scope, let `bind_params` layer the literal's
-    /// parameters on top (their types come from declared defaults in
-    /// the former, from the caller's argument types in the latter),
-    /// walk the body in source order collecting each explicit
-    /// `return(...)`/`invisible(...)` type, add the trailing
-    /// statement's implicit value, and join everything. Returns `None`
-    /// when nothing contributes a type or the join collapses to
-    /// opaque.
-    ///
-    /// The walk is a PURE return-type computation: it forces discarding
-    /// mode so it never emits diagnostics itself (a named function
-    /// body's diagnostics come from the pass-3 `check_stmt` walk, a
-    /// callback body's from `walk_callback_for_diagnostics`).
+    /// inference ([`Checker::callback_literal_return`]): clone the
+    /// captured scope, let `bind_params` layer the literal's parameters
+    /// on top, then collect each explicit `return(...)`/`invisible(...)`
+    /// type plus the trailing statement's implicit value and join them.
+    /// Returns `None` when nothing contributes a type or the join
+    /// collapses to opaque. PURE computation: forces discarding mode so
+    /// it never emits diagnostics (those come from the pass-3 walks).
     pub(crate) fn walk_literal_returns(
         &mut self,
         body: &[Stmt],
@@ -828,33 +817,19 @@ impl Checker {
     ) -> Option<RType> {
         let prev_discarding = self.discarding;
         self.discarding = true;
-        // Start from a clone of the captured scope so the body can
-        // reference enclosing bindings (`make_adder`'s `x`).
         let mut scope = captured_scope.clone();
         bind_params(&mut scope);
-        // Walk the body in source order, simulating each statement's
-        // effect on the scope so later statements (notably the trailing
-        // return expression) can reference bindings established earlier
-        // in the body. This is what lets us resolve the named-return
-        // closure pattern:
-        //     f <- function() { g <- function() { 1L }; g }
-        // Here the trailing `g` must see the `g <- function() { 1L }`
-        // binding to pick up its inferred `fn_sig`.
-        //
-        // We collect explicit `return(...)` types as we go; the trailing
-        // statement's value is added separately below. Branches in `if`
+        // Simulate each statement's scope effect in source order so the
+        // trailing return can reference bindings established earlier in
+        // the body (the named-return closure pattern). `if` branches
         // are walked without splitting the scope (v1 approximation).
         let mut returns: Vec<RType> = Vec::new();
-        // Walk the body via the unified walker (discarding mode, return
-        // collection enabled).
         for s in body {
             self.walk_stmt(s, &mut scope, Some(&mut returns));
         }
-        // Trailing expression of a braced body is the implicit return.
-        // A trailing `Stmt::FunctionDef` (a bare function literal in
-        // statement position) is also the implicit return value - this
-        // is the closure-factory pattern: `function() { function() { 1L } }`
-        // has a `Stmt::FunctionDef` as its body's last statement.
+        // The trailing expression -- or a bare trailing function
+        // literal, the closure-factory pattern -- is the implicit
+        // return.
         if let Some(t) = self.trailing_return_type(body, &mut scope, depth + 1) {
             returns.push(t);
         }

--- a/crates/ry-checker/src/infer/mod.rs
+++ b/crates/ry-checker/src/infer/mod.rs
@@ -874,7 +874,7 @@ impl Checker {
     ///
     /// Returns `None` when the body is empty, the last statement is not
     /// an expression-like form, or the trailing expression is a
-    /// `return(...)` call (which `collect_returns_stmt_at_depth`
+    /// `return(...)` call (which [`Checker::walk_literal_returns`]
     /// already counted).
     pub(crate) fn trailing_return_type(
         &mut self,

--- a/crates/ry-checker/src/infer/mod.rs
+++ b/crates/ry-checker/src/infer/mod.rs
@@ -777,41 +777,61 @@ impl Checker {
         if body.is_empty() {
             return None;
         }
-        // Signature building is a PURE return-type computation: it must
-        // never emit diagnostics (the diagnostic walk of a function body
-        // happens via check_stmt's function-body arm in pass 3). Force
-        // discarding mode for this walk regardless of the caller's mode.
-        let prev_discarding = self.discarding;
-        self.discarding = true;
-        let result = self.build_function_signature_inner(params, body, captured_scope, depth);
-        self.discarding = prev_discarding;
-        result
+        // Layer the inner function's params on top of the captured
+        // scope: each param's type comes from its default literal
+        // (`x = 1L` -> integer) or is unknown, and a defaulted param
+        // keeps its default-marker binding so narrowing can treat it
+        // as caller-replaceable.
+        let mut param_types: Vec<RType> = Vec::with_capacity(params.len());
+        let return_type = self.walk_literal_returns(body, captured_scope, depth, |scope| {
+            for p in params {
+                let t = match &p.default {
+                    Some(e) => infer_literal_default(e),
+                    None => RType::unknown(),
+                };
+                if p.default.is_some() {
+                    scope.insert_parameter_default(p.name.clone(), t.clone());
+                } else {
+                    scope.insert(p.name.clone(), t.clone());
+                }
+                param_types.push(t);
+            }
+        })?;
+        Some(Arc::new(FunctionSignature {
+            params: param_types,
+            return_type: Box::new(return_type),
+        }))
     }
 
-    pub(crate) fn build_function_signature_inner(
+    /// The closure-return inference walk shared by signature building
+    /// ([`build_function_signature`]) and higher-order callback
+    /// inference ([`crate::higher_order`]'s `callback_literal_return`):
+    /// clone the captured scope, let `bind_params` layer the literal's
+    /// parameters on top (their types come from declared defaults in
+    /// the former, from the caller's argument types in the latter),
+    /// walk the body in source order collecting each explicit
+    /// `return(...)`/`invisible(...)` type, add the trailing
+    /// statement's implicit value, and join everything. Returns `None`
+    /// when nothing contributes a type or the join collapses to
+    /// opaque.
+    ///
+    /// The walk is a PURE return-type computation: it forces discarding
+    /// mode so it never emits diagnostics itself (a named function
+    /// body's diagnostics come from the pass-3 `check_stmt` walk, a
+    /// callback body's from `walk_callback_for_diagnostics`).
+    pub(crate) fn walk_literal_returns(
         &mut self,
-        params: &[Param],
         body: &[Stmt],
         captured_scope: &Scope,
         depth: usize,
-    ) -> Option<Arc<FunctionSignature>> {
-        // Layer the inner function's params on top of the captured
-        // scope. We start from a clone of the captured scope so the
-        // body can reference enclosing bindings (`make_adder`'s `x`).
+        bind_params: impl FnOnce(&mut Scope),
+    ) -> Option<RType> {
+        let prev_discarding = self.discarding;
+        self.discarding = true;
+        // Start from a clone of the captured scope so the body can
+        // reference enclosing bindings (`make_adder`'s `x`).
         let mut scope = captured_scope.clone();
-        let mut param_types: Vec<RType> = Vec::with_capacity(params.len());
-        for p in params {
-            let t = match &p.default {
-                Some(e) => infer_literal_default(e),
-                None => RType::unknown(),
-            };
-            if p.default.is_some() {
-                scope.insert_parameter_default(p.name.clone(), t.clone());
-            } else {
-                scope.insert(p.name.clone(), t.clone());
-            }
-            param_types.push(t);
-        }
+        bind_params(&mut scope);
         // Walk the body in source order, simulating each statement's
         // effect on the scope so later statements (notably the trailing
         // return expression) can reference bindings established earlier
@@ -838,17 +858,12 @@ impl Checker {
         if let Some(t) = self.trailing_return_type(body, &mut scope, depth + 1) {
             returns.push(t);
         }
+        self.discarding = prev_discarding;
         if returns.is_empty() {
             return None;
         }
         let joined = join_all(returns.into_iter());
-        if matches!(joined.mode, Mode::Opaque) {
-            return None;
-        }
-        Some(Arc::new(FunctionSignature {
-            params: param_types,
-            return_type: Box::new(joined),
-        }))
+        (!matches!(joined.mode, Mode::Opaque)).then_some(joined)
     }
 
     /// Extract the implicit return type of a function body's trailing

--- a/crates/ry-checker/src/infer/recall.rs
+++ b/crates/ry-checker/src/infer/recall.rs
@@ -406,8 +406,7 @@ mod scalar_reduction_tests {
     #[test]
     fn known_scalar_reductions_fire_ry105() {
         fn fires(src: &str, code: &str) -> bool {
-            let mut parser = ry_core::RParser::new().expect("parser init");
-            let file = parser.parse("t.R", src).expect("parse");
+            let file = crate::tests::parse_snippet("t.R", src);
             let mut checker = crate::Checker::new("t.R");
             checker.check(&file);
             checker.take_diagnostics().iter().any(|d| d.code == code)

--- a/crates/ry-checker/src/tests/diagnostics.rs
+++ b/crates/ry-checker/src/tests/diagnostics.rs
@@ -3,8 +3,7 @@ use super::*;
 // ---- inline suppression comment tests ----
 
 fn scan_comments(src: &str) -> Vec<ry_core::ast::Comment> {
-    let mut parser = RParser::new().unwrap();
-    parser.parse("test.R", src).unwrap().comments
+    parse_snippet("test.R", src).comments
 }
 
 #[test]

--- a/crates/ry-checker/src/tests/mod.rs
+++ b/crates/ry-checker/src/tests/mod.rs
@@ -12,11 +12,19 @@ mod type_inference;
 
 // Shared fixtures used across topic modules.
 
-fn check(src: &str) -> Vec<Diagnostic> {
+/// Parse one checker-test snippet under `path`: the single
+/// `RParser::new()` + parse entry point shared by the topic modules in
+/// this directory and the inline `#[cfg(test)]` units in `collect.rs`,
+/// `infer::binop`, and `infer::index`, so parser setup cannot drift
+/// between them.
+pub(super) fn parse_snippet(path: &str, src: &str) -> SourceFile {
     let mut p = RParser::new().unwrap();
-    let f = p.parse("test.R", src).unwrap();
+    p.parse(path, src).unwrap()
+}
+
+fn check(src: &str) -> Vec<Diagnostic> {
     let mut c = Checker::new("test.R");
-    c.check(&f);
+    c.check(&parse_snippet("test.R", src));
     c.take_diagnostics()
 }
 
@@ -24,11 +32,9 @@ fn check(src: &str) -> Vec<Diagnostic> {
 /// that configure external bindings, loaded packages, imported-from
 /// metadata, or user stubs.
 fn check_with(src: &str, setup: impl FnOnce(&mut Checker)) -> Vec<Diagnostic> {
-    let mut p = RParser::new().unwrap();
-    let f = p.parse("test.R", src).unwrap();
     let mut c = Checker::new("test.R");
     setup(&mut c);
-    c.check(&f);
+    c.check(&parse_snippet("test.R", src));
     c.take_diagnostics()
 }
 
@@ -38,15 +44,12 @@ fn check_with(src: &str, setup: impl FnOnce(&mut Checker)) -> Vec<Diagnostic> {
 /// `Checker::check_with_scope`, so the tests exercise the real pass
 /// structure and cannot diverge from it.
 fn check_with_scope(src: &str) -> (Vec<Diagnostic>, Scope) {
-    let mut p = RParser::new().unwrap();
-    let f = p.parse("test.R", src).unwrap();
     let mut c = Checker::new("test.R");
-    c.check_with_scope(&f)
+    c.check_with_scope(&parse_snippet("test.R", src))
 }
 
 /// Parse helper for tests that check a `SourceFile` under a custom path
 /// (project mode, non-`test.R` names). Also used by `project::tests`.
 pub(super) fn parse_file(path: &str, src: &str) -> SourceFile {
-    let mut p = RParser::new().unwrap();
-    p.parse(path, src).unwrap()
+    parse_snippet(path, src)
 }

--- a/crates/ry-checker/src/tests/mod.rs
+++ b/crates/ry-checker/src/tests/mod.rs
@@ -15,8 +15,8 @@ mod type_inference;
 /// Parse one checker-test snippet under `path`: the single
 /// `RParser::new()` + parse entry point shared by the topic modules in
 /// this directory and the inline `#[cfg(test)]` units in `collect.rs`,
-/// `infer::binop`, and `infer::index`, so parser setup cannot drift
-/// between them.
+/// `infer::binop`, `infer::index`, and `infer::recall`, so parser setup
+/// cannot drift between them.
 pub(super) fn parse_snippet(path: &str, src: &str) -> SourceFile {
     let mut p = RParser::new().unwrap();
     p.parse(path, src).unwrap()

--- a/crates/ry-checker/src/tests/mod.rs
+++ b/crates/ry-checker/src/tests/mod.rs
@@ -12,11 +12,9 @@ mod type_inference;
 
 // Shared fixtures used across topic modules.
 
-/// Parse one checker-test snippet under `path`: the single
-/// `RParser::new()` + parse entry point shared by the topic modules in
-/// this directory and the inline `#[cfg(test)]` units in `collect.rs`,
-/// `infer::binop`, `infer::index`, and `infer::recall`, so parser setup
-/// cannot drift between them.
+/// Parse one checker-test snippet: the single parser entry point shared
+/// by these topic modules and the inline `#[cfg(test)]` units, so
+/// parser setup cannot drift between them.
 pub(super) fn parse_snippet(path: &str, src: &str) -> SourceFile {
     let mut p = RParser::new().unwrap();
     p.parse(path, src).unwrap()

--- a/crates/ry-checker/src/tests/type_inference.rs
+++ b/crates/ry-checker/src/tests/type_inference.rs
@@ -16,9 +16,8 @@ fn allows_int_plus_double() {
     assert!(diags.is_empty(), "got {:?}", diags);
 }
 
-// Table-driven form of the RY001/RY002/RY003 condition-diagnostic
-// family (the #155 conversion's shape): each row pins which family
-// code one condition source fires, that its sibling codes stay
+// Table-driven RY001/RY002/RY003 condition family: each row pins which
+// family code one condition source fires, that its sibling codes stay
 // silent, and that RY003 keeps its info-level severity. Absorbs the
 // former single-case `detects_if_on_character` and
 // `detects_long_condition_warning` tests.
@@ -55,29 +54,21 @@ fn condition_rules_fire_their_family_code() {
             "{note}: expected {expected}, got {diags:?}"
         );
         for silent in ["RY001", "RY002", "RY003"] {
-            if silent == expected {
-                continue;
-            }
             assert!(
-                diags.iter().all(|d| d.code != silent),
+                silent == expected || diags.iter().all(|d| d.code != silent),
                 "{note}: {silent} must stay silent, got {diags:?}"
             );
         }
-        if expected == "RY003" {
-            assert!(
-                diags
+        assert!(
+            expected != "RY003"
+                || diags
                     .iter()
                     .any(|d| d.code == "RY003" && d.severity == Severity::Info),
-                "{note}: RY003 is an info-level nudge, got {diags:?}"
-            );
-        }
+            "{note}: RY003 is an info-level nudge, got {diags:?}"
+        );
     }
 }
 
-// Not folded into a table: this is the only RY010-presence case in
-// type_inference.rs (the file's RY010 tables all assert absence), and
-// the rule's table-driven homes live in test modules outside this
-// cleanup's file ownership, so the single-case form stays.
 #[test]
 fn detects_unbound_var() {
     let diags = check("y <- undefined_thing\n");

--- a/crates/ry-checker/src/tests/type_inference.rs
+++ b/crates/ry-checker/src/tests/type_inference.rs
@@ -16,42 +16,66 @@ fn allows_int_plus_double() {
     assert!(diags.is_empty(), "got {:?}", diags);
 }
 
+// Table-driven form of the RY001/RY002/RY003 condition-diagnostic
+// family (the #155 conversion's shape): each row pins which family
+// code one condition source fires, that its sibling codes stay
+// silent, and that RY003 keeps its info-level severity. Absorbs the
+// former single-case `detects_if_on_character` and
+// `detects_long_condition_warning` tests.
 #[test]
-fn detects_if_on_character() {
-    let diags = check(r#"if ("x") print(1)"#);
-    assert!(diags.iter().any(|d| d.code == "RY001"));
+fn condition_rules_fire_their_family_code() {
+    for (note, src, expected) in [
+        ("integer `if` condition", "if (1L) print(1)", "RY003"),
+        (
+            "numeric-union `if` condition",
+            "x <- if (runif(1) > 0.5) 1L else 2.0\nif (x) print(1)",
+            "RY003",
+        ),
+        (
+            "invalid-union `if` condition",
+            "x <- if (runif(1) > 0.5) 1L else \"a\"\nif (x) print(1)",
+            "RY001",
+        ),
+        ("NULL `if` condition", "if (NULL) print(1)", "RY001"),
+        ("character `if` condition", r#"if ("x") print(1)"#, "RY001"),
+        (
+            "integer `while` condition",
+            "n <- 1L\nwhile (n) n <- 0L",
+            "RY003",
+        ),
+        (
+            "length-2 logical `if` condition",
+            "if (c(TRUE, FALSE)) print(1)\n",
+            "RY002",
+        ),
+    ] {
+        let diags = check(src);
+        assert!(
+            diags.iter().any(|d| d.code == expected),
+            "{note}: expected {expected}, got {diags:?}"
+        );
+        for silent in ["RY001", "RY002", "RY003"] {
+            if silent == expected {
+                continue;
+            }
+            assert!(
+                diags.iter().all(|d| d.code != silent),
+                "{note}: {silent} must stay silent, got {diags:?}"
+            );
+        }
+        if expected == "RY003" {
+            assert!(
+                diags.iter().any(|d| d.code == "RY003" && d.severity == Severity::Info),
+                "{note}: RY003 is an info-level nudge, got {diags:?}"
+            );
+        }
+    }
 }
 
-#[test]
-fn numeric_conditions_use_ry003() {
-    let integer = check("if (1L) print(1)");
-    assert!(integer.iter().any(|d| d.code == "RY003"));
-    assert!(integer.iter().all(|d| d.code != "RY001"));
-    assert!(
-        integer
-            .iter()
-            .any(|d| d.code == "RY003" && d.severity == Severity::Info)
-    );
-
-    let numeric_union = check("x <- if (runif(1) > 0.5) 1L else 2.0\nif (x) print(1)");
-    assert!(numeric_union.iter().any(|d| d.code == "RY003"));
-
-    let invalid_union = check("x <- if (runif(1) > 0.5) 1L else \"a\"\nif (x) print(1)");
-    assert!(invalid_union.iter().any(|d| d.code == "RY001"));
-
-    let null = check("if (NULL) print(1)");
-    assert!(null.iter().any(|d| d.code == "RY001"));
-
-    let while_integer = check("n <- 1L\nwhile (n) n <- 0L");
-    assert!(while_integer.iter().any(|d| d.code == "RY003"));
-}
-
-#[test]
-fn detects_long_condition_warning() {
-    let diags = check("if (c(TRUE, FALSE)) print(1)\n");
-    assert!(diags.iter().any(|d| d.code == "RY002"));
-}
-
+// Not folded into a table: this is the only RY010-presence case in
+// type_inference.rs (the file's RY010 tables all assert absence), and
+// the rule's table-driven homes live in test modules outside this
+// cleanup's file ownership, so the single-case form stays.
 #[test]
 fn detects_unbound_var() {
     let diags = check("y <- undefined_thing\n");

--- a/crates/ry-checker/src/tests/type_inference.rs
+++ b/crates/ry-checker/src/tests/type_inference.rs
@@ -65,7 +65,9 @@ fn condition_rules_fire_their_family_code() {
         }
         if expected == "RY003" {
             assert!(
-                diags.iter().any(|d| d.code == "RY003" && d.severity == Severity::Info),
+                diags
+                    .iter()
+                    .any(|d| d.code == "RY003" && d.severity == Severity::Info),
                 "{note}: RY003 is an info-level nudge, got {diags:?}"
             );
         }


### PR DESCRIPTION
## Summary
- share the closure return-inference walk
- unify union/mode-set helpers behind pinned semantics
- centralize formal-to-actual reverse lookup
- finish table-driven condition tests and parser helper consolidation
- remove stale narration left by the deduplication

This PR intentionally excludes operator S3 behavior; that is isolated in a stacked PR.

## Local review
Reviewed independently by GLM 5.3 Flash, Muse Spark 1.3, and GPT 5.6 Sol. Final exact-tip verdicts unanimously approve.

## Verification
- cargo test -p ry-checker
- cargo check --workspace --all-targets
- cargo clippy -p ry-checker --all-targets -- -D warnings
- cargo fmt --check

Closes #168
Closes #169

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved type compatibility checks for unions, opaque values, numeric coercion, and standalone assertions.
  - Improved function and callback return-type inference across parameter bindings and multiple return paths.
  - Improved argument matching and type propagation for bound arguments, predicates, and data masks.
  - Refined condition diagnostics and type narrowing while preserving appropriate severity and diagnostic labels.

- **Tests**
  - Expanded coverage for unions, coercion, assertions, callbacks, and condition-related diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->