### PR TITLE
cleanup: simplify scope inserts, inventory decode, and explain rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -246,6 +246,10 @@ suppression actions — and fixes a parser panic plus several editor issues.
 
 ### Fixed
 
+- **VS Code Explain Rule**: use the CLI's actual rule-list command and display
+  its summary without a second subprocess. Binary paths are passed literally,
+  and document-opening errors reach the command's error message.
+
 - **testthat runner classification follows the documented contract**:
   under `tests/`, only `.R`/`.r` files directly at the root (what
   `R CMD check` sources, including `tests/testthat.R`) and, under

--- a/crates/ry-checker/src/lib.rs
+++ b/crates/ry-checker/src/lib.rs
@@ -316,7 +316,8 @@ impl Scope {
     }
 
     pub(crate) fn insert_narrowed(&mut self, name: impl Into<String>, t: RType) {
-        // Narrowing preserves parameter and list-origin provenance.
+        // Preserve parameter, default-parameter, and list-origin markers;
+        // clear function aliases and lexical-function markers, then mark narrowed.
         let name = name.into();
         self.function_aliases.remove(&name);
         self.lexical_functions.remove(&name);
@@ -331,9 +332,8 @@ impl Scope {
     }
 
     pub(crate) fn insert_parameter_default(&mut self, name: impl Into<String>, t: RType) {
-        // Unlike a plain rebinding, a defaulted parameter shadows its
-        // captured-scope namesake without disturbing the lexical-function
-        // and list-origin markers (`insert` would clear both).
+        // Preserve lexical-function and list-origin markers; clear function
+        // aliases and narrowing, then set both parameter markers.
         let name = name.into();
         self.function_aliases.remove(&name);
         self.narrowed_bindings.remove(&name);

--- a/crates/ry-checker/src/lib.rs
+++ b/crates/ry-checker/src/lib.rs
@@ -316,22 +316,11 @@ impl Scope {
     }
 
     pub(crate) fn insert_narrowed(&mut self, name: impl Into<String>, t: RType) {
-        // Narrowing refines the value without rebinding the name, so the
-        // parameter and list-origin markers survive `insert`'s clearing.
+        // Narrowing preserves parameter and list-origin provenance.
         let name = name.into();
-        let was_parameter = self.parameter_bindings.contains(&name);
-        let was_default_parameter = self.default_parameter_bindings.contains(&name);
-        let had_list_origin = self.list_origin_bindings.contains(&name);
-        self.insert(name.clone(), t);
-        if was_parameter {
-            self.parameter_bindings.insert(name.clone());
-        }
-        if was_default_parameter {
-            self.default_parameter_bindings.insert(name.clone());
-        }
-        if had_list_origin {
-            self.list_origin_bindings.insert(name.clone());
-        }
+        self.function_aliases.remove(&name);
+        self.lexical_functions.remove(&name);
+        self.bindings.insert(name.clone(), t);
         self.narrowed_bindings.insert(name);
     }
 
@@ -346,15 +335,9 @@ impl Scope {
         // captured-scope namesake without disturbing the lexical-function
         // and list-origin markers (`insert` would clear both).
         let name = name.into();
-        let was_lexical_function = self.lexical_functions.contains(&name);
-        let was_list_origin = self.list_origin_bindings.contains(&name);
-        self.insert(name.clone(), t);
-        if was_lexical_function {
-            self.lexical_functions.insert(name.clone());
-        }
-        if was_list_origin {
-            self.list_origin_bindings.insert(name.clone());
-        }
+        self.function_aliases.remove(&name);
+        self.narrowed_bindings.remove(&name);
+        self.bindings.insert(name.clone(), t);
         self.parameter_bindings.insert(name.clone());
         self.default_parameter_bindings.insert(name);
     }

--- a/crates/ry-checker/src/tests/scope_resolution.rs
+++ b/crates/ry-checker/src/tests/scope_resolution.rs
@@ -1047,13 +1047,8 @@ fn attach_opens_search_path_via_unknown_bindings_scope_effect() {
 
 #[test]
 fn parameter_default_preserves_lexical_and_list_origin_markers() {
-    // Pre-deduplication, `insert_parameter_default` removed only the
-    // function-alias and narrowed markers; `lexical_functions` and
-    // `list_origin_bindings` were left untouched. Delegating to
-    // `Scope::insert` must not silently drop those two: a defaulted
-    // parameter shadowing a captured-scope name keeps its markers
-    // through `build_function_signature`'s walk, which clones the
-    // captured scope and layers parameter defaults on top.
+    // A defaulted parameter shadows a captured name while preserving its
+    // lexical-function and list-origin markers.
     let mut scope = Scope::default();
     scope.insert("d", RType::new(Mode::List, Length::One));
     scope.insert_narrowed("d", RType::unknown());

--- a/crates/ry-workspace/src/lib.rs
+++ b/crates/ry-workspace/src/lib.rs
@@ -722,42 +722,28 @@ fn serialized_inventory_uncached(path: &Path, cap: u64) -> SerializedInventory {
         degraded: false,
     };
 
-    let read_cap = cap.saturating_add(1);
     let bytes = match std::fs::read(path) {
         Ok(bytes) => bytes,
         Err(_) => return empty(),
     };
-    let compression = if bytes.starts_with(b"BZh") {
-        Some(Compression::Bzip2)
-    } else if bytes.starts_with(&[0x1f, 0x8b]) {
-        Some(Compression::Gzip)
-    } else if bytes.starts_with(&[0xfd, b'7', b'z', b'X', b'Z', 0x00]) {
-        Some(Compression::Xz)
-    } else {
-        None
+    let decoded = {
+        let decoder: Option<Box<dyn std::io::Read + '_>> = if bytes.starts_with(b"BZh") {
+            Some(Box::new(bzip2::read::BzDecoder::new(bytes.as_slice())))
+        } else if bytes.starts_with(&[0x1f, 0x8b]) {
+            Some(Box::new(flate2::read::GzDecoder::new(bytes.as_slice())))
+        } else if bytes.starts_with(&[0xfd, b'7', b'z', b'X', b'Z', 0x00]) {
+            Some(Box::new(xz2::read::XzDecoder::new(bytes.as_slice())))
+        } else {
+            None
+        };
+        decoder.map(|decoder| decode_capped(decoder, cap))
     };
-    let bytes = match compression {
-        Some(format) => {
-            let decoder: Box<dyn std::io::Read> = match format {
-                Compression::Bzip2 => Box::new(bzip2::read::BzDecoder::new(bytes.as_slice())),
-                Compression::Gzip => Box::new(flate2::read::GzDecoder::new(bytes.as_slice())),
-                Compression::Xz => Box::new(xz2::read::XzDecoder::new(bytes.as_slice())),
-            };
-            match decode_capped(decoder, read_cap, cap) {
-                Decoded::Bytes(decoded) => decoded,
-                Decoded::OverCap => return degraded(path),
-                Decoded::Failed => return empty(),
-            }
-        }
-        None => {
-            // An uncompressed file already has a known size from `metadata.len()`
-            // checked in the cached wrapper. Short-circuit before parsing if it
-            // exceeds the cap — no need to read the whole payload.
-            if bytes.len() as u64 > cap {
-                return degraded(path);
-            }
-            bytes
-        }
+    let bytes = match decoded {
+        Some(Decoded::Bytes(decoded)) => decoded,
+        Some(Decoded::OverCap) => return degraded(path),
+        Some(Decoded::Failed) => return empty(),
+        None if bytes.len() as u64 > cap => return degraded(path),
+        None => bytes,
     };
     let payload = bytes
         .strip_prefix(b"RDX2\n")
@@ -779,14 +765,6 @@ fn serialized_inventory_uncached(path: &Path, cap: u64) -> SerializedInventory {
     }
 }
 
-/// Container format of a compressed serialization, detected by magic bytes.
-#[derive(Clone, Copy)]
-enum Compression {
-    Bzip2,
-    Gzip,
-    Xz,
-}
-
 /// Outcome of decoding a compressed serialization under the byte cap.
 enum Decoded {
     /// Payload decoded and fits within the cap.
@@ -798,11 +776,15 @@ enum Decoded {
 }
 
 /// Decode `decoder` fully, stopping once the payload provably exceeds
-/// `cap`. Reading at most `read_cap` (`cap + 1`) bytes distinguishes an
+/// `cap`. Reading at most `cap + 1` bytes distinguishes an
 /// exact-cap payload from a larger one without decoding all of it.
-fn decode_capped(decoder: impl std::io::Read, read_cap: u64, cap: u64) -> Decoded {
+fn decode_capped(decoder: impl std::io::Read, cap: u64) -> Decoded {
     let mut decoded = Vec::new();
-    if decoder.take(read_cap).read_to_end(&mut decoded).is_err() {
+    if decoder
+        .take(cap.saturating_add(1))
+        .read_to_end(&mut decoded)
+        .is_err()
+    {
         return Decoded::Failed;
     }
     if decoded.len() as u64 > cap {

--- a/editors/code/src/common/commands.ts
+++ b/editors/code/src/common/commands.ts
@@ -42,11 +42,10 @@ export async function debugInformationCommand(
 }
 
 export async function explainRuleCommand(binaryPath: string): Promise<void> {
-  // Show a quick-pick over all rules, then render the explanation.
-  // `ry explain rule <code> --output-format json` already exists.
   try {
-    const listOutput = cp.execSync(
-      `"${binaryPath}" explain rules --output-format json`,
+    const listOutput = cp.execFileSync(
+      binaryPath,
+      ["explain", "rule", "--output-format", "json"],
       {
         encoding: "utf-8",
         timeout: 5000,
@@ -55,27 +54,24 @@ export async function explainRuleCommand(binaryPath: string): Promise<void> {
     const rules = JSON.parse(listOutput) as Array<{
       code: string;
       name: string;
+      summary: string;
     }>;
     const items = rules.map((r) => ({
       label: r.code,
       description: r.name,
+      summary: r.summary,
     }));
     const picked = await vscode.window.showQuickPick(items, {
       placeHolder: "Select a rule to explain",
     });
     if (!picked) return;
 
-    const explainOutput = cp.execSync(
-      `"${binaryPath}" explain rule ${picked.label} --output-format json`,
-      { encoding: "utf-8", timeout: 5000 },
-    );
-    const explanation = JSON.parse(explainOutput);
-    const md = `# ${explanation.code}: ${explanation.name}\n\n${explanation.explanation ?? ""}`;
-    const doc = vscode.workspace.openTextDocument({
+    const md = `# ${picked.label}: ${picked.description}\n\n${picked.summary}`;
+    const doc = await vscode.workspace.openTextDocument({
       content: md,
       language: "markdown",
     });
-    doc.then((d) => vscode.window.showTextDocument(d, { preview: true }));
+    await vscode.window.showTextDocument(doc, { preview: true });
   } catch (e) {
     vscode.window.showErrorMessage(`Failed to explain rule: ${e}`);
   }

--- a/editors/code/src/common/commands.ts
+++ b/editors/code/src/common/commands.ts
@@ -59,14 +59,14 @@ export async function explainRuleCommand(binaryPath: string): Promise<void> {
     const items = rules.map((r) => ({
       label: r.code,
       description: r.name,
-      summary: r.summary,
+      detail: r.summary,
     }));
     const picked = await vscode.window.showQuickPick(items, {
       placeHolder: "Select a rule to explain",
     });
     if (!picked) return;
 
-    const md = `# ${picked.label}: ${picked.description}\n\n${picked.summary}`;
+    const md = `# ${picked.label}: ${picked.description}\n\n${picked.detail}`;
     const doc = await vscode.workspace.openTextDocument({
       content: md,
       language: "markdown",


### PR DESCRIPTION
Three small independent cleanups plus one user-visible editor fix, bundled for review.

**Checker — direct scope-marker writes.** `insert_narrowed` and `insert_parameter_default` used to delegate to `Scope::insert` and then restore the provenance markers it cleared. `Scope::insert` removes all six marker sets, so writing the binding directly and removing only the markers each helper owns (`function_aliases`, `lexical_functions` for narrowing; `function_aliases`, `narrowed_bindings` for parameter defaults) has the same net effect: parameter, default-parameter, and list-origin markers survive, the rest clear. The test comment in `scope_resolution.rs` that narrated the old save-and-restore dance is updated to describe the contract instead.

**Workspace — inline decode dispatch.** `serialized_inventory_uncached` built a `Compression` enum from the magic bytes and then re-matched it to construct a decoder. It now constructs the decoder inline and the enum is deleted. `decode_capped` derives its read cap (`cap + 1`) itself instead of receiving it as a parameter. The uncompressed path keeps the same post-read size check against `cap` — the stale comment claiming a `metadata.len()` short-circuit never matched the code, which read the file unconditionally first.

**VS Code — explain rule fix** (user-facing, changelog entry included). `explainRuleCommand` invoked `explain rules`, but the CLI command is `explain rule`; it now shells out once via `execFileSync` with the binary path passed literally instead of interpolating a shell-quoted string into `execSync`, renders the picked rule from the list output's `summary` without a second subprocess, and awaits `openTextDocument`/`showTextDocument` so failures surface in the error message rather than an unhandled floating promise.

Gates run locally: `cargo check` on both crates, `cargo test -p ry-checker --lib scope_resolution` (70 passed), `cargo test -p ry-workspace` (31 passed), `npm run tsc` and `npm run fmt-check` in `editors/code`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the VS Code “Explain Rule” experience by using the correct rule-list command.
  - Rule summaries now appear directly in the rule picker and explanation view.
  - Binary paths containing spaces or special characters are handled reliably.
  - Errors encountered while opening rule explanations are surfaced clearly.

- **Performance**
  - Improved handling of compressed workspace inventory files while preserving existing size limits and fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->