### PR TITLE
fix(checker): skip unreachable recursive default operands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -259,6 +259,9 @@ suppression actions — and fixes a parser panic plus several editor issues.
 
 ### Fixed
 
+- Avoid RY098 warnings for recursive names in default expressions when literal
+  `if` conditions or short-circuit operators skip their evaluation.
+
 - Correct typed purrr multi-input map results and remove an unsupported scalar-length fallback. Await the mirai oracle result before shutting down its daemons.
 
 - Watch custom editor configuration paths and reload settings when the path changes, retaining the last valid configuration after malformed edits.

--- a/crates/ry-checker/src/infer/quoting.rs
+++ b/crates/ry-checker/src/infer/quoting.rs
@@ -222,6 +222,19 @@ fn first_executed_identifier_in_stmt(statement: &Stmt, wanted: &str) -> Option<S
         Stmt::Assign { value, .. } => first_executed_identifier(value, wanted),
         Stmt::Expr(expr) => first_executed_identifier(expr, wanted),
         Stmt::If {
+            cond: Expr::Logical(taken, _),
+            then,
+            else_,
+            ..
+        } => {
+            let branch = if *taken { Some(then) } else { else_.as_ref() };
+            branch.and_then(|statements| {
+                statements
+                    .iter()
+                    .find_map(|statement| first_executed_identifier_in_stmt(statement, wanted))
+            })
+        }
+        Stmt::If {
             cond, then, else_, ..
         } => first_executed_identifier(cond, wanted)
             .or_else(|| {
@@ -274,7 +287,16 @@ fn first_executed_identifier(expr: &Expr, wanted: &str) -> Option<Span> {
             }
         }
         Expr::BinOp { lhs, rhs, op, .. } => {
-            if matches!(op, BinOpKind::Assign | BinOpKind::SuperAssign) {
+            // A literal short-circuit operand can make the recursive name
+            // in the RHS unreachable even though the default is forced.
+            let skips_rhs = matches!(
+                (op, lhs.as_ref()),
+                (BinOpKind::AndAnd, Expr::Logical(false, _))
+                    | (BinOpKind::OrOr, Expr::Logical(true, _))
+            );
+            if skips_rhs {
+                first_executed_identifier(lhs, wanted)
+            } else if matches!(op, BinOpKind::Assign | BinOpKind::SuperAssign) {
                 first_executed_identifier(rhs, wanted)
             } else {
                 first_executed_identifier(lhs, wanted)
@@ -296,6 +318,17 @@ fn first_executed_identifier(expr: &Expr, wanted: &str) -> Option<Span> {
         Expr::Block { body, .. } => body
             .iter()
             .find_map(|statement| first_executed_identifier_in_stmt(statement, wanted)),
+        Expr::If {
+            cond, then, else_, ..
+        } if matches!(cond.as_ref(), Expr::Logical(_, _)) => {
+            if matches!(cond.as_ref(), Expr::Logical(true, _)) {
+                first_executed_identifier(then, wanted)
+            } else {
+                else_
+                    .as_ref()
+                    .and_then(|else_| first_executed_identifier(else_, wanted))
+            }
+        }
         Expr::If {
             cond, then, else_, ..
         } => first_executed_identifier(cond, wanted)

--- a/crates/ry-checker/testdata/err_recursive_default_taken_operands.R
+++ b/crates/ry-checker/testdata/err_recursive_default_taken_operands.R
@@ -1,0 +1,8 @@
+# expect: RY098, RY098, RY098, RY098, RY098, RY098
+# Adjacent taken branches still force the recursive promise.
+f_if_true <- function(x = if (TRUE) x else 1L) x
+f_if_false <- function(x = if (FALSE) 1L else x) x
+f_and <- function(x = TRUE && x) x
+f_or <- function(x = FALSE || x) x
+f_block <- function(x = { if (TRUE) x; 1L }) x
+f_condition <- function(x = if (x) 1L else 2L) x

--- a/crates/ry-checker/testdata/ok_recursive_default_skipped_operands.R
+++ b/crates/ry-checker/testdata/ok_recursive_default_skipped_operands.R
@@ -1,0 +1,8 @@
+# no-diag
+# The body forces the default, but the default never evaluates its own formal.
+f_if_false <- function(x = if (FALSE) x else 1L) x
+f_if_true <- function(x = if (TRUE) 1L else x) x
+f_and <- function(x = FALSE && x) x
+f_or <- function(x = TRUE || x) x
+f_block <- function(x = { if (FALSE) x; 1L }) x
+f_nested <- function(x = if (TRUE) { FALSE && x } else x) x

--- a/crates/ry-checker/testdata/oracle/recursive_default_skipped_operands.R
+++ b/crates/ry-checker/testdata/oracle/recursive_default_skipped_operands.R
@@ -1,0 +1,10 @@
+# oracle: must-pass
+f_if_false <- function(x = if (FALSE) x else 1L) x
+f_if_true <- function(x = if (TRUE) 1L else x) x
+f_and <- function(x = FALSE && x) x
+f_or <- function(x = TRUE || x) x
+f_block <- function(x = { if (FALSE) x; 1L }) x
+f_nested <- function(x = if (TRUE) { FALSE && x } else x) x
+stopifnot(identical(f_if_false(), 1L), identical(f_if_true(), 1L),
+          identical(f_and(), FALSE), identical(f_or(), TRUE),
+          identical(f_block(), 1L), identical(f_nested(), FALSE))

--- a/crates/ry-checker/testdata/oracle/recursive_default_taken_operands.R
+++ b/crates/ry-checker/testdata/oracle/recursive_default_taken_operands.R
@@ -1,0 +1,12 @@
+# oracle: must-warn RY098
+# oracle-claim: RY098
+f_if_true <- function(x = if (TRUE) x else 1L) x
+f_if_false <- function(x = if (FALSE) 1L else x) x
+f_and <- function(x = TRUE && x) x
+f_or <- function(x = FALSE || x) x
+f_block <- function(x = { if (TRUE) x; 1L }) x
+f_condition <- function(x = if (x) 1L else 2L) x
+for (f in list(f_if_true, f_if_false, f_and, f_or, f_block, f_condition)) {
+  result <- tryCatch(f(), error = identity)
+  stopifnot(inherits(result, "error"))
+}

--- a/crates/ry-checker/tests/snapshots/corpus__checker_fixture_diagnostics.snap
+++ b/crates/ry-checker/tests/snapshots/corpus__checker_fixture_diagnostics.snap
@@ -318,6 +318,56 @@ expression: snapshots
   fixture: err_recursive_default_literal_false_block.R
 - diagnostics:
     - code: RY098
+      message: "parameter `x` has a self-referential default that recurses when forced"
+      severity: warning
+      span:
+        column: 36
+        end: 149
+        line: 2
+        start: 148
+    - code: RY098
+      message: "parameter `x` has a self-referential default that recurses when forced"
+      severity: warning
+      span:
+        column: 46
+        end: 208
+        line: 3
+        start: 207
+    - code: RY098
+      message: "parameter `x` has a self-referential default that recurses when forced"
+      severity: warning
+      span:
+        column: 30
+        end: 243
+        line: 4
+        start: 242
+    - code: RY098
+      message: "parameter `x` has a self-referential default that recurses when forced"
+      severity: warning
+      span:
+        column: 30
+        end: 278
+        line: 5
+        start: 277
+    - code: RY098
+      message: "parameter `x` has a self-referential default that recurses when forced"
+      severity: warning
+      span:
+        column: 36
+        end: 319
+        line: 6
+        start: 318
+    - code: RY098
+      message: "parameter `x` has a self-referential default that recurses when forced"
+      severity: warning
+      span:
+        column: 32
+        end: 362
+        line: 7
+        start: 361
+  fixture: err_recursive_default_taken_operands.R
+- diagnostics:
+    - code: RY098
       message: "parameter `copy` has a self-referential default that recurses when forced"
       severity: warning
       span:
@@ -672,6 +722,8 @@ expression: snapshots
   fixture: ok_recursive_default_shadowed_strict.R
 - diagnostics: []
   fixture: ok_recursive_default_short_circuit.R
+- diagnostics: []
+  fixture: ok_recursive_default_skipped_operands.R
 - diagnostics: []
   fixture: ok_recursive_default_unforced_branch.R
 - diagnostics: []


### PR DESCRIPTION
RY098 reported recursion for defaults such as `function(x = FALSE && x) x`, even though R never evaluates the recursive operand. The same false positive affected literal `if` branches, including statements inside a default's block.

The first-executed identifier walker now skips branches selected out by literal logical conditions and the right operands of `FALSE &&` and `TRUE ||`. The handling of nonliteral conditions is unchanged.

Six passing corpus cases cover skipped branches and nested defaults; six adjacent cases retain RY098 for taken branches and evaluated conditions. Matching R oracle fixtures assert the returned values or recursive-promise errors.

Validation: `cargo test --workspace`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt --all -- --check`, and the complete R oracle matrix (`cargo test -p ry-checker --test oracle -- --include-ignored`, with `R_LIBS_USER` pointing to the installed fixture dependencies).

Related to #196. This fixes a bounded evaluation-order case; per-argument eval metadata, the withr mask inference issue, and higher-order typing of function inputs remain open.

Additional validation: strict local ecosystem checks passed for all 32 tidyverse packages and 35 Posit fast-tier packages. Committed reports are unchanged, and all 578 Posit message identities match.
