### PR TITLE
cleanup: remove inert editor settings and preserve config on reload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -165,11 +165,8 @@ suppression actions — and fixes a parser panic plus several editor issues.
 - **`enable` is honored per folder**: a workspace folder whose settings
   set `enable: false` is skipped: the language server publishes no
   diagnostics and returns no inlay hints for it. The setting was
-  accepted and ignored before. The server also stops modeling the five
-  settings it never read (`path`, `importStrategy`,
-  `addExecutableToTerminalPath`, `logLevel`, `checkTestFixtures`); the
-  editor extensions own those, and the server ignores unknown settings
-  keys either way.
+  accepted and ignored before. The server also stops modeling settings
+  it never read; unknown settings keys remain ignored.
 - **Less work per `if` during checking**: a condition that proves no type
   refinement skips the narrowing machinery, and merging branch bindings no
   longer copies the branch scopes. Diagnostics and inferred types are
@@ -245,6 +242,12 @@ suppression actions — and fixes a parser panic plus several editor issues.
   inferred types are unchanged.
 
 ### Fixed
+
+- Invalid config reloads retain the language server's last valid settings.
+  A missing explicit configuration path is also a load failure; removing an
+  automatically discovered `ry.toml` restores ancestor settings or defaults.
+- Removed the nonfunctional VS Code setting `ry.checkTestFixtures`. Set
+  `check-test-fixtures = true` in `ry.toml` to enable fixture checks.
 
 - Typeshed loading and validation now discover mixed-case nested filenames,
   including `rcpp/Rcpp.json` and `s7/S7.json`.

--- a/crates/ry-lsp/src/backend.rs
+++ b/crates/ry-lsp/src/backend.rs
@@ -1659,43 +1659,19 @@ fn load_stubs_from_config(
     Arc::new(merged)
 }
 
