### PR TITLE
cleanup: derive project defaults and simplify parse results

### DIFF
--- a/crates/ry-checker/src/project.rs
+++ b/crates/ry-checker/src/project.rs
@@ -35,6 +35,7 @@ use std::sync::Arc;
 /// a top-level function with the same name, the later `add_file` wins
 /// (matching R's own `source()` ordering, where the most recently
 /// sourced file's bindings override earlier ones).
+#[derive(Default)]
 pub struct Project {
     /// Shared function table. Populated by pass 1 from all files, then
     /// refined by pass 2. Kept on `Project` rather than recreated each
@@ -131,12 +132,6 @@ pub(crate) struct CollectedFile {
     pub(crate) loaded: HashSet<String>,
 }
 
-impl Default for Project {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 /// Replace `current` with `new` when they differ, returning whether the
 /// replacement happened. The equality-aware setters below use this to
 /// skip the all-dirty invalidation an unchanged value would cause.
@@ -152,33 +147,7 @@ fn set_if_changed<T: PartialEq>(current: &mut T, new: T) -> bool {
 impl Project {
     /// Construct an empty project with no files and empty tables.
     pub fn new() -> Self {
-        Self {
-            fn_table: FnTable::default(),
-            return_slots: ReturnSlots::default(),
-            files: Vec::new(),
-            diagnostics: Vec::new(),
-            loaded: std::collections::HashSet::new(),
-            declared_loaded: HashSet::new(),
-            bare_loaded: HashMap::new(),
-            external_bindings: HashMap::new(),
-            imported_from: HashMap::new(),
-            external_s3_methods: HashMap::new(),
-            load_bindings: HashMap::new(),
-            user_stubs: Arc::new(BTreeMap::new()),
-            collected_files: HashMap::new(),
-            file_known_vars: HashMap::new(),
-            dirty_paths: HashSet::new(),
-            invalidated_fns: HashSet::new(),
-            prev_loaded: None,
-            has_prev_emit: false,
-            file_called_fns: HashMap::new(),
-            prev_fn_returns: HashMap::new(),
-            prev_fn_signatures: HashMap::new(),
-            prev_known_vars: HashSet::new(),
-            capture_scopes: false,
-            scope_records: Vec::new(),
-            emit_count: 0,
-        }
+        Self::default()
     }
 
     /// Add a parsed file to the project. Call this for every file
@@ -190,8 +159,7 @@ impl Project {
     /// the most recently sourced file's top-level bindings override
     /// earlier ones.
     pub fn add_file(&mut self, path: String, file: SourceFile) {
-        self.dirty_paths.insert(path.clone());
-        self.files.push((path, Arc::new(file)));
+        self.add_file_arc(path, Arc::new(file));
     }
 
     /// Add a pre-parsed file without wrapping. Use when the caller

--- a/crates/ry-cli/src/pipeline.rs
+++ b/crates/ry-cli/src/pipeline.rs
@@ -87,31 +87,15 @@ pub(crate) fn parse_files(
     use rayon::prelude::*;
     let outcomes: Vec<_> = paths
         .par_iter()
-        .map(|path| {
-            let outcome = parse_one(path);
-            let action = match &outcome {
-                Ok(_) => FailureAction::Skip,
-                Err(failure) => on_failure(&failure.path, &failure.error),
-            };
-            (outcome, action)
+        .map(|path| match parse_one(path) {
+            Ok(file) => Some(Ok(file)),
+            Err(failure) => match on_failure(&failure.path, &failure.error) {
+                FailureAction::Skip => None,
+                FailureAction::Abort => Some(Err(failure)),
+            },
         })
         .collect();
-    let mut files = Vec::with_capacity(paths.len());
-    let mut abort: Option<ParseFailure> = None;
-    for (outcome, action) in outcomes {
-        match outcome {
-            Ok(file) => files.push(file),
-            Err(failure) => {
-                if action == FailureAction::Abort && abort.is_none() {
-                    abort = Some(failure);
-                }
-            }
-        }
-    }
-    match abort {
-        Some(failure) => Err(failure),
-        None => Ok(files),
-    }
+    outcomes.into_iter().flatten().collect()
 }
 
 /// Read and parse one file on the calling thread, using that thread's
@@ -260,4 +244,40 @@ pub(crate) fn resolve_groups(
         });
     }
     Ok(resolved)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    #[test]
+    fn parallel_parsing_preserves_order_and_reports_every_failure() {
+        let dir = tempfile::tempdir().unwrap();
+        let paths =
+            ["z.R", "missing-first.R", "missing-second.R", "a.R"].map(|name| dir.path().join(name));
+        for index in [0, 3] {
+            std::fs::write(&paths[index], "x <- 1\n").unwrap();
+        }
+        for action in [FailureAction::Skip, FailureAction::Abort] {
+            let failures = AtomicUsize::new(0);
+            let result = parse_files(&paths, |_, error| {
+                assert!(matches!(error, ParseError::Read(_)));
+                failures.fetch_add(1, Ordering::Relaxed);
+                action
+            });
+            assert_eq!(failures.load(Ordering::Relaxed), 2);
+            match action {
+                FailureAction::Skip => assert_eq!(
+                    result
+                        .unwrap()
+                        .iter()
+                        .map(|file| Path::new(&file.path))
+                        .collect::<Vec<_>>(),
+                    [&paths[0], &paths[3]],
+                ),
+                FailureAction::Abort => assert_eq!(result.unwrap_err().path, paths[1]),
+            }
+        }
+    }
 }


### PR DESCRIPTION
`Project::new` manually initializes every field to its default, and `add_file` repeats the insertion logic already used by `add_file_arc`. Derive `Default`, retain `new` as the public constructor, and route both insertion paths through `add_file_arc`.

The CLI parse pipeline also stores a failure action for successful parses and manually accumulates the first error. Represent each outcome as a successful file, a skipped failure, or an aborting failure, then collect the results. Parallel parsing still completes before selecting the first error in input order, so every failure reaches the reporting callback.

Net change: 12 fewer lines, including a regression for successful-file order, skipped failures, and first-error selection with all failure callbacks executed.

This PR is based on #214; its diff contains only the project and pipeline cleanup.

Validation:

- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `cargo test -p ry-checker --test oracle -- --ignored`
