### PR TITLE
fix(workspace): replace xz2 with maintained liblzma

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ All notable changes to ry are documented in this file.
 - Validate typeshed updates before replacing the vendored snapshot. Failed
   validation leaves the existing stubs and provenance intact.
 - Shorten the README and move the inferred-types reference to `docs/types.md`.
+- Replace the unmaintained xz2 bindings with liblzma for compressed R data.
+  Pin rds2rust to a tested fork revision with the same dependency switch.
 - Infer vector-constructor lengths from size values, including empty defaults
   and fractional sizes. Correct factor arithmetic with NULL and unary minus.
 - Check typed purrr callback contracts independently of output-length inference.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -210,6 +210,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -776,6 +778,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jobserver"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
+dependencies = [
+ "getrandom 0.4.3",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -803,6 +815,26 @@ name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "liblzma"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fe0a34ca854fd4f20c07f696fc8675aec78f87d88d29f5e10257a7490a1b2e1"
+dependencies = [
+ "liblzma-sys",
+]
+
+[[package]]
+name = "liblzma-sys"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0dad045e4b1b7b170be4b60b54b780cafb4490165461bac7d1cf7b703f61d5f"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -842,17 +874,6 @@ dependencies = [
  "serde_json",
  "serde_repr",
  "url",
-]
-
-[[package]]
-name = "lzma-sys"
-version = "0.1.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fda04ab3764e6cde78b9974eec4f779acaba7c4e84b36eca3cf77c581b85d27"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
 ]
 
 [[package]]
@@ -1193,13 +1214,13 @@ dependencies = [
 [[package]]
 name = "rds2rust"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df67674ef4936a30ba30180977c5cbf6d8cbaa5b3387ed95cb8cefd411c416ea"
+source = "git+https://github.com/sims1253/rds2rust?rev=5376fded908444695bf0193f41f7759a98fa953e#5376fded908444695bf0193f41f7759a98fa953e"
 dependencies = [
  "byteorder",
  "flate2",
  "indexmap",
  "js-sys",
+ "liblzma",
  "memmap2",
  "serde",
  "serde_json",
@@ -1209,7 +1230,6 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "xz2",
 ]
 
 [[package]]
@@ -1402,13 +1422,13 @@ dependencies = [
  "bzip2",
  "flate2",
  "glob",
+ "liblzma",
  "rds2rust",
  "ry-config",
  "ry-core",
  "ry-typeshed",
  "tempfile",
  "thiserror",
- "xz2",
 ]
 
 [[package]]
@@ -2125,15 +2145,6 @@ name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
-
-[[package]]
-name = "xz2"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2"
-dependencies = [
- "lzma-sys",
-]
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,10 +49,12 @@ proptest = "1.7"
 # parallelism (Project::check pass 3 + CLI parsing)
 rayon = "1"
 # Static inventory of R serialized data files (never evaluates R code).
-rds2rust = "0.2.0"
+# rds2rust 0.2.0 plus the liblzma dependency switch and an xz regression test.
+# Replace this fork pin when a registry release supports the same liblzma graph.
+rds2rust = { git = "https://github.com/sims1253/rds2rust", rev = "5376fded908444695bf0193f41f7759a98fa953e" }
 bzip2 = "0.6"
 flate2 = "1"
-xz2 = "0.1"
+liblzma = { version = "0.4.8", default-features = false }
 
 [profile.release]
 lto = "thin"

--- a/crates/ry-workspace/Cargo.toml
+++ b/crates/ry-workspace/Cargo.toml
@@ -15,7 +15,7 @@ thiserror = { workspace = true }
 rds2rust = { workspace = true }
 bzip2 = { workspace = true }
 flate2 = { workspace = true }
-xz2 = { workspace = true }
+liblzma = { workspace = true }
 glob = { workspace = true }
 
 [dev-dependencies]

--- a/crates/ry-workspace/src/serialized.rs
+++ b/crates/ry-workspace/src/serialized.rs
@@ -126,7 +126,7 @@ fn read_serialized(reader: impl std::io::Read, cap: u64) -> Decoded {
     } else if prefix.starts_with(&[0x1f, 0x8b]) {
         decode_capped(flate2::read::GzDecoder::new(reader), cap)
     } else if prefix.starts_with(&[0xfd, b'7', b'z', b'X', b'Z', 0x00]) {
-        decode_capped(xz2::read::XzDecoder::new(reader), cap)
+        decode_capped(liblzma::read::XzDecoder::new(reader), cap)
     } else {
         decode_capped(reader, cap)
     }
@@ -185,7 +185,7 @@ mod tests {
         gzip.write_all(&payload).unwrap();
         let mut bzip = bzip2::write::BzEncoder::new(Vec::new(), Default::default());
         bzip.write_all(&payload).unwrap();
-        let mut xz = xz2::write::XzEncoder::new(Vec::new(), 6);
+        let mut xz = liblzma::write::XzEncoder::new(Vec::new(), 6);
         xz.write_all(&payload).unwrap();
         for bytes in [
             payload.clone(),


### PR DESCRIPTION
Replace `xz2` with maintained `liblzma` bindings for serialized R data. Capped decoding and supported compression formats stay the same. Neither `xz2` nor `lzma-sys` remains in the resolved dependency graph.

`rds2rust 0.2.0` also depends on `xz2`. Cargo rejects mixing its `lzma-sys` with `liblzma-sys` because both declare `links = "lzma"`. Pin rds2rust to public fork revision [`5376fded908444695bf0193f41f7759a98fa953e`](https://github.com/sims1253/rds2rust/commit/5376fded908444695bf0193f41f7759a98fa953e). Compared with the published 0.2.0 source, that revision changes the compression dependency/import, refreshes its lockfile, and adds an xz roundtrip/truncation test that runs without generated R fixtures. It contains no parser behavior changes.

This makes ry responsible for retaining the fork revision and checking future rds2rust releases. Replace the git dependency with a registry version once a release uses compatible liblzma bindings, update the lockfile, and rerun the serialization and workspace gates. Builds from source need access to the public Git repository as well as the registry.

Both callers disable liblzma's default bindgen feature, so builds use supplied bindings without requiring libclang. The bindings retain MIT OR Apache-2.0 licensing. The release dry-run built all six supported targets successfully.

Validation:

- [Release dry-run on `4b3a5d9`](https://github.com/sims1253/ry/actions/runs/34057637741): all six Linux/macOS/Windows targets, global artifacts, and executable checksums passed. Publication and announcement jobs were skipped.
- `cargo test --workspace --locked`: 1,048 tests passed.
- `cargo test -p ry-checker --test oracle --locked -- --include-ignored`: all 17 tests passed.
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo fmt --all -- --check`
- `cargo +1.88.0 check --workspace --all-targets --locked`
- `cargo build -p ry-cli --release --locked`; built CLI starts and validates all 33 vendored stub files.
- `python3 ecosystem/check-cargo-edges.py`
- Fork validation: 386 passing tests with 156 R-generated fixtures, plus a wasm32-wasip2 build check.

Closes #186.
