### PR TITLE
Fix data-frame dispatch, preserve failed typeshed updates, and shorten docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,8 @@ jobs:
         run: cargo build --workspace --all-targets
       - name: Test
         run: cargo test --workspace
+      - name: Test typeshed sync
+        run: python3 -m unittest discover -s scripts -p 'test_*.py'
       - name: Performance regression tests
         run: cargo test -p ry-checker --test perf --release -- --ignored --test-threads=1
       - name: Clippy (deny warnings)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to ry are documented in this file.
 
 ### Cleanup
 
+- Resolve S3 operators before inferring data-frame results, so subclass methods
+  can return other types and conflicting methods do not retain column schemas.
+- Validate typeshed updates before replacing the vendored snapshot. Failed
+  validation leaves the existing stubs and provenance intact.
+- Shorten the README and move the inferred-types reference to `docs/types.md`.
 - Infer vector-constructor lengths from size values, including empty defaults
   and fractional sizes. Correct factor arithmetic with NULL and unary minus.
 - Check typed purrr callback contracts independently of output-length inference.

--- a/README.md
+++ b/README.md
@@ -30,17 +30,8 @@ On Windows PowerShell:
 powershell -ExecutionPolicy Bypass -c "irm https://github.com/sims1253/ry/releases/latest/download/ry-cli-installer.ps1 | iex"
 ```
 
-Or build from source with Rust 1.88 or newer:
-
-``` sh
-git clone https://github.com/sims1253/ry
-cd ry
-cargo build --release
-# binary at target/release/ry
-```
-
-Per-platform archives are also attached to GitHub releases.
-See [CHANGELOG.md](CHANGELOG.md) for release highlights and upgrade notes.
+You can also download [release archives](https://github.com/sims1253/ry/releases)
+or [build from source](docs/usage.md#building-from-source).
 
 ## Quickstart
 
@@ -65,36 +56,16 @@ To check a project, run `ry check .`. It collects `.R` and `.r` files
 recursively and exits with a nonzero status when it finds an error.
 Use `ry check --error-on-warning .` to fail on warnings too.
 
-## Configure a project
+Configure packages, runtime globals, excluded paths, and rule settings in
+[`ry.toml`](docs/configuration.md). For an existing codebase, use a
+[baseline](docs/configuration.md#confidence-tiers-and-baselines) to check only
+new findings.
 
-Put a `ry.toml` in the project root. For example:
-
-```toml
-# Packages attached outside the checked source files.
-packages = ["dplyr"]
-
-# Names supplied by your application at runtime.
-globals = ["runtime_data"]
-
-exclude = ["renv", "tests/snaps/**"]
-```
-
-ry recognizes package imports, data masking, and common tidyverse patterns.
 Package signatures come from the bundled
 [r-typeshed](https://github.com/sims1253/r-typeshed) stubs. Dynamic R code and
-missing package signatures can still produce false positives or missed bugs.
-See [package awareness and known limits](docs/usage.md#package-awareness).
-
-For an existing codebase, accept current findings in a baseline and check for
-new ones:
-
-```sh
-ry check --write-baseline ry-baseline.json .
-ry check --baseline ry-baseline.json .
-```
-
-See [configuration](docs/configuration.md) for rule settings, custom stubs,
-inline suppressions, confidence filters, and baselines.
+missing signatures can produce false positives or missed bugs. See
+[package handling](docs/usage.md#package-awareness) and
+[known limits](docs/usage.md#known-limits).
 
 ## Editors
 
@@ -108,7 +79,8 @@ See the [VS Code / Positron guide](editors/code/README.md) for settings and the
 
 ## Reference and contributing
 
-- [Usage](docs/usage.md): package handling, data masking, CI, and `dump-types`.
+- [Usage](docs/usage.md): package handling, data masking, CI, and editors.
+- [Inferred types](docs/types.md): inspect bindings with `ry dump-types`.
 - [Rules](docs/rules.md): diagnostic codes and default severities.
   Run `ry explain rule RY040` for one rule or `ry explain rule` for all rules.
 - [Changelog](CHANGELOG.md): release notes and upgrade guidance.

--- a/crates/ry-checker/src/infer/binop.rs
+++ b/crates/ry-checker/src/infer/binop.rs
@@ -19,12 +19,6 @@ impl Checker {
         if matches!(op, BinOpKind::In) {
             return RType::new(Mode::Logical, lt.length);
         }
-        // `Ops.data.frame` is implemented by base R, but its stub is
-        // necessarily opaque. Keep the useful record shape here instead of
-        // letting that opaque S3 result erase it.
-        if let Some(result) = data_frame_binop_result(op, &lt, &rt) {
-            return result;
-        }
         // Primitive operators dispatch through `+.foo` then the `Ops.foo`
         // group generic before the storage-mode rules below; a miss is
         // silent, as in R -- the primitive itself is the fallback (issue
@@ -33,6 +27,12 @@ impl Checker {
         // method from another package.
         if let Some(dispatched) = self.try_s3_binop_dispatch(op, &lt, &rt) {
             return dispatched;
+        }
+        // The opaque base `Ops.data.frame` stub falls through to schema
+        // modeling. Resolve overrides and conflicting methods first: they
+        // need not return a data frame.
+        if let Some(result) = data_frame_binop_result(op, &lt, &rt) {
+            return result;
         }
         let is_compare = is_comparison(op);
         let is_logic = matches!(

--- a/crates/ry-checker/src/tests/operator_s3_dispatch.rs
+++ b/crates/ry-checker/src/tests/operator_s3_dispatch.rs
@@ -27,6 +27,30 @@ fn code_lines(diags: &[Diagnostic], code: &str) -> Vec<usize> {
 }
 
 #[test]
+fn data_frame_operator_overrides_precede_schema_inference() {
+    let (diags, scope) = check_with_scope(
+        "`+.left` <- function(e1, e2) \"left\"\n\
+         `+.right` <- function(e1, e2) \"right\"\n\
+         chooseOpsMethod.left <- function(x, y, mx, my, cl, reverse) TRUE\n\
+         x <- structure(data.frame(a = 1), class = c(\"left\", \"data.frame\"))\n\
+         y <- structure(2, class = \"right\")\n\
+         one_sided <- x + 1\n\
+         same_method <- x + x\n\
+         conflict <- x + y\n\
+         reversed <- y + x\n",
+    );
+    assert!(diags.is_empty(), "{diags:?}");
+    for name in ["one_sided", "same_method"] {
+        assert_eq!(scope.get(name).map(|ty| ty.mode), Some(Mode::Character));
+    }
+    for name in ["conflict", "reversed"] {
+        let ty = scope.get(name).expect("operator result should be bound");
+        assert_eq!(ty.mode, Mode::Opaque);
+        assert!(ty.columns.is_none(), "{name}: {ty:?}");
+    }
+}
+
+#[test]
 fn operator_dispatches_stub_typeshed_methods() {
     // Operators share the call path's method-source ladder (#165), so a
     // method declared only in a typeshed is visible to `w1 + w2` and its

--- a/crates/ry-checker/testdata/ok_s3_data_frame_operator_override.R
+++ b/crates/ry-checker/testdata/ok_s3_data_frame_operator_override.R
@@ -1,0 +1,14 @@
+# no-diag
+`+.left` <- function(e1, e2) "left"
+`+.right` <- function(e1, e2) "right"
+chooseOpsMethod.left <- function(x, y, mx, my, cl, reverse) TRUE
+x <- structure(data.frame(a = 1), class = c("left", "data.frame"))
+y <- structure(2, class = "right")
+# Custom selection can return a string, so no frame schema is certain.
+result <- x + y
+result == "left"
+reversed <- y + x
+reversed == "left"
+d <- data.frame(a = 1, b = 2)
+shifted <- d + 1
+shifted$a

--- a/crates/ry-checker/testdata/oracle/s3_ops_data_frame_override.R
+++ b/crates/ry-checker/testdata/oracle/s3_ops_data_frame_override.R
@@ -1,0 +1,12 @@
+# oracle: must-pass
+`+.left` <- function(e1, e2) "left"
+`+.right` <- function(e1, e2) "right"
+chooseOpsMethod.left <- function(x, y, mx, my, cl, reverse) TRUE
+x <- structure(data.frame(a = 1), class = c("left", "data.frame"))
+y <- structure(2, class = "right")
+# A data.frame subclass can return an atomic value through operator dispatch.
+stopifnot(identical(x + 1, "left"), identical(x + x, "left"))
+stopifnot(identical(x + y, "left"), identical(y + x, "left"))
+# The base method still preserves an ordinary data frame's columns.
+d <- data.frame(a = 1, b = 2)
+stopifnot(identical(d + 1, data.frame(a = 2, b = 3)))

--- a/crates/ry-checker/tests/snapshots/corpus__checker_fixture_diagnostics.snap
+++ b/crates/ry-checker/tests/snapshots/corpus__checker_fixture_diagnostics.snap
@@ -847,6 +847,8 @@ expression: snapshots
 - diagnostics: []
   fixture: ok_s3_data_frame.R
 - diagnostics: []
+  fixture: ok_s3_data_frame_operator_override.R
+- diagnostics: []
   fixture: ok_s3_dispatch.R
 - diagnostics: []
   fixture: ok_s3_operator_absence_arithmetic.R

--- a/docs/types.md
+++ b/docs/types.md
@@ -1,0 +1,105 @@
+# Inferred types
+
+[Getting started](../README.md) · [Usage](usage.md) · [Configuration](configuration.md)
+
+`ry dump-types` prints names and inferred types as JSON on stdout. It uses
+the same analysis and package context as `ry check`, and the same type
+strings as editor inlay hints. The output groups bindings by lexical scope
+(the top level or a function body), so tools can query several positions
+without running the checker again.
+
+## Example
+
+Save this as `types.R`:
+
+```r
+offset <- 1L
+add_offset <- function(x = 2L) {
+  result <- x + offset
+  result
+}
+```
+
+```sh
+ry dump-types types.R
+ry dump-types types.R --position 4:3
+```
+
+The second command returns the `add_offset` scope. Its `bindings` array
+includes this entry:
+
+```json
+{"name": "offset", "kind": "closed-over", "type": "integer<len=1>", "start": [1, 1]}
+```
+
+## Output fields
+
+Positions are 1-based `[row, column]` pairs; columns count characters,
+not bytes. Scopes are ordered by start position, bindings by name.
+`unknown` marks bindings whose types ry could not infer. It does not cause
+the command to fail.
+
+Binding kinds:
+
+- `param`, a formal of this scope that the body never reassigns. A
+  reassigned formal degrades to `local` at its reassignment site
+  (R rebinds rather than narrows).
+- `local`, first assigned inside this scope's own body (assignments in
+  `if` / `for` / `while` bodies and braced value blocks count; they bind
+  in the enclosing function in R).
+- `closed-over`, function scopes only: present because the body's
+  scope is cloned from the enclosing one at the point of definition.
+- `imported`, top-level bindings the file never assigns, supplied by
+  the host environment (for example Shiny server fragments, where
+  `input` / `output` / `session` are ambient).
+
+Each binding's `start` points at its definition site, the formal, the
+first assignment, or, for `closed-over`, the site in the nearest
+enclosing scope that defines the name (`null` when none is recorded).
+For a reassigned local, this first assignment need not define its final value.
+
+## Querying a position
+
+`--position LINE:COL` (repeatable) selects the innermost recorded scope
+containing each position and drops locals whose first assignment follows it.
+Types still describe the scope at the end of its body. The option does not
+return the type at a reference or the flow state at the selected position.
+
+Save this as `reassigned.R`:
+
+```r
+x <- 1L
+y <- x
+x <- "later"
+```
+
+```sh
+ry dump-types reassigned.R --position 2:6
+```
+
+The query reports `x` as `character<len=1>` with `start: [1, 1]`, even though
+`x` is an integer when R evaluates `y <- x`. The type comes from the final
+assignment; `start` points to the first assignment. Do not use this pair as
+evidence of the type or defining assignment at the selected reference.
+
+## Files and project context
+
+A directory argument expands to every discoverable R file under it,
+using `ry check`'s discovery rules, including the discovered `ry.toml`'s
+`exclude` patterns. `--project-root <DIR>` overrides the analysis root
+for non-package files; by default each file is analyzed in the context
+of its nearest enclosing package (the ancestor directory with a
+`DESCRIPTION`), else the directory owning the discovered `ry.toml`, else
+the working directory, mirroring `ry check`'s per-package grouping. The
+exit code is 0 even when the analyzed code has
+diagnostics; it is non-zero only for usage, IO, or internal failure.
+
+## Scope limits
+
+Scopes reflect the checker's snapshot semantics: each table is the
+scope's state at the end of its body, and a nested function captures the
+enclosing scope as of its definition point (ry's documented closure
+approximation). Anonymous function literals used as call arguments are
+inferred in discarding mode and are therefore not recorded as scopes,
+but named functions defined *inside* such a callback do complete and are
+recorded, so a dump can contain a scope whose enclosing scope is absent.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -8,6 +8,7 @@
 - [Dumping inferred types](#dumping-inferred-types)
 - [Editors](#editors)
 - [Known limits](#known-limits)
+- [Building from source](#building-from-source)
 
 ## Checking files and CI
 
@@ -117,77 +118,10 @@ at column candidates.
 
 ## Dumping inferred types
 
-`ry dump-types` prints names and inferred types as JSON on stdout. It uses
-the same analysis and package context as `ry check`, and the same type
-strings as editor inlay hints. The output groups bindings by lexical scope
-(the top level or a function body), so tools can query several positions
-without running the checker again.
-
-Save this as `types.R`:
-
-```r
-offset <- 1L
-add_offset <- function(x = 2L) {
-  result <- x + offset
-  result
-}
-```
-
-```sh
-ry dump-types types.R
-ry dump-types types.R --position 4:3
-```
-
-The second command returns the `add_offset` scope. Its `bindings` array
-includes this entry:
-
-```json
-{"name": "offset", "kind": "closed-over", "type": "integer<len=1>", "start": [1, 1]}
-```
-
-Positions are 1-based `[row, column]` pairs; columns count characters,
-not bytes. Scopes are ordered by start position, bindings by name.
-`unknown` marks bindings whose types ry could not infer. It does not cause
-the command to fail.
-
-Binding kinds:
-
-- `param`, a formal of this scope that the body never reassigns. A
-  reassigned formal degrades to `local` at its reassignment site
-  (R rebinds rather than narrows).
-- `local`, first assigned inside this scope's own body (assignments in
-  `if` / `for` / `while` bodies and braced value blocks count; they bind
-  in the enclosing function in R).
-- `closed-over`, function scopes only: present because the body's
-  scope is cloned from the enclosing one at the point of definition.
-- `imported`, top-level bindings the file never assigns, supplied by
-  the host environment (for example Shiny server fragments, where
-  `input` / `output` / `session` are ambient).
-
-Each binding's `start` points at its definition site, the formal, the
-first assignment, or, for `closed-over`, the site in the nearest
-enclosing scope that defines the name (`null` when none is recorded).
-
-`--position LINE:COL` (repeatable) restricts output to the innermost
-scope containing each position and drops locals assigned after it,
-so you can query the bindings available at a given line.
-
-A directory argument expands to every discoverable R file under it,
-using `ry check`'s discovery rules, including the discovered `ry.toml`'s
-`exclude` patterns. `--project-root <DIR>` overrides the analysis root
-for non-package files; by default each file is analyzed in the context
-of its nearest enclosing package (the ancestor directory with a
-`DESCRIPTION`), else the directory owning the discovered `ry.toml`, else
-the working directory, mirroring `ry check`'s per-package grouping. The
-exit code is 0 even when the analyzed code has
-diagnostics; it is non-zero only for usage, IO, or internal failure.
-Scopes reflect the checker's snapshot semantics: each table is the
-scope's state at the end of its body, and a nested function captures the
-enclosing scope as of its definition point (ry's documented closure
-approximation). Anonymous function literals used as call arguments are
-inferred in discarding mode and are therefore not recorded as scopes,
-but named functions defined *inside* such a callback do complete and are
-recorded, so a dump can contain a scope whose enclosing scope is absent.
+Use `ry dump-types types.R` to inspect bindings and inferred types as JSON.
+Add `--position LINE:COL` to query the scope at a specific position.
+See the [inferred types reference](types.md) for an example, output fields,
+and scope limits.
 
 ## Editors
 
@@ -254,3 +188,17 @@ R6 modeling covers `self` / `private` / `super` in method bodies, not
 field types. No expansion of dynamic `exportPattern()` directives and no
 NA tracking yet. Cross-package names without stubs resolve to opaque
 values when static package metadata proves that they exist.
+
+## Building from source
+
+Install Rust 1.88 or newer, then run:
+
+```sh
+git clone https://github.com/sims1253/ry
+cd ry
+cargo build --release
+# binary at target/release/ry
+```
+
+See [Contributing](../CONTRIBUTING.md) for tests and development instructions.
+For prebuilt binaries, see the [installation instructions](../README.md#install).

--- a/scripts/sync_typeshed.sh
+++ b/scripts/sync_typeshed.sh
@@ -18,10 +18,11 @@ stubs_sha256=$(
     | cut -d' ' -f1
 )
 
-rm -rf "$vendor"
-mkdir -p "$vendor"
-cp -R "$checkout/stubs/." "$vendor/"
-cat > "$vendor/SOURCE" <<EOF
+# Validate a staged copy before replacing the last usable snapshot.
+staged=$(mktemp -d "${vendor}.XXXXXX")
+trap 'rm -rf "$staged"' EXIT
+cp -R "$checkout/stubs/." "$staged/"
+cat > "$staged/SOURCE" <<EOF
 repository: https://github.com/sims1253/r-typeshed
 commit: $commit
 tree-state: $tree_state
@@ -29,4 +30,7 @@ stubs-sha256: $stubs_sha256
 EOF
 
 cargo run --manifest-path "$repo_root/Cargo.toml" -p ry-cli -- \
-  typeshed validate "$vendor"
+  typeshed validate "$staged"
+
+rm -rf "$vendor"
+mv "$staged" "$vendor"

--- a/scripts/test_sync_typeshed.py
+++ b/scripts/test_sync_typeshed.py
@@ -1,0 +1,73 @@
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+
+class SyncTypeshedTest(unittest.TestCase):
+    def setUp(self):
+        temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(temporary.cleanup)
+        self.root = Path(temporary.name)
+        self.repo = self.root / "ry checkout"
+        scripts = self.repo / "scripts"
+        scripts.mkdir(parents=True)
+        self.script = scripts / "sync_typeshed.sh"
+        shutil.copyfile(Path(__file__).with_name("sync_typeshed.sh"), self.script)
+        self.vendor = self.repo / "crates/ry-typeshed/vendor"
+        self.vendor.mkdir(parents=True)
+        (self.vendor / "old.json").write_text("old snapshot")
+        (self.vendor / "SOURCE").write_text("old provenance")
+        self.checkout = self.root / "typeshed checkout"
+        stubs = self.checkout / "stubs/base"
+        stubs.mkdir(parents=True)
+        (stubs / "base.json").write_text('{"package": "base"}\n')
+        binaries = self.root / "bin"
+        binaries.mkdir()
+        cargo = binaries / "cargo"
+        cargo.write_text("""#!/usr/bin/env bash
+set -eu
+candidate=${!#}
+test -f "$candidate/base/base.json"
+test -f "$candidate/SOURCE"
+# The old snapshot must remain available throughout validation.
+test "$(cat "$EXPECTED_VENDOR/old.json")" = "old snapshot"
+exit "$VALIDATION_STATUS"
+""")
+        cargo.chmod(0o755)
+        self.env = dict(os.environ, PATH=f"{binaries}:{os.environ['PATH']}",
+                        EXPECTED_VENDOR=str(self.vendor))
+
+    def run_sync(self, status):
+        return subprocess.run(
+            ["bash", str(self.script), str(self.checkout)],
+            env=dict(self.env, VALIDATION_STATUS=str(status)),
+            capture_output=True, text=True,
+        )
+
+    def assert_no_staging_directory(self):
+        self.assertEqual(list(self.vendor.parent.glob("vendor.*")), [])
+
+    def test_failed_validation_preserves_snapshot_and_provenance(self):
+        result = self.run_sync(7)
+        self.assertEqual(result.returncode, 7, result.stderr)
+        self.assertEqual((self.vendor / "old.json").read_text(), "old snapshot")
+        self.assertEqual((self.vendor / "SOURCE").read_text(), "old provenance")
+        self.assertEqual(sorted(p.name for p in self.vendor.iterdir()),
+                         ["SOURCE", "old.json"])
+        self.assert_no_staging_directory()
+
+    def test_success_replaces_snapshot_after_validation(self):
+        result = self.run_sync(0)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertFalse((self.vendor / "old.json").exists())
+        self.assertEqual((self.vendor / "base/base.json").read_bytes(),
+                         (self.checkout / "stubs/base/base.json").read_bytes())
+        self.assertIn("stubs-sha256:", (self.vendor / "SOURCE").read_text())
+        self.assert_no_staging_directory()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Data-frame subclasses can define operators that return other types. Resolve S3 dispatch before inferring a frame schema, including conflicting operand methods. Add unit, corpus, and R oracle coverage. This addresses an adjacent case in #193; full chooseOpsMethod modeling remains open.

Validate typeshed updates in a temporary directory before replacing the existing snapshot, with failure-preservation tests in CI. Shorten the README and move detailed dump-types documentation to its own page, including an executable example of scope-exit semantics.

Validation: 1,048 workspace tests pass; all 17 R oracle tests pass; Clippy and formatting pass; both sync tests and documented CLI examples pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Custom data-frame operator methods now take precedence over inferred column schemas, supporting results with different shapes and avoiding incorrect schemas for conflicting methods.
  * Typeshed updates are validated before replacing the existing snapshot, preserving the current version when validation fails.

* **Documentation**
  * Added a comprehensive reference for `ry dump-types`, including output format, scope details, position queries, and exit codes.
  * Clarified source-build and project-configuration guidance, with related type information consolidated in the new reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->