### PR TITLE
cleanup: share parsed sources and fix nested stub discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -246,6 +246,9 @@ suppression actions — and fixes a parser panic plus several editor issues.
 
 ### Fixed
 
+- Typeshed loading and validation now discover mixed-case nested filenames,
+  including `rcpp/Rcpp.json` and `s7/S7.json`.
+
 - **VS Code Explain Rule**: use the CLI's actual rule-list command and display
   its summary without a second subprocess. Binary paths are passed literally,
   and document-opening errors reach the command's error message.

--- a/crates/ry-cli/src/check.rs
+++ b/crates/ry-cli/src/check.rs
@@ -448,13 +448,13 @@ fn run_check_once(paths: &[PathBuf], ctx: &CheckContext) -> Result<CheckResult> 
     let parsed = pipeline::parse_files(paths, report_check_parse_failure)
         .expect("check's parse-failure policy never aborts");
     parse_errors += paths.len() - parsed.len();
-    let parsed: Vec<pipeline::ParsedFile> = parsed
+    let parsed: Vec<Arc<ry_core::SourceFile>> = parsed
         .into_iter()
         .filter(|parsed_file| {
             file_count += 1;
-            srcs.insert(parsed_file.path.clone(), parsed_file.src.clone());
-            comments.insert(parsed_file.path.clone(), parsed_file.file.comments.clone());
-            if is_probably_not_r_source(&parsed_file.file) {
+            srcs.insert(parsed_file.path.clone(), parsed_file.source.clone());
+            comments.insert(parsed_file.path.clone(), parsed_file.comments.clone());
+            if is_probably_not_r_source(parsed_file) {
                 not_r_diagnostics.push(ry_checker::Diagnostic::new(
                     ry_checker::Severity::Info,
                     ry_core::Span::new(0, 1, 0, 0),

--- a/crates/ry-cli/src/dump.rs
+++ b/crates/ry-cli/src/dump.rs
@@ -159,10 +159,8 @@ fn collect_local_bindings(stmts: &[ry_core::ast::Stmt], out: &mut HashMap<String
     );
 }
 
-/// Map every function body in the file to its start byte, so each
-/// recorded scope can look up its own local bindings. Walks into
-/// function bodies (that is what is being indexed) but skips assignment
-/// targets; each discovered body is indexed and pruned in one step.
+/// Index local definition sites by function start byte. The shared walker
+/// visits nested functions; collecting locals stops at each function boundary.
 fn index_scope_bodies(
     stmts: &[ry_core::ast::Stmt],
     index: &mut HashMap<usize, HashMap<String, ry_core::Span>>,
@@ -175,33 +173,20 @@ fn index_scope_bodies(
         },
         |node: AstNode<'_>, _: usize| -> ControlFlow<(), Descend> {
             match node {
-                AstNode::Stmt(Stmt::FunctionDef { body, span, .. }) => {
-                    index_function_body(*span, body, index);
-                    return ControlFlow::Continue(Descend::Skip);
-                }
-                AstNode::Stmt(Stmt::Assign {
+                AstNode::Stmt(Stmt::FunctionDef { body, span, .. })
+                | AstNode::Stmt(Stmt::Assign {
                     value: Expr::Function { body, span, .. },
                     ..
                 }) => {
-                    index_function_body(*span, body, index);
-                    return ControlFlow::Continue(Descend::Skip);
+                    let mut locals = HashMap::new();
+                    collect_local_bindings(body, &mut locals);
+                    index.insert(span.start, locals);
                 }
                 _ => {}
             }
             ControlFlow::Continue(Descend::Into)
         },
     );
-}
-
-fn index_function_body(
-    span: ry_core::Span,
-    body: &[ry_core::ast::Stmt],
-    index: &mut HashMap<usize, HashMap<String, ry_core::Span>>,
-) {
-    let mut locals = HashMap::new();
-    collect_local_bindings(body, &mut locals);
-    index.insert(span.start, locals);
-    index_scope_bodies(body, index);
 }
 
 /// Per-scope classification inputs derived once per file.
@@ -549,7 +534,7 @@ pub(crate) fn run_dump_types(
                 let records = records_by_path
                     .remove(&parsed_file.path)
                     .unwrap_or_default();
-                assemble_file_dump(&parsed_file.path, &parsed_file.file, records, &positions)
+                assemble_file_dump(&parsed_file.path, parsed_file, records, &positions)
             })
             .collect(),
     };

--- a/crates/ry-cli/src/pipeline.rs
+++ b/crates/ry-cli/src/pipeline.rs
@@ -33,16 +33,6 @@ pub(crate) fn discover_config(
     }
 }
 
-/// One successfully parsed input file.
-pub(crate) struct ParsedFile {
-    /// Path exactly as diagnostics and dumps report it.
-    pub path: String,
-    /// File contents (UTF-8 or Latin-1 decoded).
-    pub src: String,
-    /// Parsed syntax tree.
-    pub file: ry_core::SourceFile,
-}
-
 /// Why one input file could not be parsed.
 #[derive(Debug)]
 pub(crate) enum ParseError {
@@ -93,9 +83,9 @@ pub(crate) enum FailureAction {
 pub(crate) fn parse_files(
     paths: &[PathBuf],
     on_failure: impl Fn(&Path, &ParseError) -> FailureAction + Sync,
-) -> Result<Vec<ParsedFile>, ParseFailure> {
+) -> Result<Vec<Arc<ry_core::SourceFile>>, ParseFailure> {
     use rayon::prelude::*;
-    let outcomes: Vec<(Result<ParsedFile, ParseFailure>, FailureAction)> = paths
+    let outcomes: Vec<_> = paths
         .par_iter()
         .map(|path| {
             let outcome = parse_one(path);
@@ -126,7 +116,7 @@ pub(crate) fn parse_files(
 
 /// Read and parse one file on the calling thread, using that thread's
 /// parser from the pool (see [`parse_files`]).
-fn parse_one(path: &Path) -> Result<ParsedFile, ParseFailure> {
+fn parse_one(path: &Path) -> Result<Arc<ry_core::SourceFile>, ParseFailure> {
     thread_local! {
         static PARSER: std::cell::RefCell<Option<ry_core::RParser>> =
             const { std::cell::RefCell::new(None) };
@@ -147,17 +137,10 @@ fn parse_one(path: &Path) -> Result<ParsedFile, ParseFailure> {
             .get_or_insert_with(|| ry_core::RParser::new().expect("parser init (thread-local)"));
         parser.parse(&path_str, &src)
     });
-    match file {
-        Ok(file) => Ok(ParsedFile {
-            path: path_str,
-            src,
-            file,
-        }),
-        Err(message) => Err(ParseFailure {
-            path: path.to_path_buf(),
-            error: ParseError::Parse(message.to_string()),
-        }),
-    }
+    file.map(Arc::new).map_err(|message| ParseFailure {
+        path: path.to_path_buf(),
+        error: ParseError::Parse(message.to_string()),
+    })
 }
 
 /// Read an R source file, accepting both UTF-8 and Latin-1 encodings.
@@ -227,7 +210,7 @@ pub(crate) struct ResolvedGroup {
 /// differently: check summarizes them in its summary line, dump-types
 /// prints one note per scope on stderr to keep stdout's JSON clean.
 pub(crate) fn resolve_groups(
-    parsed: &[ParsedFile],
+    parsed: &[Arc<ry_core::SourceFile>],
     cfg: &config::Config,
     user_stubs: &Arc<BTreeMap<String, ry_typeshed::Typeshed>>,
     fallback_roots: &[Option<&Path>],
@@ -250,7 +233,10 @@ pub(crate) fn resolve_groups(
             &resolution_root,
             cfg,
             ry_workspace::ResolutionEnvironment {
-                files: indices.iter().map(|index| &parsed[*index].file).collect(),
+                files: indices
+                    .iter()
+                    .map(|index| parsed[*index].as_ref())
+                    .collect(),
                 user_stubs,
             },
         )
@@ -259,7 +245,7 @@ pub(crate) fn resolve_groups(
             .iter()
             .map(|index| {
                 let parsed_file = &parsed[*index];
-                (parsed_file.path.clone(), Arc::new(parsed_file.file.clone()))
+                (parsed_file.path.clone(), Arc::clone(parsed_file))
             })
             .collect();
         let degraded_scopes = std::mem::take(&mut package_scope.degraded_scopes);

--- a/crates/ry-typeshed/src/lib.rs
+++ b/crates/ry-typeshed/src/lib.rs
@@ -753,7 +753,7 @@ pub fn is_known_package(name: &str) -> bool {
 }
 
 /// Load stub files from a user-supplied directory. Both flat
-/// (`<dir>/<pkg>.json`) and nested (`<dir>/<pkg>/<pkg>.json`) layouts are
+/// (`<dir>/<pkg>.json`) and nested (`<dir>/<folder>/<pkg>.json`) layouts are
 /// accepted. The `package` header names the package; legacy files fall back
 /// to their file stem. A user package replaces an embedded package wholesale.
 pub fn load_stub_dir(dir: &Path) -> Result<BTreeMap<String, Typeshed>, TypeshedError> {
@@ -794,28 +794,21 @@ pub fn load_stub_dir_with_warnings(
 /// Discover the files accepted by [`load_stub_dir`], in both flat and
 /// nested layouts.
 fn discover_stub_files(dir: &Path) -> Result<Vec<PathBuf>, TypeshedError> {
-    let entries = std::fs::read_dir(dir).map_err(|source| TypeshedError::Io {
-        path: dir.to_path_buf(),
-        source,
-    })?;
+    let mut directories = vec![dir.to_path_buf()];
     let mut paths = Vec::new();
-    for entry in entries {
-        let entry = entry.map_err(|source| TypeshedError::Io {
-            path: dir.to_path_buf(),
+    while let Some(directory) = directories.pop() {
+        let io_error = |source| TypeshedError::Io {
+            path: directory.clone(),
             source,
-        })?;
-        let path = entry.path();
-        if path.extension().and_then(|value| value.to_str()) == Some("json") {
-            paths.push(path);
-            continue;
-        }
-        if path.is_dir() {
-            let Some(name) = path.file_name() else {
-                continue;
-            };
-            let nested = path.join(name).with_extension("json");
-            if nested.is_file() {
-                paths.push(nested);
+        };
+        for entry in std::fs::read_dir(&directory).map_err(io_error)? {
+            let path = entry.map_err(io_error)?.path();
+            if path.is_dir() {
+                if directory == dir {
+                    directories.push(path);
+                }
+            } else if path.extension().is_some_and(|ext| ext == "json") {
+                paths.push(path);
             }
         }
     }
@@ -1350,17 +1343,35 @@ mod tests {
     #[test]
     fn load_stub_dir_accepts_flat_and_nested_layouts() {
         let dir = tempfile::tempdir().unwrap();
-        std::fs::write(dir.path().join("flat.json"), fixture(Some("flat"), "one")).unwrap();
-        std::fs::create_dir(dir.path().join("nested")).unwrap();
-        std::fs::write(
-            dir.path().join("nested/nested.json"),
-            fixture(Some("nested"), "two"),
-        )
-        .unwrap();
+        let paths = [
+            "flat.json",
+            "nested/nested.json",
+            "rcpp/Rcpp.json",
+            "s7/S7.json",
+        ];
+        for path in paths {
+            let path = dir.path().join(path);
+            std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+            let package = path.file_stem().unwrap().to_str().unwrap();
+            std::fs::write(&path, fixture(Some(package), "one")).unwrap();
+        }
+        // Discovery stops after one directory level and ignores non-JSON files.
+        std::fs::create_dir_all(dir.path().join("nested/deeper")).unwrap();
+        std::fs::write(dir.path().join("nested/deeper/ignored.json"), "invalid").unwrap();
+        std::fs::write(dir.path().join("nested/README.md"), "not a stub").unwrap();
 
         let stubs = load_stub_dir(dir.path()).unwrap();
-        assert!(stubs["flat"].functions.contains_key("one"));
-        assert!(stubs["nested"].functions.contains_key("two"));
+        assert_eq!(stubs.len(), paths.len());
+        for package in ["flat", "nested", "Rcpp", "S7"] {
+            assert!(stubs[package].functions.contains_key("one"));
+        }
+        assert_eq!(
+            discover_stub_files(dir.path()).unwrap(),
+            paths.map(|p| dir.path().join(p))
+        );
+        let report = validate_stub_dirs(&[dir.path().to_path_buf()]);
+        assert_eq!(report.files, paths.len());
+        assert_eq!(report.error_count(), 0, "{report:?}");
     }
 
     #[test]

--- a/editors/zed/src/lib.rs
+++ b/editors/zed/src/lib.rs
@@ -34,26 +34,6 @@ struct GithubReleaseDetails {
     downloaded_binary_path: String,
 }
 
-/// Where `language_server_binary` obtains the `ry` binary from, in
-/// precedence order. Split out from the resolution flow so the precedence
-/// itself is unit-testable: the settings and PATH lookups are host calls
-/// (`LspSettings::for_worktree`, `Worktree::which`) that only answer
-/// inside a running Zed process.
-#[derive(Debug, PartialEq)]
-enum BinarySource {
-    /// Explicit `binary.path` from the user's language-server settings.
-    Settings(String),
-
-    /// `ry` found through the worktree's PATH lookup.
-    PathLookup(String),
-
-    /// A previously downloaded binary that is still on disk.
-    Cache(String),
-
-    /// No local candidate; download from the latest GitHub release.
-    Download,
-}
-
 impl RyExtension {
     fn language_server_binary(
         &mut self,
@@ -83,20 +63,15 @@ impl RyExtension {
             .as_deref()
             .filter(|path| Self::cached_binary_on_disk(path));
 
-        match Self::resolve_binary_source(
+        if let Some(path) = Self::resolve_binary_path(
             binary_settings.and_then(|binary_settings| binary_settings.path),
             worktree.which("ry"),
             cached_path,
         ) {
-            BinarySource::Settings(path)
-            | BinarySource::PathLookup(path)
-            | BinarySource::Cache(path) => {
-                return Ok(RyBinary {
-                    path,
-                    args: binary_args,
-                });
-            }
-            BinarySource::Download => {}
+            return Ok(RyBinary {
+                path,
+                args: binary_args,
+            });
         }
 
         // All local candidates failed; download the binary from the latest
@@ -230,25 +205,15 @@ impl GithubReleaseDetails {
 }
 
 impl RyExtension {
-    /// Resolve the binary source by precedence: the user-specified path,
-    /// then a PATH lookup, then a previous download, and only then a
-    /// fresh download. The caller offers the cached path as a candidate
-    /// only while the file is still on disk.
-    fn resolve_binary_source(
+    /// Prefer settings, then PATH, then an existing cached download.
+    fn resolve_binary_path(
         settings_path: Option<String>,
         path_lookup: Option<String>,
         cached_path: Option<&str>,
-    ) -> BinarySource {
-        if let Some(path) = settings_path {
-            return BinarySource::Settings(path);
-        }
-        if let Some(path) = path_lookup {
-            return BinarySource::PathLookup(path);
-        }
-        if let Some(path) = cached_path {
-            return BinarySource::Cache(path.to_string());
-        }
-        BinarySource::Download
+    ) -> Option<String> {
+        settings_path
+            .or(path_lookup)
+            .or_else(|| cached_path.map(str::to_owned))
     }
 
     /// Whether a cached download still exists as a regular file.
@@ -332,35 +297,31 @@ zed::register_extension!(RyExtension);
 
 #[cfg(test)]
 mod test {
-    use crate::{BinarySource, GithubReleaseDetails, RyExtension};
+    use crate::{GithubReleaseDetails, RyExtension};
 
-    /// Binary resolution precedence: the user-specified path, then a PATH
-    /// hit, then a previous download. Only when no candidate exists does
-    /// the extension fall back to a download.
     #[test]
-    fn binary_source_precedence() {
-        let cached = "ry-0.9.0/ry-cli-x86_64-unknown-linux-gnu/ry";
-
-        assert_eq!(
-            RyExtension::resolve_binary_source(
-                Some("/opt/ry".into()),
-                Some("/usr/bin/ry".into()),
-                Some(cached),
+    fn binary_path_precedence() {
+        for (settings, path, cache, expected) in [
+            (
+                Some("settings"),
+                Some("path"),
+                Some("cache"),
+                Some("settings"),
             ),
-            BinarySource::Settings("/opt/ry".into())
-        );
-        assert_eq!(
-            RyExtension::resolve_binary_source(None, Some("/usr/bin/ry".into()), Some(cached),),
-            BinarySource::PathLookup("/usr/bin/ry".into())
-        );
-        assert_eq!(
-            RyExtension::resolve_binary_source(None, None, Some(cached)),
-            BinarySource::Cache(cached.into())
-        );
-        assert_eq!(
-            RyExtension::resolve_binary_source(None, None, None),
-            BinarySource::Download
-        );
+            (None, Some("path"), Some("cache"), Some("path")),
+            (None, None, Some("cache"), Some("cache")),
+            (None, None, None, None),
+        ] {
+            assert_eq!(
+                RyExtension::resolve_binary_path(
+                    settings.map(str::to_owned),
+                    path.map(str::to_owned),
+                    cache
+                )
+                .as_deref(),
+                expected,
+            );
+        }
     }
 
     /// The cache candidate is offered only while the downloaded file is


### PR DESCRIPTION
Typeshed discovery assumed each nested JSON filename matched its directory, silently skipping `rcpp/Rcpp.json` and `s7/S7.json`. Discovery now reads JSON files at the root and one directory level below it, preserving sorted results. Both loading and validation have regression coverage; the sibling r-typeshed checkout now validates all 33 files instead of 31.

The cleanup also removes the CLI parsed-file wrapper and shares `Arc<SourceFile>` values across project groups, eliminating duplicate source storage and AST clones. The dump indexer delegates recursion to the shared walker, and Zed binary resolution returns an optional path instead of an enum whose source distinctions were discarded by the caller. Existing scope-indexing and binary-precedence behavior is preserved.

Net change: 54 fewer lines across six files, including tests and the changelog.

Validation:

- `cargo test --workspace`: 1,002 passed, 10 ignored.
- `cargo test -p ry-checker --test oracle -- --ignored`: passed with R installed.
- `cargo clippy --workspace --all-targets -- -D warnings`: passed.
- Workspace and Zed formatting checks: passed.
- `cargo test --locked --manifest-path editors/zed/Cargo.toml`: 3 passed.
- Sibling typeshed validation: 33 files, zero errors, three existing key-order warnings.
- `rustup run stable cargo build --locked --manifest-path editors/zed/Cargo.toml --target wasm32-wasip2`: passed with Rust 1.98.1.

Fixes #197.

The sibling CI workaround can be removed once its pinned ry consumer includes this fix. Separate editor correctness findings are tracked in #203 and #204.

