### PR TITLE
Track corpus instruction counts with warn-only CI

### DIFF
--- a/.github/workflows/instructions.yml
+++ b/.github/workflows/instructions.yml
@@ -1,0 +1,84 @@
+name: Corpus instruction counts
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+  schedule:
+    - cron: "43 4 * * *"
+  pull_request:
+    paths:
+      - ecosystem/instructions.py
+      - ecosystem/test-instructions.py
+      - ecosystem/instruction-packages.txt
+      - docs/corpus/instructions-baseline.json
+      - .github/workflows/instructions.yml
+
+permissions:
+  contents: read
+
+concurrency:
+  group: instructions-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  instructions:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    # Gather a noise floor before making count growth a blocking check.
+    continue-on-error: true
+    env:
+      RAYON_NUM_THREADS: "1"
+      RY_NO_INSTALLED_LIBRARIES: "1"
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c
+        with:
+          toolchain: "1.98.1"
+      - name: Install instruction counter
+        run: sudo apt-get update && sudo apt-get install -y valgrind liblzma-dev
+      - name: Test ledger guards
+        run: python3 ecosystem/test-instructions.py
+      - name: Check out the fixed reference revision
+        run: |
+          baseline_ref=$(python3 -c 'import json; print(json.load(open("docs/corpus/instructions-baseline.json"))["source_revision"])')
+          [[ "$baseline_ref" =~ ^[0-9a-f]{40}$ ]]
+          git worktree add --detach "$RUNNER_TEMP/instructions-reference" "$baseline_ref"
+      # Re-measure the frozen reference under the same counter/libc/compiler.
+      # Updating its source revision requires a separately reviewed baseline change.
+      - name: Measure reference
+        continue-on-error: true
+        run: >-
+          python3 ecosystem/instructions.py measure --backend callgrind
+          --source "$RUNNER_TEMP/instructions-reference"
+          --target-dir "$RUNNER_TEMP/instructions-reference-target"
+          --output instruction-reference.json --budget 180 --package-timeout 60
+      - name: Measure current source
+        continue-on-error: true
+        run: >-
+          python3 ecosystem/instructions.py measure --backend callgrind
+          --target-dir "$RUNNER_TEMP/instructions-current-target"
+          --output instruction-current.json --budget 180 --package-timeout 60
+      - name: Report deltas
+        if: always()
+        run: |
+          if [[ -f instruction-reference.json && -f instruction-current.json ]]; then
+            python3 ecosystem/instructions.py compare instruction-reference.json instruction-current.json > instruction-summary.md
+            printf '\n### Historical ledger comparability\n\n' >> instruction-summary.md
+            python3 ecosystem/instructions.py compare docs/corpus/instructions-baseline.json instruction-current.json >> instruction-summary.md
+          else
+            printf '## Corpus instruction counts\n\nUNAVAILABLE: a build or counter failed. See the measurement logs.\n' > instruction-summary.md
+          fi
+          cat instruction-summary.md >> "$GITHUB_STEP_SUMMARY"
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: always()
+        with:
+          name: instruction-counts
+          path: |
+            instruction-reference.json
+            instruction-current.json
+            instruction-summary.md
+          retention-days: 90

--- a/.github/workflows/instructions.yml
+++ b/.github/workflows/instructions.yml
@@ -25,8 +25,6 @@ jobs:
   instructions:
     runs-on: ubuntu-24.04
     timeout-minutes: 20
-    # Gather a noise floor before making count growth a blocking check.
-    continue-on-error: true
     env:
       RAYON_NUM_THREADS: "1"
       RY_NO_INSTALLED_LIBRARIES: "1"
@@ -47,6 +45,7 @@ jobs:
           baseline_ref=$(python3 -c 'import json; print(json.load(open("docs/corpus/instructions-baseline.json"))["source_revision"])')
           [[ "$baseline_ref" =~ ^[0-9a-f]{40}$ ]]
           git worktree add --detach "$RUNNER_TEMP/instructions-reference" "$baseline_ref"
+      # Measurement failures and count growth are warn-only; harness guards are not.
       # Re-measure the frozen reference under the same counter/libc/compiler.
       # Updating its source revision requires a separately reviewed baseline change.
       - name: Measure reference
@@ -68,9 +67,10 @@ jobs:
           if [[ -f instruction-reference.json && -f instruction-current.json ]]; then
             python3 ecosystem/instructions.py compare instruction-reference.json instruction-current.json > instruction-summary.md
             printf '\n### Historical ledger comparability\n\n' >> instruction-summary.md
-            python3 ecosystem/instructions.py compare docs/corpus/instructions-baseline.json instruction-current.json >> instruction-summary.md
+            python3 ecosystem/instructions.py compare docs/corpus/instructions-baseline.json instruction-current.json > instruction-historical.md
+            tail -n +3 instruction-historical.md >> instruction-summary.md
           else
-            printf '## Corpus instruction counts\n\nUNAVAILABLE: a build or counter failed. See the measurement logs.\n' > instruction-summary.md
+            printf '## Corpus instruction counts\n\nUNAVAILABLE: a required ledger was not produced. See the preceding steps.\n' > instruction-summary.md
           fi
           cat instruction-summary.md >> "$GITHUB_STEP_SUMMARY"
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/instructions.yml
+++ b/.github/workflows/instructions.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c
+      - uses: dtolnay/rust-toolchain@d1031067263f94b142dd6c0ce24c5eb9d02d52a0 # master
         with:
           toolchain: "1.98.1"
       - name: Install instruction counter

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,10 @@ Each oracle fixture runs in a fresh `Rscript --vanilla` process. Its exit
 status determines whether R errored; fixtures cannot leak bindings, attached
 packages, or daemon state into later fixtures.
 
