### PR TITLE
Consolidate typeshed semantic validation in the consumer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -243,6 +243,11 @@ suppression actions — and fixes a parser panic plus several editor issues.
 
 ### Fixed
 
+- Typeshed validation rejects empty recycled-value parameter sets, mismatched
+  callback names and positions, and unsupported conditional-scope values.
+  Return-length rules also reject unknown or misplaced control fields.
+  Update the vendored stubs with the existing purrr callback corrections.
+
 - Invalid config reloads retain the language server's last valid settings.
   A missing explicit configuration path is also a load failure; removing an
   automatically discovered `ry.toml` restores ancestor settings or defaults.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -246,7 +246,10 @@ suppression actions — and fixes a parser panic plus several editor issues.
 - Typeshed validation rejects empty recycled-value parameter sets, mismatched
   callback names and positions, and unsupported conditional-scope values.
   Return-length rules also reject unknown or misplaced control fields.
-  Update the vendored stubs with the existing purrr callback corrections.
+  Custom stubs with missing required controls or unknown return-length fields
+  now fail to load; schema 2's documented control shapes remain unchanged.
+  Update purrr stubs with corrected callback positions and `walk2` callback
+  arguments, plus missing control parameters used in argument matching.
 
 - Invalid config reloads retain the language server's last valid settings.
   A missing explicit configuration path is also a load failure; removing an

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -246,6 +246,9 @@ suppression actions — and fixes a parser panic plus several editor issues.
 - Typeshed validation rejects empty recycled-value parameter sets, mismatched
   callback names and positions, and unsupported conditional-scope values.
   Return-length rules also reject unknown or misplaced control fields.
+  Higher-order result indices (`length_arg`, `source_arg`,
+  `template_position`) must identify a formal parameter, so custom stubs with
+  out-of-range indices that previously loaded silently now fail validation.
   Custom stubs with missing required controls or unknown return-length fields
   now fail to load; schema 2's documented control shapes remain unchanged.
   Update purrr stubs with corrected callback positions and `walk2` callback

