### PR TITLE
Integrate corrected purrr results and stabilize the mirai fixture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -243,6 +243,8 @@ suppression actions — and fixes a parser panic plus several editor issues.
 
 ### Fixed
 
+- Correct typed purrr multi-input map results and remove an unsupported scalar-length fallback. Await the mirai oracle result before shutting down its daemons.
+
 - Watch custom editor configuration paths and reload settings when the path changes, retaining the last valid configuration after malformed edits.
 
 - Re-resolve the VS Code server on restart and retain the working server if its replacement fails. Verify the installed VSIX in trusted and untrusted workspaces.

--- a/crates/ry-checker/src/higher_order.rs
+++ b/crates/ry-checker/src/higher_order.rs
@@ -55,7 +55,20 @@ impl Checker {
         let signature = self.resolve_typeshed_sig(name)?;
         let spec = signature.higher_order.as_ref()?;
         let argument_match = match_params(&signature.params, args);
-        Some(self.infer_ho_result(name, spec, args, arg_types, &argument_match, scope, span))
+        let declared_length = match &signature.return_ {
+            ReturnSpec::Concrete(ty) => json_length_to_length(JsonLength::parse(&ty.length)),
+            ReturnSpec::Slot(_) => Length::Unknown,
+        };
+        Some(self.infer_ho_result(
+            name,
+            spec,
+            declared_length,
+            args,
+            arg_types,
+            &argument_match,
+            scope,
+            span,
+        ))
     }
 
     /// Per-builtin result-type computation. Used by both pass 2 (pure,
@@ -68,6 +81,7 @@ impl Checker {
         &mut self,
         name: &str,
         spec: &HigherOrderSpec,
+        declared_length: Length,
         args: &[Arg],
         arg_types: &[RType],
         argument_match: &ArgumentMatch,
@@ -132,7 +146,7 @@ impl Checker {
                     .length_arg
                     .and_then(|i| matched_argument_type(arg_types, argument_match, i))
                     .map(|ty| ty.length)
-                    .unwrap_or(Length::One);
+                    .unwrap_or(declared_length);
                 RType::new(mode, length)
             }
             HigherOrderResultKind::SameAsArg0 => {

--- a/crates/ry-checker/src/tests/functions_classes.rs
+++ b/crates/ry-checker/src/tests/functions_classes.rs
@@ -763,3 +763,27 @@ fn user_fn_as_value_not_unbound() {
         diags
     );
 }
+
+#[test]
+fn typed_multi_input_maps_preserve_atomic_modes_without_claiming_a_length() {
+    for (suffix, value, mode) in [
+        ("chr", "\"x\"", Mode::Character),
+        ("dbl", "1.0", Mode::Double),
+        ("int", "1L", Mode::Integer),
+        ("lgl", "TRUE", Mode::Logical),
+    ] {
+        for (prefix, inputs) in [("map2", "1L, 1:3"), ("pmap", "list(1L, 1:3)")] {
+            for qualifier in ["", "purrr::"] {
+                let source = format!(
+                    "library(purrr)\nresult <- {qualifier}{prefix}_{suffix}({inputs}, function(...) {value})\n"
+                );
+                let (_, scope) = check_with_scope(&source);
+                let result = scope.get("result").unwrap();
+                assert_eq!(result.mode, mode, "{source}");
+                assert_eq!(result.length, Length::Unknown, "{source}");
+            }
+        }
+    }
+    let (_, scope) = check_with_scope("position <- Position(is.na, c(1, 2, 3))\n");
+    assert_eq!(scope.get("position").unwrap().length, Length::One);
+}

--- a/crates/ry-checker/testdata/oracle/mirai_daemons.R
+++ b/crates/ry-checker/testdata/oracle/mirai_daemons.R
@@ -3,5 +3,5 @@
 library(mirai)
 daemons(2)
 m <- mirai(sqrt(2))
-print(m)
+print(m[])
 daemons(0)

--- a/crates/ry-lsp/src/backend.rs
+++ b/crates/ry-lsp/src/backend.rs
@@ -1041,9 +1041,15 @@ impl Backend {
                 None
             }
             .unwrap_or_else(|| {
-                serde_json::json!(escape_watch_path(
-                    &path.to_string_lossy().replace('\\', "/")
-                ))
+                // String patterns are best effort: clients may only watch
+                // workspace files. External watches need RelativePattern.
+                let path = path.to_string_lossy();
+                let path = if cfg!(windows) {
+                    path.replace('\\', "/")
+                } else {
+                    path.into_owned()
+                };
+                serde_json::json!(escape_watch_path(&path))
             });
             watchers.push(serde_json::json!({"globPattern": pattern}));
         }