+The [instruction-count corpus guide](docs/corpus/instructions.md) explains
+the fixed performance sample, local measurements, and warn-only CI deltas.
+Run `python3 ecosystem/test-instructions.py` after changing that harness.
+
 ## Fixture conventions
 
 - `crates/ry-checker/testdata/ok_*.R` -- must produce zero diagnostics.

--- a/docs/corpus/README.md
+++ b/docs/corpus/README.md
@@ -26,6 +26,11 @@ the pre-change baseline (729 identities, hermetic, measured on the
 audited starting tree). Neither gated CI; both are re-derivable from the
 audit records summarized in [`pre-governance-measurement.md`](pre-governance-measurement.md).
 
+## Instruction counts
+
+The [instruction baseline](instructions-baseline.json) records the fixed performance
+sample. See the [measurement guide](instructions.md) for local runs and CI deltas.
+
 ## Parser invariant evidence
 
 [`parser-option-audit-0.9.md`](parser-option-audit-0.9.md) records the complete

--- a/docs/corpus/instructions-baseline.json
+++ b/docs/corpus/instructions-baseline.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "created_at": "2026-09-06T17:49:34.534792+00:00",
+  "created_at": "2026-09-06T18:41:56.071281+00:00",
   "source_revision": "24b4cbfbfa4a7d65473640fa6eaeb7611a223d81",
   "source_dirty": false,
   "binary_sha256": "c251aeb91903bfa136990430e3a0f97eb21ef25387d5fa98949c4115a63d336f",
@@ -36,12 +36,10 @@
     "config": "empty R/ry.toml",
     "counter_environment": "fixed variables plus tool PATH and empty temporary HOME",
     "manifest_sha256": "9828c69304bb77c0402297e8b15d18611cae6de6c00f84c77836b5d2c0abf1bc",
-    "harness_sha256": "b649dc6e0b8505c89ec491f5ae2d616d8bfe5584f82069dd8e91858566ce38f3",
+    "harness_sha256": "13c5d3482f9a4280f8718fc13034da7567ab038279c96ddee32636ba32539dc3",
     "repetitions": 3
   },
-  "fallback_notes": [
-    "perf is not installed"
-  ],
+  "fallback_notes": [],
   "packages": [
     {
       "package": "glue",
@@ -50,11 +48,11 @@
       "status": "measured",
       "tree": "b6d7f2771e0824206123c0cb140d92ec0c963b0d",
       "counts": [
-        299325684,
-        299408590,
-        299499612
+        299454159,
+        299393861,
+        299251257
       ],
-      "instructions": 299408590
+      "instructions": 299393861
     },
     {
       "package": "stringr",
@@ -63,11 +61,11 @@
       "status": "measured",
       "tree": "daa0d49a54b5bfec88035b9377b9fa522e551ccc",
       "counts": [
-        895313413,
-        896140032,
-        893662138
+        894529652,
+        894101245,
+        893771548
       ],
-      "instructions": 895313413
+      "instructions": 894101245
     },
     {
       "package": "withr",
@@ -76,11 +74,11 @@
       "status": "measured",
       "tree": "c51c9c9f4c5c2e83c02762c6fb31273e81a5de77",
       "counts": [
-        467718298,
-        467920767,
-        467914577
+        467563344,
+        467603912,
+        467813669
       ],
-      "instructions": 467914577
+      "instructions": 467603912
     }
   ]
 }

