### PR TITLE
fix(checker): follow forced short-circuit operands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -268,6 +268,8 @@ suppression actions — and fixes a parser panic plus several editor issues.
 
 ### Fixed
 
+- Detect recursive defaults forced by `TRUE && x` and `FALSE || x`, including nested operands.
+
 - Detect recursive and prematurely forced defaults passed to `base::identity` or
   `base::force`, while preserving laziness in quoted, masked, and conditional calls.
 

--- a/crates/ry-checker/src/infer/quoting.rs
+++ b/crates/ry-checker/src/infer/quoting.rs
@@ -207,9 +207,19 @@ fn definitely_forced_identifier(expr: &Expr, wanted: &str) -> Option<Span> {
         },
         Expr::BinOp {
             lhs,
-            op: BinOpKind::AndAnd | BinOpKind::OrOr,
+            rhs,
+            op: op @ (BinOpKind::AndAnd | BinOpKind::OrOr),
             ..
-        } => definitely_forced_identifier(lhs, wanted),
+        } => definitely_forced_identifier(lhs, wanted).or_else(|| {
+            // Only these literal operands guarantee evaluation of the RHS.
+            matches!(
+                (op, lhs.as_ref()),
+                (BinOpKind::AndAnd, Expr::Logical(true, _))
+                    | (BinOpKind::OrOr, Expr::Logical(false, _))
+            )
+            .then(|| definitely_forced_identifier(rhs, wanted))
+            .flatten()
+        }),
         Expr::Block { body, span } => {
             guaranteed_force_before_replacement(body, wanted).then_some(*span)
         }

--- a/crates/ry-checker/testdata/err_recursive_default_forced_operands.R
+++ b/crates/ry-checker/testdata/err_recursive_default_forced_operands.R
@@ -1,0 +1,9 @@
+# expect: RY098, RY098, RY098, RY098, RY098
+and_default <- function(x = x) TRUE && x
+or_default <- function(x = x) FALSE || x
+nested <- function(x = x) TRUE && (FALSE || x)
+qualified <- function(x = x) base::force(TRUE && x)
+late <- function(x = value) {
+  FALSE || x
+  value <- TRUE
+}

--- a/crates/ry-checker/testdata/ok_recursive_default_conditional_operands.R
+++ b/crates/ry-checker/testdata/ok_recursive_default_conditional_operands.R
@@ -1,0 +1,7 @@
+# no-diag
+skip_and <- function(x = x) FALSE && x
+skip_or <- function(x = x) TRUE || x
+dynamic_and <- function(flag, x = x) flag && x
+dynamic_or <- function(flag, x = x) flag || x
+nested_skip <- function(x = x) TRUE && (TRUE || x)
+quoted <- function(x = x) TRUE && base::quote(x)

--- a/crates/ry-checker/testdata/oracle/recursive_default_conditional_operands.R
+++ b/crates/ry-checker/testdata/oracle/recursive_default_conditional_operands.R
@@ -1,0 +1,13 @@
+# oracle: must-pass
+skip_and <- function(x = x) FALSE && x
+skip_or <- function(x = x) TRUE || x
+dynamic_and <- function(flag, x = x) flag && x
+dynamic_or <- function(flag, x = x) flag || x
+nested_skip <- function(x = x) TRUE && (TRUE || x)
+quoted <- function(x = x) TRUE && base::quote(x)
+stopifnot(identical(skip_and(), FALSE), identical(skip_or(), TRUE))
+stopifnot(identical(dynamic_and(FALSE), FALSE), identical(dynamic_or(TRUE), TRUE))
+stopifnot(identical(nested_skip(), TRUE))
+# quote returns a symbol, so && rejects its type without forcing x.
+result <- tryCatch(quoted(), error = function(e) e)
+stopifnot(inherits(result, "error"), !grepl("promise already under evaluation", conditionMessage(result)))