@@ -1737,6 +1743,8 @@ fn custom_config_paths(state: &State) -> Vec<PathBuf> {
     paths
 }
 
+// LSP does not define literal escaping. Use VS Code/minimatch's bracket
+// convention; support for literal brackets varies across client engines.
 fn escape_watch_path(path: &str) -> String {
     path.chars()
         .map(|ch| match ch {

--- a/crates/ry-lsp/src/diagnostics.rs
+++ b/crates/ry-lsp/src/diagnostics.rs
@@ -138,8 +138,16 @@ pub(super) fn make_ignore_action(
         format!("# ry: ignore[{}]", codes.join(", "))
     };
     let new_line = match comment {
-        Some(comment) if !trailing.is_empty() => {
-            // Keep prose after a bracketed directive, replacing only the directive.
+        Some(comment)
+            if !trailing.is_empty()
+                && !comment
+                    .body
+                    .trim_start()
+                    .to_ascii_lowercase()
+                    .starts_with("noqa:") =>
+        {
+            // Replace bracketed directives. Colon-form noqa has no delimiter
+            // separating codes from prose, so preserve that comment below.
             let suffix = comment
                 .body
                 .find(']')

--- a/crates/ry-lsp/src/diagnostics.rs
+++ b/crates/ry-lsp/src/diagnostics.rs
@@ -139,15 +139,16 @@ pub(super) fn make_ignore_action(
     };
     let new_line = match comment {
         Some(comment)
-            if !trailing.is_empty()
-                && !comment
-                    .body
-                    .trim_start()
-                    .to_ascii_lowercase()
-                    .starts_with("noqa:") =>
+            if !trailing.is_empty() && {
+                let body = comment.body.trim_start().to_ascii_lowercase();
+                ["ry: ignore", "ry:ignore", "noqa"].iter().any(|marker| {
+                    body.strip_prefix(marker).is_some_and(|rest| {
+                        rest.trim_start().starts_with('[') && rest.contains(']')
+                    })
+                })
+            } =>
         {
-            // Replace bracketed directives. Colon-form noqa has no delimiter
-            // separating codes from prose, so preserve that comment below.
+            // Only bracketed directives delimit their codes from trailing prose.
             let suffix = comment
                 .body
                 .find(']')

--- a/crates/ry-lsp/tests/suppression_edits.rs
+++ b/crates/ry-lsp/tests/suppression_edits.rs
@@ -10,6 +10,8 @@ fn suppression_edits_remove_only_the_target_and_preserve_source() {
         for (source, target_line, code, editable) in [
             ("x <- never_bound_here # explanation\ny <- other\n", 0, "RY010", true),
             ("x <- never_bound_here # noqa: RY040 [note]\ny <- other\n", 0, "RY010", true),
+            ("x <- never_bound_here # noqa RY040 reason\ny <- other\n", 0, "RY010", true),
+            ("x <- never_bound_here # ry:ignore RY040 reason\ny <- other\n", 0, "RY010", true),
             ("x <- 1L + \"s\"; y <- never_bound_here # ry: ignore[RY040] reason\nz <- other\n", 0, "RY010", true),
             ("x <- \"café # text\nlast\"\ny <- never_bound_here # explanation\nz <- other\n", 2, "RY010", true),
             ("x <- \"first\nlast\" + 1L\ny <- other\n", 0, "RY040", false),

--- a/crates/ry-lsp/tests/suppression_edits.rs
+++ b/crates/ry-lsp/tests/suppression_edits.rs
@@ -9,6 +9,7 @@ fn suppression_edits_remove_only_the_target_and_preserve_source() {
     tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap().block_on(async {
         for (source, target_line, code, editable) in [
             ("x <- never_bound_here # explanation\ny <- other\n", 0, "RY010", true),
+            ("x <- never_bound_here # noqa: RY040 [note]\ny <- other\n", 0, "RY010", true),
             ("x <- 1L + \"s\"; y <- never_bound_here # ry: ignore[RY040] reason\nz <- other\n", 0, "RY010", true),
             ("x <- \"café # text\nlast\"\ny <- never_bound_here # explanation\nz <- other\n", 2, "RY010", true),
             ("x <- \"first\nlast\" + 1L\ny <- other\n", 0, "RY040", false),

--- a/crates/ry-typeshed/vendor/SOURCE
+++ b/crates/ry-typeshed/vendor/SOURCE
@@ -1,4 +1,4 @@
 repository: https://github.com/sims1253/r-typeshed
-commit: 6911905744ab0d1337cd157995fcc68dbd7ceb8f
+commit: 68c9aef64d5a07d59d21fbb77ed42bdf56965c2c
 tree-state: clean
-stubs-sha256: f3c366677c5fac49342e73dcf4d5e4b64484ce252b72b6cdd0174ea6809f806f
+stubs-sha256: fddc0617a47f1048f5c80f1ca9a9c5cfbe00791d4e5f987778c8ac50b392611d

--- a/crates/ry-typeshed/vendor/purrr/purrr.json
+++ b/crates/ry-typeshed/vendor/purrr/purrr.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "2",
   "package": "purrr",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "functions": {
     "accumulate": {
       "params": [
@@ -249,11 +249,11 @@
         "...",
         ".progress"
       ],
-      "higher_order": {"callback_param": ".f", "callback_position": 2, "callback_args": ["element_of_arg0", "element_of_arg1"], "result": {"kind": "list_of_callback_return", "include_callback_schema": true}},
+      "higher_order": {"callback_param": ".f", "callback_position": 2, "callback_args": ["element_of_arg0", "element_of_arg1"], "result": {"kind": "vector_of", "mode": "character"}},
       "return": {
         "mode": "character",
         "length": "unknown",
-        "na": false
+        "na": true
       }
     },
     "map2_dbl": {
@@ -264,11 +264,11 @@
         "...",
         ".progress"
       ],
-      "higher_order": {"callback_param": ".f", "callback_position": 2, "callback_args": ["element_of_arg0", "element_of_arg1"], "result": {"kind": "list_of_callback_return", "include_callback_schema": true}},
+      "higher_order": {"callback_param": ".f", "callback_position": 2, "callback_args": ["element_of_arg0", "element_of_arg1"], "result": {"kind": "vector_of", "mode": "double"}},
       "return": {
         "mode": "double",
         "length": "unknown",
-        "na": false
+        "na": true
       }
     },
     "map2_int": {
@@ -279,11 +279,11 @@
         "...",
         ".progress"
       ],
-      "higher_order": {"callback_param": ".f", "callback_position": 2, "callback_args": ["element_of_arg0", "element_of_arg1"], "result": {"kind": "list_of_callback_return", "include_callback_schema": true}},
+      "higher_order": {"callback_param": ".f", "callback_position": 2, "callback_args": ["element_of_arg0", "element_of_arg1"], "result": {"kind": "vector_of", "mode": "integer"}},
       "return": {
         "mode": "integer",
         "length": "unknown",
-        "na": false
+        "na": true
       }
     },
     "map2_lgl": {
@@ -294,11 +294,11 @@
         "...",
         ".progress"
       ],
-      "higher_order": {"callback_param": ".f", "callback_position": 2, "callback_args": ["element_of_arg0", "element_of_arg1"], "result": {"kind": "list_of_callback_return", "include_callback_schema": true}},
+      "higher_order": {"callback_param": ".f", "callback_position": 2, "callback_args": ["element_of_arg0", "element_of_arg1"], "result": {"kind": "vector_of", "mode": "logical"}},
       "return": {
         "mode": "logical",
         "length": "unknown",
-        "na": false
+        "na": true
       }
     },
     "map_chr": {
@@ -312,7 +312,7 @@
       "return": {
         "mode": "character",
         "length": "arg0",
-        "na": false
+        "na": true
       }
     },
     "map_dbl": {
@@ -326,7 +326,7 @@
       "return": {
         "mode": "double",
         "length": "arg0",
-        "na": false
+        "na": true
       }
     },
     "map_if": {
@@ -355,7 +355,7 @@
       "return": {
         "mode": "integer",
         "length": "arg0",
-        "na": false
+        "na": true
       }
     },
     "map_lgl": {
@@ -369,7 +369,7 @@
       "return": {
         "mode": "logical",
         "length": "arg0",
-        "na": false
+        "na": true
       }
     },
     "map_vec": {
@@ -384,7 +384,7 @@
       "return": {
         "mode": "opaque",
         "length": "arg0",
-        "na": false
+        "na": true
       }
     },
     "negate": {
@@ -452,11 +452,11 @@
         "...",
         ".progress"
       ],
-      "higher_order": {"callback_param": ".f", "callback_position": 1, "callback_args": ["element_of_arg0", "element_of_arg1"], "result": {"kind": "list_of_callback_return", "include_callback_schema": true}},
+      "higher_order": {"callback_param": ".f", "callback_position": 1, "callback_args": ["element_of_arg0", "element_of_arg1"], "result": {"kind": "vector_of", "mode": "character"}},
       "return": {
         "mode": "character",
         "length": "unknown",
-        "na": false
+        "na": true
       }
     },
     "pmap_dbl": {
@@ -466,11 +466,11 @@
         "...",
         ".progress"
       ],
-      "higher_order": {"callback_param": ".f", "callback_position": 1, "callback_args": ["element_of_arg0", "element_of_arg1"], "result": {"kind": "list_of_callback_return", "include_callback_schema": true}},
+      "higher_order": {"callback_param": ".f", "callback_position": 1, "callback_args": ["element_of_arg0", "element_of_arg1"], "result": {"kind": "vector_of", "mode": "double"}},
       "return": {
         "mode": "double",
         "length": "unknown",
-        "na": false
+        "na": true
       }
     },
     "pmap_int": {
@@ -480,11 +480,11 @@
         "...",
         ".progress"
       ],
-      "higher_order": {"callback_param": ".f", "callback_position": 1, "callback_args": ["element_of_arg0", "element_of_arg1"], "result": {"kind": "list_of_callback_return", "include_callback_schema": true}},
+      "higher_order": {"callback_param": ".f", "callback_position": 1, "callback_args": ["element_of_arg0", "element_of_arg1"], "result": {"kind": "vector_of", "mode": "integer"}},
       "return": {
         "mode": "integer",
         "length": "unknown",
-        "na": false
+        "na": true
       }
     },
     "pmap_lgl": {
@@ -494,11 +494,11 @@
         "...",
         ".progress"
       ],
-      "higher_order": {"callback_param": ".f", "callback_position": 1, "callback_args": ["element_of_arg0", "element_of_arg1"], "result": {"kind": "list_of_callback_return", "include_callback_schema": true}},
+      "higher_order": {"callback_param": ".f", "callback_position": 1, "callback_args": ["element_of_arg0", "element_of_arg1"], "result": {"kind": "vector_of", "mode": "logical"}},
       "return": {
         "mode": "logical",
         "length": "unknown",
-        "na": false
+        "na": true
       }
     },
     "pwalk": {

--- a/editors/code/src/common/binary.ts
+++ b/editors/code/src/common/binary.ts
@@ -99,13 +99,13 @@ function findOnPath(binary: string): string | undefined {
   return undefined;
 }
 
+const execFileAsync = promisify(execFile);
+
 /**
  * Probe the ry binary version by executing `ry version --output-format json`.
  * Returns undefined if the binary cannot be executed or the output
  * cannot be parsed.
  */
-const execFileAsync = promisify(execFile);
-
 export async function getRyVersion(
   binaryPath: string,
 ): Promise<VersionInfo | undefined> {

--- a/editors/code/src/common/binary.ts
+++ b/editors/code/src/common/binary.ts
@@ -13,7 +13,8 @@
  */
 
 import * as path from "path";
-import * as cp from "child_process";
+import { execFile } from "child_process";
+import { promisify } from "util";
 import * as fs from "fs";
 import { BUNDLED_RY_EXECUTABLE, RY_BINARY_NAME } from "./constants";
 import {
@@ -103,18 +104,21 @@ function findOnPath(binary: string): string | undefined {
  * Returns undefined if the binary cannot be executed or the output
  * cannot be parsed.
  */
-export function getRyVersion(binaryPath: string): VersionInfo | undefined {
+const execFileAsync = promisify(execFile);
+
+export async function getRyVersion(
+  binaryPath: string,
+): Promise<VersionInfo | undefined> {
   try {
-    const output = cp.execFileSync(
+    const { stdout } = await execFileAsync(
       binaryPath,
       ["version", "--output-format", "json"],
       {
         encoding: "utf-8",
         timeout: 5000,
-        stdio: ["pipe", "pipe", "pipe"],
       },
     );
-    const parsed = JSON.parse(output);
+    const parsed = JSON.parse(stdout);
     const version = parsed.version as string | undefined;
     if (!version) return undefined;
     return versionFromString(version);

--- a/editors/code/src/extension.ts
+++ b/editors/code/src/extension.ts
@@ -85,7 +85,7 @@ export async function activate(
   const runServer = async () => {
     const nextSettings = readSettings();
     const path = findRyBinaryPath(nextSettings, !vscode.workspace.isTrusted);
-    const nextBinary = { path, version: getRyVersion(path) };
+    const nextBinary = { path, version: await getRyVersion(path) };
     const error = checkVersionCapability(
       nextBinary,
       MINIMUM_SETTINGS_CHANNEL_VERSION,

--- a/editors/code/src/test/binary.test.ts
+++ b/editors/code/src/test/binary.test.ts
@@ -8,7 +8,7 @@
  */
 
 import { describe, it, expect } from "bun:test";
-import { findRyBinaryPath } from "../common/binary";
+import { findRyBinaryPath, getRyVersion } from "../common/binary";
 import { BUNDLED_RY_EXECUTABLE } from "../common/constants";
 import * as fs from "fs";
 import * as os from "os";
@@ -84,3 +84,28 @@ it("skips directories and non-executable files before a runnable candidate", () 
     fs.rmSync(dir, { recursive: true, force: true });
   }
 });
+
+it.skipIf(process.platform === "win32")(
+  "version probing leaves the event loop responsive",
+  async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "ry-version-"));
+    try {
+      const binary = path.join(dir, "ry");
+      fs.writeFileSync(
+        binary,
+        `#!/bin/sh\nsleep 0.1\necho '{"version":"0.9.0"}'\n`,
+        { mode: 0o755 },
+      );
+      let resolved = false;
+      const probe = getRyVersion(binary).then((version) => {
+        resolved = true;
+        return version;
+      });
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(resolved).toBe(false);
+      expect(await probe).toEqual({ major: 0, minor: 9, patch: 0 });
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  },
+);


### PR DESCRIPTION
Sync the merged r-typeshed purrr fixes: typed map2/pmap results are atomic vectors with unknown lengths, and typed maps may return missing values. Use the declared return length when a higher-order result has no `length_arg`; the previous unconditional scalar fallback made attached `map2_*` calls length one. `Position` keeps its declared scalar result.

The regression checks all eight typed multi-input functions, both attached and namespace-qualified, plus Position. It failed on the previous scalar fallback and passes with this change. Callback-contract validation remains tracked in #221.

Also wait for the mirai oracle result before shutting down its daemons. The old fixture intermittently hung during teardown; the awaited form passed five consecutive standalone runs and two complete oracle runs.

Validation: full workspace tests, clippy, formatting, all 13 R oracle tests, and 33 vendored stub validations passed. Includes the latest reviewed suppression-comment preservation follow-up from #218.