--- a/docs/corpus/instructions-baseline.json
+++ b/docs/corpus/instructions-baseline.json
@@ -1,0 +1,86 @@
+{
+  "schema_version": 1,
+  "created_at": "2026-09-06T17:49:34.534792+00:00",
+  "source_revision": "24b4cbfbfa4a7d65473640fa6eaeb7611a223d81",
+  "source_dirty": false,
+  "binary_sha256": "c251aeb91903bfa136990430e3a0f97eb21ef25387d5fa98949c4115a63d336f",
+  "cargo_lock_sha256": "12df440f0e59e191dec34c015f6b64f781fd134fa3d167f0b4ccd816a9df529c",
+  "metadata": {
+    "backend": "callgrind",
+    "backend_version": "valgrind-3.25.1",
+    "architecture": "x86_64",
+    "system": "Linux",
+    "cpu": "AMD Ryzen 5 PRO 5650U with Radeon Graphics",
+    "libc": [
+      "glibc",
+      "2.44"
+    ],
+    "rustc": "rustc 1.98.1 (48a229cea 2026-09-01)\nbinary: rustc\ncommit-hash: 48a229ceaefd4985c50990b14116b6d856af0985\ncommit-date: 2026-09-01\nhost: x86_64-unknown-linux-gnu\nrelease: 1.98.1\nLLVM version: 22.1.8",
+    "cargo": "cargo 1.98.1 (797e8a9bc 2026-08-05)",
+    "cc": "cc (GCC) 16.2.1 20260810",
+    "build_profile": "release",
+    "build_flags": {},
+    "command": [
+      "check",
+      "--exit-zero",
+      "--output-format",
+      "json",
+      "<package>/R"
+    ],
+    "environment": {
+      "RY_NO_INSTALLED_LIBRARIES": "1",
+      "RAYON_NUM_THREADS": "1",
+      "LC_ALL": "C",
+      "TZ": "UTC"
+    },
+    "config": "empty R/ry.toml",
+    "counter_environment": "fixed variables plus tool PATH and empty temporary HOME",
+    "manifest_sha256": "9828c69304bb77c0402297e8b15d18611cae6de6c00f84c77836b5d2c0abf1bc",
+    "harness_sha256": "b649dc6e0b8505c89ec491f5ae2d616d8bfe5584f82069dd8e91858566ce38f3",
+    "repetitions": 3
+  },
+  "fallback_notes": [
+    "perf is not installed"
+  ],
+  "packages": [
+    {
+      "package": "glue",
+      "url": "https://github.com/tidyverse/glue.git",
+      "revision": "da9c73f7a3de6a27f3103cb5bb2355820a4c3a6a",
+      "status": "measured",
+      "tree": "b6d7f2771e0824206123c0cb140d92ec0c963b0d",
+      "counts": [
+        299325684,
+        299408590,
+        299499612
+      ],
+      "instructions": 299408590
+    },
+    {
+      "package": "stringr",
+      "url": "https://github.com/tidyverse/stringr.git",
+      "revision": "ae054b1d28f630fee22ddb3cb7525396e62af4fe",
+      "status": "measured",
+      "tree": "daa0d49a54b5bfec88035b9377b9fa522e551ccc",
+      "counts": [
+        895313413,
+        896140032,
+        893662138
+      ],
+      "instructions": 895313413
+    },
+    {
+      "package": "withr",
+      "url": "https://github.com/r-lib/withr.git",
+      "revision": "c8539fe735a5b6cdb496c68bca8248f8b6b4d419",
+      "status": "measured",
+      "tree": "c51c9c9f4c5c2e83c02762c6fb31273e81a5de77",
+      "counts": [
+        467718298,
+        467920767,
+        467914577
+      ],
+      "instructions": 467914577
+    }
+  ]
+}