-/// Discover the effective `ry.toml` config for a folder. An editor
-/// `configuration` override is resolved relative to `folder_root` (unless
-/// absolute) and loaded directly, falling back to directory discovery on
-/// failure. Returns `Ok(default)` when no `ry.toml` is found, and `Err`
-/// only when discovery itself fails so callers can decide whether to
-/// retain a previous config. Disk I/O happens here — callers MUST run
-/// this outside the state lock.
+/// Load a folder's explicit configuration or discover its nearest `ry.toml`.
+/// Missing discovered configuration uses defaults; read and parse failures
+/// reach the caller so reloads can retain the last valid configuration.
+/// Callers must keep this disk I/O outside the state lock.
 fn discover_folder_config(
     folder_settings: &FolderSettings,
     folder_root: &std::path::Path,
 ) -> std::result::Result<ry_config::Config, ry_config::ConfigError> {
-    if let Some(config_rel) = &folder_settings.configuration {
-        let config_path = if PathBuf::from(config_rel).is_absolute() {
-            PathBuf::from(config_rel)
-        } else {
-            folder_root.join(config_rel)
-        };
-        match ry_config::Config::load_file(&config_path) {
-            Ok(cfg) => return Ok(cfg),
-            Err(error) => {
-                tracing::warn!(
-                    path = %config_path.display(),
-                    %error,
-                    "failed to load configuration override; falling back to discovery"
-                );
-                return Ok(ry_config::Config::discover(folder_root)
-                    .ok()
-                    .flatten()
-                    .map(|(_, c)| c)
-                    .unwrap_or_default());
-            }
-        }
+    if let Some(config_path) = &folder_settings.configuration {
+        return ry_config::Config::load_file(&folder_root.join(config_path));
     }
-    Ok(ry_config::Config::discover(folder_root)
-        .ok()
-        .flatten()
-        .map(|(_, c)| c)
+    Ok(ry_config::Config::discover(folder_root)?
+        .map(|(_, config)| config)
         .unwrap_or_default())
 }
 
@@ -1810,8 +1786,8 @@ fn build_folder_contexts(
 /// Rebuild a single folder's analysis context from disk.
 ///
 /// Each field is reloaded independently. On any sub-failure (config parse,
-/// baseline parse) the **last valid value for that field is retained** and a
-/// visible warning emitted — a corrupt reload never silently clears the
+/// baseline parse) the last valid value for that field is retained and the
+/// failure is logged — a corrupt reload never silently clears the
 /// baseline. `folder_settings`, `workspace_context`, and `project_cache`
 /// are not config-file-derived (they come from editor push / the background
 /// indexer / incremental checks respectively) and are carried over

--- a/crates/ry-lsp/src/settings.rs
+++ b/crates/ry-lsp/src/settings.rs
@@ -6,14 +6,9 @@
 //! support `workspace/configuration` pull) receive full per-folder
 //! settings, while VS Code can additionally use the pull mechanism.
 //!
-//! Only settings the server acts on are modeled. The editor owns the
-//! rest, in two groups. `path`, `importStrategy`, and `logLevel` are
-//! resolved by the VS Code extension (binary discovery in
-//! `common/binary.ts`, the `--log-level` launch argument in
-//! `common/server.ts`). `checkTestFixtures` is read and forwarded by
-//! the extension, but nothing applies it anywhere yet. Either way the
-//! server ignores unknown keys, so accepting them here would only
-//! pretend to honor them.
+//! Only settings the server acts on are modeled. The VS Code extension
+//! handles `path`, `importStrategy`, and `logLevel`; the server ignores
+//! unknown keys.
 
 use serde::{Deserialize, Serialize};
 

--- a/crates/ry-lsp/tests/configuration_refresh.rs
+++ b/crates/ry-lsp/tests/configuration_refresh.rs
@@ -39,8 +39,10 @@ where
 fn count_code(publish: &Value, code: &str) -> usize {
     publish["params"]["diagnostics"]
         .as_array()
-        .map(|diags| diags.iter().filter(|d| d["code"] == code).count())
-        .unwrap_or(0)
+        .expect("publishDiagnostics array")
+        .iter()
+        .filter(|diagnostic| diagnostic["code"] == code)
+        .count()
 }
 
 // ════════════════════════════════════════════════════════════════════════════
@@ -285,4 +287,94 @@ fn enable_false_skips_inlay_hints_for_the_folder() {
         drop(session);
         let _ = tokio::time::timeout(std::time::Duration::from_secs(3), server).await;
     })
+}
+
+#[test]
+fn config_reload_retains_valid_settings_on_failure() {
+    run(async {
+        for mode in ["discovered", "relative", "absolute"] {
+            let fixture = FixtureProject::empty().unwrap();
+            let config_name = if mode == "discovered" {
+                "ry.toml"
+            } else {
+                "config/ry.toml"
+            };
+            fixture.write_file("ry.toml", "").unwrap();
+            fixture
+                .write_file(config_name, "ignore = ['RY002']\n")
+                .unwrap();
+            let config_uri = file_uri(&fixture.path(config_name)).unwrap();
+            let source = "if (c(TRUE, FALSE)) print(1)\n";
+            fixture.write_file("main.R", source).unwrap();
+            let options = match mode {
+                "relative" => Some(json!({"settings": [{"configuration": config_name}]})),
+                "absolute" => {
+                    Some(json!({"settings": [{"configuration": fixture.path(config_name)}]}))
+                }
+                _ => None,
+            };
+            let (mut session, server) =
+                spawn_session(&[fixture.root()], json!({}), options.clone()).await;
+            let uri = file_uri(&fixture.path("main.R")).unwrap();
+            let mark = session.publication_mark();
+            session.open(&uri, 1, source).await.unwrap();
+            let initial = session
+                .published_diagnostics_after(&uri, mark)
+                .await
+                .unwrap();
+            assert_eq!(count_code(&initial, "RY002"), 0, "{mode}: {initial}");
+
+            let mut latest = initial;
+            // A missing discovered config removes its settings. A missing
+            // explicit override is a load failure and retains its settings.
+            for (content, expected) in [
+                (Some("ignore = ["), 0),
+                (None, usize::from(mode == "discovered")),
+                (Some("ignore = ['RY002']\n"), 0),
+                (Some(""), 1),
+            ] {
+                match content {
+                    Some(content) => {
+                        fixture.write_file(config_name, content).unwrap();
+                    }
+                    None => std::fs::remove_file(fixture.path(config_name)).unwrap(),
+                }
+                harness::sync_barrier(&mut session, &uri).await;
+                let mark = session.publication_mark();
+                session.notify("workspace/didChangeWatchedFiles", json!({
+                    "changes": [{"uri": config_uri, "type": if content.is_some() { 2 } else { 3 }}]
+                })).await.unwrap();
+                let after = session
+                    .published_diagnostics_after(&uri, mark)
+                    .await
+                    .unwrap();
+                assert_eq!(
+                    count_code(&after, "RY002"),
+                    expected,
+                    "{mode}, {content:?}: {after}"
+                );
+                latest = after;
+            }
+            harness::join_session(session, server).await;
+
+            // A cold server has no previous config to retain. Failed explicit
+            // overrides use defaults, even if a different ry.toml is valid.
+            for content in ["", "ignore = ["] {
+                fixture
+                    .write_file("ry.toml", "ignore = ['RY002']\n")
+                    .unwrap();
+                fixture.write_file(config_name, content).unwrap();
+                let (mut cold, server) =
+                    spawn_session(&[fixture.root()], json!({}), options.clone()).await;
+                let mark = cold.publication_mark();
+                cold.open(&uri, 1, source).await.unwrap();
+                let publish = cold.published_diagnostics_after(&uri, mark).await.unwrap();
+                assert_eq!(
+                    publish["params"]["diagnostics"], latest["params"]["diagnostics"],
+                    "{mode}, {content:?}: cold config"
+                );
+                harness::join_session(cold, server).await;
+            }
+        }
+    });
 }

--- a/crates/ry-lsp/tests/configuration_refresh.rs
+++ b/crates/ry-lsp/tests/configuration_refresh.rs
@@ -292,20 +292,35 @@ fn enable_false_skips_inlay_hints_for_the_folder() {
 #[test]
 fn config_reload_retains_valid_settings_on_failure() {
     run(async {
-        for mode in ["discovered", "relative", "absolute"] {
+        for mode in ["discovered", "relative", "absolute", "ancestor"] {
             let fixture = FixtureProject::empty().unwrap();
-            let config_name = if mode == "discovered" {
-                "ry.toml"
-            } else {
-                "config/ry.toml"
+            let config_name = match mode {
+                "discovered" => "ry.toml",
+                "ancestor" => "nested/ry.toml",
+                _ => "config/ry.toml",
             };
-            fixture.write_file("ry.toml", "").unwrap();
+            let workspace_root = fixture.path(if mode == "ancestor" { "nested" } else { "" });
+            fixture
+                .write_file(
+                    "ry.toml",
+                    if mode == "ancestor" {
+                        "error = ['RY002']\n"
+                    } else {
+                        ""
+                    },
+                )
+                .unwrap();
             fixture
                 .write_file(config_name, "ignore = ['RY002']\n")
                 .unwrap();
             let config_uri = file_uri(&fixture.path(config_name)).unwrap();
             let source = "if (c(TRUE, FALSE)) print(1)\n";
-            fixture.write_file("main.R", source).unwrap();
+            let source_name = if mode == "ancestor" {
+                "nested/main.R"
+            } else {
+                "main.R"
+            };
+            fixture.write_file(source_name, source).unwrap();
             let options = match mode {
                 "relative" => Some(json!({"settings": [{"configuration": config_name}]})),
                 "absolute" => {
@@ -314,8 +329,8 @@ fn config_reload_retains_valid_settings_on_failure() {
                 _ => None,
             };
             let (mut session, server) =
-                spawn_session(&[fixture.root()], json!({}), options.clone()).await;
-            let uri = file_uri(&fixture.path("main.R")).unwrap();
+                spawn_session(&[&workspace_root], json!({}), options.clone()).await;
+            let uri = file_uri(&fixture.path(source_name)).unwrap();
             let mark = session.publication_mark();
             session.open(&uri, 1, source).await.unwrap();
             let initial = session
@@ -325,11 +340,11 @@ fn config_reload_retains_valid_settings_on_failure() {
             assert_eq!(count_code(&initial, "RY002"), 0, "{mode}: {initial}");
 
             let mut latest = initial;
-            // A missing discovered config removes its settings. A missing
-            // explicit override is a load failure and retains its settings.
+            // A missing discovered config restores ancestor settings or defaults.
+            // A missing explicit override is a load failure and retains its settings.
             for (content, expected) in [
                 (Some("ignore = ["), 0),
-                (None, usize::from(mode == "discovered")),
+                (None, usize::from(matches!(mode, "discovered" | "ancestor"))),
                 (Some("ignore = ['RY002']\n"), 0),
                 (Some(""), 1),
             ] {
@@ -353,6 +368,19 @@ fn config_reload_retains_valid_settings_on_failure() {
                     expected,
                     "{mode}, {content:?}: {after}"
                 );
+                if mode == "ancestor" && content.is_none() {
+                    // The ancestor promotes RY002 to an error; defaults only warn.
+                    let diagnostic = after["params"]["diagnostics"]
+                        .as_array()
+                        .unwrap()
+                        .iter()
+                        .find(|diagnostic| diagnostic["code"] == "RY002")
+                        .unwrap();
+                    assert_eq!(
+                        diagnostic["severity"], 1,
+                        "ancestor config must apply: {after}"
+                    );
+                }
                 latest = after;
             }
             harness::join_session(session, server).await;
@@ -365,7 +393,7 @@ fn config_reload_retains_valid_settings_on_failure() {
                     .unwrap();
                 fixture.write_file(config_name, content).unwrap();
                 let (mut cold, server) =
-                    spawn_session(&[fixture.root()], json!({}), options.clone()).await;
+                    spawn_session(&[&workspace_root], json!({}), options.clone()).await;
                 let mark = cold.publication_mark();
                 cold.open(&uri, 1, source).await.unwrap();
                 let publish = cold.published_diagnostics_after(&uri, mark).await.unwrap();

--- a/editors/code/.vscodeignore
+++ b/editors/code/.vscodeignore
@@ -9,7 +9,9 @@ testFixture/**
 
 # Build tooling and configs are not needed at runtime.
 esbuild.js
-tsconfig.json
+eslint.config.mjs
+.vscode-test.js
+tsconfig*.json
 justfile
 .gitignore
 bun.lock

--- a/editors/code/README.md
+++ b/editors/code/README.md
@@ -36,8 +36,10 @@ Install from Open VSX via Positron's extension gallery.
 | `ry.lint.warn`         | `[]`              | Rules to treat as warnings                                      |
 | `ry.minConfidence`     | `low`             | Minimum confidence (`low`, `medium`, `high`)                    |
 | `ry.baseline`          |                   | Path to a baseline diagnostics file                             |
-| `ry.checkTestFixtures` | `false`           | Check fixture data under `tests/`                               |
 | `ry.logLevel`          | `warn`            | Server log level                                                |
+
+To check fixture data under `tests/`, set `check-test-fixtures = true` in
+your project’s `ry.toml`.
 
 ## Commands
 

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -179,12 +179,6 @@
           "scope": "resource",
           "type": "string"
         },
-        "ry.checkTestFixtures": {
-          "default": false,
-          "markdownDescription": "Check R fixture data nested under a package's `tests/` tree.",
-          "scope": "resource",
-          "type": "boolean"
-        },
         "ry.logLevel": {
           "default": "warn",
           "enum": [

--- a/editors/code/src/common/settings.ts
+++ b/editors/code/src/common/settings.ts
@@ -17,7 +17,6 @@ export interface ISettings {
   lint: ILintSettings;
   minConfidence?: "low" | "medium" | "high";
   baseline?: string;
-  checkTestFixtures?: boolean;
   logLevel?: string;
 }
 
@@ -53,31 +52,14 @@ export function getWorkspaceSettings(
   namespace: string,
   folder: vscode.WorkspaceFolder,
 ): ISettings {
-  const config = getConfiguration(namespace, folder.uri);
-  return {
-    enable: config.get<boolean>("enable"),
-    path: config.get<string[]>("path"),
-    configuration: config.get<string>("configuration"),
-    importStrategy: config.get<"fromEnvironment" | "useBundled">(
-      "importStrategy",
-      "fromEnvironment",
-    ),
-    lint: {
-      select: getExplicitValue<string[]>(config, "lint.select"),
-      extendSelect: getExplicitValue<string[]>(config, "lint.extendSelect"),
-      ignore: getExplicitValue<string[]>(config, "lint.ignore"),
-      error: getExplicitValue<string[]>(config, "lint.error"),
-      warn: getExplicitValue<string[]>(config, "lint.warn"),
-    },
-    minConfidence: config.get<"low" | "medium" | "high">("minConfidence"),
-    baseline: config.get<string>("baseline"),
-    checkTestFixtures: config.get<boolean>("checkTestFixtures"),
-    logLevel: config.get<string>("logLevel"),
-  };
+  return readSettings(getConfiguration(namespace, folder.uri));
 }
 
 export function getGlobalSettings(namespace: string): ISettings {
-  const config = getConfiguration(namespace);
+  return readSettings(getConfiguration(namespace));
+}
+
+function readSettings(config: vscode.WorkspaceConfiguration): ISettings {
   return {
     enable: config.get<boolean>("enable"),
     path: config.get<string[]>("path"),
@@ -95,7 +77,6 @@ export function getGlobalSettings(namespace: string): ISettings {
     },
     minConfidence: config.get<"low" | "medium" | "high">("minConfidence"),
     baseline: config.get<string>("baseline"),
-    checkTestFixtures: config.get<boolean>("checkTestFixtures"),
     logLevel: config.get<string>("logLevel"),
   };
 }


### PR DESCRIPTION
A malformed ry.toml reload silently replaced the language server's last valid config with defaults. The loader swallowed errors before the existing retention branch could handle them. Removing those fallbacks lets reloads retain valid settings and log the failure. Missing discovered configuration still falls back to ancestors or defaults; a missing explicit override is an error. At startup, where no previous config exists, failures use defaults rather than silently choosing a different config file.

The extension also advertised `ry.checkTestFixtures` without applying it. Remove that setting and its forwarding, document the working `check-test-fixtures` option in ry.toml, and consolidate the identical global/folder settings readers. Exclude three test/build configuration files that were unnecessarily included in the VSIX.

The regression test reproduced the config-loss bug before the fix. It exercises discovered, relative, absolute, and nested workspace config paths through real LSP notifications: corruption, deletion, repair, valid replacement, and cold-start behavior. Failed reloads preserve RY002 suppression; valid replacements converge to the cold server's full diagnostics. The nested case deletes a nearer config and requires the ancestor's RY002 error severity, distinguishing inherited settings from default warnings. A mutation that skips ancestor discovery fails this assertion.

Validation:

- `cargo test --workspace`: 1,003 passed, 10 ignored; final configuration-refresh suite also passed after strengthening the cold-start assertions.
- Full ignored R oracle suite, Clippy with warnings denied, and Rust formatting checks passed.
- Extension TypeScript check, build, and full Prettier check passed.
- Packaged a VSIX with `--no-dependencies` and installed it into an isolated VS Code profile. Verified the inert setting is absent from the installed manifest, README, and bundle, and the three build/test files are excluded. This checks package contents, not a GUI diagnostic session.

47 fewer lines outside tests; the new protocol coverage makes the total diff 73 lines larger.

Fixes #203. Fixes #204.

Custom configuration filenames such as team.toml are not watched for changes; that separate watcher-lifecycle gap is tracked in #206. The reload tests here use ry.toml basenames that the current watchers recognize.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Invalid configuration reloads now retain the last valid settings.
  - Missing configuration files are handled consistently, including discovered and explicitly specified files.
  - Removing an automatically discovered configuration restores ancestor settings or defaults.

- **Configuration**
  - The VS Code `ry.checkTestFixtures` setting has been removed.
  - Enable fixture checking with `check-test-fixtures = true` in `ry.toml`.
  - Unknown configuration keys are now ignored by the language server.

- **Documentation**
  - Updated language-server and extension configuration documentation to reflect these changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
