### PR TITLE
fix: validate and bound analysis inputs consistently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -243,6 +243,16 @@ suppression actions — and fixes a parser panic plus several editor issues.
 
 ### Fixed
 
+- Reject duplicate function keys and S3 dispatch definitions when loading
+  typesheds. Function key ordering no longer produces a validation warning.
+- CLI and LSP use the same UTF-8/Latin-1 source decoder for on-disk R files.
+- Environment profile paths use anchored glob matching, preventing bindings
+  from leaking into directories with similar names.
+- Serialized workspace files stream through the decoded-byte limit instead
+  of allocating the complete input before checking the limit. The setting
+  continues to limit decoded bytes, so compression overhead does not reject
+  an otherwise valid exact-cap payload.
+
 - `ry typeshed validate` rejects duplicate formal names, including repeated
   `...`, in function and S3 method signatures.
 

--- a/README.md
+++ b/README.md
@@ -308,6 +308,21 @@ max-file-bytes = 2097152 # bytes per R file (default: 2 MiB)
 max-depth      = 64      # directory depth (default: 64)
 ```
 
+Use an environment profile for bindings supplied only to selected files:
+
+```toml
+[[environments]]
+name = "shiny"
+bindings = ["input", "output", "session"]
+paths = ["inst/shiny/**"]
+```
+
+Profile paths are glob patterns relative to the configuration directory, even
+when checking a nested package. `*` stays within one path component; `**`
+includes descendants. Use forward slashes on every platform. Existing paths
+are resolved through symlinks before matching. A programmatically constructed
+configuration without a file location uses the analysis root.
+
 CLI flags override the config only when passed explicitly.
 When multiple paths are checked, the first path anchors config discovery;
 that one configuration applies to the complete invocation.

--- a/crates/ry-cli/src/main.rs
+++ b/crates/ry-cli/src/main.rs
@@ -440,20 +440,12 @@ fn run_explain_typeshed() -> Result<ExitCode> {
 fn run_typeshed_validate(dirs: &[PathBuf], quiet: bool) -> Result<ExitCode> {
     let report = ry_typeshed::validate_stub_dirs(dirs);
     let errors = report.error_count();
-    let warnings = report.warning_count();
     if !quiet {
         for problem in &report.problems {
-            let level = match problem.level {
-                ry_typeshed::ValidationLevel::Error => "error",
-                ry_typeshed::ValidationLevel::Warning => "warning",
-            };
-            eprintln!("{}: {level}: {}", problem.path.display(), problem.message);
+            eprintln!("{}: error: {}", problem.path.display(), problem.message);
         }
     }
-    println!(
-        "Validated {} stub files: {errors} errors, {warnings} warnings.",
-        report.files
-    );
+    println!("Validated {} stub files: {errors} errors.", report.files);
     Ok(if errors == 0 {
         ExitCode::SUCCESS
     } else {

--- a/crates/ry-cli/src/pipeline.rs
+++ b/crates/ry-cli/src/pipeline.rs
@@ -59,7 +59,7 @@ pub(crate) struct ParseFailure {
 }
 
 /// What a command does with a failed file.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy)]
 pub(crate) enum FailureAction {
     /// Drop the file and keep going.
     Skip,
@@ -105,7 +105,7 @@ fn parse_one(path: &Path) -> Result<Arc<ry_core::SourceFile>, ParseFailure> {
         static PARSER: std::cell::RefCell<Option<ry_core::RParser>> =
             const { std::cell::RefCell::new(None) };
     }
-    let src = match read_r_source(path) {
+    let src = match ry_workspace::read_r_source(path) {
         Ok(src) => src,
         Err(error) => {
             return Err(ParseFailure {
@@ -125,20 +125,6 @@ fn parse_one(path: &Path) -> Result<Arc<ry_core::SourceFile>, ParseFailure> {
         path: path.to_path_buf(),
         error: ParseError::Parse(message.to_string()),
     })
-}
-
-/// Read an R source file, accepting both UTF-8 and Latin-1 encodings.
-///
-/// R accepts Latin-1 source files, so retry an invalid UTF-8 decode by mapping
-/// every input byte directly to the corresponding Unicode code point.
-fn read_r_source(path: &Path) -> std::io::Result<String> {
-    match std::fs::read_to_string(path) {
-        Ok(source) => Ok(source),
-        Err(error) if error.kind() == std::io::ErrorKind::InvalidData => {
-            std::fs::read(path).map(|bytes| bytes.into_iter().map(char::from).collect())
-        }
-        Err(error) => Err(error),
-    }
 }
 
 /// Nearest ancestor directory (starting at the path itself for

--- a/crates/ry-cli/tests/typeshed_e2e.rs
+++ b/crates/ry-cli/tests/typeshed_e2e.rs
@@ -152,7 +152,7 @@ fn quiet_prints_summary_only() {
 }
 
 #[test]
-fn warns_without_failing_on_unsorted_function_keys() {
+fn function_key_order_does_not_affect_validation() {
     let tmp = tempfile::tempdir().unwrap();
     fs::write(
         tmp.path().join("order.json"),
@@ -169,10 +169,7 @@ fn warns_without_failing_on_unsorted_function_keys() {
     let output = validate(tmp.path());
     let text = output_text(&output);
     assert!(output.status.success(), "{text}");
-    assert!(
-        text.contains("warning: function keys are not sorted"),
-        "{text}"
-    );
+    assert!(text.contains("0 errors."), "{text}");
 }
 
 #[test]

--- a/crates/ry-config/src/config.rs
+++ b/crates/ry-config/src/config.rs
@@ -73,6 +73,9 @@ pub struct EnvironmentConfig {
     pub bindings: Vec<String>,
     #[serde(default)]
     pub paths: Vec<String>,
+    /// Directory containing the configuration, assigned when it is loaded.
+    #[serde(skip)]
+    pub root: Option<PathBuf>,
 }
 
 /// Parsed contents of a `ry.toml` project config file.
@@ -206,6 +209,23 @@ impl Config {
             source,
         })?;
         let root = path.parent().unwrap_or(Path::new("."));
+        for profile in &mut cfg.environments {
+            profile.root = Some(
+                std::path::absolute(root).map_err(|source| ConfigError::Read {
+                    path: path.to_path_buf(),
+                    source,
+                })?,
+            );
+            for pattern in &profile.paths {
+                glob::Pattern::new(&pattern.replace('\\', "/")).map_err(|source| {
+                    ConfigError::InvalidEnvironmentPattern {
+                        path: path.to_path_buf(),
+                        pattern: pattern.clone(),
+                        source,
+                    }
+                })?;
+            }
+        }
         for dir in &mut cfg.typeshed {
             if dir.is_relative() {
                 *dir = root.join(&*dir);
@@ -434,6 +454,12 @@ pub enum ConfigError {
         "config file {path} has invalid value for {field}: bounded discovery limits must be positive integers, zero is not permitted"
     )]
     InvalidIndex { path: PathBuf, field: &'static str },
+    #[error("config file {path} has invalid environment path pattern `{pattern}`: {source}")]
+    InvalidEnvironmentPattern {
+        path: PathBuf,
+        pattern: String,
+        source: glob::PatternError,
+    },
 }
 
 #[cfg(test)]
@@ -441,6 +467,17 @@ mod tests {
     use super::*;
     use std::fs;
     use tempfile::TempDir;
+
+    #[test]
+    fn invalid_environment_globs_are_configuration_errors() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("ry.toml");
+        fs::write(&path, "[[environments]]\nname = 'broken'\npaths = ['[']\n").unwrap();
+        assert!(matches!(
+            Config::load_file(&path),
+            Err(ConfigError::InvalidEnvironmentPattern { .. })
+        ));
+    }
 
     #[test]
     fn defaults_match_expectations() {

--- a/crates/ry-lsp/src/index.rs
+++ b/crates/ry-lsp/src/index.rs
@@ -45,7 +45,7 @@ fn parse_paths(paths: &[PathBuf]) -> HashMap<String, Arc<SourceFile>> {
         Err(_) => return parsed,
     };
     for path in paths {
-        let Ok(source) = std::fs::read_to_string(path) else {
+        let Ok(source) = ry_workspace::read_r_source(path) else {
             continue;
         };
         if let Ok(file) = parser.parse(&path.to_string_lossy(), &source) {

--- a/crates/ry-lsp/tests/input_boundaries.rs
+++ b/crates/ry-lsp/tests/input_boundaries.rs
@@ -1,0 +1,124 @@
+mod harness;
+
+use harness::{
+    file_uri, join_session, normalize_diagnostics, ry_binary, spawn_session, sync_barrier,
+};
+use ry_testkit::FixtureProject;
+use serde_json::{Value, json};
+use std::process::Command;
+
+fn cli(fixture: &FixtureProject, target: &str) -> Vec<Value> {
+    let output = Command::new(ry_binary())
+        .current_dir(fixture.root())
+        .args(["check", "--output-format", "json", target])
+        .output()
+        .unwrap();
+    assert!(
+        matches!(output.status.code(), Some(0 | 1)),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    serde_json::from_slice(&output.stdout).unwrap()
+}
+
+#[test]
+fn latin1_sibling_survives_open_and_close() {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap()
+        .block_on(async {
+            let fixture = FixtureProject::empty().unwrap();
+            let source = "value <- make_label() + 1\n";
+            fixture.write_file("main.R", source).unwrap();
+            fixture
+                .write_file("helper.R", b"make_label <- function() \"caf\xe9\"\n")
+                .unwrap();
+            assert!(cli(&fixture, ".").iter().any(|d| d["code"] == "RY040"));
+            let uri = file_uri(&fixture.path("main.R"));
+            let helper_uri = file_uri(&fixture.path("helper.R"));
+            let (mut session, server) = spawn_session(&[fixture.root()], json!({}), None).await;
+            let mark = session.publication_mark();
+            session.open(&uri, 1, source).await.unwrap();
+            let first = session
+                .published_diagnostics_after(&uri, mark)
+                .await
+                .unwrap();
+            let expected = normalize_diagnostics(&first);
+            assert!(expected.iter().any(|d| d["code"] == "RY040"), "{first}");
+            for (version, open) in [(2, true), (3, false)] {
+                if open {
+                    session
+                        .open(&helper_uri, 1, "make_label <- function() \"café\"\n")
+                        .await
+                        .unwrap();
+                } else {
+                    session
+                        .notify(
+                            "textDocument/didClose",
+                            json!({"textDocument":{"uri":helper_uri}}),
+                        )
+                        .await
+                        .unwrap();
+                }
+                sync_barrier(&mut session, &uri).await;
+                let mark = session.publication_mark();
+                session
+                    .change(&uri, version, json!([{"text":source}]))
+                    .await
+                    .unwrap();
+                let publish = session
+                    .published_diagnostics_after(&uri, mark)
+                    .await
+                    .unwrap();
+                assert_eq!(normalize_diagnostics(&publish), expected);
+            }
+            join_session(session, server).await;
+        });
+}
+
+#[test]
+fn environment_paths_are_anchored_globs_in_both_frontends() {
+    tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap().block_on(async {
+    let fixture = FixtureProject::empty().unwrap();
+    fixture.write_file("ry.toml", "[[environments]]\nname = 'shiny'\nbindings = ['profile_binding']\npaths = ['pkg/inst/shiny/**', 'pkg/exact.R']\n").unwrap();
+    fixture
+        .write_file("pkg/DESCRIPTION", "Package: example\nVersion: 0.1\n")
+        .unwrap();
+    let paths = [
+        "pkg/inst/shiny/main.R",
+        "pkg/inst/shiny/nested/main.R",
+        "pkg/exact.R",
+        "pkg/inst/shiny-unrelated/main.R",
+        "ancestor/pkg/inst/shiny/main.R",
+    ];
+    for path in paths {
+        fixture.write_file(path, "profile_binding\n").unwrap();
+    }
+    let (mut session, server) = spawn_session(&[fixture.root()], json!({}), None).await;
+    for (index, path) in paths.iter().enumerate() {
+        let expected_unbound = index >= 3;
+        let findings = cli(&fixture, path);
+        assert_eq!(
+            findings.iter().any(|d| d["code"] == "RY010"),
+            expected_unbound,
+            "{path}: {findings:?}"
+        );
+        let uri = file_uri(&fixture.path(path));
+        let mark = session.publication_mark();
+        session.open(&uri, 1, "profile_binding\n").await.unwrap();
+        let publish = session
+            .published_diagnostics_after(&uri, mark)
+            .await
+            .unwrap();
+        assert_eq!(
+            normalize_diagnostics(&publish)
+                .iter()
+                .any(|d| d["code"] == "RY010"),
+            expected_unbound,
+            "{path}: {publish}"
+        );
+    }
+    join_session(session, server).await;
+    });
+}

--- a/crates/ry-typeshed/src/lib.rs
+++ b/crates/ry-typeshed/src/lib.rs
@@ -841,7 +841,6 @@ pub fn validate_stub_dirs(dirs: &[PathBuf]) -> ValidationReport {
             Err(error) => {
                 report.problems.push(ValidationProblem {
                     path: dir.clone(),
-
                     message: validation_error_message(&error),
                 });
                 continue;
@@ -850,7 +849,6 @@ pub fn validate_stub_dirs(dirs: &[PathBuf]) -> ValidationReport {
         if paths.is_empty() {
             report.problems.push(ValidationProblem {
                 path: dir.clone(),
-
                 message: "no stub files found".to_string(),
             });
             continue;
@@ -882,7 +880,6 @@ fn validate_stub_file(path: &Path, report: &mut ValidationReport) {
         Err(error) => {
             report.problems.push(ValidationProblem {
                 path: path.to_path_buf(),
-
                 message: validation_error_message(&error),
             });
             return;
@@ -938,7 +935,6 @@ fn validate_stub_file(path: &Path, report: &mut ValidationReport) {
 fn validation_error(report: &mut ValidationReport, path: &Path, message: impl Into<String>) {
     report.problems.push(ValidationProblem {
         path: path.to_path_buf(),
-
         message: message.into(),
     });
 }

--- a/crates/ry-typeshed/src/lib.rs
+++ b/crates/ry-typeshed/src/lib.rs
@@ -370,6 +370,12 @@ pub enum TypeshedError {
         path: PathBuf,
         schema_version: String,
     },
+    #[error("duplicate S3 method `{generic}.{class}` in `{path}", path = path.display())]
+    DuplicateMethod {
+        path: PathBuf,
+        generic: String,
+        class: String,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
@@ -586,21 +592,8 @@ pub fn load_base() -> Result<Typeshed, TypeshedError> {
     parse_typeshed(BASE_JSON, Path::new("<embedded base>"))
 }
 
-/// File-level insertion order of the `functions` map.
-///
-/// This visitor and the `_with_order` parse twins exist only for
-/// `validate_stub_file`'s "function keys are not sorted" warning; every
-/// other consumer reads the sorted `BTreeMap` (#172). Load-bearing, not
-/// dead: the vendored stubs still contain adjacent inversions (base.json
-/// `load` > `lm`, rlang.json `:=` > `!!`, shiny.json `testServer` >
-/// `reactive`), `scripts/sync_typeshed.sh` runs `ry typeshed validate`
-/// over the tree it syncs, and ry-cli's
-/// `warns_without_failing_on_unsorted_function_keys` e2e test pins the
-/// warning plus a successful exit. Delete once the complete upstream
-/// pipeline emits sorted maps; without this visitor a sortedness check
-/// needs a second JSON pass or serde_json's `preserve_order`, which
-/// changes map ordering workspace-wide.
-struct RawFunctions(Vec<(String, FunctionSig)>);
+/// Reject duplicate JSON keys before they can overwrite a signature.
+struct RawFunctions(BTreeMap<String, FunctionSig>);
 
 impl<'de> Deserialize<'de> for RawFunctions {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
@@ -620,9 +613,13 @@ impl<'de> Deserialize<'de> for RawFunctions {
             where
                 A: MapAccess<'de>,
             {
-                let mut entries = Vec::with_capacity(map.size_hint().unwrap_or(0));
-                while let Some(entry) = map.next_entry()? {
-                    entries.push(entry);
+                let mut entries = BTreeMap::new();
+                while let Some((name, signature)) = map.next_entry::<String, FunctionSig>()? {
+                    if entries.insert(name.clone(), signature).is_some() {
+                        return Err(serde::de::Error::custom(format!(
+                            "duplicate function `{name}`"
+                        )));
+                    }
                 }
                 Ok(RawFunctions(entries))
             }
@@ -649,10 +646,7 @@ struct RawFile {
     s3_methods: Vec<RawS3Method>,
 }
 
-fn parse_typeshed_with_order(
-    json: &str,
-    path: &Path,
-) -> Result<(Typeshed, Vec<String>), TypeshedError> {
+fn parse_typeshed(json: &str, path: &Path) -> Result<Typeshed, TypeshedError> {
     let raw: RawFile = serde_json::from_str(json).map_err(|source| TypeshedError::JsonAtPath {
         path: path.to_path_buf(),
         source,
@@ -665,36 +659,26 @@ fn parse_typeshed_with_order(
             schema_version: schema_version.to_string(),
         });
     }
-    let mut functions = std::collections::BTreeMap::new();
-    let function_order = raw
-        .functions
-        .0
-        .iter()
-        .map(|(name, _)| name.clone())
-        .collect();
-    for (k, v) in raw.functions.0 {
-        functions.insert(k, v);
-    }
-    let mut s3_methods = std::collections::BTreeMap::new();
+    let mut s3_methods = BTreeMap::new();
     for m in raw.s3_methods {
-        s3_methods.insert((m.generic, m.class), m.signature);
+        let key = (m.generic, m.class);
+        if s3_methods.insert(key.clone(), m.signature).is_some() {
+            return Err(TypeshedError::DuplicateMethod {
+                path: path.to_path_buf(),
+                generic: key.0,
+                class: key.1,
+            });
+        }
     }
-    Ok((
-        Typeshed {
-            schema_version: raw.schema_version,
-            package: raw.package,
-            version: raw.version,
-            functions,
-            globals: raw.globals,
-            datasets: raw.datasets,
-            s3_methods,
-        },
-        function_order,
-    ))
-}
-
-fn parse_typeshed(json: &str, path: &Path) -> Result<Typeshed, TypeshedError> {
-    parse_typeshed_with_order(json, path).map(|(typeshed, _)| typeshed)
+    Ok(Typeshed {
+        schema_version: raw.schema_version,
+        package: raw.package,
+        version: raw.version,
+        functions: raw.functions.0,
+        globals: raw.globals,
+        datasets: raw.datasets,
+        s3_methods,
+    })
 }
 
 /// Load the base typeshed and cache it for the life of the process.
@@ -823,27 +807,16 @@ fn discover_stub_files(dir: &Path) -> Result<Vec<PathBuf>, TypeshedError> {
 
 /// Load one stub through the normative parser used by the runtime loader.
 fn load_stub_file(path: &Path) -> Result<Typeshed, TypeshedError> {
-    load_stub_file_with_order(path).map(|(typeshed, _)| typeshed)
-}
-
-fn load_stub_file_with_order(path: &Path) -> Result<(Typeshed, Vec<String>), TypeshedError> {
     let json = std::fs::read_to_string(path).map_err(|source| TypeshedError::Io {
         path: path.to_path_buf(),
         source,
     })?;
-    parse_typeshed_with_order(&json, path)
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ValidationLevel {
-    Error,
-    Warning,
+    parse_typeshed(&json, path)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ValidationProblem {
     pub path: PathBuf,
-    pub level: ValidationLevel,
     pub message: String,
 }
 
@@ -855,17 +828,7 @@ pub struct ValidationReport {
 
 impl ValidationReport {
     pub fn error_count(&self) -> usize {
-        self.problems
-            .iter()
-            .filter(|problem| problem.level == ValidationLevel::Error)
-            .count()
-    }
-
-    pub fn warning_count(&self) -> usize {
-        self.problems
-            .iter()
-            .filter(|problem| problem.level == ValidationLevel::Warning)
-            .count()
+        self.problems.len()
     }
 }
 
@@ -878,7 +841,7 @@ pub fn validate_stub_dirs(dirs: &[PathBuf]) -> ValidationReport {
             Err(error) => {
                 report.problems.push(ValidationProblem {
                     path: dir.clone(),
-                    level: ValidationLevel::Error,
+
                     message: validation_error_message(&error),
                 });
                 continue;
@@ -887,7 +850,7 @@ pub fn validate_stub_dirs(dirs: &[PathBuf]) -> ValidationReport {
         if paths.is_empty() {
             report.problems.push(ValidationProblem {
                 path: dir.clone(),
-                level: ValidationLevel::Error,
+
                 message: "no stub files found".to_string(),
             });
             continue;
@@ -902,6 +865,9 @@ pub fn validate_stub_dirs(dirs: &[PathBuf]) -> ValidationReport {
 
 fn validation_error_message(error: &TypeshedError) -> String {
     match error {
+        TypeshedError::DuplicateMethod { generic, class, .. } => {
+            format!("duplicate S3 method `{generic}.{class}`")
+        }
         TypeshedError::Io { source, .. } => format!("failed to read typeshed: {source}"),
         TypeshedError::JsonAtPath { source, .. } => format!("typeshed parse error: {source}"),
         TypeshedError::UnsupportedSchema { schema_version, .. } => {
@@ -911,12 +877,12 @@ fn validation_error_message(error: &TypeshedError) -> String {
 }
 
 fn validate_stub_file(path: &Path, report: &mut ValidationReport) {
-    let (typeshed, function_order) = match load_stub_file_with_order(path) {
+    let typeshed = match load_stub_file(path) {
         Ok(parsed) => parsed,
         Err(error) => {
             report.problems.push(ValidationProblem {
                 path: path.to_path_buf(),
-                level: ValidationLevel::Error,
+
                 message: validation_error_message(&error),
             });
             return;
@@ -935,14 +901,6 @@ fn validate_stub_file(path: &Path, report: &mut ValidationReport) {
             format!("package `{actual}` does not match file name `{expected}.json`"),
         ),
         _ => {}
-    }
-
-    if !function_order.windows(2).all(|pair| pair[0] <= pair[1]) {
-        report.problems.push(ValidationProblem {
-            path: path.to_path_buf(),
-            level: ValidationLevel::Warning,
-            message: "function keys are not sorted".to_string(),
-        });
     }
 
     let mut owners: HashMap<&str, &str> = typeshed
@@ -980,7 +938,7 @@ fn validate_stub_file(path: &Path, report: &mut ValidationReport) {
 fn validation_error(report: &mut ValidationReport, path: &Path, message: impl Into<String>) {
     report.problems.push(ValidationProblem {
         path: path.to_path_buf(),
-        level: ValidationLevel::Error,
+
         message: message.into(),
     });
 }
@@ -1661,8 +1619,7 @@ mod tests {
                 report
                     .problems
                     .iter()
-                    .any(|problem| problem.level == ValidationLevel::Error
-                        && problem.message.contains(message)),
+                    .any(|problem| problem.message.contains(message)),
                 "{pointer}: expected {message}: {report:?}"
             );
         }
@@ -1692,6 +1649,54 @@ mod tests {
                     report.problems[0].message.starts_with(
                         "s3_methods[print.example].params[1].name: duplicate parameter"
                     )
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn duplicate_definitions_are_rejected_before_loading() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("fixture.json");
+        let signature = r#"{"params": [], "return": "arg0"}"#;
+        let duplicate_functions = format!(
+            r#"{{"schema_version":"2","package":"fixture","version":"test","functions":{{"f":{signature},"f":{signature}}}}}"#
+        );
+        std::fs::write(&path, duplicate_functions).unwrap();
+        assert!(
+            load_stub_file(&path)
+                .unwrap_err()
+                .to_string()
+                .contains("duplicate function `f`")
+        );
+        assert_eq!(
+            validate_stub_dirs(&[dir.path().to_path_buf()]).error_count(),
+            1
+        );
+        for (generic, class, errors) in [
+            ("print", "example", 1),
+            ("print", "other", 0),
+            ("summary", "example", 0),
+        ] {
+            let stub = serde_json::json!({
+                "schema_version": "2", "package": "fixture", "version": "test", "functions": {},
+                "s3_methods": [
+                    {"generic": "print", "class": "example", "params": [], "return": "arg0"},
+                    {"generic": generic, "class": class, "params": [], "return": "arg0"}
+                ]
+            });
+            std::fs::write(&path, stub.to_string()).unwrap();
+            assert_eq!(
+                validate_stub_dirs(&[dir.path().to_path_buf()]).error_count(),
+                errors
+            );
+            if errors == 0 {
+                assert_eq!(load_stub_file(&path).unwrap().s3_methods.len(), 2);
+            } else {
+                let error = load_stub_file(&path).unwrap_err().to_string();
+                assert!(
+                    error.contains("print.example") && error.contains("fixture.json"),
+                    "{error}"
                 );
             }
         }

--- a/crates/ry-workspace/src/lib.rs
+++ b/crates/ry-workspace/src/lib.rs
@@ -43,6 +43,8 @@ pub struct WorkspaceContext {
 pub enum ResolveError {
     #[error("workspace root is not a directory: {0}")]
     InvalidRoot(PathBuf),
+    #[error("invalid environment path pattern: {0}")]
+    InvalidEnvironmentPattern(#[from] glob::PatternError),
 }
 
 /// Inventory of a serialized R data file (`.rda`/`.rdata`). `bindings`
@@ -76,6 +78,15 @@ fn file_stem_binding(path: &Path) -> HashSet<String> {
         .unwrap_or_default()
 }
 
+/// Read R source as UTF-8, falling back to Latin-1 for invalid UTF-8.
+/// Both frontends use this policy for on-disk source; open editor buffers
+/// already arrive as Unicode through LSP.
+pub fn read_r_source(path: &Path) -> std::io::Result<String> {
+    let bytes = std::fs::read(path)?;
+    Ok(String::from_utf8(bytes)
+        .unwrap_or_else(|error| error.into_bytes().into_iter().map(char::from).collect()))
+}
+
 struct LibraryRoot {
     path: PathBuf,
     max_depth: usize,
@@ -105,6 +116,22 @@ pub fn resolve_workspace_context<'a>(
     if !root.is_dir() {
         return Err(ResolveError::InvalidRoot(root.to_path_buf()));
     }
+    let profiles = config
+        .environments
+        .iter()
+        .map(|profile| {
+            let patterns = profile
+                .paths
+                .iter()
+                .map(|pattern| glob::Pattern::new(&pattern.replace('\\', "/")))
+                .collect::<Result<Vec<_>, _>>()?;
+            let anchor = profile.root.as_deref().unwrap_or(root);
+            let anchor = anchor
+                .canonicalize()
+                .unwrap_or_else(|_| anchor.to_path_buf());
+            Ok((profile, patterns, anchor))
+        })
+        .collect::<Result<Vec<_>, glob::PatternError>>()?;
     let files = environment.files;
     let user_stubs = environment.user_stubs;
     let all_paths: Vec<PathBuf> = files.iter().map(|file| PathBuf::from(&file.path)).collect();
@@ -147,13 +174,27 @@ pub fn resolve_workspace_context<'a>(
         let mut file_imported_from = HashMap::new();
         let mut source_package = None;
         file_bindings.extend(configured_globals.iter().cloned());
-        for profile in &config.environments {
-            if profile.paths.iter().any(|pattern| {
-                file.path
-                    .replace('\\', "/")
-                    .contains(pattern.trim_end_matches("/**"))
-            }) {
-                file_bindings.extend(profile.bindings.iter().cloned());
+        if !profiles.is_empty()
+            && let Ok(path) = Path::new(&file.path)
+                .canonicalize()
+                .or_else(|_| std::path::absolute(&file.path))
+        {
+            for (profile, patterns, anchor) in &profiles {
+                let Ok(relative) = path.strip_prefix(anchor) else {
+                    continue;
+                };
+                let relative = relative.to_string_lossy().replace('\\', "/");
+                if patterns.iter().any(|pattern| {
+                    pattern.matches_with(
+                        &relative,
+                        glob::MatchOptions {
+                            require_literal_separator: true,
+                            ..Default::default()
+                        },
+                    )
+                }) {
+                    file_bindings.extend(profile.bindings.iter().cloned());
+                }
             }
         }
         if let Some(root) = r_package_root(Path::new(&file.path)) {
@@ -393,7 +434,7 @@ fn source_package_dynamic_bindings(root: &Path) -> SourceBindings {
         return found;
     };
     for path in paths {
-        let Ok(source) = std::fs::read_to_string(&path) else {
+        let Ok(source) = read_r_source(&path) else {
             continue;
         };
         let Ok(file) = parser.parse(&path.to_string_lossy(), &source) else {
@@ -548,7 +589,7 @@ fn testthat_helper_context(root: &Path) -> TestthatHelperContext {
         {
             continue;
         }
-        let Ok(source) = std::fs::read_to_string(&path) else {
+        let Ok(source) = read_r_source(&path) else {
             continue;
         };
         let Ok(file) = parser.parse(&path.to_string_lossy(), &source) else {
@@ -629,7 +670,7 @@ fn source_package_datasets(root: &Path, max_serialized_bytes: u64) -> DataInvent
                 }
             }
             "r" => {
-                let Ok(source) = std::fs::read_to_string(&path) else {
+                let Ok(source) = read_r_source(&path) else {
                     continue;
                 };
                 let Ok(mut parser) = ry_core::RParser::new() else {
@@ -722,28 +763,14 @@ fn serialized_inventory_uncached(path: &Path, cap: u64) -> SerializedInventory {
         degraded: false,
     };
 
-    let bytes = match std::fs::read(path) {
-        Ok(bytes) => bytes,
+    let file = match std::fs::File::open(path) {
+        Ok(file) => file,
         Err(_) => return empty(),
     };
-    let decoded = {
-        let decoder: Option<Box<dyn std::io::Read + '_>> = if bytes.starts_with(b"BZh") {
-            Some(Box::new(bzip2::read::BzDecoder::new(bytes.as_slice())))
-        } else if bytes.starts_with(&[0x1f, 0x8b]) {
-            Some(Box::new(flate2::read::GzDecoder::new(bytes.as_slice())))
-        } else if bytes.starts_with(&[0xfd, b'7', b'z', b'X', b'Z', 0x00]) {
-            Some(Box::new(xz2::read::XzDecoder::new(bytes.as_slice())))
-        } else {
-            None
-        };
-        decoder.map(|decoder| decode_capped(decoder, cap))
-    };
-    let bytes = match decoded {
-        Some(Decoded::Bytes(decoded)) => decoded,
-        Some(Decoded::OverCap) => return degraded(path),
-        Some(Decoded::Failed) => return empty(),
-        None if bytes.len() as u64 > cap => return degraded(path),
-        None => bytes,
+    let bytes = match read_serialized(file, cap) {
+        Decoded::Bytes(bytes) => bytes,
+        Decoded::OverCap => return degraded(path),
+        Decoded::Failed => return empty(),
     };
     let payload = bytes
         .strip_prefix(b"RDX2\n")
@@ -762,6 +789,25 @@ fn serialized_inventory_uncached(path: &Path, cap: u64) -> SerializedInventory {
     SerializedInventory {
         bindings,
         degraded: false,
+    }
+}
+
+fn read_serialized(reader: impl std::io::Read, cap: u64) -> Decoded {
+    use std::io::Read;
+    let mut reader = reader;
+    let mut prefix = Vec::with_capacity(6);
+    if reader.by_ref().take(6).read_to_end(&mut prefix).is_err() {
+        return Decoded::Failed;
+    }
+    let reader = prefix.as_slice().chain(reader);
+    if prefix.starts_with(b"BZh") {
+        decode_capped(bzip2::read::BzDecoder::new(reader), cap)
+    } else if prefix.starts_with(&[0x1f, 0x8b]) {
+        decode_capped(flate2::read::GzDecoder::new(reader), cap)
+    } else if prefix.starts_with(&[0xfd, b'7', b'z', b'X', b'Z', 0x00]) {
+        decode_capped(xz2::read::XzDecoder::new(reader), cap)
+    } else {
+        decode_capped(reader, cap)
     }
 }
 
@@ -2160,5 +2206,78 @@ mod shared_tests {
                 .unwrap()
                 .matches(r"file\x")
         );
+    }
+}
+
+#[cfg(test)]
+mod input_tests {
+    use super::*;
+    use std::io::{Read, Write};
+
+    struct TinyReads<'a> {
+        bytes: &'a [u8],
+        consumed: usize,
+    }
+    impl Read for TinyReads<'_> {
+        fn read(&mut self, buffer: &mut [u8]) -> std::io::Result<usize> {
+            let length = buffer.len().min(1);
+            let count = self.bytes.read(&mut buffer[..length])?;
+            self.consumed += count;
+            Ok(count)
+        }
+    }
+
+    #[test]
+    fn serialization_reads_are_capped_and_detect_fragmented_headers() {
+        let payload: Vec<u8> = (0..=255).collect();
+        let mut gzip = flate2::write::GzEncoder::new(Vec::new(), Default::default());
+        gzip.write_all(&payload).unwrap();
+        let mut bzip = bzip2::write::BzEncoder::new(Vec::new(), Default::default());
+        bzip.write_all(&payload).unwrap();
+        let mut xz = xz2::write::XzEncoder::new(Vec::new(), 6);
+        xz.write_all(&payload).unwrap();
+        for bytes in [
+            payload.clone(),
+            gzip.finish().unwrap(),
+            bzip.finish().unwrap(),
+            xz.finish().unwrap(),
+        ] {
+            let mut reader = TinyReads {
+                bytes: &bytes,
+                consumed: 0,
+            };
+            assert!(
+                matches!(read_serialized(&mut reader, 256), Decoded::Bytes(result) if result == payload)
+            );
+            assert!(matches!(
+                read_serialized(bytes.as_slice(), 255),
+                Decoded::OverCap
+            ));
+        }
+        let bytes = vec![b'x'; 65536];
+        let mut reader = TinyReads {
+            bytes: &bytes,
+            consumed: 0,
+        };
+        assert!(matches!(read_serialized(&mut reader, 16), Decoded::OverCap));
+        assert_eq!(reader.consumed, 17);
+        for corrupt in [
+            b"BZh".as_slice(),
+            &[0x1f, 0x8b],
+            &[0xfd, b'7', b'z', b'X', b'Z', 0],
+        ] {
+            assert!(matches!(read_serialized(corrupt, 256), Decoded::Failed));
+        }
+    }
+
+    #[test]
+    fn source_decoding_is_shared_and_read_errors_remain_errors() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("source.R");
+        for bytes in ["café <- 1\n".as_bytes(), b"caf\xe9 <- 1\n"] {
+            std::fs::write(&path, bytes).unwrap();
+            assert_eq!(read_r_source(&path).unwrap(), "café <- 1\n");
+        }
+        assert!(read_r_source(&dir.path().join("missing.R")).is_err());
     }
 }

--- a/crates/ry-workspace/src/lib.rs
+++ b/crates/ry-workspace/src/lib.rs
@@ -940,7 +940,7 @@ fn loaded_serialized_bindings(
 /// Parse an R NAMESPACE file with the regular R parser. This handles quoted
 /// names, comments, and multiline directives without a second parser.
 fn read_namespace(path: &Path) -> NamespaceMetadata {
-    let Ok(src) = std::fs::read_to_string(path) else {
+    let Ok(src) = read_r_source(path) else {
         return NamespaceMetadata::default();
     };
     let Ok(mut parser) = ry_core::RParser::new() else {


### PR DESCRIPTION
Fix four input-boundary defects found during the cleanup review:

- Reject duplicate function keys and S3 dispatch definitions before they overwrite earlier signatures. Remove function-order tracking and the cosmetic sortedness warning; validation now reports errors only.
- Share UTF-8/Latin-1 source decoding between the CLI, LSP index, and auxiliary R-source readers. Read each source once.
- Match environment profiles with globs anchored to the configuration directory, rather than substrings of absolute paths. Preserve the anchor when checking nested packages and reject malformed patterns.
- Stream serialized workspaces through the decoded-byte limit. Compression overhead does not count against that limit, and oversized uncompressed input is no longer fully allocated before checking it.

Fixes #213, #201, #212, and #199. Also removes the unused equality derives noted in #215's review.

Validation includes workspace tests, Clippy, rustfmt, the R oracle, CLI/LSP transcripts for Latin-1 open/close and environment scope, duplicate-definition loader tests, and instrumented stream tests covering fragmented headers, exact-cap payloads, corrupt streams, and bounded reads. Sibling r-typeshed generator and provenance audits pass with the existing R test library.

This PR builds on #215. Larger inference and editor lifecycle changes remain separate.