--- a/docs/corpus/instructions.md
+++ b/docs/corpus/instructions.md
@@ -1,0 +1,81 @@
+# Corpus instruction counts
+
+The fixed sample in [instruction-packages.txt](../../ecosystem/instruction-packages.txt)
+tracks the cost of checking glue, stringr, and withr. These are full commit pins
+from the ecosystem corpus. The harness checks each package's `R/` directory;
+it does not install packages or execute R code.
+
+Run this command from the repository root on Linux:
+
+```sh
+python3 ecosystem/instructions.py measure --output instruction-current.json
+```
+
+The command builds ry in release mode with `--locked`, fetches the pinned
+sources, and records three counts per package. It uses `perf stat` with the
+user-space `instructions:u` event when available. If perf is missing, denied
+by the host, or cannot count instructions, it uses Valgrind's Callgrind `Ir`
+counter. Install `perf` or `valgrind`, plus the usual Rust build dependencies.
+Use `--backend perf` or `--backend callgrind` to require one counter.
+
+Each count includes process startup, analysis, and JSON formatting. Output
+goes to `/dev/null`. The recorded value is the median; the ledger retains all
+three measurements. This measures instructions, not elapsed time. The timeout
+is only a resource limit. Rust's randomized hashing can still cause small
+instruction-count differences, so this is not a claim of perfectly repeatable
+counts.
+
+The harness sets `RAYON_NUM_THREADS=1` and `RY_NO_INSTALLED_LIBRARIES=1`, and
+places an empty `R/ry.toml` in each private sample checkout. This excludes host
+R libraries and project configuration. Counter processes inherit only `PATH`
+plus the fixed variables and an empty temporary `HOME`; Callgrind ignores
+user option files. The sample commit and Git tree identify
+the source bytes; a dirty sample checkout is rejected. The ledger also records
+the binary hash, ry revision, compiler, build flags, architecture, CPU, libc,
+counter version, harness hash, and measurement settings.
+
+## Compare runs
+
+```sh
+python3 ecosystem/instructions.py compare \
+  docs/corpus/instructions-baseline.json instruction-current.json
+```
+
+The report warns when a package grows by more than 10%. Use `--threshold 15`
+to choose a different percentage. Growth never changes the comparison's exit
+status. Missing measurements are `UNAVAILABLE`; changed sample pins or
+measurement metadata are `INCOMPARABLE`. Perf and Callgrind counts are never
+compared with each other. A failed measurement command exits nonzero and
+preserves completed rows when the failure occurs during package measurement.
+An unavailable counter or failed build produces a ledger with unavailable rows.
+The perf parser follows the documented [CSV field order](https://man7.org/linux/man-pages/man1/perf-stat.1.html#CSV_FORMAT)
+and rejects missing or multiplexed counters.
+
+The default measurement budget is 180 seconds, with at most 60 seconds for
+each counter invocation. The build has a separate 600-second limit. Use
+`--budget` and `--package-timeout` for larger local runs. Fetching package
+sources has a separate per-command timeout of 120 seconds. Keep the fixed
+sample small enough to fit the CI budget.
+
+## CI and baseline updates
+
+[Corpus instruction counts](../../.github/workflows/instructions.yml) runs on
+merges to main, daily, and on manual dispatch. Changes to the harness also run
+it in pull requests. The job has a 20-minute limit and is warn-only. The normal
+single-file performance tests remain the blocking latency checks.
+
+The committed [baseline ledger](instructions-baseline.json) contains actual
+Callgrind measurements. Its host may differ from a CI runner. CI therefore
+checks out the baseline's fixed `source_revision` and measures it again with
+the same compiler, counter, and sample as the current code. Both builds use
+separate target directories. The job summary reports these comparable deltas
+and explains whether the historical absolute counts are comparable. Artifacts
+retain both ledgers and the report for 90 days.
+
+The reference revision stays fixed between runs; it does not follow main.
+Change it only in a reviewed baseline update after investigating the reported
+growth. Generate the replacement ledger from a clean checkout of the intended
+reference revision, inspect the counts, and commit it separately from a
+performance change. Keep the package pins unchanged so a new baseline does
+not hide a change in the workload. A toolchain update should also review the
+new noise floor before changing the warning threshold.

--- a/docs/corpus/instructions.md
+++ b/docs/corpus/instructions.md
@@ -61,8 +61,10 @@ sample small enough to fit the CI budget.
 
 [Corpus instruction counts](../../.github/workflows/instructions.yml) runs on
 merges to main, daily, and on manual dispatch. Changes to the harness also run
-it in pull requests. The job has a 20-minute limit and is warn-only. The normal
-single-file performance tests remain the blocking latency checks.
+it in pull requests. The job has a 20-minute limit. Count growth and measurement
+failures are warn-only; failed harness tests or an invalid reference revision
+fail the check. The normal single-file performance tests remain the blocking
+latency checks.
 
 The committed [baseline ledger](instructions-baseline.json) contains actual
 Callgrind measurements. Its host may differ from a CI runner. CI therefore

--- a/ecosystem/instruction-packages.txt
+++ b/ecosystem/instruction-packages.txt
@@ -1,0 +1,5 @@
+# Fixed instruction-count sample. Keep these pins stable across ry releases.
+# Selected from packages.txt; package code is never executed.
+glue	https://github.com/tidyverse/glue.git	da9c73f7a3de6a27f3103cb5bb2355820a4c3a6a
+stringr	https://github.com/tidyverse/stringr.git	ae054b1d28f630fee22ddb3cb7525396e62af4fe
+withr	https://github.com/r-lib/withr.git	c8539fe735a5b6cdb496c68bca8248f8b6b4d419

--- a/ecosystem/instructions.py
+++ b/ecosystem/instructions.py
@@ -1,0 +1,283 @@
+#!/usr/bin/env python3
+"""Measure the fixed corpus sample; compare only compatible instruction counts."""
+
+import argparse
+import hashlib
+import json
+import math
+import os
+from pathlib import Path
+import platform
+import re
+import signal
+import shutil
+import statistics
+import subprocess
+import sys
+import tempfile
+import time
+from datetime import datetime, timezone
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MANIFEST = ROOT / "ecosystem/instruction-packages.txt"
+COMMAND = ["check", "--exit-zero", "--output-format", "json", "<package>/R"]
+ENVIRONMENT = {"RY_NO_INSTALLED_LIBRARIES": "1", "RAYON_NUM_THREADS": "1", "LC_ALL": "C", "TZ": "UTC"}
+
+
+def run(command, cwd=None, timeout=120, env=None):
+    return subprocess.run(command, cwd=cwd, env=env, text=True, capture_output=True,
+                          check=True, timeout=timeout).stdout.strip()
+
+
+def digest(path):
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def samples():
+    result = []
+    for line in MANIFEST.read_text().splitlines():
+        if not line or line.startswith("#"):
+            continue
+        name, url, revision = line.split()
+        if not re.fullmatch(r"[A-Za-z][A-Za-z0-9._-]*", name) or not re.fullmatch(r"[0-9a-f]{40}", revision):
+            raise ValueError("Sample names and full commit pins are required")
+        if any(row["package"] == name for row in result):
+            raise ValueError(f"Duplicate sample: {name}")
+        result.append({"package": name, "url": url, "revision": revision})
+    if not result:
+        raise ValueError("Instruction sample is empty")
+    return result
+
+
+def parse_perf(text):
+    for line in text.splitlines():
+        fields = line.split(";")
+        if len(fields) >= 3 and fields[2].strip() == "instructions:u":
+            value = fields[0].strip()
+            # perf prints <not supported>/<not counted> instead of a count.
+            if not value.isdecimal() or int(value) <= 0:
+                raise ValueError("perf did not return a positive instruction count")
+            # Reject multiplexed/scaled counters rather than call them exact counts.
+            if len(fields) < 5 or fields[4].strip().rstrip("%") not in ("100", "100.00"):
+                raise ValueError("perf instruction counter was multiplexed")
+            return int(value)
+    raise ValueError("perf instruction count is missing")
+
+
+def parse_callgrind(text):
+    events = re.search(r"^events:\s*(.+)$", text, re.MULTILINE)
+    totals = re.findall(r"^totals:\s*(.+)$", text, re.MULTILINE)
+    if not events or not totals or "Ir" not in events[1].split():
+        raise ValueError("Callgrind Ir total is missing")
+    columns = totals[-1].split()
+    index = events[1].split().index("Ir")
+    if index >= len(columns):
+        raise ValueError("Callgrind Ir total is incomplete")
+    value = int(columns[index])
+    if value <= 0:
+        raise ValueError("Callgrind returned a nonpositive instruction count")
+    return value
+
+
+def counter_command(backend, output, command):
+    if backend == "perf":
+        return ["perf", "stat", "--no-big-num", "--no-scale", "-x", ";", "-e", "instructions:u", "-o", str(output), "--", *command]
+    return ["valgrind", "--command-line-only=yes", "--tool=callgrind", "--quiet", "--cache-sim=no", "--branch-sim=no",
+            "--collect-jumps=no", "--callgrind-out-file=" + str(output), *command]
+
+
+def count(backend, command, cwd, timeout, env):
+    with tempfile.TemporaryDirectory(prefix="ry-counter-") as directory:
+        output = Path(directory) / "counter.txt"
+        counter_env = dict(ENVIRONMENT, PATH=env.get("PATH", os.defpath), HOME=directory)
+        measured = subprocess.Popen(counter_command(backend, output, command), cwd=cwd, env=counter_env,
+                                    stdout=subprocess.DEVNULL, stderr=subprocess.PIPE,
+                                    text=True, start_new_session=True)
+        try:
+            _, stderr = measured.communicate(timeout=timeout)
+        except subprocess.TimeoutExpired:
+            os.killpg(measured.pid, signal.SIGKILL)
+            measured.communicate()
+            raise
+        if measured.returncode:
+            raise RuntimeError(f"counter/checker exited {measured.returncode}: {stderr[-2000:].strip()}")
+        return (parse_perf if backend == "perf" else parse_callgrind)(output.read_text())
+
+
+def select_backend(requested, env):
+    failures = []
+    for backend in (["perf", "callgrind"] if requested == "auto" else [requested]):
+        executable = "perf" if backend == "perf" else "valgrind"
+        if not shutil.which(executable):
+            failures.append(f"{executable} is not installed")
+            continue
+        try:
+            count(backend, [shutil.which("true")], ROOT, 30, env)
+            version = run([executable, "--version"], env=env)
+            return backend, version, failures
+        except (OSError, RuntimeError, ValueError, subprocess.SubprocessError) as error:
+            failures.append(f"{backend}: {error}")
+    raise RuntimeError("No usable instruction counter: " + "; ".join(failures))
+
+
+def prepare_sample(sample, cache):
+    directory = cache / (sample["package"] + "-" + sample["revision"])
+    if not (directory / ".git").exists():
+        directory.mkdir(parents=True, exist_ok=True)
+        run(["git", "init", "--quiet", str(directory)])
+        run(["git", "-C", str(directory), "fetch", "--quiet", "--depth", "1", sample["url"], sample["revision"]])
+        run(["git", "-C", str(directory), "checkout", "--quiet", "--detach", "FETCH_HEAD"])
+    if run(["git", "rev-parse", "HEAD"], cwd=directory) != sample["revision"]:
+        raise ValueError(f"Sample checkout changed: {directory}")
+    config = directory / "R/ry.toml"
+    # This file belongs to the harness, not to the pinned package.
+    if run(["git", "ls-files", "R/ry.toml"], cwd=directory):
+        raise ValueError("Pinned sample contains R/ry.toml; review the measurement contract")
+    config.unlink(missing_ok=True)
+    if run(["git", "status", "--porcelain", "--untracked-files=all"], cwd=directory):
+        raise ValueError(f"Sample checkout is dirty: {directory}")
+    config.write_text("")  # Stop config discovery before it reaches the host project.
+    return directory, run(["git", "rev-parse", "HEAD^{tree}"], cwd=directory)
+
+
+def measure(args):
+    source = args.source.resolve()
+    env = dict(os.environ, **ENVIRONMENT, GIT_TERMINAL_PROMPT="0")
+    if env.get("CARGO_BUILD_TARGET"):
+        raise ValueError("Unset CARGO_BUILD_TARGET for the native instruction benchmark")
+    backend, backend_version, fallback = select_backend(args.backend, env)
+    # Cargo must build the measured source, never an unrelated executable on PATH.
+    build = ["cargo", "build", "--release", "--locked", "-p", "ry-cli", "--bin", "ry",
+             "--target-dir", str(args.target_dir.resolve())]
+    subprocess.run(build, cwd=source, env=env, check=True, timeout=600)
+    binary = args.target_dir.resolve() / "release/ry"
+    rustc = run(["rustc", "-vV"], cwd=source, env=env)
+    cpu = "unknown"
+    if Path("/proc/cpuinfo").exists():
+        cpu = next((line.split(":", 1)[1].strip() for line in Path("/proc/cpuinfo").read_text().splitlines()
+                    if line.startswith("model name")), "unknown")
+    metadata = {
+        "backend": backend, "backend_version": backend_version,
+        "architecture": platform.machine(), "system": platform.system(), "cpu": cpu,
+        "libc": list(platform.libc_ver()), "rustc": rustc,
+        "cargo": run(["cargo", "--version"], cwd=source, env=env),
+        "cc": run(["cc", "--version"], env=env).splitlines()[0],
+        "build_profile": "release", "build_flags": {key: env[key] for key in sorted(env) if
+            key in ("RUSTFLAGS", "CARGO_ENCODED_RUSTFLAGS", "CFLAGS", "CXXFLAGS", "LDFLAGS", "CC", "CXX")
+            or key.startswith(("CARGO_PROFILE_", "CARGO_BUILD_", "CARGO_TARGET_"))},
+        "command": COMMAND, "environment": ENVIRONMENT, "config": "empty R/ry.toml",
+        "counter_environment": "fixed variables plus tool PATH and empty temporary HOME",
+        "manifest_sha256": digest(MANIFEST), "harness_sha256": digest(Path(__file__)), "repetitions": args.repetitions,
+    }
+    ledger = {"schema_version": 1, "created_at": datetime.now(timezone.utc).isoformat(),
+              "source_revision": run(["git", "rev-parse", "HEAD"], cwd=source),
+              "source_dirty": bool(run(["git", "status", "--porcelain", "--untracked-files=all", "--",
+                                        "crates", "Cargo.toml", "Cargo.lock", "build.rs", ".cargo",
+                                        "rust-toolchain", "rust-toolchain.toml"], cwd=source)),
+              "binary_sha256": digest(binary), "cargo_lock_sha256": digest(source / "Cargo.lock"),
+              "metadata": metadata, "fallback_notes": fallback, "packages": []}
+    deadline = time.monotonic() + args.budget
+    cache = args.cache.resolve()
+    cache.mkdir(parents=True, exist_ok=True)
+    for sample in samples():
+        row = dict(sample, status="unavailable")
+        try:
+            if time.monotonic() >= deadline:
+                raise TimeoutError("measurement budget exhausted")
+            directory, tree = prepare_sample(sample, cache)
+            row["tree"] = tree
+            values = []
+            for _ in range(args.repetitions):
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise TimeoutError("measurement budget exhausted")
+                values.append(count(backend, [str(binary), *COMMAND[:-1], str(directory / "R")], directory,
+                                    min(args.package_timeout, remaining), env))
+            row.update(status="measured", counts=values, instructions=statistics.median(values))
+        except (OSError, RuntimeError, ValueError, subprocess.SubprocessError) as error:
+            row["reason"] = str(error)
+        ledger["packages"].append(row)
+        print(f"{row['package']}: {row.get('instructions', row.get('reason'))}", file=sys.stderr)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(ledger, indent=2) + "\n")
+    return 0 if all(row["status"] == "measured" for row in ledger["packages"]) else 1
+
+
+def compare(baseline, current, threshold):
+    if not math.isfinite(threshold) or threshold < 0:
+        raise ValueError("Threshold must be a finite, nonnegative percentage")
+    lines = ["## Corpus instruction counts", "", f"Warning threshold: +{threshold:g}%. Counts include checker startup and JSON output.", ""]
+    if any(ledger["metadata"].get("backend") == "unavailable" for ledger in (baseline, current)):
+        return "\n".join(lines + ["**UNAVAILABLE:** a counter or build failed. See the ledger reasons and measurement logs.", ""])
+    mismatch = [key for key in sorted(set(baseline["metadata"]) | set(current["metadata"]))
+                if baseline["metadata"].get(key) != current["metadata"].get(key)]
+    if baseline.get("schema_version") != 1 or current.get("schema_version") != 1:
+        mismatch.append("schema_version")
+    if mismatch:
+        return "\n".join(lines + ["**INCOMPARABLE:** " + ", ".join(mismatch), "No regression claim is made.", ""])
+    lines += [f"Baseline: `{baseline['source_revision']}`. Current: `{current['source_revision']}`.", "",
+              "| Package | Baseline | Current | Delta | Status |", "| --- | ---: | ---: | ---: | --- |"]
+    previous = {row["package"]: row for row in baseline["packages"]}
+    current_names = {row["package"] for row in current["packages"]}
+    for name in sorted(previous.keys() - current_names):
+        lines.append(f"| {name} | - | - | - | UNAVAILABLE current row |")
+    for row in current["packages"]:
+        old = previous.get(row["package"])
+        if row["status"] != "measured" or (old and old["status"] != "measured"):
+            lines.append(f"| {row['package']} | - | - | - | UNAVAILABLE |")
+        elif not old or any(old.get(key) != row.get(key) for key in ("revision", "tree", "url")):
+            lines.append(f"| {row['package']} | - | - | - | INCOMPARABLE sample |")
+        else:
+            if any(type(item.get("instructions")) not in (int, float) or not math.isfinite(item["instructions"])
+                   or item["instructions"] <= 0 for item in (old, row)):
+                raise ValueError(f"Invalid measured count for {row['package']}")
+            delta = 100 * (row["instructions"] / old["instructions"] - 1)
+            status = "WARNING" if delta > threshold else "ok"
+            lines.append(f"| {row['package']} | {old['instructions']:,.0f} | {row['instructions']:,.0f} | {delta:+.2f}% | {status} |")
+    return "\n".join(lines) + "\n"
+
+
+def positive(value):
+    value = int(value)
+    if value <= 0:
+        raise argparse.ArgumentTypeError("must be positive")
+    return value
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    commands = parser.add_subparsers(dest="command", required=True)
+    measure_parser = commands.add_parser("measure")
+    measure_parser.add_argument("--source", type=Path, default=ROOT)
+    measure_parser.add_argument("--output", type=Path, required=True)
+    measure_parser.add_argument("--backend", choices=["auto", "perf", "callgrind"], default="auto")
+    measure_parser.add_argument("--target-dir", type=Path, default=ROOT / "target/instructions")
+    measure_parser.add_argument("--cache", type=Path, default=ROOT / "ecosystem/.cache/instructions")
+    measure_parser.add_argument("--budget", type=positive, default=180, help="total measurement budget in seconds (build has a separate 600-second cap)")
+    measure_parser.add_argument("--package-timeout", type=positive, default=60)
+    measure_parser.add_argument("--repetitions", type=positive, default=3)
+    compare_parser = commands.add_parser("compare")
+    compare_parser.add_argument("baseline", type=Path)
+    compare_parser.add_argument("current", type=Path)
+    compare_parser.add_argument("--threshold", type=float, default=10.0)
+    args = parser.parse_args()
+    try:
+        if args.command == "measure":
+            return measure(args)
+        print(compare(json.loads(args.baseline.read_text()), json.loads(args.current.read_text()), args.threshold), end="")
+        return 0  # Growth is warn-only; measurement/format errors still fail.
+    except (OSError, RuntimeError, ValueError, subprocess.SubprocessError) as error:
+        print(f"instructions: {error}", file=sys.stderr)
+        if args.command == "measure":
+            # Even an unavailable counter or failed build gets an explicit report.
+            ledger = {"schema_version": 1, "created_at": datetime.now(timezone.utc).isoformat(),
+                      "metadata": {"backend": "unavailable"}, "reason": str(error),
+                      "packages": [dict(sample, status="unavailable", reason=str(error)) for sample in samples()]}
+            args.output.parent.mkdir(parents=True, exist_ok=True)
+            args.output.write_text(json.dumps(ledger, indent=2) + "\n")
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ecosystem/instructions.py
+++ b/ecosystem/instructions.py
@@ -141,7 +141,7 @@ def prepare_sample(sample, cache):
     return directory, run(["git", "rev-parse", "HEAD^{tree}"], cwd=directory)
 
 
