### PR TITLE
fix(checker): share S3 lookup with operator dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -206,6 +206,23 @@ suppression actions — and fixes a parser panic plus several editor issues.
   lookalikes such as `testing.R` and legacy S-dialect spellings
   (`.S`/`.s`/`.q`) anywhere under `tests/` are fixtures — skipped
   unless `check_test_fixtures` is enabled (#174).
+- **Operator S3 dispatch sees the same methods as calls** (#165): the
+  primitive operators now resolve `+.foo` and `Ops.foo` methods through
+  the same source ladder as ordinary generic calls — external
+  registrations, project functions, the base typeshed, and package
+  typesheds — instead of the first two only, so a method declared only in
+  a typeshed is now found by `x + 1` and not just by the equivalent call
+  form `+(x, 1)`. A dispatch miss is silent, as in R: the primitive
+  itself is the fallback, so no RY050 (`missing-s3-method`) is reported
+  and `+.default` is never consulted. `&&`/`||` never dispatch through
+  `Ops`, so an `Ops` method can no longer hide their RY031/RY032
+  diagnostics. Factor arithmetic warns RY042 for any counterpart (base
+  `Ops.factor` preempts the primitive, so `factor + list` now warns
+  instead of erroring RY040) and no longer stacks a false RY041 recycling
+  warning on top — the method returns `NA` without recycling. When both
+  operands define different applicable methods, the checker still uses
+  the first applicable one; R's `chooseOpsMethod` behavior is tracked
+  separately (#193).
 - **`bquote` quotes unquotes inside braced bodies**: a `.(x)` in
   `bquote({ 1 == .(x) })` was not recognized as quoting, so the
   argument passed at the call site was treated as eagerly evaluated and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -212,9 +212,9 @@ suppression actions — and fixes a parser panic plus several editor issues.
   package typesheds. A miss is silent, as in R (the primitive is the
   fallback): no RY050, and `+.default` is never consulted as a
   fallback. `&&`/`||` never dispatch through `Ops`, so their
-  RY031/RY032 diagnostics cannot be hidden. Factor arithmetic warns RY042 for any counterpart
-  (`factor + list` warns instead of erroring RY040) without a false
-  RY041 recycling warning. Differing methods on both operands still
+  RY031/RY032 diagnostics cannot be hidden. Factor arithmetic warns RY042
+  for any counterpart (`factor + list` warns instead of erroring RY040)
+  without a false RY041 recycling warning. Differing methods on both operands still
   resolve first-applicable; R's `chooseOpsMethod` is tracked
   separately (#193).
 - **`bquote` quotes unquotes inside braced bodies**: a `.(x)` in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -206,22 +206,16 @@ suppression actions — and fixes a parser panic plus several editor issues.
   lookalikes such as `testing.R` and legacy S-dialect spellings
   (`.S`/`.s`/`.q`) anywhere under `tests/` are fixtures — skipped
   unless `check_test_fixtures` is enabled (#174).
-- **Operator S3 dispatch sees the same methods as calls** (#165): the
-  primitive operators now resolve `+.foo` and `Ops.foo` methods through
-  the same source ladder as ordinary generic calls — external
-  registrations, project functions, the base typeshed, and package
-  typesheds — instead of the first two only, so a method declared only in
-  a typeshed is now found by `x + 1` and not just by the equivalent call
-  form `+(x, 1)`. A dispatch miss is silent, as in R: the primitive
-  itself is the fallback, so no RY050 (`missing-s3-method`) is reported
-  and `+.default` is never consulted. `&&`/`||` never dispatch through
-  `Ops`, so an `Ops` method can no longer hide their RY031/RY032
-  diagnostics. Factor arithmetic warns RY042 for any counterpart (base
-  `Ops.factor` preempts the primitive, so `factor + list` now warns
-  instead of erroring RY040) and no longer stacks a false RY041 recycling
-  warning on top — the method returns `NA` without recycling. When both
-  operands define different applicable methods, the checker still uses
-  the first applicable one; R's `chooseOpsMethod` behavior is tracked
+- **Operator S3 dispatch sees the same methods as calls** (#165):
+  `x + 1` now resolves `+.foo`/`Ops.foo` through the same source ladder
+  as `+(x, 1)` — external registrations, project functions, base and
+  package typesheds. A miss is silent, as in R (the primitive is the
+  fallback): no RY050, and `+.default` is never consulted as a
+  fallback. `&&`/`||` never dispatch through `Ops`, so their
+  RY031/RY032 diagnostics cannot be hidden. Factor arithmetic warns RY042 for any counterpart
+  (`factor + list` warns instead of erroring RY040) without a false
+  RY041 recycling warning. Differing methods on both operands still
+  resolve first-applicable; R's `chooseOpsMethod` is tracked
   separately (#193).
 - **`bquote` quotes unquotes inside braced bodies**: a `.(x)` in
   `bquote({ 1 == .(x) })` was not recognized as quoting, so the

--- a/crates/ry-checker/src/higher_order.rs
+++ b/crates/ry-checker/src/higher_order.rs
@@ -504,12 +504,9 @@ impl Checker {
     /// Try S3 dispatch for a known generic. Returns `Some(rt)` if a
     /// method was found or a diagnostic was emitted (the caller should
     /// use the returned type directly). Returns `None` only when the
-    /// caller should fall through to other resolution paths.
-    ///
-    /// The method-source ladder ([`Checker::s3_lookup_method`]) is
-    /// shared with operator dispatch (`infer/binop.rs`); the miss tail
-    /// is not -- see [`Checker::s3_dispatch_miss`] for why operators
-    /// deliberately never reach it.
+    /// caller should fall through to other resolution paths. The
+    /// method-source ladder is shared with operator dispatch
+    /// (`infer/binop.rs`); the miss tail is not.
     ///
     /// Design note: we deliberately return `Option<RType>` rather than
     /// `RType` because the caller (`infer_call`) may still want to
@@ -551,15 +548,14 @@ impl Checker {
                 }
             }
         }
-        let classes = class_vector_names(&cv).join(", ");
-        self.s3_dispatch_miss(generic, &generics, &classes, span)
+        self.s3_dispatch_miss(generic, &generics, &cv, span)
     }
 
-    /// The method-source ladder for one `(generic, class)` rung:
+    /// One `(generic, class)` rung of the method-source ladder:
     /// external registrations, the project fn table, the base typeshed,
-    /// then package typesheds. `try_s3_dispatch` and the operator
-    /// dispatch in `infer/binop.rs` share this lookup so the two paths
-    /// cannot disagree about which methods exist.
+    /// then package typesheds. Shared with the operator dispatch in
+    /// `infer/binop.rs` so the two paths cannot disagree about which
+    /// methods exist.
     pub(crate) fn s3_lookup_method(&self, generic: &str, class: &str) -> Option<S3MethodSource> {
         let key = (generic.to_string(), class.to_string());
         if self.external_s3_methods.contains(&key) {
@@ -580,11 +576,9 @@ impl Checker {
             .map(|sig| S3MethodSource::Stub(Box::new(sig)))
     }
 
-    /// A project method's return: a specific generic (`abs.foo` called
-    /// as `abs`) has an inferable return, while a group method
-    /// (`Math.foo` reached from any member generic) only promises that
-    /// the operation is supported, not its result shape. Shared by
-    /// call and operator dispatch.
+    /// A project method's return: a specific method (`abs.foo` called
+    /// as `abs`) has an inferable return; a group method (`Math.foo`)
+    /// only promises that the operation is supported, not its shape.
     pub(crate) fn s3_specific_or_group_return(&self, specific: bool, slot: usize) -> RType {
         if specific {
             self.return_slots.get(slot)
@@ -593,29 +587,19 @@ impl Checker {
         }
     }
 
-    /// The call path's post-walk miss tail; operators deliberately
-    /// never reach it. A `<generic>.default` method is a real S3
-    /// dispatch target, not merely evidence that `generic` uses S3:
-    /// when it exists in any method source, a miss for a class-specific
-    /// method falls through to it and must remain silent. Without a
-    /// default, we report only for a generic that has at least one
-    /// project-defined S3 method. This is the conservative
-    /// cross-package gate: an un-stubbed dependency may own a foreign
-    /// class, while a local method proves that this project owns the
-    /// generic's dispatch surface. `classes` names the value(s) the
-    /// generic was applied to, for the RY050 message.
-    ///
-    /// Operator dispatch skips this tail because a primitive operator
-    /// has a fallback of its own: real R silently computes `bar + 1`
-    /// with the primitive when no `+.bar`/`Ops.bar` method exists, so a
-    /// miss there is neither an error nor opaque -- the caller's
-    /// storage-mode rules model the primitive fallback (issue #165's
-    /// RY050 criterion was corrected against this).
+    /// The call path's post-walk miss tail; operators never reach it,
+    /// because a primitive operator is its own fallback in R (issue
+    /// #165): a miss there is silent and modeled by the caller's
+    /// storage-mode rules. Here, a `<generic>.default` method is a real
+    /// dispatch target, so a miss with one stays silent. Otherwise we
+    /// report RY050 only for generics with a project-defined method:
+    /// an un-stubbed dependency may own a foreign class, while a local
+    /// method proves this project owns the dispatch surface.
     fn s3_dispatch_miss(
         &mut self,
         generic: &str,
         generics: &[&str],
-        classes: &str,
+        cv: &ClassVector,
         span: Span,
     ) -> Option<RType> {
         let has_default = generics.iter().any(|candidate| {
@@ -641,6 +625,14 @@ impl Checker {
         // The generic has no dispatch target for this class. Emit RY050
         // and return opaque so callers don't trip further diagnostics on
         // the result.
+        let classes = cv
+            .names
+            .iter()
+            .take(cv.len as usize)
+            .flatten()
+            .map(|class| class.as_ref())
+            .collect::<Vec<_>>()
+            .join(", ");
         self.emit(
             Severity::Warning,
             span,
@@ -654,31 +646,18 @@ impl Checker {
     }
 }
 
-/// One method-source hit in the S3 dispatch ladder shared by call
-/// dispatch ([`Checker::try_s3_dispatch`]) and operator dispatch
-/// (`infer/binop.rs`).
+/// One method-source hit in the S3 dispatch ladder shared by call and
+/// operator dispatch.
 pub(crate) enum S3MethodSource {
-    /// A method registered through package metadata: it exists, but its
-    /// body is not analyzable, so dispatch can only conclude opaque.
+    /// Registered through package metadata: not analyzable, so dispatch
+    /// can only conclude opaque.
     Registered,
     /// A project-defined method (`generic.class <- function(...)`) and
     /// its refined return slot.
     Project(usize),
     /// A stub signature from the base typeshed or a package typeshed.
-    /// Boxed: a `FunctionSig` is large, and the ladder consults several
-    /// sources per rung that usually miss.
+    /// Boxed: `FunctionSig` is large, and the ladder usually misses.
     Stub(Box<FunctionSig>),
-}
-
-/// The class names of a class vector in dispatch order, for the call
-/// path's RY050 message.
-fn class_vector_names(cv: &ClassVector) -> Vec<&str> {
-    cv.names
-        .iter()
-        .take(cv.len as usize)
-        .flatten()
-        .map(|class| class.as_ref())
-        .collect()
 }
 
 /// S3 group generics used by ordinary function calls. Operator expressions

--- a/crates/ry-checker/src/higher_order.rs
+++ b/crates/ry-checker/src/higher_order.rs
@@ -506,14 +506,10 @@ impl Checker {
     /// use the returned type directly). Returns `None` only when the
     /// caller should fall through to other resolution paths.
     ///
-    /// RY050 emission policy: a `<generic>.default` method is a real S3
-    /// dispatch target, not merely evidence that `generic` uses S3. When
-    /// it exists in any method source, a miss for a class-specific method
-    /// falls through to it and must remain silent. Without a default, we
-    /// report only for a generic that has at least one project-defined S3
-    /// method. This is the conservative cross-package gate: an un-stubbed
-    /// dependency may own a foreign class, while a local method proves that
-    /// this project owns the generic's dispatch surface.
+    /// The method-source ladder ([`Checker::s3_lookup_method`]) is
+    /// shared with operator dispatch (`infer/binop.rs`); the miss tail
+    /// is not -- see [`Checker::s3_dispatch_miss`] for why operators
+    /// deliberately never reach it.
     ///
     /// Design note: we deliberately return `Option<RType>` rather than
     /// `RType` because the caller (`infer_call`) may still want to
@@ -543,34 +539,85 @@ impl Checker {
                 continue;
             }
             for candidate in &generics {
-                let key = ((*candidate).to_string(), class.to_string());
-                if self.external_s3_methods.contains(&key) {
-                    return Some(RType::unknown());
-                }
-                if let Some(slot) = self.fn_table.s3_methods.get(&key).cloned() {
-                    return Some(if *candidate == generic {
-                        self.return_slots.get(slot)
-                    } else {
-                        RType::unknown()
-                    });
-                }
-                if let Some(sig) = self.typeshed.s3_methods.get(&key).cloned() {
-                    return Some(self.apply_sig(&sig, arg_types, &[]));
-                }
-                let sig = self.available_package_names().find_map(|pkg| {
-                    self.package_typeshed(pkg)
-                        .and_then(|t| t.s3_methods.get(&key))
-                        .cloned()
-                });
-                if let Some(sig) = sig {
-                    return Some(self.apply_sig(&sig, arg_types, &[]));
+                match self.s3_lookup_method(candidate, class) {
+                    Some(S3MethodSource::Registered) => return Some(RType::unknown()),
+                    Some(S3MethodSource::Project(slot)) => {
+                        return Some(self.s3_specific_or_group_return(*candidate == generic, slot));
+                    }
+                    Some(S3MethodSource::Stub(sig)) => {
+                        return Some(self.apply_sig(&sig, arg_types, &[]));
+                    }
+                    None => {}
                 }
             }
         }
-        // A default method is the final S3 dispatch fallback. Consult
-        // every source used for specific methods above (plus external
-        // registrations), and do not report a missing class method when
-        // dispatch can reach one.
+        let classes = class_vector_names(&cv).join(", ");
+        self.s3_dispatch_miss(generic, &generics, &classes, span)
+    }
+
+    /// The method-source ladder for one `(generic, class)` rung:
+    /// external registrations, the project fn table, the base typeshed,
+    /// then package typesheds. `try_s3_dispatch` and the operator
+    /// dispatch in `infer/binop.rs` share this lookup so the two paths
+    /// cannot disagree about which methods exist.
+    pub(crate) fn s3_lookup_method(&self, generic: &str, class: &str) -> Option<S3MethodSource> {
+        let key = (generic.to_string(), class.to_string());
+        if self.external_s3_methods.contains(&key) {
+            return Some(S3MethodSource::Registered);
+        }
+        if let Some(slot) = self.fn_table.s3_methods.get(&key) {
+            return Some(S3MethodSource::Project(*slot));
+        }
+        if let Some(sig) = self.typeshed.s3_methods.get(&key) {
+            return Some(S3MethodSource::Stub(Box::new(sig.clone())));
+        }
+        self.available_package_names()
+            .find_map(|pkg| {
+                self.package_typeshed(pkg)
+                    .and_then(|typeshed| typeshed.s3_methods.get(&key))
+                    .cloned()
+            })
+            .map(|sig| S3MethodSource::Stub(Box::new(sig)))
+    }
+
+    /// A project method's return: a specific generic (`abs.foo` called
+    /// as `abs`) has an inferable return, while a group method
+    /// (`Math.foo` reached from any member generic) only promises that
+    /// the operation is supported, not its result shape. Shared by
+    /// call and operator dispatch.
+    pub(crate) fn s3_specific_or_group_return(&self, specific: bool, slot: usize) -> RType {
+        if specific {
+            self.return_slots.get(slot)
+        } else {
+            RType::unknown()
+        }
+    }
+
+    /// The call path's post-walk miss tail; operators deliberately
+    /// never reach it. A `<generic>.default` method is a real S3
+    /// dispatch target, not merely evidence that `generic` uses S3:
+    /// when it exists in any method source, a miss for a class-specific
+    /// method falls through to it and must remain silent. Without a
+    /// default, we report only for a generic that has at least one
+    /// project-defined S3 method. This is the conservative
+    /// cross-package gate: an un-stubbed dependency may own a foreign
+    /// class, while a local method proves that this project owns the
+    /// generic's dispatch surface. `classes` names the value(s) the
+    /// generic was applied to, for the RY050 message.
+    ///
+    /// Operator dispatch skips this tail because a primitive operator
+    /// has a fallback of its own: real R silently computes `bar + 1`
+    /// with the primitive when no `+.bar`/`Ops.bar` method exists, so a
+    /// miss there is neither an error nor opaque -- the caller's
+    /// storage-mode rules model the primitive fallback (issue #165's
+    /// RY050 criterion was corrected against this).
+    fn s3_dispatch_miss(
+        &mut self,
+        generic: &str,
+        generics: &[&str],
+        classes: &str,
+        span: Span,
+    ) -> Option<RType> {
         let has_default = generics.iter().any(|candidate| {
             let default_key = ((*candidate).to_string(), "default".to_string());
             self.fn_table.s3_methods.contains_key(&default_key)
@@ -584,10 +631,6 @@ impl Checker {
         if has_default {
             return Some(RType::unknown());
         }
-
-        // Without a default, use the project-owned-method fallback gate.
-        // External/typeshed methods alone cannot prove that this project owns
-        // the class, so suppress RY050 for potentially un-stubbed packages.
         let has_known_s3_method =
             self.fn_table.s3_methods.keys().any(|(known_generic, _)| {
                 generics.iter().any(|candidate| known_generic == candidate)
@@ -604,12 +647,38 @@ impl Checker {
             "RY050",
             format!(
                 "S3 generic `{}` called on value with classes [{}] but no matching method is defined",
-                generic,
-                cv.names.iter().take(cv.len as usize).flatten().map(|class| class.as_ref()).collect::<Vec<_>>().join(", "),
+                generic, classes,
             ),
         );
         Some(RType::unknown())
     }
+}
+
+/// One method-source hit in the S3 dispatch ladder shared by call
+/// dispatch ([`Checker::try_s3_dispatch`]) and operator dispatch
+/// (`infer/binop.rs`).
+pub(crate) enum S3MethodSource {
+    /// A method registered through package metadata: it exists, but its
+    /// body is not analyzable, so dispatch can only conclude opaque.
+    Registered,
+    /// A project-defined method (`generic.class <- function(...)`) and
+    /// its refined return slot.
+    Project(usize),
+    /// A stub signature from the base typeshed or a package typeshed.
+    /// Boxed: a `FunctionSig` is large, and the ladder consults several
+    /// sources per rung that usually miss.
+    Stub(Box<FunctionSig>),
+}
+
+/// The class names of a class vector in dispatch order, for the call
+/// path's RY050 message.
+fn class_vector_names(cv: &ClassVector) -> Vec<&str> {
+    cv.names
+        .iter()
+        .take(cv.len as usize)
+        .flatten()
+        .map(|class| class.as_ref())
+        .collect()
 }
 
 /// S3 group generics used by ordinary function calls. Operator expressions

--- a/crates/ry-checker/src/infer/binop.rs
+++ b/crates/ry-checker/src/infer/binop.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::higher_order::S3MethodSource;
 use ry_core::walk::{AstNode, Descend, Walk, walk_expr};
 use std::ops::ControlFlow;
 
@@ -40,9 +41,14 @@ impl Checker {
         }
         // Primitive operators dispatch through an operator-specific method
         // (`+.foo`) and then the `Ops.foo` group generic before applying the
-        // storage-mode rules below. A dynamically classed value is likewise
-        // not proof that the primitive is invalid: its runtime class may
-        // provide a method from another package.
+        // storage-mode rules below. Unlike an ordinary generic, a dispatch
+        // miss is silent: the primitive itself is the fallback (issue #165's
+        // original RY050 criterion was corrected against real R, where
+        // defining `+.foo` or `Ops.foo` does not make `bar + 1` warn -- the
+        // primitive computes it). The storage-mode rules below are that
+        // fallback. A dynamically classed value is likewise not proof that
+        // the primitive is invalid: its runtime class may provide a method
+        // from another package.
         if let Some(dispatched) = self.try_s3_binop_dispatch(op, &lt, &rt) {
             return dispatched;
         }
@@ -147,10 +153,9 @@ impl Checker {
             return RType::unknown();
         }
         let recycles = non_divisible_recycling(lt.length, rt.length);
-        let has_factor = lt.class.contains("factor") || rt.class.contains("factor");
-        if let Some(t) = lt.arith(rt) {
+        let emit_recycle_warning = |this: &mut Self| {
             if let Some((lhs_len, rhs_len)) = recycles {
-                self.emit(
+                this.emit(
                     Severity::Warning,
                     span,
                     "RY041",
@@ -159,14 +164,26 @@ impl Checker {
                     ),
                 );
             }
-            if has_factor {
-                self.emit(
-                    Severity::Warning,
-                    span,
-                    "RY042",
-                    "arithmetic on a factor produces `NA`; operate on its levels or convert it explicitly",
-                );
-            }
+        };
+        if lt.class.contains("factor") || rt.class.contains("factor") {
+            // Base R's `Ops.factor` warns "'+' not meaningful for factors"
+            // for *any* arithmetic involving a factor and returns `NA`, no
+            // matter what the other operand is (`factor + 1` and
+            // `factor + list` behave alike). Report RY042 before the
+            // lattice rules: the dispatched method preempts the
+            // primitive's own mode-mismatch error, so a list counterpart
+            // must stay a warning, not become RY040.
+            self.emit(
+                Severity::Warning,
+                span,
+                "RY042",
+                "arithmetic on a factor produces `NA`; operate on its levels or convert it explicitly",
+            );
+            emit_recycle_warning(self);
+            return lt.arith(rt).unwrap_or_else(RType::unknown);
+        }
+        if let Some(t) = lt.arith(rt) {
+            emit_recycle_warning(self);
             return t;
         }
         self.emit(
@@ -181,11 +198,23 @@ impl Checker {
         RType::unknown()
     }
 
-    /// Resolve operator S3 dispatch for one operand. An unknown class on a
-    /// concrete mode means any class vector may apply, so the result is
-    /// unknowable. Each known class is tried against the operator's own
-    /// method, then the `Ops` group generic.
-    fn s3_dispatch_on_operand(&self, symbol: &str, operand: &RType) -> Option<RType> {
+    /// Resolve operator S3 dispatch for one operand through the shared
+    /// method-source ladder (`s3_lookup_method`): the operator's own
+    /// method (`+.foo`), then the `Ops` group generic, across project
+    /// methods, stub signatures, and external registrations. An unknown
+    /// class on a concrete mode means any class vector may apply, so
+    /// the result is unknowable. `operands` is the full operator
+    /// argument list (both sides of a binary op): a stub signature is
+    /// applied to it. `None` is a dispatch miss, which for operators is
+    /// silent: unlike an ordinary generic, the primitive itself is R's
+    /// fallback, so the caller falls through to the storage-mode rules
+    /// below instead of reporting a missing method.
+    fn s3_dispatch_on_operand(
+        &mut self,
+        symbol: &str,
+        operands: &[&RType],
+        operand: &RType,
+    ) -> Option<RType> {
         if operand.class.is_unknown() && !matches!(operand.mode, Mode::Opaque | Mode::Union) {
             return Some(RType::unknown());
         }
@@ -196,26 +225,38 @@ impl Checker {
             .take(operand.class.len as usize)
             .flatten()
         {
+            if &**class == "default" {
+                continue;
+            }
             for generic in [symbol, "Ops"] {
-                if self
-                    .external_s3_methods
-                    .contains(&(generic.to_string(), class.to_string()))
-                {
-                    return Some(RType::unknown());
-                }
-                if let Some(slot) = self
-                    .fn_table
-                    .s3_methods
-                    .get(&(generic.to_string(), class.to_string()))
-                {
-                    // A specific operator method has an inferable return;
-                    // a group method only promises that this operator is
-                    // supported, not its result shape.
-                    return Some(if generic == symbol {
-                        self.return_slots.get(*slot)
-                    } else {
-                        RType::unknown()
-                    });
+                match self.s3_lookup_method(generic, class) {
+                    Some(S3MethodSource::Registered) => return Some(RType::unknown()),
+                    Some(S3MethodSource::Project(slot)) => {
+                        // A specific operator method has an inferable
+                        // return; a group method only promises that this
+                        // operator is supported, not its result shape.
+                        return Some(self.s3_specific_or_group_return(generic == symbol, slot));
+                    }
+                    Some(S3MethodSource::Stub(sig)) => {
+                        // A specific stub, or a group stub declaring a
+                        // usable shape, is this operator's method.
+                        let arg_types = operands
+                            .iter()
+                            .map(|operand| (**operand).clone())
+                            .collect::<Vec<_>>();
+                        let result = self.apply_sig(&sig, &arg_types, &[]);
+                        if generic == symbol || !matches!(result.mode, Mode::Opaque) {
+                            return Some(result);
+                        }
+                        // An opaque group stub (every embedded `Ops.*`
+                        // entry) offers no shape: fall through like a
+                        // miss, so the storage-mode rules keep modeling
+                        // these base classes (`Ops.factor`'s
+                        // not-meaningful warning, `Ops.Date` arithmetic)
+                        // and keep their diagnostics instead of
+                        // collapsing to opaque.
+                    }
+                    None => {}
                 }
             }
         }
@@ -223,32 +264,43 @@ impl Checker {
     }
 
     pub(crate) fn try_s3_binop_dispatch(
-        &self,
+        &mut self,
         op: BinOpKind,
         lhs: &RType,
         rhs: &RType,
     ) -> Option<RType> {
-        let symbol = op_symbol(op);
+        // `:`, the pipes, and `%in%` are not S3 generics. `&&`/`||` never
+        // dispatch either: in R they are strictly logical short-circuit
+        // primitives -- an `Ops.foo` method cannot intercept them -- so
+        // their length/type diagnostics below always fire.
         if matches!(
             op,
-            BinOpKind::In | BinOpKind::Colon | BinOpKind::PipeForward | BinOpKind::PipeNative
+            BinOpKind::In
+                | BinOpKind::Colon
+                | BinOpKind::PipeForward
+                | BinOpKind::PipeNative
+                | BinOpKind::AndAnd
+                | BinOpKind::OrOr
         ) {
             return None;
         }
-        for operand in [lhs, rhs] {
-            if let Some(dispatched) = self.s3_dispatch_on_operand(symbol, operand) {
-                return Some(dispatched);
-            }
-        }
-        None
+        let symbol = op_symbol(op);
+        let operands = [lhs, rhs];
+        operands
+            .iter()
+            .find_map(|operand| self.s3_dispatch_on_operand(symbol, &operands, operand))
     }
 
-    pub(crate) fn try_s3_unary_dispatch(&self, op: UnaryOpKind, operand: &RType) -> Option<RType> {
+    pub(crate) fn try_s3_unary_dispatch(
+        &mut self,
+        op: UnaryOpKind,
+        operand: &RType,
+    ) -> Option<RType> {
         let symbol = match op {
             UnaryOpKind::Neg => "-",
             UnaryOpKind::Not => "!",
         };
-        self.s3_dispatch_on_operand(symbol, operand)
+        self.s3_dispatch_on_operand(symbol, &[operand], operand)
     }
 
     pub(crate) fn infer_short_circuit_binop(

--- a/crates/ry-checker/src/infer/binop.rs
+++ b/crates/ry-checker/src/infer/binop.rs
@@ -39,16 +39,12 @@ impl Checker {
         if let Some(result) = data_frame_binop_result(op, &lt, &rt) {
             return result;
         }
-        // Primitive operators dispatch through an operator-specific method
-        // (`+.foo`) and then the `Ops.foo` group generic before applying the
-        // storage-mode rules below. Unlike an ordinary generic, a dispatch
-        // miss is silent: the primitive itself is the fallback (issue #165's
-        // original RY050 criterion was corrected against real R, where
-        // defining `+.foo` or `Ops.foo` does not make `bar + 1` warn -- the
-        // primitive computes it). The storage-mode rules below are that
-        // fallback. A dynamically classed value is likewise not proof that
-        // the primitive is invalid: its runtime class may provide a method
-        // from another package.
+        // Primitive operators dispatch through `+.foo` then the `Ops.foo`
+        // group generic before the storage-mode rules below; a miss is
+        // silent, as in R -- the primitive itself is the fallback (issue
+        // #165). A dynamically classed value is likewise not proof that
+        // the primitive is invalid: its runtime class may provide a
+        // method from another package.
         if let Some(dispatched) = self.try_s3_binop_dispatch(op, &lt, &rt) {
             return dispatched;
         }
@@ -152,33 +148,12 @@ impl Checker {
             );
             return RType::unknown();
         }
-        let recycles = non_divisible_recycling(lt.length, rt.length);
-        let emit_recycle_warning = |this: &mut Self| {
-            if let Some((lhs_len, rhs_len)) = recycles {
-                this.emit(
-                    Severity::Warning,
-                    span,
-                    "RY041",
-                    format!(
-                        "vector lengths {lhs_len} and {rhs_len} do not divide evenly; R will recycle with a warning"
-                    ),
-                );
-            }
-        };
         if lt.class.contains("factor") || rt.class.contains("factor") {
-            // Base R's `Ops.factor` warns "'+' not meaningful for factors"
-            // for *any* arithmetic involving a factor and returns
-            // `rep.int(NA, max(length(e1), length(e2)))`, no matter what
-            // the other operand is (`factor + 1` and `factor + list`
-            // behave alike). Report RY042 before the lattice rules: the
-            // dispatched method preempts the primitive's own mode-mismatch
-            // error, so a list counterpart must stay a warning, not become
-            // RY040. That dispatch equally preempts the primitive's
-            // recycling: the method never warns about uneven operand
-            // lengths (verified against R 4.6), so no factor path may
-            // emit RY041's "R will recycle with a warning" claim -- not
-            // even where the storage modes would arith-combine (`factor +
-            // 1:2` warns only about meaninglessness in real R).
+            // Base `Ops.factor` preempts the primitive for *any* factor
+            // arithmetic and returns `NA` without ever recycling
+            // (verified against R 4.6, even where the modes would
+            // arith-combine): RY042 only -- never RY041, and a list
+            // counterpart stays a warning instead of RY040.
             self.emit(
                 Severity::Warning,
                 span,
@@ -187,8 +162,18 @@ impl Checker {
             );
             return lt.arith(rt).unwrap_or_else(RType::unknown);
         }
+        let recycles = non_divisible_recycling(lt.length, rt.length);
         if let Some(t) = lt.arith(rt) {
-            emit_recycle_warning(self);
+            if let Some((lhs_len, rhs_len)) = recycles {
+                self.emit(
+                    Severity::Warning,
+                    span,
+                    "RY041",
+                    format!(
+                        "vector lengths {lhs_len} and {rhs_len} do not divide evenly; R will recycle with a warning"
+                    ),
+                );
+            }
             return t;
         }
         self.emit(
@@ -203,17 +188,12 @@ impl Checker {
         RType::unknown()
     }
 
-    /// Resolve operator S3 dispatch for one operand through the shared
-    /// method-source ladder (`s3_lookup_method`): the operator's own
-    /// method (`+.foo`), then the `Ops` group generic, across project
-    /// methods, stub signatures, and external registrations. An unknown
-    /// class on a concrete mode means any class vector may apply, so
-    /// the result is unknowable. `operands` is the full operator
-    /// argument list (both sides of a binary op): a stub signature is
-    /// applied to it. `None` is a dispatch miss, which for operators is
-    /// silent: unlike an ordinary generic, the primitive itself is R's
-    /// fallback, so the caller falls through to the storage-mode rules
-    /// below instead of reporting a missing method.
+    /// Resolve operator S3 dispatch for one operand: the operator's own
+    /// method (`+.foo`), then `Ops.foo`, through the shared
+    /// `s3_lookup_method` ladder. An unknown class on a concrete mode
+    /// means any class vector may apply, so the result is unknowable.
+    /// `operands` is the full operator argument list, which a stub
+    /// signature is applied to.
     fn s3_dispatch_on_operand(
         &mut self,
         symbol: &str,
@@ -237,29 +217,24 @@ impl Checker {
                 match self.s3_lookup_method(generic, class) {
                     Some(S3MethodSource::Registered) => return Some(RType::unknown()),
                     Some(S3MethodSource::Project(slot)) => {
-                        // A specific operator method has an inferable
-                        // return; a group method only promises that this
-                        // operator is supported, not its result shape.
                         return Some(self.s3_specific_or_group_return(generic == symbol, slot));
                     }
                     Some(S3MethodSource::Stub(sig)) => {
-                        // A specific stub, or a group stub declaring a
-                        // usable shape, is this operator's method.
                         let arg_types = operands
                             .iter()
                             .map(|operand| (**operand).clone())
                             .collect::<Vec<_>>();
                         let result = self.apply_sig(&sig, &arg_types, &[]);
+                        // A specific stub, or a group stub declaring a
+                        // usable shape, is this operator's method.
                         if generic == symbol || !matches!(result.mode, Mode::Opaque) {
                             return Some(result);
                         }
                         // An opaque group stub (every embedded `Ops.*`
                         // entry) offers no shape: fall through like a
                         // miss, so the storage-mode rules keep modeling
-                        // these base classes (`Ops.factor`'s
-                        // not-meaningful warning, `Ops.Date` arithmetic)
-                        // and keep their diagnostics instead of
-                        // collapsing to opaque.
+                        // these base classes with their own diagnostics
+                        // (`Ops.factor`'s warning, `Ops.Date` arithmetic).
                     }
                     None => {}
                 }
@@ -274,10 +249,9 @@ impl Checker {
         lhs: &RType,
         rhs: &RType,
     ) -> Option<RType> {
-        // `:`, the pipes, and `%in%` are not S3 generics. `&&`/`||` never
-        // dispatch either: in R they are strictly logical short-circuit
-        // primitives -- an `Ops.foo` method cannot intercept them -- so
-        // their length/type diagnostics below always fire.
+        // `:`, the pipes, and `%in%` are not S3 generics, and `&&`/`||`
+        // are strictly logical short-circuit primitives that no `Ops`
+        // method can intercept, so their diagnostics always fire.
         if matches!(
             op,
             BinOpKind::In

--- a/crates/ry-checker/src/infer/binop.rs
+++ b/crates/ry-checker/src/infer/binop.rs
@@ -167,19 +167,24 @@ impl Checker {
         };
         if lt.class.contains("factor") || rt.class.contains("factor") {
             // Base R's `Ops.factor` warns "'+' not meaningful for factors"
-            // for *any* arithmetic involving a factor and returns `NA`, no
-            // matter what the other operand is (`factor + 1` and
-            // `factor + list` behave alike). Report RY042 before the
-            // lattice rules: the dispatched method preempts the
-            // primitive's own mode-mismatch error, so a list counterpart
-            // must stay a warning, not become RY040.
+            // for *any* arithmetic involving a factor and returns
+            // `rep.int(NA, max(length(e1), length(e2)))`, no matter what
+            // the other operand is (`factor + 1` and `factor + list`
+            // behave alike). Report RY042 before the lattice rules: the
+            // dispatched method preempts the primitive's own mode-mismatch
+            // error, so a list counterpart must stay a warning, not become
+            // RY040. That dispatch equally preempts the primitive's
+            // recycling: the method never warns about uneven operand
+            // lengths (verified against R 4.6), so no factor path may
+            // emit RY041's "R will recycle with a warning" claim -- not
+            // even where the storage modes would arith-combine (`factor +
+            // 1:2` warns only about meaninglessness in real R).
             self.emit(
                 Severity::Warning,
                 span,
                 "RY042",
                 "arithmetic on a factor produces `NA`; operate on its levels or convert it explicitly",
             );
-            emit_recycle_warning(self);
             return lt.arith(rt).unwrap_or_else(RType::unknown);
         }
         if let Some(t) = lt.arith(rt) {

--- a/crates/ry-checker/src/tests/data_frames_s3.rs
+++ b/crates/ry-checker/src/tests/data_frames_s3.rs
@@ -40,29 +40,15 @@ fn s3_dispatch_known_method() {
 
 #[test]
 fn registered_unexported_s3_method_in_stub_satisfies_dispatch() {
-    let dir = tempfile::tempdir().unwrap();
-    std::fs::write(
-        dir.path().join("base.json"),
-        r#"{
-            "schema_version": "1",
-            "package": "base",
-            "version": "test",
-            "functions": {},
-            "s3_methods": [
-                {"generic": "print", "class": "default", "params": ["x", "..."], "return": {"mode": "opaque", "length": "unknown"}}
-            ]
-        }"#,
-    )
-    .unwrap();
-    let stubs = Arc::new(ry_typeshed::load_stub_dir(dir.path()).unwrap());
-    let diagnostics = check_with(
+    let (diagnostics, _) = check_with_stubs(
         "x <- structure(list(), class = \"unexported\")\nprint(x)\n",
-        |c| c.set_user_stubs(stubs),
+        &[(
+            "base.json",
+            r#"{"version":"t","functions":{},"s3_methods":[{"generic":"print","class":"default","params":["x","..."],"return":{"mode":"opaque","length":"unknown"}}]}"#,
+        )],
     );
     assert!(
-        diagnostics
-            .iter()
-            .all(|diagnostic| diagnostic.code != "RY050"),
+        diagnostics.iter().all(|d| d.code != "RY050"),
         "a registered default method must satisfy S3 dispatch: {diagnostics:?}"
     );
 }

--- a/crates/ry-checker/src/tests/mod.rs
+++ b/crates/ry-checker/src/tests/mod.rs
@@ -47,6 +47,20 @@ fn check_with_scope(src: &str) -> (Vec<Diagnostic>, Scope) {
     c.check_with_scope(&parse_snippet("test.R", src))
 }
 
+/// `check_with_scope` plus stub typeshed files (file name, raw JSON)
+/// written into one temp directory. A file's stem is its package key:
+/// `base.json` replaces the embedded base typeshed, any other name
+/// becomes a package typeshed.
+fn check_with_stubs(src: &str, stub_files: &[(&str, &str)]) -> (Vec<Diagnostic>, Scope) {
+    let dir = tempfile::tempdir().unwrap();
+    for (name, json) in stub_files {
+        std::fs::write(dir.path().join(name), json).unwrap();
+    }
+    let mut c = Checker::new("test.R");
+    c.set_user_stubs(Arc::new(ry_typeshed::load_stub_dir(dir.path()).unwrap()));
+    c.check_with_scope(&parse_snippet("test.R", src))
+}
+
 /// Parse helper for tests that check a `SourceFile` under a custom path
 /// (project mode, non-`test.R` names). Also used by `project::tests`.
 pub(super) fn parse_file(path: &str, src: &str) -> SourceFile {

--- a/crates/ry-checker/src/tests/mod.rs
+++ b/crates/ry-checker/src/tests/mod.rs
@@ -5,6 +5,7 @@ mod data_frames_s3;
 mod diagnostics;
 mod functions_classes;
 mod narrowing;
+mod operator_s3_dispatch;
 mod packages_typeshed;
 mod quoting_data_mask;
 mod scope_resolution;

--- a/crates/ry-checker/src/tests/operator_s3_dispatch.rs
+++ b/crates/ry-checker/src/tests/operator_s3_dispatch.rs
@@ -1,0 +1,301 @@
+use super::*;
+
+/// `check_with_scope` plus stub typeshed files (file name, raw JSON)
+/// installed from one temp directory, for tests that assert both the
+/// diagnostics and the inferred result type of dispatch through
+/// stub-declared methods. A `base.json` replaces the embedded base
+/// typeshed wholesale; other files become package typesheds. The
+/// un-stubbed behavior of the same source is compared with plain
+/// [`check`].
+fn check_with_stubs(src: &str, stub_files: &[(&str, &str)]) -> (Vec<Diagnostic>, Scope) {
+    let dir = tempfile::tempdir().unwrap();
+    for (name, json) in stub_files {
+        std::fs::write(dir.path().join(name), json).unwrap();
+    }
+    let stubs = Arc::new(ry_typeshed::load_stub_dir(dir.path()).unwrap());
+    let mut c = Checker::new("test.R");
+    c.set_user_stubs(stubs);
+    c.check_with_scope(&parse_snippet("test.R", src))
+}
+
+#[test]
+fn operator_dispatches_stub_typeshed_specific_method() {
+    // A `+.widget` method that exists only in a stub typeshed must be
+    // visible to the operator path, exactly as it is to normal call
+    // dispatch (#165): with the stub, `w1 + w2` uses the stub's return
+    // shape; without it, the same program reaches the arithmetic rules
+    // and reports the list-mode mismatch.
+    let stub = r#"{
+        "schema_version": "1",
+        "package": "base",
+        "version": "test",
+        "functions": {},
+        "s3_methods": [
+            {"generic": "+", "class": "widget", "params": ["e1", "e2"], "return": {"mode": "double", "length": "1"}}
+        ]
+    }"#;
+    let src = "w1 <- structure(list(a = 1), class = \"widget\")\n\
+               w2 <- structure(list(b = 2), class = \"widget\")\n\
+               total <- w1 + w2\n";
+    let (with, scope) = check_with_stubs(src, &[("base.json", stub)]);
+    assert!(
+        with.iter().all(|d| d.code != "RY040"),
+        "the stubbed `+.widget` method must satisfy operator dispatch: {with:?}"
+    );
+    assert!(
+        check(src).iter().any(|d| d.code == "RY040"),
+        "without the stub the same operands must reach the arithmetic rules"
+    );
+    let total = scope.get("total").expect("total should be bound");
+    assert_eq!(
+        (total.mode, total.length),
+        (Mode::Double, Length::One),
+        "the stub's return shape must win over the opaque dispatch default: {total:?}"
+    );
+}
+
+#[test]
+fn operator_dispatches_stub_typeshed_group_method_shape() {
+    // An `Ops.gadget` group-generic stub with a usable shape is
+    // dispatched with that shape (the group rung shares the ladder;
+    // only an *opaque* group stub defers to the base-type rules).
+    let stub = r#"{
+        "schema_version": "1",
+        "package": "base",
+        "version": "test",
+        "functions": {},
+        "s3_methods": [
+            {"generic": "Ops", "class": "gadget", "params": ["e1", "e2"], "return": {"mode": "logical", "length": "1"}}
+        ]
+    }"#;
+    let src = "g1 <- structure(c(\"a\"), class = \"gadget\")\n\
+               g2 <- structure(c(\"b\"), class = \"gadget\")\n\
+               merged <- g1 + g2\n";
+    let (with, scope) = check_with_stubs(src, &[("base.json", stub)]);
+    assert!(
+        with.is_empty(),
+        "the stubbed `Ops.gadget` method must satisfy operator dispatch: {with:?}"
+    );
+    assert!(
+        check(src).iter().any(|d| d.code == "RY040"),
+        "without the stub, character arithmetic must be rejected"
+    );
+    let merged = scope.get("merged").expect("merged should be bound");
+    assert_eq!(
+        (merged.mode, merged.length),
+        (Mode::Logical, Length::One),
+        "the group stub's declared shape must be applied: {merged:?}"
+    );
+}
+
+#[test]
+fn stub_default_method_does_not_hijack_operator_dispatch() {
+    // Real R never consults `+.default` for an operator whose class has
+    // no method: the primitive computes the result (and errors for a
+    // list operand) regardless of any `.default` method defined
+    // anywhere. So a stub `+.default` must not suppress the primitive's
+    // own rules -- unlike the call path, where `.default` is a real
+    // fallback (#165, corrected against verified R semantics).
+    let stub = r#"{
+        "schema_version": "1",
+        "package": "base",
+        "version": "test",
+        "functions": {},
+        "s3_methods": [
+            {"generic": "+", "class": "default", "params": ["e1", "e2"], "return": {"mode": "opaque", "length": "unknown"}}
+        ]
+    }"#;
+    let src = "x <- structure(list(), class = \"unhandled\")\ny <- x + 1\n";
+    let (with, _) = check_with_stubs(src, &[("base.json", stub)]);
+    assert!(
+        with.iter().any(|d| d.code == "RY040") && with.iter().all(|d| d.code != "RY050"),
+        "a stub `+.default` must neither satisfy nor report operator dispatch: {with:?}"
+    );
+}
+
+#[test]
+fn operator_dispatch_miss_falls_back_to_the_primitive() {
+    // Real R silently computes `bar + 1` with the primitive even when
+    // `+.foo` or `Ops.foo` exists for another class: unlike ordinary
+    // generics, a primitive operator is its own fallback. A miss must
+    // not report RY050, must not conclude opaque through an unrelated
+    // method, and must keep the primitive's own checks (#165's RY050
+    // criterion, corrected against verified R semantics).
+    let (diags, scope) = check_with_scope(
+        "`+.foo` <- function(e1, e2) 1L\n\
+         x <- structure(1, class = \"bar\")\n\
+         y <- x + 1\n\
+         bad <- structure(list(a = 1), class = \"bar\") + 1\n",
+    );
+    assert!(
+        diags.iter().all(|d| d.code != "RY050"),
+        "an operator miss is R's silent primitive fallback: {diags:?}"
+    );
+    let y = scope.get("y").expect("y should be bound");
+    assert_eq!(
+        y.mode,
+        Mode::Double,
+        "numeric-classed arithmetic keeps the primitive result: {y:?}"
+    );
+    assert!(
+        diags.iter().any(|d| d.code == "RY040"),
+        "the list-mode operand must stay arithmetic-checked: {diags:?}"
+    );
+}
+
+#[test]
+fn short_circuit_operators_never_dispatch_through_ops() {
+    // `&&`/`||` are strictly logical short-circuit primitives in R: no
+    // `Ops` group dispatch, so an `Ops.flagged` method cannot intercept
+    // them, and the ordinary length/type diagnostics keep firing
+    // (#165, pinned against verified R semantics).
+    let (diags, scope) = check_with_scope(
+        "`Ops.flagged` <- function(e1, e2) 1L\n\
+         a <- structure(TRUE, class = \"flagged\")\n\
+         both <- a && a\n\
+         either <- a || a\n\
+         v <- structure(c(TRUE, FALSE), class = \"flagged\")\n\
+         long <- v && a\n\
+         s <- structure(\"x\", class = \"flagged\")\n\
+         typed <- s || a\n",
+    );
+    for name in ["both", "either"] {
+        let t = scope.get(name).expect("result should be bound");
+        assert_eq!(
+            (t.mode, t.length),
+            (Mode::Logical, Length::One),
+            "`{name}` must be the primitive logical(1) result, not a dispatch: {t:?}"
+        );
+    }
+    assert!(
+        diags.iter().any(|d| d.code == "RY032"),
+        "the vector `&&` operand must still report RY032: {diags:?}"
+    );
+    assert!(
+        diags.iter().any(|d| d.code == "RY031"),
+        "the character `||` operand must still report RY031: {diags:?}"
+    );
+}
+
+#[test]
+fn opaque_group_stubs_keep_the_base_operator_diagnostics() {
+    // Every embedded `Ops.<class>` stub is opaque, but that must not
+    // silence the storage-mode rules: base R's own `Ops.factor` warns
+    // for *any* factor arithmetic (`factor + list` included), and
+    // `Date + character` is the primitive's own error. Falling through
+    // keeps both diagnostics while preserving the useful shaping for
+    // `factor + 1` and `Date` arithmetic (#165).
+    let (diags, scope) = check_with_scope(
+        "f <- factor(c(\"a\", \"b\"))\n\
+         l <- list(1)\n\
+         z <- f + l\n\
+         w <- f + 1\n\
+         d <- structure(19000, class = \"Date\")\n\
+         y <- d + \"x\"\n\
+         ok <- d + 1\n",
+    );
+    let factor_lines = diags
+        .iter()
+        .filter(|d| d.code == "RY042")
+        .map(|d| d.span.line)
+        .collect::<Vec<_>>();
+    assert_eq!(
+        factor_lines,
+        vec![2, 3],
+        "factor arithmetic keeps RY042 for both the list and numeric counterpart: {diags:?}"
+    );
+    assert!(
+        diags.iter().all(|d| d.code != "RY040" || d.span.line == 5),
+        "the Date+character primitive error stays, factor arithmetic must not become RY040: {diags:?}"
+    );
+    assert!(
+        diags.iter().any(|d| d.code == "RY040" && d.span.line == 5),
+        "Date + character must retain the primitive-mode error: {diags:?}"
+    );
+    let ok = scope.get("ok").expect("ok should be bound");
+    assert_eq!(
+        ok.mode,
+        Mode::Double,
+        "Date arithmetic keeps the lattice result: {ok:?}"
+    );
+    // Unary `-` on a factor is deliberately unpinned: R warns and
+    // returns NA, which the checker's silent shaping does not model.
+}
+
+#[test]
+fn operator_dispatch_tries_rhs_and_class_vector_order() {
+    // R tries the LHS operand's classes, then the RHS's, and within one
+    // operand the class vector in order: `1 + y` dispatches on `y`, and
+    // a `c("second", "first")` value finds `+.first` only because
+    // "second" has no method.
+    let (diags, scope) = check_with_scope(
+        "`+.rhs` <- function(e1, e2) \"R\"\n\
+         `+.first` <- function(e1, e2) \"F\"\n\
+         y <- structure(1, class = \"rhs\")\n\
+         from_rhs <- 1 + y\n\
+         z <- structure(1, class = c(\"second\", \"first\"))\n\
+         from_order <- z + 1\n",
+    );
+    assert!(
+        diags.is_empty(),
+        "both dispatched operators must be silent: {diags:?}"
+    );
+    for (name, expected) in [("from_rhs", "R"), ("from_order", "F")] {
+        let t = scope.get(name).unwrap_or_else(|| panic!("{name} bound"));
+        assert_eq!(
+            t.mode,
+            Mode::Character,
+            "`{name}` must use the `{expected}` method's return: {t:?}"
+        );
+    }
+}
+
+#[test]
+fn operator_dispatches_package_typeshed_method() {
+    // The ladder's last rung: an operator method declared in a package
+    // typeshed (not the project fn table, not base) is visible to the
+    // operator path, mirroring the call path's lookup.
+    let package = r#"{
+        "schema_version": "1",
+        "package": "acme",
+        "version": "test",
+        "functions": {},
+        "s3_methods": [
+            {"generic": "+", "class": "widget", "params": ["e1", "e2"], "return": {"mode": "integer", "length": "1"}}
+        ]
+    }"#;
+    let src = "w <- structure(1, class = \"widget\")\nout <- w + w\n";
+    let (with, scope) = check_with_stubs(src, &[("acme.json", package)]);
+    assert!(
+        with.is_empty(),
+        "the package stub's `+.widget` must satisfy operator dispatch: {with:?}"
+    );
+    let out = scope.get("out").expect("out should be bound");
+    assert_eq!(
+        (out.mode, out.length),
+        (Mode::Integer, Length::One),
+        "the package stub's declared shape must be applied: {out:?}"
+    );
+}
+
+#[test]
+fn operator_method_absence_still_reaches_arithmetic_checks() {
+    // Without any dispatchable method, operator inference keeps using
+    // the base-type rules: compatible storage modes produce their
+    // arithmetic result silently, incompatible ones still report RY040.
+    let (diags, scope) = check_with_scope(
+        "ok <- structure(1, class = \"plain\") + 1\n\
+         bad <- structure(list(a = 1), class = \"plain\") + 1\n",
+    );
+    let bad = diags.iter().filter(|d| d.code == "RY040").count();
+    assert_eq!(
+        bad, 1,
+        "the list-mode operand must stay arithmetic-checked: {diags:?}"
+    );
+    let ok = scope.get("ok").expect("ok should be bound");
+    assert_eq!(
+        ok.mode,
+        Mode::Double,
+        "numeric-classed arithmetic keeps the lattice result: {ok:?}"
+    );
+}

--- a/crates/ry-checker/src/tests/operator_s3_dispatch.rs
+++ b/crates/ry-checker/src/tests/operator_s3_dispatch.rs
@@ -223,6 +223,47 @@ fn opaque_group_stubs_keep_the_base_operator_diagnostics() {
 }
 
 #[test]
+fn factor_arithmetic_does_not_warn_about_recycling() {
+    // `Ops.factor` preempts the primitive for *all* arithmetic: real R
+    // warns "'+' not meaningful for factors" and returns
+    // `rep.int(NA, max(length(e1), length(e2)))` without ever recycling,
+    // so no factor path may claim "R will recycle with a warning"
+    // (verified against R 4.6: neither `f + list(1, 2)` nor `f + 1:2`
+    // emits the `longer object length ...` warning). The list line is
+    // the review corner where the lattice cannot combine the operands
+    // at all; the `1:2` line is where it can, so gating on `arith`
+    // succeeding alone would not suffice. RY042 stays on both, and the
+    // ordinary non-factor recycling case keeps its warning.
+    let (diags, _) = check_with_scope(
+        "f <- structure(1:3, class = \"factor\")\n\
+         l <- list(1, 2)\n\
+         a <- f + l\n\
+         b <- f + 1:2\n\
+         plain <- c(1, 2, 3) + c(10, 20)\n",
+    );
+    let ry042_lines = diags
+        .iter()
+        .filter(|d| d.code == "RY042")
+        .map(|d| d.span.line)
+        .collect::<Vec<_>>();
+    assert_eq!(
+        ry042_lines,
+        vec![2, 3],
+        "factor arithmetic keeps RY042 for both the list and numeric counterpart: {diags:?}"
+    );
+    let ry041_lines = diags
+        .iter()
+        .filter(|d| d.code == "RY041")
+        .map(|d| d.span.line)
+        .collect::<Vec<_>>();
+    assert_eq!(
+        ry041_lines,
+        vec![4],
+        "only the non-factor line may warn about recycling: {diags:?}"
+    );
+}
+
+#[test]
 fn operator_dispatch_tries_rhs_and_class_vector_order() {
     // R tries the LHS operand's classes, then the RHS's, and within one
     // operand the class vector in order: `1 + y` dispatches on `y`, and

--- a/crates/ry-checker/src/tests/operator_s3_dispatch.rs
+++ b/crates/ry-checker/src/tests/operator_s3_dispatch.rs
@@ -1,126 +1,135 @@
 use super::*;
 
-/// `check_with_scope` plus stub typeshed files (file name, raw JSON)
-/// installed from one temp directory, for tests that assert both the
-/// diagnostics and the inferred result type of dispatch through
-/// stub-declared methods. A `base.json` replaces the embedded base
-/// typeshed wholesale; other files become package typesheds. The
-/// un-stubbed behavior of the same source is compared with plain
-/// [`check`].
-fn check_with_stubs(src: &str, stub_files: &[(&str, &str)]) -> (Vec<Diagnostic>, Scope) {
-    let dir = tempfile::tempdir().unwrap();
-    for (name, json) in stub_files {
-        std::fs::write(dir.path().join(name), json).unwrap();
+/// One `s3_methods` stub entry: an operator method over `e1`/`e2`
+/// returning one value of `mode`.
+fn op_method(generic: &str, class: &str, mode: &str) -> String {
+    format!(
+        r#"{{"generic":"{generic}","class":"{class}","params":["e1","e2"],"return":{{"mode":"{mode}","length":"1"}}}}"#
+    )
+}
+
+/// A minimal stub file for [`check_with_stubs`]; the file's stem is the
+/// package key.
+fn stub_file(methods: &[String]) -> String {
+    format!(
+        r#"{{"version":"t","functions":{{}},"s3_methods":[{}]}}"#,
+        methods.join(",")
+    )
+}
+
+/// The source lines carrying `code`, in emission order.
+fn code_lines(diags: &[Diagnostic], code: &str) -> Vec<usize> {
+    diags
+        .iter()
+        .filter(|d| d.code == code)
+        .map(|d| d.span.line)
+        .collect()
+}
+
+#[test]
+fn operator_dispatches_stub_typeshed_methods() {
+    // Operators share the call path's method-source ladder (#165), so a
+    // method declared only in a typeshed is visible to `w1 + w2` and its
+    // declared shape wins. Only the list/character rows make `is_empty`
+    // dispatch-sensitive, so each carries a without-stub control that
+    // must report RY040; the package row's double operands stay silent
+    // either way, so its integer shape assertion pins the stub where
+    // the primitive would say double.
+    let cases = [
+        (
+            "base.json",
+            stub_file(&[op_method("+", "widget", "double")]),
+            "w1 <- structure(list(a = 1), class = \"widget\")\n\
+             w2 <- structure(list(b = 2), class = \"widget\")\n\
+             total <- w1 + w2\n",
+            "total",
+            Mode::Double,
+            true,
+        ),
+        (
+            "acme.json",
+            stub_file(&[op_method("+", "widget", "integer")]),
+            "w <- structure(1, class = \"widget\")\nout <- w + w\n",
+            "out",
+            Mode::Integer,
+            false,
+        ),
+        (
+            "base.json",
+            stub_file(&[op_method("Ops", "gadget", "logical")]),
+            "g1 <- structure(\"a\", class = \"gadget\")\n\
+             g2 <- structure(\"b\", class = \"gadget\")\n\
+             merged <- g1 + g2\n",
+            "merged",
+            Mode::Logical,
+            true,
+        ),
+    ];
+    for (file, json, src, binding, mode, dispatch_sensitive) in cases {
+        let (with, scope) = check_with_stubs(src, &[(file, &json)]);
+        assert!(
+            with.is_empty(),
+            "the stubbed method must satisfy operator dispatch: {with:?}"
+        );
+        assert_eq!(
+            scope.get(binding).map(|t| (t.mode, t.length)),
+            Some((mode, Length::One)),
+            "the stub's declared shape must be applied for `{binding}`"
+        );
+        if dispatch_sensitive {
+            let without = check(src);
+            assert!(
+                without.iter().any(|d| d.code == "RY040"),
+                "without the stub the arithmetic rules must flag `{binding}`: {without:?}"
+            );
+        }
     }
-    let stubs = Arc::new(ry_typeshed::load_stub_dir(dir.path()).unwrap());
-    let mut c = Checker::new("test.R");
-    c.set_user_stubs(stubs);
-    c.check_with_scope(&parse_snippet("test.R", src))
-}
-
-#[test]
-fn operator_dispatches_stub_typeshed_specific_method() {
-    // A `+.widget` method that exists only in a stub typeshed must be
-    // visible to the operator path, exactly as it is to normal call
-    // dispatch (#165): with the stub, `w1 + w2` uses the stub's return
-    // shape; without it, the same program reaches the arithmetic rules
-    // and reports the list-mode mismatch.
-    let stub = r#"{
-        "schema_version": "1",
-        "package": "base",
-        "version": "test",
-        "functions": {},
-        "s3_methods": [
-            {"generic": "+", "class": "widget", "params": ["e1", "e2"], "return": {"mode": "double", "length": "1"}}
-        ]
-    }"#;
-    let src = "w1 <- structure(list(a = 1), class = \"widget\")\n\
-               w2 <- structure(list(b = 2), class = \"widget\")\n\
-               total <- w1 + w2\n";
-    let (with, scope) = check_with_stubs(src, &[("base.json", stub)]);
-    assert!(
-        with.iter().all(|d| d.code != "RY040"),
-        "the stubbed `+.widget` method must satisfy operator dispatch: {with:?}"
-    );
-    assert!(
-        check(src).iter().any(|d| d.code == "RY040"),
-        "without the stub the same operands must reach the arithmetic rules"
-    );
-    let total = scope.get("total").expect("total should be bound");
-    assert_eq!(
-        (total.mode, total.length),
-        (Mode::Double, Length::One),
-        "the stub's return shape must win over the opaque dispatch default: {total:?}"
-    );
-}
-
-#[test]
-fn operator_dispatches_stub_typeshed_group_method_shape() {
-    // An `Ops.gadget` group-generic stub with a usable shape is
-    // dispatched with that shape (the group rung shares the ladder;
-    // only an *opaque* group stub defers to the base-type rules).
-    let stub = r#"{
-        "schema_version": "1",
-        "package": "base",
-        "version": "test",
-        "functions": {},
-        "s3_methods": [
-            {"generic": "Ops", "class": "gadget", "params": ["e1", "e2"], "return": {"mode": "logical", "length": "1"}}
-        ]
-    }"#;
-    let src = "g1 <- structure(c(\"a\"), class = \"gadget\")\n\
-               g2 <- structure(c(\"b\"), class = \"gadget\")\n\
-               merged <- g1 + g2\n";
-    let (with, scope) = check_with_stubs(src, &[("base.json", stub)]);
-    assert!(
-        with.is_empty(),
-        "the stubbed `Ops.gadget` method must satisfy operator dispatch: {with:?}"
-    );
-    assert!(
-        check(src).iter().any(|d| d.code == "RY040"),
-        "without the stub, character arithmetic must be rejected"
-    );
-    let merged = scope.get("merged").expect("merged should be bound");
-    assert_eq!(
-        (merged.mode, merged.length),
-        (Mode::Logical, Length::One),
-        "the group stub's declared shape must be applied: {merged:?}"
-    );
 }
 
 #[test]
 fn stub_default_method_does_not_hijack_operator_dispatch() {
-    // Real R never consults `+.default` for an operator whose class has
-    // no method: the primitive computes the result (and errors for a
-    // list operand) regardless of any `.default` method defined
-    // anywhere. So a stub `+.default` must not suppress the primitive's
-    // own rules -- unlike the call path, where `.default` is a real
-    // fallback (#165, corrected against verified R semantics).
-    let stub = r#"{
-        "schema_version": "1",
-        "package": "base",
-        "version": "test",
-        "functions": {},
-        "s3_methods": [
-            {"generic": "+", "class": "default", "params": ["e1", "e2"], "return": {"mode": "opaque", "length": "unknown"}}
-        ]
-    }"#;
-    let src = "x <- structure(list(), class = \"unhandled\")\ny <- x + 1\n";
-    let (with, _) = check_with_stubs(src, &[("base.json", stub)]);
+    // R's operators have no implicit `.default` fallback: the primitive
+    // itself is the fallback, so a `.default` stub must neither satisfy
+    // dispatch nor report a missing method (#165, corrected against
+    // real R -- unlike the call path, where `.default` is a real
+    // fallback). The second case queries the guarded rung itself: an
+    // operand whose class vector is literally `"default"` skips the
+    // `.default` stub and falls back to ry's primitive. Divergence: R
+    // walks the operand's class vector without special-casing, so it
+    // would dispatch the literal `+.default` for a class named
+    // `"default"` (verified against R 4.6.1, which returns the method's
+    // value in either operand order); ry deliberately skips the
+    // `"default"` rung so operator dispatch stays default-free -- an
+    // accepted divergence for a pathological class name.
+    let json = stub_file(&[op_method("+", "default", "opaque")]);
+    let (with, _) = check_with_stubs(
+        "x <- structure(list(), class = \"unhandled\")\ny <- x + 1\n",
+        &[("base.json", &json)],
+    );
     assert!(
         with.iter().any(|d| d.code == "RY040") && with.iter().all(|d| d.code != "RY050"),
         "a stub `+.default` must neither satisfy nor report operator dispatch: {with:?}"
+    );
+    let (guarded, scope) = check_with_stubs(
+        "d <- structure(1, class = \"default\")\nout <- d + 1\n",
+        &[("base.json", &json)],
+    );
+    assert!(
+        guarded.is_empty(),
+        "the guarded rung must fall back to the primitive silently: {guarded:?}"
+    );
+    assert_eq!(
+        scope.get("out").map(|t| (t.mode, t.length)),
+        Some((Mode::Double, Length::One)),
+        "the primitive fallback keeps the numeric result"
     );
 }
 
 #[test]
 fn operator_dispatch_miss_falls_back_to_the_primitive() {
     // Real R silently computes `bar + 1` with the primitive even when
-    // `+.foo` or `Ops.foo` exists for another class: unlike ordinary
-    // generics, a primitive operator is its own fallback. A miss must
-    // not report RY050, must not conclude opaque through an unrelated
-    // method, and must keep the primitive's own checks (#165's RY050
-    // criterion, corrected against verified R semantics).
+    // `+.foo` exists for another class: no RY050, and the primitive's
+    // own checks still apply (#165, corrected against real R).
     let (diags, scope) = check_with_scope(
         "`+.foo` <- function(e1, e2) 1L\n\
          x <- structure(1, class = \"bar\")\n\
@@ -131,24 +140,23 @@ fn operator_dispatch_miss_falls_back_to_the_primitive() {
         diags.iter().all(|d| d.code != "RY050"),
         "an operator miss is R's silent primitive fallback: {diags:?}"
     );
-    let y = scope.get("y").expect("y should be bound");
     assert_eq!(
-        y.mode,
-        Mode::Double,
-        "numeric-classed arithmetic keeps the primitive result: {y:?}"
+        scope.get("y").map(|t| t.mode),
+        Some(Mode::Double),
+        "numeric-classed arithmetic keeps the primitive result"
     );
-    assert!(
-        diags.iter().any(|d| d.code == "RY040"),
-        "the list-mode operand must stay arithmetic-checked: {diags:?}"
+    assert_eq!(
+        code_lines(&diags, "RY040"),
+        vec![3],
+        "only the list-mode operand stays arithmetic-checked: {diags:?}"
     );
 }
 
 #[test]
 fn short_circuit_operators_never_dispatch_through_ops() {
     // `&&`/`||` are strictly logical short-circuit primitives in R: no
-    // `Ops` group dispatch, so an `Ops.flagged` method cannot intercept
-    // them, and the ordinary length/type diagnostics keep firing
-    // (#165, pinned against verified R semantics).
+    // `Ops` dispatch can intercept them, and the ordinary length/type
+    // diagnostics keep firing (#165).
     let (diags, scope) = check_with_scope(
         "`Ops.flagged` <- function(e1, e2) 1L\n\
          a <- structure(TRUE, class = \"flagged\")\n\
@@ -160,11 +168,10 @@ fn short_circuit_operators_never_dispatch_through_ops() {
          typed <- s || a\n",
     );
     for name in ["both", "either"] {
-        let t = scope.get(name).expect("result should be bound");
         assert_eq!(
-            (t.mode, t.length),
-            (Mode::Logical, Length::One),
-            "`{name}` must be the primitive logical(1) result, not a dispatch: {t:?}"
+            scope.get(name).map(|t| (t.mode, t.length)),
+            Some((Mode::Logical, Length::One)),
+            "`{name}` must be the primitive logical(1) result"
         );
     }
     assert!(
@@ -179,12 +186,11 @@ fn short_circuit_operators_never_dispatch_through_ops() {
 
 #[test]
 fn opaque_group_stubs_keep_the_base_operator_diagnostics() {
-    // Every embedded `Ops.<class>` stub is opaque, but that must not
-    // silence the storage-mode rules: base R's own `Ops.factor` warns
-    // for *any* factor arithmetic (`factor + list` included), and
-    // `Date + character` is the primitive's own error. Falling through
-    // keeps both diagnostics while preserving the useful shaping for
-    // `factor + 1` and `Date` arithmetic (#165).
+    // Every embedded `Ops.<class>` stub is opaque; falling through on
+    // an opaque group stub keeps the storage-mode rules modeling those
+    // base classes: `Ops.factor` warns for *any* factor arithmetic
+    // (`factor + list` included), and `Date + character` stays the
+    // primitive's own RY040 (#165).
     let (diags, scope) = check_with_scope(
         "f <- factor(c(\"a\", \"b\"))\n\
          l <- list(1)\n\
@@ -194,46 +200,34 @@ fn opaque_group_stubs_keep_the_base_operator_diagnostics() {
          y <- d + \"x\"\n\
          ok <- d + 1\n",
     );
-    let factor_lines = diags
-        .iter()
-        .filter(|d| d.code == "RY042")
-        .map(|d| d.span.line)
-        .collect::<Vec<_>>();
     assert_eq!(
-        factor_lines,
+        code_lines(&diags, "RY042"),
         vec![2, 3],
         "factor arithmetic keeps RY042 for both the list and numeric counterpart: {diags:?}"
     );
-    assert!(
-        diags.iter().all(|d| d.code != "RY040" || d.span.line == 5),
-        "the Date+character primitive error stays, factor arithmetic must not become RY040: {diags:?}"
-    );
-    assert!(
-        diags.iter().any(|d| d.code == "RY040" && d.span.line == 5),
-        "Date + character must retain the primitive-mode error: {diags:?}"
-    );
-    let ok = scope.get("ok").expect("ok should be bound");
     assert_eq!(
-        ok.mode,
-        Mode::Double,
-        "Date arithmetic keeps the lattice result: {ok:?}"
+        code_lines(&diags, "RY040"),
+        vec![5],
+        "only Date + character is the primitive-mode error: {diags:?}"
     );
-    // Unary `-` on a factor is deliberately unpinned: R warns and
-    // returns NA, which the checker's silent shaping does not model.
+    assert_eq!(
+        code_lines(&diags, "RY041"),
+        Vec::<usize>::new(),
+        "no operand pair recycles unevenly on this source: {diags:?}"
+    );
+    assert_eq!(
+        scope.get("ok").map(|t| t.mode),
+        Some(Mode::Double),
+        "Date arithmetic keeps the lattice result"
+    );
 }
 
 #[test]
 fn factor_arithmetic_does_not_warn_about_recycling() {
-    // `Ops.factor` preempts the primitive for *all* arithmetic: real R
-    // warns "'+' not meaningful for factors" and returns
-    // `rep.int(NA, max(length(e1), length(e2)))` without ever recycling,
-    // so no factor path may claim "R will recycle with a warning"
-    // (verified against R 4.6: neither `f + list(1, 2)` nor `f + 1:2`
-    // emits the `longer object length ...` warning). The list line is
-    // the review corner where the lattice cannot combine the operands
-    // at all; the `1:2` line is where it can, so gating on `arith`
-    // succeeding alone would not suffice. RY042 stays on both, and the
-    // ordinary non-factor recycling case keeps its warning.
+    // `Ops.factor` preempts the primitive for all factor arithmetic and
+    // never recycles (verified against R 4.6): RY042 only, never RY041
+    // -- including where the modes would arith-combine (`f + 1:2`) and
+    // where they cannot (`f + list`). The plain line keeps RY041.
     let (diags, _) = check_with_scope(
         "f <- structure(1:3, class = \"factor\")\n\
          l <- list(1, 2)\n\
@@ -241,25 +235,20 @@ fn factor_arithmetic_does_not_warn_about_recycling() {
          b <- f + 1:2\n\
          plain <- c(1, 2, 3) + c(10, 20)\n",
     );
-    let ry042_lines = diags
-        .iter()
-        .filter(|d| d.code == "RY042")
-        .map(|d| d.span.line)
-        .collect::<Vec<_>>();
     assert_eq!(
-        ry042_lines,
+        code_lines(&diags, "RY042"),
         vec![2, 3],
         "factor arithmetic keeps RY042 for both the list and numeric counterpart: {diags:?}"
     );
-    let ry041_lines = diags
-        .iter()
-        .filter(|d| d.code == "RY041")
-        .map(|d| d.span.line)
-        .collect::<Vec<_>>();
     assert_eq!(
-        ry041_lines,
+        code_lines(&diags, "RY041"),
         vec![4],
         "only the non-factor line may warn about recycling: {diags:?}"
+    );
+    assert_eq!(
+        code_lines(&diags, "RY040"),
+        Vec::<usize>::new(),
+        "factor arithmetic never reports the primitive-mode error on this source: {diags:?}"
     );
 }
 
@@ -281,62 +270,11 @@ fn operator_dispatch_tries_rhs_and_class_vector_order() {
         diags.is_empty(),
         "both dispatched operators must be silent: {diags:?}"
     );
-    for (name, expected) in [("from_rhs", "R"), ("from_order", "F")] {
-        let t = scope.get(name).unwrap_or_else(|| panic!("{name} bound"));
+    for name in ["from_rhs", "from_order"] {
         assert_eq!(
-            t.mode,
-            Mode::Character,
-            "`{name}` must use the `{expected}` method's return: {t:?}"
+            scope.get(name).map(|t| t.mode),
+            Some(Mode::Character),
+            "`{name}` must use the dispatched method's return"
         );
     }
-}
-
-#[test]
-fn operator_dispatches_package_typeshed_method() {
-    // The ladder's last rung: an operator method declared in a package
-    // typeshed (not the project fn table, not base) is visible to the
-    // operator path, mirroring the call path's lookup.
-    let package = r#"{
-        "schema_version": "1",
-        "package": "acme",
-        "version": "test",
-        "functions": {},
-        "s3_methods": [
-            {"generic": "+", "class": "widget", "params": ["e1", "e2"], "return": {"mode": "integer", "length": "1"}}
-        ]
-    }"#;
-    let src = "w <- structure(1, class = \"widget\")\nout <- w + w\n";
-    let (with, scope) = check_with_stubs(src, &[("acme.json", package)]);
-    assert!(
-        with.is_empty(),
-        "the package stub's `+.widget` must satisfy operator dispatch: {with:?}"
-    );
-    let out = scope.get("out").expect("out should be bound");
-    assert_eq!(
-        (out.mode, out.length),
-        (Mode::Integer, Length::One),
-        "the package stub's declared shape must be applied: {out:?}"
-    );
-}
-
-#[test]
-fn operator_method_absence_still_reaches_arithmetic_checks() {
-    // Without any dispatchable method, operator inference keeps using
-    // the base-type rules: compatible storage modes produce their
-    // arithmetic result silently, incompatible ones still report RY040.
-    let (diags, scope) = check_with_scope(
-        "ok <- structure(1, class = \"plain\") + 1\n\
-         bad <- structure(list(a = 1), class = \"plain\") + 1\n",
-    );
-    let bad = diags.iter().filter(|d| d.code == "RY040").count();
-    assert_eq!(
-        bad, 1,
-        "the list-mode operand must stay arithmetic-checked: {diags:?}"
-    );
-    let ok = scope.get("ok").expect("ok should be bound");
-    assert_eq!(
-        ok.mode,
-        Mode::Double,
-        "numeric-classed arithmetic keeps the lattice result: {ok:?}"
-    );
 }

--- a/crates/ry-checker/testdata/ok_s3_operator_absence_arithmetic.R
+++ b/crates/ry-checker/testdata/ok_s3_operator_absence_arithmetic.R
@@ -1,0 +1,6 @@
+# no-diag
+# No operator or `Ops` method exists for `plain`, and the project defines
+# none either: the operator falls back to the base-type arithmetic rules
+# silently, exactly as R's internal primitive does.
+x <- structure(c(1, 2), class = "plain")
+y <- x + 1

--- a/crates/ry-checker/testdata/oracle/operator_s3_absence.R
+++ b/crates/ry-checker/testdata/oracle/operator_s3_absence.R
@@ -1,0 +1,7 @@
+# oracle: must-pass
+# Arithmetic on a classed numeric with no `Ops` method anywhere uses R's
+# internal primitive rules: R computes it fine, and ry must neither flag
+# an error nor report a missing S3 method (RY050) for it.
+x <- structure(c(1, 2), class = "local_record")
+total <- x + x
+stopifnot(is.numeric(total), length(total) == 2)

--- a/crates/ry-checker/tests/snapshots/corpus__checker_fixture_diagnostics.snap
+++ b/crates/ry-checker/tests/snapshots/corpus__checker_fixture_diagnostics.snap
@@ -683,6 +683,8 @@ expression: snapshots
 - diagnostics: []
   fixture: ok_s3_dispatch.R
 - diagnostics: []
+  fixture: ok_s3_operator_absence_arithmetic.R
+- diagnostics: []
   fixture: ok_s4_terra_named_vector.R
 - diagnostics: []
   fixture: ok_s7_class_callable.R


### PR DESCRIPTION
## Summary
- route operator S3 lookup through the same external/project/base/package method ladder as ordinary calls
- make typeshed-declared and package-typeshed operator methods visible
- preserve R operator semantics: misses fall through to primitives, `&&`/`||` never dispatch, and opaque group stubs do not suppress primitive diagnostics
- add dedicated RHS, class-order, package-rung, default, factor, Date, and fallback coverage

## Stack
This PR is stacked on #191 (`cleanup/checker-infer-dedupe`) and should be reviewed against that base. After #191 merges, retarget this PR to `main`. The exact review range is one focused commit.

## Local review
Reviewed independently by GLM 5.3 Flash, Muse Spark 1.3, and GPT 5.6 Sol. The initial implementation over-warned versus R; all findings were corrected and final exact-tip verdicts unanimously approve.

## Verification
- cargo test -p ry-checker
- full workspace test suite
- R-backed oracle suite (same three pre-existing known gaps)
- cargo check --workspace --all-targets
- cargo clippy -p ry-checker --all-targets
- cargo fmt --check

Closes #165