--- a/crates/ry-checker/testdata/oracle/recursive_default_forced_operands.R
+++ b/crates/ry-checker/testdata/oracle/recursive_default_forced_operands.R
@@ -1,0 +1,16 @@
+# oracle: must-warn RY098
+# oracle-claim: RY098
+and_default <- function(x = x) TRUE && x
+or_default <- function(x = x) FALSE || x
+nested <- function(x = x) TRUE && (FALSE || x)
+qualified <- function(x = x) base::force(TRUE && x)
+late <- function(x = value) {
+  FALSE || x
+  value <- TRUE
+}
+for (f in list(and_default, or_default, nested, qualified)) {
+  result <- tryCatch(f(), error = function(e) e)
+  stopifnot(inherits(result, "error"), grepl("promise already under evaluation", conditionMessage(result)))
+}
+result <- tryCatch(late(), error = function(e) e)
+stopifnot(inherits(result, "error"), grepl("value", conditionMessage(result)))

--- a/crates/ry-checker/tests/snapshots/corpus__checker_fixture_diagnostics.snap
+++ b/crates/ry-checker/tests/snapshots/corpus__checker_fixture_diagnostics.snap
@@ -367,6 +367,48 @@ expression: snapshots
       message: "parameter `x` has a self-referential default that recurses when forced"
       severity: warning
       span:
+        column: 28
+        end: 73
+        line: 1
+        start: 72
+    - code: RY098
+      message: "parameter `x` has a self-referential default that recurses when forced"
+      severity: warning
+      span:
+        column: 27
+        end: 113
+        line: 2
+        start: 112
+    - code: RY098
+      message: "parameter `x` has a self-referential default that recurses when forced"
+      severity: warning
+      span:
+        column: 23
+        end: 150
+        line: 3
+        start: 149
+    - code: RY098
+      message: "parameter `x` has a self-referential default that recurses when forced"
+      severity: warning
+      span:
+        column: 26
+        end: 200
+        line: 4
+        start: 199
+    - code: RY098
+      message: "parameter `x` may force its default before body-local `value` is assigned"
+      severity: warning
+      span:
+        column: 11
+        end: 267
+        line: 6
+        start: 266
+  fixture: err_recursive_default_forced_operands.R
+- diagnostics:
+    - code: RY098
+      message: "parameter `x` has a self-referential default that recurses when forced"
+      severity: warning
+      span:
         column: 18
         end: 108
         line: 2
@@ -776,6 +818,8 @@ expression: snapshots
   fixture: ok_recursion.R
 - diagnostics: []
   fixture: ok_recursive_default_captured.R
+- diagnostics: []
+  fixture: ok_recursive_default_conditional_operands.R
 - diagnostics: []
   fixture: ok_recursive_default_conditional_return.R
 - diagnostics: []


### PR DESCRIPTION
`function(x = x) TRUE && x` and `function(x = x) FALSE || x` recurse when called without an argument, but RY098 skipped their right operands. Follow the right operand when a literal logical left operand guarantees its evaluation. Dynamic conditions and skipped operands remain conservative.

Adds five warning cases covering both operators, nested expressions, qualified `base::force`, and a default that references a body-local variable before assignment. Adjacent tests cover skipped operands, dynamic conditions, and quoted arguments. R oracle fixtures verify the runtime results. This addresses another bounded case in #196; the general eval-metadata walker remains outside this change.

Validation:
- `cargo test -p ry-checker` passed.
- Full R oracle passed: 13 tests, including the normally ignored fixture matrix.
- Checker clippy with `-D warnings`, formatting, and diff checks passed.
- Removing the fix makes the new warning fixture fail: expected five RY098 warnings, got none. Restored the fix and reran checker tests successfully.
- Strict tidyverse comparison passed for 32 packages at both R/ and package root.
- Strict Posit fast comparison passed for 35 packages; all 578 message identities match. Reports and ledgers are unchanged.