-def measure(args):
+def measure(args, selected_samples):
     source = args.source.resolve()
     env = dict(os.environ, **ENVIRONMENT, GIT_TERMINAL_PROMPT="0")
     if env.get("CARGO_BUILD_TARGET"):
@@ -180,7 +180,7 @@ def measure(args):
     deadline = time.monotonic() + args.budget
     cache = args.cache.resolve()
     cache.mkdir(parents=True, exist_ok=True)
-    for sample in samples():
+    for sample in selected_samples:
         row = dict(sample, status="unavailable")
         try:
             if time.monotonic() >= deadline:
@@ -262,9 +262,11 @@ def main():
     compare_parser.add_argument("current", type=Path)
     compare_parser.add_argument("--threshold", type=float, default=10.0)
     args = parser.parse_args()
+    selected_samples = []
     try:
         if args.command == "measure":
-            return measure(args)
+            selected_samples = samples()
+            return measure(args, selected_samples)
         print(compare(json.loads(args.baseline.read_text()), json.loads(args.current.read_text()), args.threshold), end="")
         return 0  # Growth is warn-only; measurement/format errors still fail.
     except (OSError, RuntimeError, ValueError, subprocess.SubprocessError) as error:
@@ -273,7 +275,7 @@ def main():
             # Even an unavailable counter or failed build gets an explicit report.
             ledger = {"schema_version": 1, "created_at": datetime.now(timezone.utc).isoformat(),
                       "metadata": {"backend": "unavailable"}, "reason": str(error),
-                      "packages": [dict(sample, status="unavailable", reason=str(error)) for sample in samples()]}
+                      "packages": [dict(sample, status="unavailable", reason=str(error)) for sample in selected_samples]}
             args.output.parent.mkdir(parents=True, exist_ok=True)
             args.output.write_text(json.dumps(ledger, indent=2) + "\n")
         return 1