--- a/crates/ry-typeshed/src/lib.rs
+++ b/crates/ry-typeshed/src/lib.rs
@@ -94,7 +94,7 @@ pub enum DefaultCurrentScope {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
-#[serde(tag = "kind", rename_all = "snake_case")]
+#[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
 pub enum ReturnLengthSpec {
     /// An exact zero fact only: all nonzero outcomes remain unknown.
     ZeroIfAnyParamZero {
@@ -109,19 +109,24 @@ pub struct RecycledValuesLengthSpec {
     pub value_params: Vec<String>,
     pub control_params: Vec<String>,
     pub all_values_zero: String,
-    pub collapse: RecycledLengthControl,
-    pub recycle0: RecycledLengthControl,
+    pub collapse: CollapseLengthControl,
+    pub recycle0: RecycleZeroLengthControl,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
-pub struct RecycledLengthControl {
+pub struct CollapseLengthControl {
     pub param: String,
     pub when: String,
-    #[serde(default)]
-    pub length: Option<String>,
-    #[serde(default)]
-    pub any_value_zero: Option<String>,
+    pub length: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct RecycleZeroLengthControl {
+    pub param: String,
+    pub when: String,
+    pub any_value_zero: String,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
@@ -1045,6 +1050,22 @@ fn validate_function_semantics(
             );
         }
     };
+    if let Some(higher_order) = &signature.higher_order
+        && signature
+            .params
+            .get(higher_order.callback_position)
+            .map(|param| &param.name)
+            != Some(&higher_order.callback_param)
+    {
+        validation_error(
+            report,
+            path,
+            format!(
+                "{location}.higher_order.callback_position: must identify callback_param `{}`",
+                higher_order.callback_param
+            ),
+        );
+    }
     if let Some(predicate) = &signature.predicate {
         validate_param(report, "predicate.subject_param", &predicate.subject_param);
         validate_rtype(
@@ -1092,6 +1113,15 @@ fn validate_function_semantics(
         }
     }
     if let Some(effect) = &signature.conditional_scope_effect {
+        if !effect.current_scope_when.equals {
+            validation_error(
+                report,
+                path,
+                format!(
+                    "{location}.conditional_scope_effect.current_scope_when.equals: must be true"
+                ),
+            );
+        }
         validate_param(
             report,
             "conditional_scope_effect.current_scope_when.param",
@@ -1099,14 +1129,15 @@ fn validate_function_semantics(
         );
     }
     if let Some(length) = &signature.return_length {
+        let repeated = |params: &[String]| {
+            params
+                .iter()
+                .enumerate()
+                .any(|(index, param)| params[..index].contains(param))
+        };
         match length {
             ReturnLengthSpec::ZeroIfAnyParamZero { params } => {
-                if params.len() < 2
-                    || params
-                        .iter()
-                        .enumerate()
-                        .any(|(index, param)| params[..index].contains(param))
-                {
+                if params.len() < 2 || repeated(params) {
                     validation_error(
                         report,
                         path,
@@ -1118,15 +1149,16 @@ fn validate_function_semantics(
                 }
             }
             ReturnLengthSpec::RecycledValues(spec) => {
+                if spec.value_params.is_empty() {
+                    validation_error(
+                        report,
+                        path,
+                        format!("{location}.return_length.value_params: must not be empty"),
+                    );
+                }
                 for param in spec.value_params.iter().chain(&spec.control_params) {
                     validate_param(report, "return_length parameter", param);
                 }
-                let repeated = |params: &[String]| {
-                    params
-                        .iter()
-                        .enumerate()
-                        .any(|(index, param)| params[..index].contains(param))
-                };
                 if repeated(&spec.value_params)
                     || repeated(&spec.control_params)
                     || spec
@@ -1157,9 +1189,9 @@ fn validate_function_semantics(
                 }
                 if spec.all_values_zero != "zero"
                     || spec.collapse.when != "non_null"
-                    || spec.collapse.length.as_deref() != Some("1")
+                    || spec.collapse.length != "1"
                     || spec.recycle0.when != "true"
-                    || spec.recycle0.any_value_zero.as_deref() != Some("zero")
+                    || spec.recycle0.any_value_zero != "zero"
                 {
                     validation_error(
                         report,
@@ -1432,47 +1464,109 @@ mod tests {
     }
 
     #[test]
-    fn recycled_values_controls_and_exact_zero_parameters_are_validated() {
-        let dir = tempfile::tempdir().unwrap();
-        std::fs::write(
-            dir.path().join("fixture.json"),
-            r#"{"schema_version":"2","package":"fixture","version":"test","functions":{"zero":{"params":["a","b"],"return":{"mode":"logical","length":"unknown"},"return_length":{"kind":"zero_if_any_param_zero","params":["a","b","a"]}},"recycled":{"params":["x","collapse"],"return":{"mode":"character","length":"unknown"},"return_length":{"kind":"recycled_values","value_params":["x"],"control_params":[],"all_values_zero":"zero","collapse":{"param":"collapse","when":"non_null","length":"1"},"recycle0":{"param":"collapse","when":"true","any_value_zero":"zero"}}}}}"#,
-        )
-        .unwrap();
-        let report = validate_stub_dirs(&[dir.path().to_path_buf()]);
-        assert_eq!(report.error_count(), 3, "{report:?}");
-        assert!(
-            report
-                .problems
-                .iter()
-                .any(|problem| problem.message.contains("distinct parameters"))
-        );
-        assert_eq!(
-            report
-                .problems
-                .iter()
-                .filter(|problem| problem.message.contains("must declare a control parameter"))
-                .count(),
-            2
-        );
-    }
-
-    #[test]
-    fn invalid_assertion_provenance_is_reported_without_discarding_schema_two() {
+    fn function_semantics_contracts_are_validated() {
+        use serde_json::json;
+        let valid: serde_json::Value =
+            serde_json::from_str(include_str!("../testdata/function-semantics.json")).unwrap();
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("fixture.json");
-        std::fs::write(
-            &path,
-            r#"{"schema_version":"2","package":"fixture","version":"test","functions":{"check":{"params":["x","arg"],"return":{"mode":"null","length":"0"},"assertion":{"subject_param":"x","target":{"mode":"character","length":"1"},"provenance":{"kind":"standalone_types_check","fingerprint_params":["arg","call"]}}}}}"#,
-        )
-        .unwrap();
-        let report = validate_stub_dirs(&[dir.path().to_path_buf()]);
-        assert_eq!(report.error_count(), 1);
-        assert!(
-            report.problems[0]
-                .message
-                .contains("unknown parameter `call`")
-        );
+        let validate = |value: &serde_json::Value| {
+            std::fs::write(&path, serde_json::to_string(value).unwrap()).unwrap();
+            validate_stub_dirs(&[dir.path().to_path_buf()])
+        };
+        let report = validate(&valid);
+        assert_eq!(report.error_count(), 0, "{report:?}");
+        assert_eq!(report.files, 1);
+
+        for (pointer, value, message) in [
+            (
+                "/functions/check_string/params",
+                json!(["x", "allow_null", "allow_na", "arg"]),
+                "unknown parameter `call`",
+            ),
+            (
+                "/functions/recycle/return_length/control_params",
+                json!(["recycle0"]),
+                "collapse.param: must declare a control parameter",
+            ),
+            (
+                "/functions/recycle/return_length/control_params",
+                json!(["collapse"]),
+                "recycle0.param: must declare a control parameter",
+            ),
+            (
+                "/functions/intersect_like/return_length/params",
+                json!(["x", "y", "x"]),
+                "require distinct parameters",
+            ),
+            (
+                "/functions/recycle/return_length/value_params",
+                json!([]),
+                "must not be empty",
+            ),
+            (
+                "/functions/recycle/return_length/value_params",
+                json!(["...", "..."]),
+                "disjoint and unique",
+            ),
+            (
+                "/functions/recycle/return_length/control_params",
+                json!(["collapse", "recycle0", "collapse"]),
+                "disjoint and unique",
+            ),
+            (
+                "/functions/recycle/return_length/value_params",
+                json!(["collapse"]),
+                "disjoint and unique",
+            ),
+            (
+                "/functions/source_like/conditional_scope_effect/current_scope_when/equals",
+                json!(false),
+                "must be true",
+            ),
+            (
+                "/functions/apply/higher_order/callback_position",
+                json!(2),
+                "callback_position",
+            ),
+            (
+                "/functions/apply/higher_order/callback_position",
+                json!(0),
+                "callback_position",
+            ),
+            (
+                "/functions/apply/higher_order/callback_param",
+                json!("missing"),
+                "callback_position",
+            ),
+            (
+                "/functions/intersect_like/return_length",
+                json!({"kind":"zero_if_any_param_zero", "params":["x","y"], "extra":true}),
+                "unknown field",
+            ),
+            (
+                "/functions/recycle/return_length/collapse",
+                json!({"param":"collapse", "when":"non_null", "length":"1", "any_value_zero":null}),
+                "unknown field",
+            ),
+            (
+                "/functions/recycle/return_length/recycle0",
+                json!({"param":"recycle0", "when":"true", "any_value_zero":"zero", "length":null}),
+                "unknown field",
+            ),
+        ] {
+            let mut invalid = valid.clone();
+            *invalid.pointer_mut(pointer).unwrap() = value;
+            let report = validate(&invalid);
+            assert!(
+                report
+                    .problems
+                    .iter()
+                    .any(|problem| problem.level == ValidationLevel::Error
+                        && problem.message.contains(message)),
+                "{pointer}: expected {message}: {report:?}"
+            );
+        }
     }
 
     #[test]

--- a/crates/ry-typeshed/src/lib.rs
+++ b/crates/ry-typeshed/src/lib.rs
@@ -1031,6 +1031,23 @@ fn validate_signature(
             format!("{location}.higher_order.result.mode: invalid mode `{mode}`"),
         );
     }
+    if let Some(higher_order) = &signature.higher_order {
+        for (field, index) in [
+            ("length_arg", higher_order.result.length_arg),
+            ("source_arg", higher_order.result.source_arg),
+            ("template_position", higher_order.result.template_position),
+        ] {
+            if index.is_some_and(|index| index >= signature.params.len()) {
+                validation_error(
+                    report,
+                    path,
+                    format!(
+                        "{location}.higher_order.result.{field}: must identify a formal parameter"
+                    ),
+                );
+            }
+        }
+    }
     validate_function_semantics(report, path, location, signature);
 }
 
@@ -1113,12 +1130,14 @@ fn validate_function_semantics(
         }
     }
     if let Some(effect) = &signature.conditional_scope_effect {
+        // Schema 2 restricts this rule to a true trigger, even though the checker
+        // can compare either boolean. Keep producers within the documented contract.
         if !effect.current_scope_when.equals {
             validation_error(
                 report,
                 path,
                 format!(
-                    "{location}.conditional_scope_effect.current_scope_when.equals: must be true"
+                    "{location}.conditional_scope_effect.current_scope_when.equals: only `equals: true` is supported"
                 ),
             );
         }
@@ -1129,7 +1148,7 @@ fn validate_function_semantics(
         );
     }
     if let Some(length) = &signature.return_length {
-        let repeated = |params: &[String]| {
+        let has_duplicates = |params: &[String]| {
             params
                 .iter()
                 .enumerate()
@@ -1137,11 +1156,13 @@ fn validate_function_semantics(
         };
         match length {
             ReturnLengthSpec::ZeroIfAnyParamZero { params } => {
-                if params.len() < 2 || repeated(params) {
+                if params.len() < 2 || has_duplicates(params) {
                     validation_error(
                         report,
                         path,
-                        format!("{location}.return_length.params: require distinct parameters"),
+                        format!(
+                            "{location}.return_length.params: require at least two distinct parameters"
+                        ),
                     );
                 }
                 for param in params {
@@ -1157,10 +1178,10 @@ fn validate_function_semantics(
                     );
                 }
                 for param in spec.value_params.iter().chain(&spec.control_params) {
-                    validate_param(report, "return_length parameter", param);
+                    validate_param(report, "return_length.params", param);
                 }
-                if repeated(&spec.value_params)
-                    || repeated(&spec.control_params)
+                if has_duplicates(&spec.value_params)
+                    || has_duplicates(&spec.control_params)
                     || spec
                         .value_params
                         .iter()
@@ -1480,6 +1501,61 @@ mod tests {
 
         for (pointer, value, message) in [
             (
+                "/functions/recycle/return_length/all_values_zero",
+                json!("unsupported"),
+                "unsupported recycled-values rule",
+            ),
+            (
+                "/functions/recycle/return_length/collapse/when",
+                json!("unsupported"),
+                "unsupported recycled-values rule",
+            ),
+            (
+                "/functions/recycle/return_length/collapse/length",
+                json!("unsupported"),
+                "unsupported recycled-values rule",
+            ),
+            (
+                "/functions/recycle/return_length/recycle0/when",
+                json!("unsupported"),
+                "unsupported recycled-values rule",
+            ),
+            (
+                "/functions/recycle/return_length/recycle0/any_value_zero",
+                json!("unsupported"),
+                "unsupported recycled-values rule",
+            ),
+            (
+                "/functions/intersect_like/return_length/params",
+                json!(["x"]),
+                "require at least two distinct parameters",
+            ),
+            (
+                "/functions/check_string/assertion/provenance/fingerprint_params",
+                json!(["call", "arg"]),
+                "unsupported provenance",
+            ),
+            (
+                "/functions/check_string/assertion/provenance/kind",
+                json!("unsupported"),
+                "unknown variant",
+            ),
+            (
+                "/functions/apply/higher_order/result",
+                json!({"kind":"list_of_callback_return", "length_arg":99}),
+                "result.length_arg: must identify a formal parameter",
+            ),
+            (
+                "/functions/apply/higher_order/result",
+                json!({"kind":"list_of_callback_return", "source_arg":99}),
+                "result.source_arg: must identify a formal parameter",
+            ),
+            (
+                "/functions/apply/higher_order/result",
+                json!({"kind":"list_of_callback_return", "template_position":99}),
+                "result.template_position: must identify a formal parameter",
+            ),
+            (
                 "/functions/check_string/params",
                 json!(["x", "allow_null", "allow_na", "arg"]),
                 "unknown parameter `call`",
@@ -1497,7 +1573,7 @@ mod tests {
             (
                 "/functions/intersect_like/return_length/params",
                 json!(["x", "y", "x"]),
-                "require distinct parameters",
+                "require at least two distinct parameters",
             ),
             (
                 "/functions/recycle/return_length/value_params",
@@ -1522,7 +1598,7 @@ mod tests {
             (
                 "/functions/source_like/conditional_scope_effect/current_scope_when/equals",
                 json!(false),
-                "must be true",
+                "only `equals: true` is supported",
             ),
             (
                 "/functions/apply/higher_order/callback_position",
@@ -1590,6 +1666,9 @@ mod tests {
 
     #[test]
     fn every_known_package_loads() {
+        let report = validate_stub_dirs(&[Path::new(env!("CARGO_MANIFEST_DIR")).join("vendor")]);
+        assert_eq!(report.error_count(), 0, "{report:?}");
+        assert!(report.files > 0, "vendored stubs must be discovered");
         for name in known_packages() {
             assert!(load_package(name).is_some(), "{name} must load");
         }

--- a/crates/ry-typeshed/testdata/function-semantics.json
+++ b/crates/ry-typeshed/testdata/function-semantics.json
@@ -1,0 +1,57 @@
+{
+  "schema_version": "2",
+  "package": "fixture",
+  "version": "test",
+  "functions": {
+    "apply": {
+      "params": ["x", "f"],
+      "return": {"mode": "list", "length": "unknown"},
+      "higher_order": {"callback_param": "f", "callback_position": 1, "callback_args": ["element_of_arg0"], "result": {"kind": "list_of_callback_return"}}
+    },
+    "predicate": {
+      "params": [{"name": "x", "required": true}],
+      "return": {"mode": "logical", "length": "1", "na": false},
+      "predicate": {"subject_param": "x", "target": {"mode": "null", "length": "0", "na": false}}
+    },
+    "check_string": {
+      "params": ["x", "allow_null", "allow_na", "arg", "call"],
+      "return": {"mode": "null", "length": "0", "na": false},
+      "assertion": {
+        "subject_param": "x",
+        "target": {"mode": "character", "length": "1", "na": false},
+        "allow_null_param": "allow_null",
+        "allow_na_param": "allow_na",
+        "provenance": {"kind": "standalone_types_check", "fingerprint_params": ["arg", "call"]}
+      }
+    },
+    "intersect_like": {
+      "params": ["x", "y"],
+      "return": {"mode": "opaque", "length": "unknown", "na": true},
+      "return_length": {
+        "kind": "zero_if_any_param_zero",
+        "params": ["x", "y"]
+      }
+    },
+    "recycle": {
+      "params": ["...", "collapse", "recycle0"],
+      "return": {"mode": "character", "length": "longest_arg", "na": true},
+      "return_length": {
+        "kind": "recycled_values",
+        "value_params": ["..."],
+        "control_params": ["collapse", "recycle0"],
+        "all_values_zero": "zero",
+        "collapse": {"param": "collapse", "when": "non_null", "length": "1"},
+        "recycle0": {"param": "recycle0", "when": "true", "any_value_zero": "zero"}
+      }
+    },
+    "source_like": {
+      "params": ["local"],
+      "return": {"mode": "opaque", "length": "unknown", "na": false},
+      "conditional_scope_effect": {
+        "effect": "unknown_bindings",
+        "current_scope_when": {"param": "local", "equals": true},
+        "default_current_scope": "top_level"
+      }
+    }
+  }
+}

--- a/crates/ry-typeshed/vendor/SOURCE
+++ b/crates/ry-typeshed/vendor/SOURCE
@@ -1,4 +1,4 @@
 repository: https://github.com/sims1253/r-typeshed
-commit: 17e71dc317c76481703b3f7ce4cd72e09130b3f3
+commit: 6911905744ab0d1337cd157995fcc68dbd7ceb8f
 tree-state: clean
-stubs-sha256: 4689b338a07d2710a2840c79060c1a672ea31fc1f1d459e342b175e978130b13
+stubs-sha256: f3c366677c5fac49342e73dcf4d5e4b64484ce252b72b6cdd0174ea6809f806f

--- a/crates/ry-typeshed/vendor/purrr/purrr.json
+++ b/crates/ry-typeshed/vendor/purrr/purrr.json
@@ -1,13 +1,17 @@
 {
   "schema_version": "2",
   "package": "purrr",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "functions": {
     "accumulate": {
       "params": [
         ".x",
         ".f",
-        "..."
+        "...",
+        ".init",
+        ".dir",
+        ".simplify",
+        ".ptype"
       ],
       "higher_order": {"callback_param": ".f", "callback_position": 1, "callback_args": ["accumulator_and_element"], "result": {"kind": "callback_return"}},
       "return": {
@@ -164,7 +168,8 @@
     },
     "in_parallel": {
       "params": [
-        ".f"
+        ".f",
+        "..."
       ],
       "higher_order": {"callback_param": ".f", "callback_position": 0, "callback_args": [], "result": {"kind": "callback_identity"}},
       "return": {
@@ -211,7 +216,8 @@
       "params": [
         ".x",
         ".f",
-        "..."
+        "...",
+        ".progress"
       ],
       "higher_order": {"callback_param": ".f", "callback_position": 1, "callback_args": ["element_of_arg0"], "result": {"kind": "list_of_callback_return", "length_arg": 0, "include_callback_schema": true}},
       "return": {
@@ -225,7 +231,8 @@
         ".x",
         ".y",
         ".f",
-        "..."
+        "...",
+        ".progress"
       ],
       "higher_order": {"callback_param": ".f", "callback_position": 2, "callback_args": ["element_of_arg0", "element_of_arg1"], "result": {"kind": "list_of_callback_return", "include_callback_schema": true}},
       "return": {
@@ -239,7 +246,8 @@
         ".x",
         ".y",
         ".f",
-        "..."
+        "...",
+        ".progress"
       ],
       "higher_order": {"callback_param": ".f", "callback_position": 2, "callback_args": ["element_of_arg0", "element_of_arg1"], "result": {"kind": "list_of_callback_return", "include_callback_schema": true}},
       "return": {
@@ -253,7 +261,8 @@
         ".x",
         ".y",
         ".f",
-        "..."
+        "...",
+        ".progress"
       ],
       "higher_order": {"callback_param": ".f", "callback_position": 2, "callback_args": ["element_of_arg0", "element_of_arg1"], "result": {"kind": "list_of_callback_return", "include_callback_schema": true}},
       "return": {
@@ -267,7 +276,8 @@
         ".x",
         ".y",
         ".f",
-        "..."
+        "...",
+        ".progress"
       ],
       "higher_order": {"callback_param": ".f", "callback_position": 2, "callback_args": ["element_of_arg0", "element_of_arg1"], "result": {"kind": "list_of_callback_return", "include_callback_schema": true}},
       "return": {
@@ -281,7 +291,8 @@
         ".x",
         ".y",
         ".f",
-        "..."
+        "...",
+        ".progress"
       ],
       "higher_order": {"callback_param": ".f", "callback_position": 2, "callback_args": ["element_of_arg0", "element_of_arg1"], "result": {"kind": "list_of_callback_return", "include_callback_schema": true}},
       "return": {
@@ -294,7 +305,8 @@
       "params": [
         ".x",
         ".f",
-        "..."
+        "...",
+        ".progress"
       ],
       "higher_order": {"callback_param": ".f", "callback_position": 1, "callback_args": ["element_of_arg0"], "result": {"kind": "vector_of", "mode": "character", "length_arg": 0}},
       "return": {
@@ -307,7 +319,8 @@
       "params": [
         ".x",
         ".f",
-        "..."
+        "...",
+        ".progress"
       ],
       "higher_order": {"callback_param": ".f", "callback_position": 1, "callback_args": ["element_of_arg0"], "result": {"kind": "vector_of", "mode": "double", "length_arg": 0}},
       "return": {
@@ -321,9 +334,10 @@
         ".x",
         ".p",
         ".f",
-        "..."
+        "...",
+        ".else"
       ],
-      "higher_order": {"callback_param": ".f", "callback_position": 1, "callback_args": ["element_of_arg0"], "result": {"kind": "list_of_callback_return", "length_arg": 0, "include_callback_schema": true}},
+      "higher_order": {"callback_param": ".f", "callback_position": 2, "callback_args": ["element_of_arg0"], "result": {"kind": "list_of_callback_return", "length_arg": 0, "include_callback_schema": true}},
       "return": {
         "mode": "list",
         "length": "arg0",
@@ -334,7 +348,8 @@
       "params": [
         ".x",
         ".f",
-        "..."
+        "...",
+        ".progress"
       ],
       "higher_order": {"callback_param": ".f", "callback_position": 1, "callback_args": ["element_of_arg0"], "result": {"kind": "vector_of", "mode": "integer", "length_arg": 0}},
       "return": {
@@ -347,7 +362,8 @@
       "params": [
         ".x",
         ".f",
-        "..."
+        "...",
+        ".progress"
       ],
       "higher_order": {"callback_param": ".f", "callback_position": 1, "callback_args": ["element_of_arg0"], "result": {"kind": "vector_of", "mode": "logical", "length_arg": 0}},
       "return": {
@@ -360,7 +376,9 @@
       "params": [
         ".x",
         ".f",
-        "..."
+        "...",
+        ".ptype",
+        ".progress"
       ],
       "higher_order": {"callback_param": ".f", "callback_position": 1, "callback_args": ["element_of_arg0"], "result": {"kind": "vector_of", "mode": "opaque", "length_arg": 0}},
       "return": {
@@ -417,9 +435,10 @@
       "params": [
         ".l",
         ".f",
-        "..."
+        "...",
+        ".progress"
       ],
-      "higher_order": {"callback_param": ".f", "callback_position": 2, "callback_args": ["element_of_arg0", "element_of_arg1"], "result": {"kind": "list_of_callback_return", "include_callback_schema": true}},
+      "higher_order": {"callback_param": ".f", "callback_position": 1, "callback_args": ["element_of_arg0", "element_of_arg1"], "result": {"kind": "list_of_callback_return", "include_callback_schema": true}},
       "return": {
         "mode": "list",
         "length": "unknown",
@@ -430,9 +449,10 @@
       "params": [
         ".l",
         ".f",
-        "..."
+        "...",
+        ".progress"
       ],
-      "higher_order": {"callback_param": ".f", "callback_position": 2, "callback_args": ["element_of_arg0", "element_of_arg1"], "result": {"kind": "list_of_callback_return", "include_callback_schema": true}},
+      "higher_order": {"callback_param": ".f", "callback_position": 1, "callback_args": ["element_of_arg0", "element_of_arg1"], "result": {"kind": "list_of_callback_return", "include_callback_schema": true}},
       "return": {
         "mode": "character",
         "length": "unknown",
@@ -443,9 +463,10 @@
       "params": [
         ".l",
         ".f",
-        "..."
+        "...",
+        ".progress"
       ],
-      "higher_order": {"callback_param": ".f", "callback_position": 2, "callback_args": ["element_of_arg0", "element_of_arg1"], "result": {"kind": "list_of_callback_return", "include_callback_schema": true}},
+      "higher_order": {"callback_param": ".f", "callback_position": 1, "callback_args": ["element_of_arg0", "element_of_arg1"], "result": {"kind": "list_of_callback_return", "include_callback_schema": true}},
       "return": {
         "mode": "double",
         "length": "unknown",
@@ -456,9 +477,10 @@
       "params": [
         ".l",
         ".f",
-        "..."
+        "...",
+        ".progress"
       ],
-      "higher_order": {"callback_param": ".f", "callback_position": 2, "callback_args": ["element_of_arg0", "element_of_arg1"], "result": {"kind": "list_of_callback_return", "include_callback_schema": true}},
+      "higher_order": {"callback_param": ".f", "callback_position": 1, "callback_args": ["element_of_arg0", "element_of_arg1"], "result": {"kind": "list_of_callback_return", "include_callback_schema": true}},
       "return": {
         "mode": "integer",
         "length": "unknown",
@@ -469,9 +491,10 @@
       "params": [
         ".l",
         ".f",
-        "..."
+        "...",
+        ".progress"
       ],
-      "higher_order": {"callback_param": ".f", "callback_position": 2, "callback_args": ["element_of_arg0", "element_of_arg1"], "result": {"kind": "list_of_callback_return", "include_callback_schema": true}},
+      "higher_order": {"callback_param": ".f", "callback_position": 1, "callback_args": ["element_of_arg0", "element_of_arg1"], "result": {"kind": "list_of_callback_return", "include_callback_schema": true}},
       "return": {
         "mode": "logical",
         "length": "unknown",
@@ -482,7 +505,8 @@
       "params": [
         ".l",
         ".f",
-        "..."
+        "...",
+        ".progress"
       ],
       "higher_order": {"callback_param": ".f", "callback_position": 1, "callback_args": ["element_of_arg0"], "result": {"kind": "first_arg", "source_arg": 0}},
       "return": {
@@ -495,7 +519,9 @@
       "params": [
         ".x",
         ".f",
-        "..."
+        "...",
+        ".init",
+        ".dir"
       ],
       "higher_order": {"callback_param": ".f", "callback_position": 1, "callback_args": ["accumulator_and_element"], "result": {"kind": "callback_return"}},
       "return": {
@@ -563,7 +589,8 @@
       "params": [
         ".x",
         ".f",
-        "..."
+        "...",
+        ".progress"
       ],
       "higher_order": {"callback_param": ".f", "callback_position": 1, "callback_args": ["element_of_arg0"], "result": {"kind": "first_arg", "source_arg": 0}},
       "return": {
@@ -577,9 +604,10 @@
         ".x",
         ".y",
         ".f",
-        "..."
+        "...",
+        ".progress"
       ],
-      "higher_order": {"callback_param": ".f", "callback_position": 1, "callback_args": ["element_of_arg0"], "result": {"kind": "first_arg", "source_arg": 0}},
+      "higher_order": {"callback_param": ".f", "callback_position": 2, "callback_args": ["element_of_arg0", "element_of_arg1"], "result": {"kind": "first_arg", "source_arg": 0}},
       "return": {
         "mode": "opaque",
         "length": "arg0",

--- a/crates/ry-typeshed/vendor/rlang/rlang.json
+++ b/crates/ry-typeshed/vendor/rlang/rlang.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "2",
   "package": "rlang",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "datasets": {
     "na_chr": {
       "mode": "character",


### PR DESCRIPTION
Typeshed validation accepted empty recycled-value sets, inconsistent callback positions, and control fields belonging to a different rule. Tighten those contracts and bounds-check higher-order result indices. One valid fixture and 26 invalid cases cover the contracts, and the existing package-loading test now validates the committed vendor tree.

The vendor sync imports r-typeshed’s corrected purrr callback positions, missing formal parameters, and `walk2` callback arguments. These change checker argument matching and callback inference. The rlang change is a version-only bump. Custom stubs with missing required controls or unknown return-length fields now fail during loading; the documented schema-2 shapes are unchanged.

Companion https://github.com/sims1253/r-typeshed/pull/11 deletes the duplicate R validator and fixtures while retaining audits against real R implementations. Merge this PR first, then pin the companion to the resulting main commit before merging it (including after a squash or rebase).

Validation: workspace tests, clippy with warnings denied, formatting, all 33 vendored stubs, and the full R oracle pass. With purrr 1.2.2, mirai 2.7.2, and carrier 0.3.0.4 installed, the oracle reports 81/84 satisfied, three existing known gaps, and zero missing-package skips. R provenance audits and generator tests pass. Three existing key-order warnings remain.

Review follow-ups: the pre-existing pmap callback/result model needs a coordinated schema/checker extension, already tracked in https://github.com/sims1253/r-typeshed/issues/8. Duplicate formal-name validation is tracked in #209. Keep the existing string contract checks rather than adding singleton enums in this migration.

Refs #198; close it after both PRs land.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added stricter validation for function semantics, including callbacks, conditional scopes, recycled values, return-length controls, required parameters, and unknown fields.
  - Added coverage for additional function-semantics fixtures and vendored package validation.

- **Bug Fixes**
  - Corrected purrr function parameters and callback metadata.
  - Updated rlang and purrr typeshed metadata to newer versions.
  - Documented the expanded validation rules in the unreleased changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->