--- a/ecosystem/test-instructions.py
+++ b/ecosystem/test-instructions.py
@@ -2,11 +2,17 @@
 """Counter parsing and comparison guards; no hardware counter required."""
 
 import copy
+import contextlib
+import io
+import json
 import os
 from pathlib import Path
 import shutil
 import subprocess
+import sys
+import tempfile
 import unittest
+from unittest import mock
 
 import instructions
 
@@ -72,6 +78,27 @@ class ComparisonTests(unittest.TestCase):
     def test_failed_build_ledgers_need_no_revision_or_counts(self):
         failed = {"schema_version": 1, "metadata": {"backend": "unavailable"}, "packages": []}
         self.assertIn("UNAVAILABLE", instructions.compare(failed, failed, 10))
+
+
+class ManifestFailureTests(unittest.TestCase):
+    def test_invalid_manifest_still_writes_failure_ledger(self):
+        valid = "glue https://example.invalid/glue " + "a" * 40 + "\n"
+        for contents in ("glue https://example.invalid/glue not-a-pin\n", valid + valid, "glue missing-column\n"):
+            with self.subTest(contents=contents), tempfile.TemporaryDirectory() as directory:
+                manifest = Path(directory) / "packages.txt"
+                output = Path(directory) / "ledger.json"
+                manifest.write_text(contents)
+                stderr = io.StringIO()
+                with mock.patch.object(instructions, "MANIFEST", manifest), \
+                     mock.patch.object(sys, "argv", ["instructions.py", "measure", "--output", str(output)]), \
+                     mock.patch.object(instructions, "measure") as measure, contextlib.redirect_stderr(stderr):
+                    self.assertEqual(instructions.main(), 1)
+                measure.assert_not_called()
+                ledger = json.loads(output.read_text())
+                self.assertEqual(ledger["packages"], [])
+                self.assertEqual(ledger["metadata"]["backend"], "unavailable")
+                self.assertTrue(ledger["reason"])
+                self.assertNotIn("Traceback", stderr.getvalue())
 
 
 if __name__ == "__main__":

--- a/ecosystem/test-instructions.py
+++ b/ecosystem/test-instructions.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Counter parsing and comparison guards; no hardware counter required."""
+
+import copy
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import unittest
+
+import instructions
+
+
+class CounterTests(unittest.TestCase):
+    def test_perf_uses_actual_unscaled_counter(self):
+        self.assertEqual(instructions.parse_perf("12345;;instructions:u;1000;100.00;;\n"), 12345)
+        for text in ("<not counted>;;instructions:u;0;0.00", "123;;instructions:u;100;50.00", "123;;instructions:u", ""):
+            with self.assertRaises(ValueError):
+                instructions.parse_perf(text)
+
+    def test_callgrind_selects_ir_event(self):
+        self.assertEqual(instructions.parse_callgrind("events: Dr Ir Dw\ntotals: 10 12345 20\n"), 12345)
+        for text in ("events: Dr\ntotals: 10", "events: Ir\nsummary: 0\n", "events: Ir\ntotals: 0"):
+            with self.assertRaises(ValueError):
+                instructions.parse_callgrind(text)
+
+    @unittest.skipUnless(shutil.which("valgrind"), "Callgrind is not installed")
+    def test_real_counter_and_timeout(self):
+        env = dict(os.environ, **instructions.ENVIRONMENT)
+        self.assertGreater(instructions.count("callgrind", [shutil.which("true")], Path.cwd(), 30, env), 0)
+        with self.assertRaises(subprocess.TimeoutExpired):
+            instructions.count("callgrind", [shutil.which("sleep"), "10"], Path.cwd(), 0.01, env)
+
+
+class ComparisonTests(unittest.TestCase):
+    def setUp(self):
+        self.old = {"schema_version": 1, "source_revision": "a" * 40,
+                    "metadata": {"backend": "callgrind", "architecture": "x86_64", "rustc": "fixed"},
+                    "packages": [{"package": "glue", "revision": "b" * 40, "tree": "c" * 40,
+                                  "url": "https://example.invalid/glue", "status": "measured", "instructions": 100}]}
+        self.new = copy.deepcopy(self.old)
+
+    def test_growth_warns_without_changing_counts(self):
+        self.new["packages"][0]["instructions"] = 125
+        report = instructions.compare(self.old, self.new, 10)
+        self.assertIn("+25.00% | WARNING", report)
+
+    def test_incompatible_backend_architecture_or_toolchain_has_no_delta(self):
+        for field in self.old["metadata"]:
+            changed = copy.deepcopy(self.new)
+            changed["metadata"][field] = "different"
+            report = instructions.compare(self.old, changed, 10)
+            self.assertIn("INCOMPARABLE", report)
+            self.assertNotIn("| Delta |", report)
+
+    def test_changed_sample_is_not_a_regression(self):
+        self.new["packages"][0]["revision"] = "d" * 40
+        self.assertIn("INCOMPARABLE sample", instructions.compare(self.old, self.new, 10))
+
+    def test_failed_and_missing_measurements_are_explicit(self):
+        self.new["packages"][0] = {"package": "glue", "status": "unavailable", "reason": "timeout"}
+        self.assertIn("UNAVAILABLE", instructions.compare(self.old, self.new, 10))
+        self.new["packages"] = []
+        self.assertIn("UNAVAILABLE current row", instructions.compare(self.old, self.new, 10))
+
+    def test_invalid_counts_are_rejected(self):
+        for count in (0, -1, "123", None, True, float("nan"), float("inf")):
+            self.new["packages"][0]["instructions"] = count
+            with self.assertRaises(ValueError):
+                instructions.compare(self.old, self.new, 10)
+
+    def test_failed_build_ledgers_need_no_revision_or_counts(self):
+        failed = {"schema_version": 1, "metadata": {"backend": "unavailable"}, "packages": []}
+        self.assertIn("UNAVAILABLE", instructions.compare(failed, failed, 10))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds a fixed, commit-pinned glue/stringr/withr sample and a per-package instruction ledger using perf with a Callgrind fallback. CI remeasures the frozen reference and current source in the same environment, reports growth above 10%, and keeps growth and measurement failures warn-only within a 20-minute job limit. Harness tests and invalid reference revisions fail the check. Incompatible metadata and unavailable counters are reported explicitly.

The committed baseline contains actual Callgrind medians: 299,393,861, 894,101,245, and 467,603,912 instructions. Source revision, sample and harness hashes, and raw-count medians were verified; elapsed time is only a timeout, never a measurement proxy.

Validation: ten tests passed, including malformed-manifest fallback, real Callgrind, and timeout cleanup; unavailable/budget reports, actionlint, and zizmor passed. A separate reference build measured within 0.03% of the baseline. Hardware perf was unavailable locally, so its parser was checked against the documented format rather than a live hardware run.

Closes #127.

GitHub Actions validation: the instruction-count workflow completed both measurements and uploaded its ledgers/report. Same-runner reference/current differences were +0.02% (glue), -0.04% (stringr), and +0.02% (withr). Historical local counts were correctly marked incomparable because the counter version, compiler, CPU, and libc differ.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a reproducible instruction-count measurement tool for a fixed sample of packages.
  - Added comparison reporting to identify performance growth and incompatible measurement results.
  - Added a versioned baseline for tracking instruction-count changes over time.

- **Documentation**
  - Added guidance for running measurements, interpreting results, updating baselines, and maintaining the sample corpus.
  - Linked instruction-count resources from the corpus documentation and contribution guide.

- **Tests**
  - Added coverage for measurement parsing, comparison outcomes, failures, and timeout handling.

- **Chores**
  - Added automated scheduled and pull-request checks with downloadable measurement reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->