### PR TITLE
feat(cli): export versioned structured analysis facts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,10 @@ suppression actions — and fixes a parser panic plus several editor issues.
 
 ### Added
 
+- `ry dump-facts` exports versioned structured types, scope-exit snapshots,
+  UTF-8 source spans, and analysis context hashes for downstream tools.
+  See the [facts schema](docs/facts.md). Existing `dump-types` output is unchanged.
+
 - Zed verifies downloaded server executables against published SHA-256 sidecars
   and rechecks cached binaries before starting them. Missing or invalid sidecars
   and mismatched binaries fail installation and remove the download directory.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,6 +171,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -315,6 +324,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -390,6 +408,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
 name = "dashmap"
 version = "5.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -400,6 +428,16 @@ dependencies = [
  "lock_api",
  "once_cell",
  "parking_lot_core",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -552,6 +590,16 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -1343,6 +1391,7 @@ dependencies = [
  "ry-workspace",
  "serde",
  "serde_json",
+ "sha2",
  "tempfile",
  "tokio",
  "tracing",
@@ -1508,6 +1557,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -1929,6 +1989,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
 name = "unarray"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1988,6 +2054,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wait-timeout"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ clap_complete = "4.6.7"
 # misc
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+sha2 = "0.10"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tokio = "1"

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ See the [VS Code / Positron guide](editors/code/README.md) for settings and the
 
 - [Usage](docs/usage.md): package handling, data masking, CI, and editors.
 - [Inferred types](docs/types.md): inspect bindings with `ry dump-types`.
+- [Structured facts](docs/facts.md): versioned types and source spans for tooling.
 - [Rules](docs/rules.md): diagnostic codes and default severities.
   Run `ry explain rule RY040` for one rule or `ry explain rule` for all rules.
 - [Changelog](CHANGELOG.md): release notes and upgrade guidance.

--- a/crates/ry-checker/src/lib.rs
+++ b/crates/ry-checker/src/lib.rs
@@ -268,6 +268,17 @@ fn is_shiny_app_fragment_path(path: &str) -> bool {
     })
 }
 
+/// Built-in runtime names supplied to this file by path-based host detection.
+/// Consumers of analysis snapshots can include this effective environment in
+/// cache identities. Detection reads Shiny marker files but never executes R.
+pub fn builtin_environment_bindings(path: &str) -> &'static [&'static str] {
+    if is_shiny_app_fragment_path(path) {
+        crate::semantic_lists::BUILTIN_ENVIRONMENT_BINDINGS
+    } else {
+        &[]
+    }
+}
+
 /// A single scope's binding table.
 #[derive(Debug, Clone, Default)]
 pub struct Scope {
@@ -1001,10 +1012,8 @@ impl Checker {
         {
             scope.mark_search_path_unknown();
         }
-        if is_shiny_app_fragment_path(&self.path) {
-            for name in crate::semantic_lists::BUILTIN_ENVIRONMENT_BINDINGS {
-                scope.insert(*name, RType::unknown());
-            }
+        for name in builtin_environment_bindings(&self.path) {
+            scope.insert(*name, RType::unknown());
         }
         scope
     }

--- a/crates/ry-cli/Cargo.toml
+++ b/crates/ry-cli/Cargo.toml
@@ -36,7 +36,7 @@ tokio = { workspace = true, features = ["rt-multi-thread", "io-std"] }
 # Parallel file parsing. tree-sitter parsers are not
 # `Send`, so the parse loop uses a rayon thread-local parser pool.
 rayon = { workspace = true }
-sha2 = "0.10"
+sha2 = { workspace = true }
 
 [dev-dependencies]
 ry-testkit = { path = "../ry-testkit" }

--- a/crates/ry-cli/Cargo.toml
+++ b/crates/ry-cli/Cargo.toml
@@ -36,6 +36,7 @@ tokio = { workspace = true, features = ["rt-multi-thread", "io-std"] }
 # Parallel file parsing. tree-sitter parsers are not
 # `Send`, so the parse loop uses a rayon thread-local parser pool.
 rayon = { workspace = true }
+sha2 = "0.10"
 
 [dev-dependencies]
 ry-testkit = { path = "../ry-testkit" }

--- a/crates/ry-cli/src/dump.rs
+++ b/crates/ry-cli/src/dump.rs
@@ -117,7 +117,10 @@ fn line_char_col_to_offset(source: &str, row: usize, col: usize) -> Option<usize
 /// arguments, so the dump reports exactly what a `ry check` run
 /// infers). The *name* bound to a function literal
 /// (`inner <- function(...)`) is itself a local of this scope.
-fn collect_local_bindings(stmts: &[ry_core::ast::Stmt], out: &mut HashMap<String, ry_core::Span>) {
+pub(crate) fn collect_local_bindings(
+    stmts: &[ry_core::ast::Stmt],
+    out: &mut HashMap<String, ry_core::Span>,
+) {
     let _ = walk_stmts(
         stmts,
         Walk {
@@ -161,7 +164,7 @@ fn collect_local_bindings(stmts: &[ry_core::ast::Stmt], out: &mut HashMap<String
 
 /// Index local definition sites by function start byte. The shared walker
 /// visits nested functions; collecting locals stops at each function boundary.
-fn index_scope_bodies(
+pub(crate) fn index_scope_bodies(
     stmts: &[ry_core::ast::Stmt],
     index: &mut HashMap<usize, HashMap<String, ry_core::Span>>,
 ) {

--- a/crates/ry-cli/src/facts.rs
+++ b/crates/ry-cli/src/facts.rs
@@ -1,0 +1,441 @@
+//! Versioned scope-exit evidence. This module exports the checker's snapshots;
+//! it never reconstructs flow state or resolves references by spelling.
+
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::io::Read;
+use std::path::{Path, PathBuf};
+use std::process::ExitCode;
+
+use miette::{IntoDiagnostic, Result};
+use ry_checker::{ScopeRecord, ScopeRecordKind};
+use ry_core::{SourceFile, Span};
+use serde_json::{Value, json};
+use sha2::{Digest, Sha256};
+
+use crate::{check, dump, facts_types, pipeline};
+
+fn digest(bytes: &[u8]) -> String {
+    format!("sha256:{:x}", Sha256::digest(bytes))
+}
+
+fn executable_digest() -> Result<String> {
+    let mut file =
+        std::fs::File::open(std::env::current_exe().into_diagnostic()?).into_diagnostic()?;
+    let mut hasher = Sha256::new();
+    let mut buffer = [0u8; 65536];
+    loop {
+        let count = file.read(&mut buffer).into_diagnostic()?;
+        if count == 0 {
+            break;
+        }
+        hasher.update(&buffer[..count]);
+    }
+    Ok(format!("sha256:{:x}", hasher.finalize()))
+}
+
+fn json_digest(value: &Value) -> String {
+    digest(&serde_json::to_vec(value).expect("JSON values serialize"))
+}
+
+fn utf8_path(path: &Path) -> Result<String> {
+    path.to_str()
+        .map(str::to_owned)
+        .ok_or_else(|| miette::miette!("dump-facts requires UTF-8 paths: {}", path.display()))
+}
+
+fn file_identity(path: &Path) -> Result<String> {
+    let path = path.canonicalize().into_diagnostic()?;
+    path.to_str()
+        .map(str::to_owned)
+        .ok_or_else(|| miette::miette!("dump-facts requires UTF-8 file paths: {}", path.display()))
+}
+
+fn sorted_sets<K: Ord + Clone + serde::Serialize, V: Ord + Clone + serde::Serialize>(
+    map: &HashMap<K, std::collections::HashSet<V>>,
+) -> Value {
+    let sorted: BTreeMap<_, BTreeSet<_>> = map
+        .iter()
+        .map(|(key, values)| (key.clone(), values.iter().cloned().collect()))
+        .collect();
+    json!(sorted)
+}
+
+/// Hash exactly the environment supplied to Project, including the static
+/// installed-package and serialized-data inventories the resolver consumed.
+fn workspace_value(workspace: &ry_workspace::WorkspaceContext) -> Value {
+    let loads: BTreeMap<_, _> = workspace
+        .load_bindings
+        .iter()
+        .map(|(path, values)| (path, sorted_sets(values)))
+        .collect();
+    json!({
+        "attached_packages": workspace.attached_packages.iter().collect::<BTreeSet<_>>(),
+        "bare_bindings": sorted_sets(&workspace.bare_bindings),
+        "external_bindings": sorted_sets(&workspace.external_bindings),
+        "imported_bindings": workspace.imported_bindings,
+        "s3_methods": sorted_sets(&workspace.s3_methods),
+        "load_bindings": loads,
+    })
+}
+
+fn custom_typeshed_value(stubs: &BTreeMap<String, ry_typeshed::Typeshed>) -> Value {
+    let mut packages = BTreeMap::new();
+    for (name, stub) in stubs {
+        // JSON object keys cannot encode the (generic, class) pair.
+        let mut serializable = stub.clone();
+        serializable.s3_methods.clear();
+        let mut value = json!(serializable);
+        value["s3_methods"] = json!(
+            stub.s3_methods
+                .iter()
+                .map(|((generic, class), signature)| {
+                    json!({"generic": generic, "class": class, "signature": signature})
+                })
+                .collect::<Vec<_>>()
+        );
+        packages.insert(name, value);
+    }
+    json!(packages)
+}
+
+fn source_span(source: &str, span: Span) -> Value {
+    if span.start > span.end
+        || span.end > source.len()
+        || !source.is_char_boundary(span.start)
+        || !source.is_char_boundary(span.end)
+    {
+        return Value::Null;
+    }
+    let position = |offset| {
+        let before = &source[..offset];
+        let line_start = before.rfind('\n').map_or(0, |index| index + 1);
+        [
+            before.bytes().filter(|byte| *byte == b'\n').count() + 1,
+            source[line_start..offset].chars().count() + 1,
+        ]
+    };
+    json!({
+        "bytes": [span.start, span.end],
+        "start": position(span.start),
+        "end": position(span.end),
+    })
+}
+
+fn scope_kind(kind: ScopeRecordKind) -> &'static str {
+    match kind {
+        ScopeRecordKind::Top => "top",
+        ScopeRecordKind::Function => "function",
+    }
+}
+
+fn export_scopes(
+    file: &SourceFile,
+    mut records: Vec<ScopeRecord>,
+    imported_from: Option<&HashMap<String, String>>,
+) -> Vec<Value> {
+    records.sort_by_key(|record| (record.span.start, record.span.end, scope_kind(record.kind)));
+    records.dedup_by(|a, b| a.kind == b.kind && a.span == b.span);
+    let mut function_locals = HashMap::new();
+    dump::index_scope_bodies(&file.stmts, &mut function_locals);
+    let mut top_locals = HashMap::new();
+    dump::collect_local_bindings(&file.stmts, &mut top_locals);
+    let locals: Vec<_> = records
+        .iter()
+        .map(|record| match record.kind {
+            ScopeRecordKind::Top => top_locals.clone(),
+            ScopeRecordKind::Function => function_locals
+                .get(&record.span.start)
+                .cloned()
+                .unwrap_or_default(),
+        })
+        .collect();
+    records.iter().enumerate().map(|(index, record)| {
+        let mut enclosing: Vec<_> = records.iter().enumerate().filter(|(other, outer)| {
+            *other != index && outer.span.start <= record.span.start && record.span.end <= outer.span.end
+                && (outer.span != record.span || outer.kind == ScopeRecordKind::Top)
+        }).collect();
+        enclosing.sort_by_key(|(_, outer)| (outer.span.end - outer.span.start, scope_kind(outer.kind)));
+        let mut bindings: Vec<_> = record.scope.bindings.iter().map(|(name, ty)| {
+            let parameter = record.params.iter().find(|(param, _)| param == name);
+            let local = locals[index].get(name);
+            let (kind, site_kind, site) = if let Some((_, span)) = parameter.filter(|_| record.scope.parameter_bindings.contains(name)) {
+                ("param", "formal", Some(*span))
+            } else if let Some(span) = local {
+                ("local", "first_assignment", Some(*span))
+            } else if record.kind == ScopeRecordKind::Function {
+                let site = enclosing.iter().find_map(|(outer_index, outer)| {
+                    outer.params.iter().find(|(param, _)| param == name).map(|(_, span)| ("formal", *span))
+                        .or_else(|| locals[*outer_index].get(name).map(|span| ("first_assignment", *span)))
+                });
+                ("closed_over", site.map_or("unavailable", |(kind, _)| kind), site.map(|(_, span)| span))
+            } else {
+                ("imported", "unavailable", None)
+            };
+            let span = site.filter(|span| span.start < span.end).map(|span| source_span(&file.source, span)).unwrap_or(Value::Null);
+            json!({
+                "name": name,
+                "kind": kind,
+                "snapshot_kind": "scope_exit",
+                "type": facts_types::export_type(ty),
+                "declaration": {
+                    "kind": if span.is_null() { "unavailable" } else { site_kind },
+                    "span": span,
+                    "defines_final_value": "not_established",
+                },
+                "origin": {
+                    "function_alias_target": record.scope.function_aliases.get(name),
+                    "imported_from": if kind == "imported" || (kind == "closed_over" && site.is_none()) {
+                        imported_from.and_then(|imports| imports.get(name))
+                    } else { None },
+                    "list_derived": record.scope.list_origin_bindings.contains(name),
+                    "default_parameter_derived": record.scope.default_parameter_bindings.contains(name),
+                },
+            })
+        }).collect();
+        bindings.sort_by(|a,b| a["name"].as_str().cmp(&b["name"].as_str()));
+        json!({
+            "kind": scope_kind(record.kind),
+            "name": record.name,
+            "snapshot_kind": "scope_exit",
+            "span": if record.kind == ScopeRecordKind::Top ||
+                (record.span.start < record.span.end && function_locals.contains_key(&record.span.start)) {
+                source_span(&file.source, record.span)
+            } else { Value::Null },
+            "data_mask_unknown": record.scope.data_mask_unknown,
+            "search_path_unknown": record.scope.search_path_unknown,
+            "bindings": bindings,
+        })
+    }).collect()
+}
+
+pub(crate) fn run_dump_facts(
+    files: Vec<PathBuf>,
+    project_root: Option<PathBuf>,
+    format: &str,
+) -> Result<ExitCode> {
+    if format != "json" {
+        return Err(miette::miette!(
+            "unknown --format `{format}`; only `json` is supported"
+        ));
+    }
+    let search_start = files.first().cloned().unwrap_or_else(|| PathBuf::from("."));
+    let (config_root, cfg) = match pipeline::discover_config(&search_start) {
+        Ok(found) => found,
+        Err(code) => return Ok(code),
+    };
+    let mut paths = Vec::new();
+    let mut truncations = Vec::new();
+    for root in &files {
+        if !root.exists() {
+            return Err(miette::miette!(
+                "{}: no such file or directory",
+                root.display()
+            ));
+        }
+        let mut found = ry_workspace::discover_r_files(
+            root,
+            config_root.as_deref(),
+            &cfg,
+            cfg.check_test_fixtures,
+        );
+        if found.truncated.max_files_hit {
+            return Err(miette::miette!(
+                "{}: dump-facts cannot export a deterministic file set after max-files truncation; increase index.max-files or narrow the input",
+                root.display()
+            ));
+        }
+        found.truncated.oversized_files.sort();
+        found.truncated.depth_pruned_dirs.sort();
+        if found.truncated.any_hit() {
+            check::report_truncation(&found.truncated, root);
+            truncations.push(json!({
+                "root": file_identity(root)?,
+                "max_files_hit": found.truncated.max_files_hit,
+                "oversized_files": found.truncated.oversized_files.iter().map(|(path, size)| {
+                    Ok((utf8_path(path)?, size))
+                }).collect::<Result<Vec<_>>>()?,
+                "depth_pruned_dirs": found.truncated.depth_pruned_dirs.iter().map(|path| utf8_path(path)).collect::<Result<Vec<_>>>()?,
+            }));
+        }
+        paths.extend(found.files);
+    }
+    check::sort_and_deduplicate_paths(&mut paths);
+    let parsed = pipeline::parse_files(&paths, |_, _| pipeline::FailureAction::Abort)
+        .map_err(|failure| miette::miette!("{}: {}", failure.path.display(), failure.error))?;
+    let mut sources = BTreeMap::new();
+    let mut canonical_files = BTreeSet::new();
+    for file in &parsed {
+        if !file.parse_errors.is_empty() {
+            return Err(miette::miette!(
+                "{}: dump-facts cannot export facts from source with syntax errors",
+                file.path
+            ));
+        }
+        // The shared parser accepts Latin-1. Facts must splice the original
+        // bytes, so reject transcoded or concurrently modified input.
+        let bytes = std::fs::read(&file.path).into_diagnostic()?;
+        if bytes != file.source.as_bytes() {
+            return Err(miette::miette!(
+                "{}: dump-facts requires unchanged UTF-8 source; input is non-UTF-8 or changed while reading",
+                file.path
+            ));
+        }
+        let identity = file_identity(Path::new(&file.path))?;
+        if !canonical_files.insert(identity.clone()) {
+            return Err(miette::miette!(
+                "dump-facts received the same physical file through multiple paths: {identity}"
+            ));
+        }
+        sources.insert(
+            file.path.clone(),
+            json!({
+                "path": identity,
+                "source_hash": digest(&bytes),
+            }),
+        );
+    }
+    let user_stubs = check::load_user_stubs(&cfg.typeshed);
+    let groups = pipeline::resolve_groups(
+        &parsed,
+        &cfg,
+        &user_stubs,
+        &[project_root.as_deref(), config_root.as_deref()],
+    )?;
+    let build =
+        json!({"version": env!("CARGO_PKG_VERSION"), "executable_hash": executable_digest()?});
+    let configuration = json!({
+        "root": config_root.as_deref().map(file_identity).transpose()?,
+        "effective": cfg,
+        "environment_roots": cfg.environments.iter().map(|profile| &profile.root).collect::<Vec<_>>(),
+    });
+    let typeshed = json!({
+        "bundled_source": ry_typeshed::SOURCE,
+        "bundled_build_hash": build["executable_hash"],
+        "custom_hash": json_digest(&custom_typeshed_value(&user_stubs)),
+        "custom_packages": user_stubs.keys().collect::<Vec<_>>(),
+    });
+    let mut contexts = Vec::new();
+    let mut exported = Vec::new();
+    for group in groups {
+        let input = group.check_input;
+        let workspace = input
+            .workspace
+            .as_ref()
+            .expect("resolved groups have workspace context");
+        let mut context_sources: Vec<_> = input
+            .files
+            .iter()
+            .map(|(path, _)| sources[path].clone())
+            .collect();
+        context_sources.sort_by(|a, b| a["path"].as_str().cmp(&b["path"].as_str()));
+        let builtin_environments: BTreeMap<_, _> = input
+            .files
+            .iter()
+            .map(|(path, _)| {
+                (
+                    sources[path]["path"].as_str().expect("canonical path"),
+                    ry_checker::builtin_environment_bindings(path),
+                )
+            })
+            .collect();
+        let context = json!({
+            "builtin_environments": builtin_environments,
+            "root": file_identity(&group.resolution_root)?,
+            "build": build,
+            "config_hash": json_digest(&configuration),
+            "typeshed": typeshed,
+            "sources": context_sources,
+            "workspace_hash": json_digest(&workspace_value(workspace)),
+            "degraded_scopes": group.degraded_scopes.iter().map(|(path, reason)| {
+                Ok((utf8_path(path)?, reason))
+            }).collect::<Result<Vec<_>>>()?,
+        });
+        let context_id = json_digest(&context);
+        contexts.push(json!({"id": context_id, "inputs": context}));
+        let imported = workspace.imported_bindings.clone();
+        let group_files = input.files.clone();
+        let mut captures: HashMap<_, _> = check::check_project_with_scope_capture(input)
+            .into_iter()
+            .collect();
+        for (path, file) in group_files {
+            if builtin_environments[sources[&path]["path"].as_str().expect("canonical path")]
+                != ry_checker::builtin_environment_bindings(&path)
+            {
+                return Err(miette::miette!(
+                    "{path}: built-in environment changed during analysis; retry dump-facts"
+                ));
+            }
+            let records = captures.remove(&path).unwrap_or_default();
+            exported.push(json!({
+                "path": sources[&path]["path"],
+                "source_hash": sources[&path]["source_hash"],
+                "context_id": context_id,
+                "scopes": export_scopes(&file, records, imported.get(&path)),
+                "imports": imported.get(&path).map(|imports| imports.iter().collect::<BTreeMap<_,_>>()).unwrap_or_default(),
+            }));
+        }
+    }
+    exported.sort_by(|a, b| a["path"].as_str().cmp(&b["path"].as_str()));
+    contexts.sort_by(|a, b| a["id"].as_str().cmp(&b["id"].as_str()));
+    truncations.sort_by_key(Value::to_string);
+    let result = json!({
+        "schema_version": 1,
+        "producer": build,
+        "snapshot_kind": "scope_exit",
+        "coordinates": {"encoding": "utf-8", "bytes": "zero_based_half_open", "line_column": "one_based_unicode_scalar", "tab_width": 1},
+        "configuration": configuration,
+        "contexts": contexts,
+        "discovery": {"complete": truncations.is_empty(), "truncations": truncations},
+        "files": exported,
+    });
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&result).into_diagnostic()?
+    );
+    Ok(ExitCode::SUCCESS)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ry_checker::Scope;
+    use ry_core::{RParser, RType};
+
+    #[test]
+    fn synthetic_spans_and_scope_uncertainty_remain_explicit() {
+        let file = RParser::new()
+            .unwrap()
+            .parse("sample.R", "x <- 1L\n")
+            .unwrap();
+        let mut scope = Scope::default();
+        scope.data_mask_unknown = true;
+        scope.search_path_unknown = true;
+        scope.bindings.insert("synthetic".into(), RType::unknown());
+        scope.parameter_bindings.insert("synthetic".into());
+        let record = ScopeRecord {
+            kind: ScopeRecordKind::Function,
+            name: None,
+            span: Span::default(),
+            params: vec![("synthetic".into(), Span::default())],
+            scope,
+        };
+        let output = export_scopes(&file, vec![record], None);
+        assert!(output[0]["span"].is_null());
+        assert_eq!(output[0]["data_mask_unknown"], true);
+        assert_eq!(output[0]["search_path_unknown"], true);
+        let declaration = &output[0]["bindings"][0]["declaration"];
+        assert_eq!(declaration["kind"], "unavailable");
+        assert!(declaration["span"].is_null());
+    }
+
+    #[test]
+    fn invalid_byte_boundaries_never_become_source_spans() {
+        assert!(source_span("é", Span::new(1, 2, 0, 1)).is_null());
+        assert!(source_span("x", Span::new(0, 2, 0, 0)).is_null());
+        assert!(source_span("x", Span::new(1, 0, 0, 1)).is_null());
+        assert_eq!(
+            source_span("é", Span::new(0, 2, 0, 0))["end"],
+            json!([1, 2])
+        );
+    }
+}

--- a/crates/ry-cli/src/facts.rs
+++ b/crates/ry-cli/src/facts.rs
@@ -128,51 +128,47 @@ fn scope_kind(kind: ScopeRecordKind) -> &'static str {
     }
 }
 
-fn export_scopes(
-    file: &SourceFile,
-    mut records: Vec<ScopeRecord>,
-    imported_from: Option<&HashMap<String, String>>,
-) -> Vec<Value> {
+fn export_scopes(file: &SourceFile, mut records: Vec<ScopeRecord>) -> Vec<Value> {
     records.sort_by_key(|record| (record.span.start, record.span.end, scope_kind(record.kind)));
     records.dedup_by(|a, b| a.kind == b.kind && a.span == b.span);
     let mut function_locals = HashMap::new();
     dump::index_scope_bodies(&file.stmts, &mut function_locals);
     let mut top_locals = HashMap::new();
     dump::collect_local_bindings(&file.stmts, &mut top_locals);
-    let locals: Vec<_> = records
-        .iter()
-        .map(|record| match record.kind {
-            ScopeRecordKind::Top => top_locals.clone(),
+    let empty_locals = HashMap::new();
+    let mut scopes = Vec::new();
+    for record in records {
+        let locals = match record.kind {
+            ScopeRecordKind::Top => &top_locals,
             ScopeRecordKind::Function => function_locals
                 .get(&record.span.start)
-                .cloned()
-                .unwrap_or_default(),
-        })
-        .collect();
-    records.iter().enumerate().map(|(index, record)| {
-        let mut enclosing: Vec<_> = records.iter().enumerate().filter(|(other, outer)| {
-            *other != index && outer.span.start <= record.span.start && record.span.end <= outer.span.end
-                && (outer.span != record.span || outer.kind == ScopeRecordKind::Top)
-        }).collect();
-        enclosing.sort_by_key(|(_, outer)| (outer.span.end - outer.span.start, scope_kind(outer.kind)));
-        let mut bindings: Vec<_> = record.scope.bindings.iter().map(|(name, ty)| {
+                .unwrap_or(&empty_locals),
+        };
+        let mut bindings = Vec::new();
+        for (name, ty) in &record.scope.bindings {
             let parameter = record.params.iter().find(|(param, _)| param == name);
-            let local = locals[index].get(name);
-            let (kind, site_kind, site) = if let Some((_, span)) = parameter.filter(|_| record.scope.parameter_bindings.contains(name)) {
+            let (kind, site_kind, site) = if let Some((_, span)) =
+                parameter.filter(|_| record.scope.parameter_bindings.contains(name))
+            {
                 ("param", "formal", Some(*span))
-            } else if let Some(span) = local {
+            } else if let Some(span) = locals.get(name) {
                 ("local", "first_assignment", Some(*span))
-            } else if record.kind == ScopeRecordKind::Function {
-                let site = enclosing.iter().find_map(|(outer_index, outer)| {
-                    outer.params.iter().find(|(param, _)| param == name).map(|(_, span)| ("formal", *span))
-                        .or_else(|| locals[*outer_index].get(name).map(|span| ("first_assignment", *span)))
-                });
-                ("closed_over", site.map_or("unavailable", |(kind, _)| kind), site.map(|(_, span)| span))
             } else {
-                ("imported", "unavailable", None)
+                // Scope does not track provenance for every insertion.
+                // assign() can shadow inherited or imported names without
+                // leaving an AST assignment site in this scope.
+                ("unclassified", "unavailable", None)
             };
-            let span = site.filter(|span| span.start < span.end).map(|span| source_span(&file.source, span)).unwrap_or(Value::Null);
-            json!({
+            let span = site
+                .filter(|span| span.start < span.end)
+                .map(|span| source_span(&file.source, span))
+                .unwrap_or(Value::Null);
+            let callee_alias = record
+                .scope
+                .function_aliases
+                .get(name)
+                .map(|target| json!({"target": target, "resolution": "not_established"}));
+            bindings.push(json!({
                 "name": name,
                 "kind": kind,
                 "snapshot_kind": "scope_exit",
@@ -183,17 +179,14 @@ fn export_scopes(
                     "defines_final_value": "not_established",
                 },
                 "origin": {
-                    "function_alias_target": record.scope.function_aliases.get(name),
-                    "imported_from": if kind == "imported" || (kind == "closed_over" && site.is_none()) {
-                        imported_from.and_then(|imports| imports.get(name))
-                    } else { None },
+                    "callee_alias": callee_alias,
                     "list_derived": record.scope.list_origin_bindings.contains(name),
                     "default_parameter_derived": record.scope.default_parameter_bindings.contains(name),
                 },
-            })
-        }).collect();
-        bindings.sort_by(|a,b| a["name"].as_str().cmp(&b["name"].as_str()));
-        json!({
+            }));
+        }
+        bindings.sort_by(|a, b| a["name"].as_str().cmp(&b["name"].as_str()));
+        scopes.push(json!({
             "kind": scope_kind(record.kind),
             "name": record.name,
             "snapshot_kind": "scope_exit",
@@ -204,8 +197,9 @@ fn export_scopes(
             "data_mask_unknown": record.scope.data_mask_unknown,
             "search_path_unknown": record.scope.search_path_unknown,
             "bindings": bindings,
-        })
-    }).collect()
+        }));
+    }
+    scopes
 }
 
 pub(crate) fn run_dump_facts(
@@ -226,6 +220,7 @@ pub(crate) fn run_dump_facts(
     let mut paths = Vec::new();
     let mut truncations = Vec::new();
     for root in &files {
+        utf8_path(root)?;
         if !root.exists() {
             return Err(miette::miette!(
                 "{}: no such file or directory",
@@ -260,6 +255,9 @@ pub(crate) fn run_dump_facts(
         paths.extend(found.files);
     }
     check::sort_and_deduplicate_paths(&mut paths);
+    for path in &paths {
+        utf8_path(path)?;
+    }
     let parsed = pipeline::parse_files(&paths, |_, _| pipeline::FailureAction::Abort)
         .map_err(|failure| miette::miette!("{}: {}", failure.path.display(), failure.error))?;
     let mut sources = BTreeMap::new();
@@ -370,7 +368,7 @@ pub(crate) fn run_dump_facts(
                 "path": sources[&path]["path"],
                 "source_hash": sources[&path]["source_hash"],
                 "context_id": context_id,
-                "scopes": export_scopes(&file, records, imported.get(&path)),
+                "scopes": export_scopes(&file, records),
                 "imports": imported.get(&path).map(|imports| imports.iter().collect::<BTreeMap<_,_>>()).unwrap_or_default(),
             }));
         }
@@ -419,7 +417,7 @@ mod tests {
             params: vec![("synthetic".into(), Span::default())],
             scope,
         };
-        let output = export_scopes(&file, vec![record], None);
+        let output = export_scopes(&file, vec![record]);
         assert!(output[0]["span"].is_null());
         assert_eq!(output[0]["data_mask_unknown"], true);
         assert_eq!(output[0]["search_path_unknown"], true);

--- a/crates/ry-cli/src/facts_types.rs
+++ b/crates/ry-cli/src/facts_types.rs
@@ -1,0 +1,224 @@
+//! Structured views of checker types. This module does not infer new facts.
+
+use ry_core::RType;
+use ry_core::types::{Length, Mode};
+use serde_json::{Value, json};
+
+pub(crate) fn export_type(ty: &RType) -> Value {
+    let mode = match ty.mode {
+        Mode::Logical => "logical",
+        Mode::Integer => "integer",
+        Mode::Double => "double",
+        Mode::Complex => "complex",
+        Mode::Character => "character",
+        Mode::Raw => "raw",
+        Mode::List => "list",
+        Mode::Null => "null",
+        Mode::Function => "function",
+        Mode::Opaque => "opaque",
+        Mode::Union => "union",
+    };
+    let length = match ty.length {
+        Length::Zero => json!({"kind": "known", "value": 0}),
+        Length::One => json!({"kind": "known", "value": 1}),
+        Length::Known(value) => json!({"kind": "known", "value": value}),
+        Length::Unknown => json!({"kind": "unknown"}),
+    };
+    let class_names: Vec<_> = ty
+        .class
+        .names
+        .iter()
+        .take(usize::from(ty.class.len))
+        .map(|name| name.as_deref())
+        .collect();
+    let class = json!({
+        "kind": if ty.class.known { "known" } else { "unknown" },
+        "names": class_names,
+        // The checker stores only the first four classes. At capacity it
+        // cannot tell us whether the original class vector was longer.
+        "capacity": 4,
+        "may_be_truncated": ty.class.len >= 4,
+    });
+    let columns = match &ty.columns {
+        None => json!({"kind": "unknown"}),
+        Some(schema) => json!({
+            "kind": if schema.complete { "complete" } else { "partial" },
+            "entries": schema.columns.iter().map(|(name, ty)| {
+                json!({"key": name, "type": export_type(ty)})
+            }).collect::<Vec<_>>(),
+            "locally_constructed": schema.locally_constructed,
+        }),
+    };
+    let members = match &ty.members {
+        Some(members) => {
+            let mut types: Vec<_> = members.iter().map(export_type).collect();
+            // Union order has no meaning. Sort the entire structured value,
+            // including nested members, instead of its abbreviated Display.
+            types.sort_by_cached_key(Value::to_string);
+            json!({"kind": "known", "types": types})
+        }
+        None if ty.mode == Mode::Union => json!({"kind": "unknown"}),
+        None => json!({"kind": "not_applicable"}),
+    };
+    let function = match &ty.fn_sig {
+        Some(signature) => json!({
+            "kind": "partial",
+            "params": signature.params.iter().map(export_type).collect::<Vec<_>>(),
+            "parameters_complete": false,
+            "return_type": export_type(&signature.return_type),
+        }),
+        None if matches!(ty.mode, Mode::Function | Mode::Opaque | Mode::Union) => {
+            json!({"kind": "unknown"})
+        }
+        None => json!({"kind": "not_applicable"}),
+    };
+    json!({
+        "kind": "r_type",
+        "mode": mode,
+        "length": length,
+        "class": class,
+        "columns": columns,
+        "members": members,
+        "function": function,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ry_core::types::{ClassVector, ColumnSchema, FunctionSignature};
+    use std::sync::Arc;
+
+    #[test]
+    fn unknown_empty_and_partial_columns_are_distinct() {
+        let unknown = export_type(&RType::unknown());
+        let empty = RType::new(Mode::List, Length::Zero).with_columns(Arc::new(ColumnSchema {
+            columns: vec![],
+            complete: true,
+            locally_constructed: true,
+        }));
+        let partial =
+            RType::new(Mode::List, Length::Unknown).with_columns(Arc::new(ColumnSchema {
+                columns: vec![],
+                complete: false,
+                locally_constructed: false,
+            }));
+        assert_eq!(unknown["columns"], json!({"kind": "unknown"}));
+        assert_eq!(export_type(&empty)["columns"]["kind"], "complete");
+        assert_eq!(export_type(&empty)["columns"]["entries"], json!([]));
+        assert_eq!(export_type(&partial)["columns"]["kind"], "partial");
+        assert_eq!(export_type(&partial)["columns"]["entries"], json!([]));
+        assert_eq!(unknown["function"]["kind"], "unknown");
+    }
+
+    #[test]
+    fn classes_preserve_order_unknownness_and_capacity_limit() {
+        assert_eq!(export_type(&RType::unknown())["class"]["kind"], "unknown");
+        let plain = RType::scalar(Mode::Integer);
+        assert_eq!(export_type(&plain)["class"]["kind"], "known");
+        assert_eq!(export_type(&plain)["class"]["names"], json!([]));
+        let classed = plain.with_class(ClassVector::from_slice(&["z", "a", "b", "c", "d"]));
+        let class = &export_type(&classed)["class"];
+        assert_eq!(class["names"], json!(["z", "a", "b", "c"]));
+        assert_eq!(class["may_be_truncated"], true);
+    }
+
+    #[test]
+    fn nested_columns_preserve_order_and_duplicate_names() {
+        let leaf = RType::scalar(Mode::Integer);
+        let record =
+            RType::new(Mode::List, Length::Known(3)).with_columns(Arc::new(ColumnSchema {
+                columns: vec![
+                    ("z".into(), leaf.clone()),
+                    ("a".into(), RType::unknown()),
+                    ("z".into(), leaf),
+                ],
+                complete: false,
+                locally_constructed: true,
+            }));
+        let value = export_type(&record);
+        let entries = value["columns"]["entries"].as_array().unwrap();
+        assert_eq!(
+            entries
+                .iter()
+                .map(|entry| entry["key"].as_str().unwrap())
+                .collect::<Vec<_>>(),
+            ["z", "a", "z"]
+        );
+        assert_eq!(entries[1]["type"]["mode"], "opaque");
+        assert_eq!(value["length"], json!({"kind": "known", "value": 3}));
+    }
+
+    #[test]
+    fn column_keys_do_not_claim_to_be_actual_field_names() {
+        // The checker uses this key for an unnamed slot but can also receive
+        // the same spelling as an explicit name. RType cannot distinguish them.
+        let ty = RType::new(Mode::List, Length::One).with_columns(Arc::new(ColumnSchema {
+            columns: vec![("[[1]]".into(), RType::scalar(Mode::Integer))],
+            complete: true,
+            locally_constructed: true,
+        }));
+        let value = export_type(&ty);
+        let entry = &value["columns"]["entries"][0];
+        assert_eq!(entry["key"], "[[1]]");
+        assert!(entry.get("name").is_none());
+    }
+
+    #[test]
+    fn union_order_is_canonical_and_missing_members_are_unknown() {
+        let a = RType::scalar(Mode::Integer);
+        let b = RType::scalar(Mode::Character);
+        let forward = RType::union(Arc::from([a.clone(), b.clone()]));
+        let reverse = RType::union(Arc::from([b, a]));
+        assert_eq!(export_type(&forward), export_type(&reverse));
+        let malformed = RType {
+            members: None,
+            ..forward
+        };
+        assert_eq!(export_type(&malformed)["members"]["kind"], "unknown");
+    }
+
+    #[test]
+    fn function_parameters_are_partial_even_when_empty() {
+        let opaque = RType::scalar(Mode::Function);
+        assert_eq!(export_type(&opaque)["function"]["kind"], "unknown");
+        let closure = opaque.with_fn_sig(Arc::new(FunctionSignature {
+            params: vec![],
+            return_type: Box::new(RType::scalar(Mode::Integer)),
+        }));
+        let value = export_type(&closure);
+        assert_eq!(value["function"]["kind"], "partial");
+        assert_eq!(value["function"]["parameters_complete"], false);
+        assert_eq!(value["function"]["params"], json!([]));
+        assert_eq!(value["function"]["return_type"]["mode"], "integer");
+    }
+
+    #[test]
+    fn every_mode_and_length_has_a_stable_tag() {
+        for (mode, tag) in [
+            (Mode::Logical, "logical"),
+            (Mode::Integer, "integer"),
+            (Mode::Double, "double"),
+            (Mode::Complex, "complex"),
+            (Mode::Character, "character"),
+            (Mode::Raw, "raw"),
+            (Mode::List, "list"),
+            (Mode::Null, "null"),
+            (Mode::Function, "function"),
+            (Mode::Opaque, "opaque"),
+            (Mode::Union, "union"),
+        ] {
+            assert_eq!(export_type(&RType::new(mode, Length::Unknown))["mode"], tag);
+        }
+        for (length, value) in [(Length::Zero, 0), (Length::One, 1), (Length::Known(99), 99)] {
+            assert_eq!(
+                export_type(&RType::new(Mode::Integer, length))["length"],
+                json!({"kind": "known", "value": value})
+            );
+        }
+        assert_eq!(
+            export_type(&RType::unknown())["length"],
+            json!({"kind": "unknown"})
+        );
+    }
+}

--- a/crates/ry-cli/src/main.rs
+++ b/crates/ry-cli/src/main.rs
@@ -1,5 +1,7 @@
 mod check;
 mod dump;
+mod facts;
+mod facts_types;
 mod pipeline;
 
 use std::io::IsTerminal;
@@ -193,6 +195,18 @@ enum Cmd {
         #[arg(long = "position", value_name = "LINE:COL", value_parser = dump::parse_dump_position)]
         positions: Vec<(usize, usize)>,
     },
+    /// Export versioned structured facts at scope exit, as JSON.
+    DumpFacts {
+        /// R files or directories to analyze.
+        #[arg(required = true)]
+        files: Vec<PathBuf>,
+        /// Analysis root for files outside an R package.
+        #[arg(long, value_name = "DIR")]
+        project_root: Option<PathBuf>,
+        /// Output format. Only `json` is supported.
+        #[arg(long, value_name = "FORMAT", default_value = "json")]
+        format: String,
+    },
     /// Start the language server. Speaks the Language Server Protocol
     /// (LSP) over stdio, publishing type-check diagnostics for open R
     /// files. Connect to it from any LSP-aware editor (VS Code, Neovim,
@@ -292,6 +306,11 @@ fn main() -> Result<ExitCode> {
             format,
             positions,
         } => dump::run_dump_types(files, project_root, &format, positions),
+        Cmd::DumpFacts {
+            files,
+            project_root,
+            format,
+        } => facts::run_dump_facts(files, project_root, &format),
         Cmd::Server { log_level } => {
             // The LSP server reads JSON-RPC from stdin and writes
             // JSON-RPC to stdout. CRITICAL: any tracing or log output

--- a/crates/ry-cli/src/pipeline.rs
+++ b/crates/ry-cli/src/pipeline.rs
@@ -162,6 +162,7 @@ where
 /// workspace context wrapped as a `CheckInput`, plus the degraded-scope
 /// notes the command reports in its own voice.
 pub(crate) struct ResolvedGroup {
+    pub resolution_root: PathBuf,
     pub check_input: crate::check::CheckInput,
     pub degraded_scopes: Vec<(PathBuf, &'static str)>,
 }
@@ -199,6 +200,13 @@ pub(crate) fn resolve_groups(
                     .map(PathBuf::from)
             })
             .unwrap_or_else(|| std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")));
+        // A relative file such as R/main.R can find DESCRIPTION at the
+        // empty ancestor path. That ancestor is the working directory.
+        let resolution_root = if resolution_root.as_os_str().is_empty() {
+            PathBuf::from(".")
+        } else {
+            resolution_root
+        };
         let mut package_scope = ry_workspace::resolve_workspace_context(
             &resolution_root,
             cfg,
@@ -221,6 +229,7 @@ pub(crate) fn resolve_groups(
         let degraded_scopes = std::mem::take(&mut package_scope.degraded_scopes);
         let workspace = package_scope;
         resolved.push(ResolvedGroup {
+            resolution_root,
             check_input: crate::check::CheckInput {
                 files: analysis_files,
                 user_stubs: Arc::clone(user_stubs),

--- a/crates/ry-cli/tests/facts_context.rs
+++ b/crates/ry-cli/tests/facts_context.rs
@@ -1,0 +1,287 @@
+//! Cache identities and input safety for the structured facts exporter.
+
+use std::fs;
+use std::path::Path;
+use std::process::{Command, Output};
+
+use serde_json::Value;
+
+fn run(root: &Path, files: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_ry"))
+        .current_dir(root)
+        .args(["dump-facts", "--format", "json"])
+        .args(files)
+        .output()
+        .expect("invoke ry dump-facts")
+}
+
+fn dump(root: &Path, files: &[&str]) -> Value {
+    let output = run(root, files);
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    serde_json::from_slice(&output.stdout).expect("facts are JSON")
+}
+
+fn file<'a>(dump: &'a Value, name: &str) -> &'a Value {
+    dump["files"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|file| Path::new(file["path"].as_str().unwrap()).ends_with(name))
+        .unwrap_or_else(|| panic!("missing {name}: {dump}"))
+}
+
+fn context<'a>(dump: &'a Value, source: &Value) -> &'a Value {
+    dump["contexts"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|context| context["id"] == source["context_id"])
+        .expect("source refers to an exported context")
+}
+
+fn assert_context_changed(before: &Value, after: &Value, name: &str) {
+    let old = file(before, name);
+    let new = file(after, name);
+    assert_eq!(
+        old["source_hash"], new["source_hash"],
+        "the target source is unchanged"
+    );
+    assert_ne!(
+        old["context_id"], new["context_id"],
+        "context changes must invalidate cached facts"
+    );
+}
+
+fn stub(mode: &str) -> String {
+    serde_json::json!({
+        "schema_version": "2", "package": "factspkg", "version": "test",
+        "functions": {"value": {"params": [], "return": {"mode": mode, "length": "1"}}}
+    })
+    .to_string()
+}
+
+#[test]
+fn rejects_latin1_instead_of_exporting_transcoded_byte_spans() {
+    let temp = tempfile::tempdir().unwrap();
+    fs::write(temp.path().join("latin1.R"), b"caf\xe9 <- 1L\n").unwrap();
+    let output = run(temp.path(), &["latin1.R"]);
+    assert!(!output.status.success());
+    assert!(
+        output.stdout.is_empty(),
+        "an invalid input must not yield usable facts"
+    );
+    assert!(String::from_utf8_lossy(&output.stderr).contains("UTF-8"));
+}
+
+#[test]
+fn repeated_runs_and_reversed_file_arguments_produce_identical_json() {
+    let temp = tempfile::tempdir().unwrap();
+    fs::write(
+        temp.path().join("ry.toml"),
+        "globals = [\"ambient_z\", \"ambient_a\"]\n",
+    )
+    .unwrap();
+    fs::write(
+        temp.path().join("a.R"),
+        "z <- 1L\na <- list(last = z, first = 2L)\n",
+    )
+    .unwrap();
+    fs::write(temp.path().join("b.R"), "f <- function(x) { y <- x; y }\n").unwrap();
+    let first = run(temp.path(), &["b.R", "a.R"]);
+    assert!(
+        first.status.success(),
+        "{}",
+        String::from_utf8_lossy(&first.stderr)
+    );
+    for files in [["b.R", "a.R"], ["a.R", "b.R"]] {
+        let repeated = run(temp.path(), &files);
+        assert!(
+            repeated.status.success(),
+            "{}",
+            String::from_utf8_lossy(&repeated.stderr)
+        );
+        if first.stdout != repeated.stdout {
+            let original = String::from_utf8_lossy(&first.stdout);
+            let changed = String::from_utf8_lossy(&repeated.stdout);
+            let difference = original
+                .lines()
+                .zip(changed.lines())
+                .enumerate()
+                .find(|(_, (old, new))| old != new);
+            panic!("facts changed for {files:?}; first differing line: {difference:?}");
+        }
+    }
+    let facts: Value = serde_json::from_slice(&first.stdout).unwrap();
+    let paths: Vec<_> = facts["files"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|file| file["path"].as_str().unwrap())
+        .collect();
+    assert!(paths.windows(2).all(|pair| pair[0] < pair[1]));
+    for path in paths {
+        assert!(Path::new(path).is_absolute());
+        assert_eq!(Path::new(path).canonicalize().unwrap(), Path::new(path));
+    }
+}
+
+#[test]
+fn namespace_import_changes_invalidate_unchanged_source() {
+    let temp = tempfile::tempdir().unwrap();
+    fs::create_dir(temp.path().join("R")).unwrap();
+    fs::write(
+        temp.path().join("DESCRIPTION"),
+        "Package: factsfixture\nVersion: 0.0.1\nImports: stats\n",
+    )
+    .unwrap();
+    fs::write(temp.path().join("NAMESPACE"), "importFrom(stats, median)\n").unwrap();
+    fs::write(temp.path().join("R/main.R"), "x <- 1L\n").unwrap();
+    let before = dump(temp.path(), &["R/main.R"]);
+    fs::write(temp.path().join("NAMESPACE"), "importFrom(stats, sd)\n").unwrap();
+    let after = dump(temp.path(), &["R/main.R"]);
+    assert_context_changed(&before, &after, "R/main.R");
+    assert_ne!(
+        context(&before, file(&before, "R/main.R"))["inputs"]["workspace_hash"],
+        context(&after, file(&after, "R/main.R"))["inputs"]["workspace_hash"]
+    );
+}
+
+#[test]
+fn custom_stub_content_invalidates_context_without_a_version_change() {
+    let temp = tempfile::tempdir().unwrap();
+    fs::create_dir(temp.path().join("stubs")).unwrap();
+    fs::write(temp.path().join("ry.toml"), "typeshed = [\"stubs\"]\n").unwrap();
+    fs::write(temp.path().join("main.R"), "x <- factspkg::value()\n").unwrap();
+    fs::write(temp.path().join("stubs/factspkg.json"), stub("integer")).unwrap();
+    let before = dump(temp.path(), &["main.R"]);
+    fs::write(temp.path().join("stubs/factspkg.json"), stub("character")).unwrap();
+    let after = dump(temp.path(), &["main.R"]);
+    assert_context_changed(&before, &after, "main.R");
+    assert_ne!(
+        context(&before, file(&before, "main.R"))["inputs"]["typeshed"]["custom_hash"],
+        context(&after, file(&after, "main.R"))["inputs"]["typeshed"]["custom_hash"]
+    );
+}
+
+#[test]
+fn another_analyzed_source_invalidates_the_shared_group_context() {
+    let temp = tempfile::tempdir().unwrap();
+    fs::write(temp.path().join("main.R"), "answer <- helper()\n").unwrap();
+    fs::write(temp.path().join("helper.R"), "helper <- function() 1L\n").unwrap();
+    let before = dump(temp.path(), &["main.R", "helper.R"]);
+    fs::write(
+        temp.path().join("helper.R"),
+        "helper <- function() \"changed\"\n",
+    )
+    .unwrap();
+    let after = dump(temp.path(), &["main.R", "helper.R"]);
+    assert_context_changed(&before, &after, "main.R");
+    assert_ne!(
+        file(&before, "helper.R")["source_hash"],
+        file(&after, "helper.R")["source_hash"]
+    );
+    assert_eq!(
+        file(&after, "main.R")["context_id"],
+        file(&after, "helper.R")["context_id"]
+    );
+}
+
+#[test]
+fn effective_config_changes_invalidate_unchanged_source() {
+    let temp = tempfile::tempdir().unwrap();
+    fs::write(temp.path().join("main.R"), "x <- ambient\n").unwrap();
+    fs::write(temp.path().join("ry.toml"), "globals = []\n").unwrap();
+    let before = dump(temp.path(), &["main.R"]);
+    fs::write(temp.path().join("ry.toml"), "globals = [\"ambient\"]\n").unwrap();
+    let after = dump(temp.path(), &["main.R"]);
+    assert_context_changed(&before, &after, "main.R");
+    assert_ne!(
+        context(&before, file(&before, "main.R"))["inputs"]["config_hash"],
+        context(&after, file(&after, "main.R"))["inputs"]["config_hash"]
+    );
+}
+
+#[test]
+fn exporting_facts_does_not_execute_the_analyzed_source() {
+    let temp = tempfile::tempdir().unwrap();
+    fs::write(
+        temp.path().join("main.R"),
+        concat!(
+            "writeLines(\"source was executed\", \"executed.txt\")\n",
+            "stop(\"analysis must not execute this code\")\n",
+        ),
+    )
+    .unwrap();
+    let facts = dump(temp.path(), &["main.R"]);
+    assert_eq!(facts["files"].as_array().unwrap().len(), 1);
+    assert!(!temp.path().join("executed.txt").exists());
+}
+
+#[test]
+fn unselected_shiny_marker_invalidates_ambient_binding_facts() {
+    let temp = tempfile::tempdir().unwrap();
+    fs::write(temp.path().join("fragment.R"), "x <- 1L\n").unwrap();
+    let before = dump(temp.path(), &["fragment.R"]);
+    let binding_names = |facts: &Value| {
+        file(facts, "fragment.R")["scopes"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|scope| scope["kind"] == "top")
+            .unwrap()["bindings"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|binding| binding["name"].as_str().unwrap().to_owned())
+            .collect::<Vec<_>>()
+    };
+    assert_eq!(binding_names(&before), ["x"]);
+    // The marker is deliberately outside the selected analysis sources.
+    let marker = temp.path().join("app.R");
+    fs::write(&marker, "# Shiny application marker\n").unwrap();
+    let with_marker = dump(temp.path(), &["fragment.R"]);
+    assert_context_changed(&before, &with_marker, "fragment.R");
+    assert_eq!(
+        binding_names(&with_marker),
+        ["input", "output", "session", "x"]
+    );
+    assert_eq!(with_marker["files"].as_array().unwrap().len(), 1);
+    fs::remove_file(marker).unwrap();
+    let removed = dump(temp.path(), &["fragment.R"]);
+    assert_context_changed(&with_marker, &removed, "fragment.R");
+    assert_eq!(
+        file(&before, "fragment.R")["context_id"],
+        file(&removed, "fragment.R")["context_id"]
+    );
+    assert_eq!(binding_names(&before), binding_names(&removed));
+}
+
+#[cfg(unix)]
+#[test]
+fn oversized_non_utf8_path_returns_an_error_without_panicking() {
+    use std::ffi::OsString;
+    use std::os::unix::ffi::OsStringExt;
+
+    let temp = tempfile::tempdir().unwrap();
+    fs::write(temp.path().join("ry.toml"), "[index]\nmax-file-bytes = 1\n").unwrap();
+    let filename = OsString::from_vec(b"oversized\xff.R".to_vec());
+    fs::write(temp.path().join(filename), b"x <- 1L\n").unwrap();
+    let output = run(temp.path(), &["."]);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(!output.status.success());
+    assert_ne!(
+        output.status.code(),
+        Some(101),
+        "must report an input error: {stderr}"
+    );
+    assert!(!stderr.contains("panicked"), "{stderr}");
+    assert!(stderr.contains("UTF-8"), "{stderr}");
+    assert!(
+        output.stdout.is_empty(),
+        "must not emit unusable truncation paths"
+    );
+}

--- a/crates/ry-cli/tests/facts_context.rs
+++ b/crates/ry-cli/tests/facts_context.rs
@@ -262,26 +262,25 @@ fn unselected_shiny_marker_invalidates_ambient_binding_facts() {
 
 #[cfg(unix)]
 #[test]
-fn oversized_non_utf8_path_returns_an_error_without_panicking() {
+fn non_utf8_discovered_and_truncated_paths_return_explicit_errors() {
     use std::ffi::OsString;
     use std::os::unix::ffi::OsStringExt;
 
     let temp = tempfile::tempdir().unwrap();
-    fs::write(temp.path().join("ry.toml"), "[index]\nmax-file-bytes = 1\n").unwrap();
-    let filename = OsString::from_vec(b"oversized\xff.R".to_vec());
+    let filename = OsString::from_vec(b"source\xff.R".to_vec());
     fs::write(temp.path().join(filename), b"x <- 1L\n").unwrap();
-    let output = run(temp.path(), &["."]);
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(!output.status.success());
-    assert_ne!(
-        output.status.code(),
-        Some(101),
-        "must report an input error: {stderr}"
-    );
-    assert!(!stderr.contains("panicked"), "{stderr}");
-    assert!(stderr.contains("UTF-8"), "{stderr}");
-    assert!(
-        output.stdout.is_empty(),
-        "must not emit unusable truncation paths"
-    );
+    for config in ["[index]\nmax-file-bytes = 1\n", ""] {
+        fs::write(temp.path().join("ry.toml"), config).unwrap();
+        let output = run(temp.path(), &["."]);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(!output.status.success());
+        assert_ne!(
+            output.status.code(),
+            Some(101),
+            "must report an input error: {stderr}"
+        );
+        assert!(!stderr.contains("panicked"), "{stderr}");
+        assert!(stderr.contains("UTF-8"), "{stderr}");
+        assert!(output.stdout.is_empty(), "must not emit unusable paths");
+    }
 }

--- a/crates/ry-cli/tests/facts_e2e.rs
+++ b/crates/ry-cli/tests/facts_e2e.rs
@@ -1,0 +1,250 @@
+use std::fs;
+use std::process::{Command, Output};
+
+use serde_json::{Value, json};
+
+fn invoke(directory: &std::path::Path, command: &str, args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_ry"))
+        .current_dir(directory)
+        .arg(command)
+        .args(args)
+        .output()
+        .unwrap()
+}
+
+fn facts(directory: &std::path::Path, args: &[&str]) -> Value {
+    let output = invoke(directory, "dump-facts", args);
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    serde_json::from_slice(&output.stdout).unwrap()
+}
+
+fn binding<'a>(scope: &'a Value, name: &str) -> &'a Value {
+    scope["bindings"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|entry| entry["name"] == name)
+        .unwrap()
+}
+
+#[test]
+fn scope_exit_and_first_assignment_are_not_reference_facts() {
+    let dir = tempfile::tempdir().unwrap();
+    fs::write(
+        dir.path().join("scope.R"),
+        "x <- 1L\ny <- x\nx <- \"later\"\nf <- function(x) x\n",
+    )
+    .unwrap();
+    let output = facts(dir.path(), &["scope.R"]);
+    assert_eq!(output["schema_version"], 1);
+    assert_eq!(output["snapshot_kind"], "scope_exit");
+    let scopes = output["files"][0]["scopes"].as_array().unwrap();
+    let top = scopes.iter().find(|scope| scope["kind"] == "top").unwrap();
+    let x = binding(top, "x");
+    assert_eq!(x["type"]["mode"], "character");
+    assert_eq!(x["declaration"]["kind"], "first_assignment");
+    assert_eq!(x["declaration"]["span"]["bytes"], json!([0, 1]));
+    assert_eq!(x["declaration"]["defines_final_value"], "not_established");
+    assert_eq!(binding(top, "y")["type"]["mode"], "integer");
+    let inner = scopes.iter().find(|scope| scope["name"] == "f").unwrap();
+    assert_eq!(binding(inner, "x")["kind"], "param");
+    assert_ne!(
+        binding(inner, "x")["declaration"]["span"],
+        x["declaration"]["span"]
+    );
+    for scope in scopes {
+        assert_eq!(scope["snapshot_kind"], "scope_exit");
+        for entry in scope["bindings"].as_array().unwrap() {
+            assert_eq!(entry["snapshot_kind"], "scope_exit");
+            assert!(entry.get("type_at_reference").is_none());
+        }
+    }
+    let rejected = invoke(dir.path(), "dump-facts", &["scope.R", "--position", "2:6"]);
+    assert!(!rejected.status.success());
+    let old = invoke(dir.path(), "dump-types", &["scope.R", "--position", "2:6"]);
+    assert!(old.status.success());
+    let old: Value = serde_json::from_slice(&old.stdout).unwrap();
+    assert!(old.get("schema_version").is_none());
+    assert_eq!(
+        binding(&old["files"][0]["scopes"][0], "x")["type"],
+        "character<len=1>"
+    );
+}
+
+#[test]
+fn byte_spans_round_trip_unicode_tabs_and_multiline_functions() {
+    let dir = tempfile::tempdir().unwrap();
+    let source = "é <- 1L\r\nf <- function(λ) {\r\n\t結果 <- λ\r\n\t結果\r\n}\r\n`空 白` <- 1L\r\n";
+    fs::write(dir.path().join("unicode.R"), source).unwrap();
+    let output = facts(dir.path(), &["unicode.R"]);
+    assert_eq!(output["coordinates"]["bytes"], "zero_based_half_open");
+    let scopes = output["files"][0]["scopes"].as_array().unwrap();
+    for scope in scopes {
+        let range = scope["span"]["bytes"].as_array().unwrap();
+        let slice =
+            &source[range[0].as_u64().unwrap() as usize..range[1].as_u64().unwrap() as usize];
+        if scope["kind"] == "function" {
+            assert!(slice.starts_with("function(λ)"));
+            assert!(slice.ends_with('}'));
+        }
+        for entry in scope["bindings"].as_array().unwrap() {
+            if let Some(range) = entry["declaration"]["span"]["bytes"].as_array() {
+                let actual = &source
+                    [range[0].as_u64().unwrap() as usize..range[1].as_u64().unwrap() as usize];
+                let name = entry["name"].as_str().unwrap();
+                assert_eq!(actual, if name == "空 白" { "`空 白`" } else { name });
+            }
+        }
+    }
+    let inner = scopes.iter().find(|scope| scope["name"] == "f").unwrap();
+    assert_eq!(
+        binding(inner, "結果")["declaration"]["span"]["start"],
+        json!([3, 2])
+    );
+    assert_eq!(
+        binding(inner, "結果")["declaration"]["span"]["end"],
+        json!([3, 4])
+    );
+    assert_eq!(binding(inner, "é")["kind"], "closed_over");
+}
+
+#[test]
+fn aliases_and_unknown_search_paths_are_explicit() {
+    let dir = tempfile::tempdir().unwrap();
+    fs::write(
+        dir.path().join("alias.R"),
+        "f <- base::identity\nlibrary(package_which_does_not_exist_ry_facts)\nx <- unavailable_value_ry_facts\n",
+    )
+    .unwrap();
+    let output = facts(dir.path(), &["alias.R"]);
+    let scope = &output["files"][0]["scopes"][0];
+    assert_eq!(scope["search_path_unknown"], true);
+    assert_eq!(scope["data_mask_unknown"], false);
+    assert_eq!(
+        binding(scope, "f")["origin"]["function_alias_target"],
+        "base::identity"
+    );
+    assert_eq!(binding(scope, "x")["type"]["mode"], "opaque");
+    assert_eq!(binding(scope, "x")["type"]["columns"]["kind"], "unknown");
+}
+
+#[test]
+fn bounded_discovery_is_not_reported_as_complete() {
+    let dir = tempfile::tempdir().unwrap();
+    fs::write(dir.path().join("ry.toml"), "[index]\nmax-file-bytes = 9\n").unwrap();
+    fs::write(dir.path().join("a.R"), "a <- 1L\n").unwrap();
+    fs::write(dir.path().join("b.R"), "b <- 2L # oversized\n").unwrap();
+    let output = facts(dir.path(), &["."]);
+    assert_eq!(output["discovery"]["complete"], false);
+    assert_eq!(output["files"].as_array().unwrap().len(), 1);
+    assert_eq!(
+        output["discovery"]["truncations"][0]["oversized_files"]
+            .as_array()
+            .unwrap()
+            .len(),
+        1
+    );
+}
+
+#[test]
+fn parse_failures_cannot_silently_omit_requested_facts() {
+    let dir = tempfile::tempdir().unwrap();
+    fs::write(dir.path().join("bad.R"), "function(\n").unwrap();
+    let output = invoke(dir.path(), "dump-facts", &["bad.R"]);
+    assert!(!output.status.success());
+    assert!(output.stdout.is_empty());
+}
+
+#[test]
+fn file_count_caps_reject_unstable_discovery_subsets() {
+    let dir = tempfile::tempdir().unwrap();
+    fs::write(dir.path().join("ry.toml"), "[index]\nmax-files = 1\n").unwrap();
+    fs::write(dir.path().join("a.R"), "a <- 1L\n").unwrap();
+    fs::write(dir.path().join("b.R"), "b <- 2L\n").unwrap();
+    let output = invoke(dir.path(), "dump-facts", &["."]);
+    assert!(!output.status.success());
+    assert!(output.stdout.is_empty());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("max-files"));
+}
+
+#[test]
+fn captured_data_masks_keep_uncertainty_in_nested_scopes() {
+    let dir = tempfile::tempdir().unwrap();
+    fs::write(
+        dir.path().join("mask.R"),
+        "f <- function(df) with(df, { g <- function() column; g() })\n",
+    )
+    .unwrap();
+    let output = facts(dir.path(), &["mask.R"]);
+    let scopes = output["files"][0]["scopes"].as_array().unwrap();
+    let outer = scopes.iter().find(|scope| scope["name"] == "f").unwrap();
+    let masked = scopes.iter().find(|scope| scope["name"] == "g").unwrap();
+    assert_eq!(outer["data_mask_unknown"], false);
+    assert_eq!(masked["data_mask_unknown"], true);
+    assert_eq!(masked["snapshot_kind"], "scope_exit");
+    assert_eq!(binding(masked, "df")["kind"], "closed_over");
+}
+
+#[test]
+fn relative_package_input_records_import_origin() {
+    let dir = tempfile::tempdir().unwrap();
+    fs::create_dir(dir.path().join("R")).unwrap();
+    fs::write(
+        dir.path().join("DESCRIPTION"),
+        "Package: factsfixture\nVersion: 1.0\n",
+    )
+    .unwrap();
+    fs::write(
+        dir.path().join("NAMESPACE"),
+        "importFrom(facts_dependency, imported_function)\n",
+    )
+    .unwrap();
+    fs::write(dir.path().join("R/main.R"), "x <- imported_function()\n").unwrap();
+    let output = facts(dir.path(), &["R/main.R"]);
+    assert_eq!(
+        output["files"][0]["imports"]["imported_function"],
+        "facts_dependency"
+    );
+    // Workspace imports are resolver metadata, not captured lexical bindings.
+    assert!(
+        output["files"][0]["scopes"][0]["bindings"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .all(|entry| entry["name"] != "imported_function")
+    );
+    let legacy = invoke(dir.path(), "dump-types", &["R/main.R"]);
+    assert!(
+        legacy.status.success(),
+        "{}",
+        String::from_utf8_lossy(&legacy.stderr)
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn duplicate_canonical_file_ids_are_rejected() {
+    let dir = tempfile::tempdir().unwrap();
+    fs::write(dir.path().join("source.R"), "x <- 1L\n").unwrap();
+    std::os::unix::fs::symlink(dir.path().join("source.R"), dir.path().join("alias.R")).unwrap();
+    let output = invoke(dir.path(), "dump-facts", &["source.R", "alias.R"]);
+    assert!(!output.status.success());
+    assert!(output.stdout.is_empty());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("same physical file"));
+}
+
+#[test]
+fn unnamed_list_elements_export_schema_keys_without_named_field_claims() {
+    let dir = tempfile::tempdir().unwrap();
+    fs::write(dir.path().join("list.R"), "x <- list(1L, label = \"a\")\n").unwrap();
+    let output = facts(dir.path(), &["list.R"]);
+    let columns = &binding(&output["files"][0]["scopes"][0], "x")["type"]["columns"];
+    assert_eq!(columns["kind"], "complete");
+    assert_eq!(columns["entries"][0]["key"], "[[1]]");
+    assert_eq!(columns["entries"][1]["key"], "label");
+    assert!(columns["entries"][0].get("name").is_none());
+}

--- a/crates/ry-cli/tests/facts_e2e.rs
+++ b/crates/ry-cli/tests/facts_e2e.rs
@@ -109,7 +109,7 @@ fn byte_spans_round_trip_unicode_tabs_and_multiline_functions() {
         binding(inner, "結果")["declaration"]["span"]["end"],
         json!([3, 4])
     );
-    assert_eq!(binding(inner, "é")["kind"], "closed_over");
+    assert_eq!(binding(inner, "é")["kind"], "unclassified");
 }
 
 #[test]
@@ -125,7 +125,7 @@ fn aliases_and_unknown_search_paths_are_explicit() {
     assert_eq!(scope["search_path_unknown"], true);
     assert_eq!(scope["data_mask_unknown"], false);
     assert_eq!(
-        binding(scope, "f")["origin"]["function_alias_target"],
+        binding(scope, "f")["origin"]["callee_alias"]["target"],
         "base::identity"
     );
     assert_eq!(binding(scope, "x")["type"]["mode"], "opaque");
@@ -186,7 +186,7 @@ fn captured_data_masks_keep_uncertainty_in_nested_scopes() {
     assert_eq!(outer["data_mask_unknown"], false);
     assert_eq!(masked["data_mask_unknown"], true);
     assert_eq!(masked["snapshot_kind"], "scope_exit");
-    assert_eq!(binding(masked, "df")["kind"], "closed_over");
+    assert_eq!(binding(masked, "df")["kind"], "unclassified");
 }
 
 #[test]
@@ -247,4 +247,40 @@ fn unnamed_list_elements_export_schema_keys_without_named_field_claims() {
     assert_eq!(columns["entries"][0]["key"], "[[1]]");
     assert_eq!(columns["entries"][1]["key"], "label");
     assert!(columns["entries"][0].get("name").is_none());
+}
+
+#[test]
+fn dynamic_assignments_do_not_invent_imported_or_captured_provenance() {
+    let dir = tempfile::tempdir().unwrap();
+    fs::create_dir(dir.path().join("R")).unwrap();
+    fs::write(
+        dir.path().join("DESCRIPTION"),
+        "Package: factsfixture\nVersion: 1.0\n",
+    )
+    .unwrap();
+    fs::write(dir.path().join("NAMESPACE"), "importFrom(stats, median)\n").unwrap();
+    fs::write(
+        dir.path().join("R/main.R"),
+        concat!(
+            "assign(\"median\", 1L)\ny <- median\n",
+            "x <- \"outer\"\nf <- function() { assign(\"x\", 1L); x }\n",
+        ),
+    )
+    .unwrap();
+    let output = facts(dir.path(), &["R/main.R"]);
+    let scopes = output["files"][0]["scopes"].as_array().unwrap();
+    let top = scopes.iter().find(|scope| scope["kind"] == "top").unwrap();
+    let nested = scopes.iter().find(|scope| scope["name"] == "f").unwrap();
+    assert_eq!(output["files"][0]["imports"]["median"], "stats");
+    for entry in [binding(top, "median"), binding(nested, "x")] {
+        assert_eq!(entry["type"]["mode"], "integer");
+        assert_eq!(entry["kind"], "unclassified");
+        assert_eq!(entry["declaration"]["kind"], "unavailable");
+        assert!(entry["declaration"]["span"].is_null());
+        assert!(entry["origin"].get("imported_from").is_none());
+    }
+    let y = binding(top, "y");
+    assert_eq!(y["type"]["mode"], "integer");
+    assert_eq!(y["origin"]["callee_alias"]["target"], "median");
+    assert_eq!(y["origin"]["callee_alias"]["resolution"], "not_established");
 }

--- a/docs/facts.md
+++ b/docs/facts.md
@@ -82,32 +82,42 @@ A binding has:
 | Field | Meaning |
 | --- | --- |
 | `name` | The binding's name in this scope snapshot. |
-| `kind` | `"param"`, `"local"`, `"closed_over"`, or `"imported"`. |
+| `kind` | `"param"`, `"local"`, or `"unclassified"`. |
 | `snapshot_kind` | `"scope_exit"`. |
 | `type` | The structured type below. |
 | `declaration` | A source site and its role, when available. |
-| `origin` | Available alias, import, and derivation information. |
+| `origin` | Raw checker alias and derivation metadata. |
 
-A reassigned formal is `local`. A `closed_over` binding comes from the
-captured enclosing scope. `imported` covers top-level bindings supplied by
-the analysis environment, including runtime globals declared in config.
+`param` identifies an own formal that still has the checker's parameter marker.
+`local` identifies a name with a syntactic assignment site in this scope's AST.
+These categories describe recorded metadata, not proof that an assignment
+executes or supplies the final value. An AST walker can see assignments in
+quoted or defused code.
+
+Other bindings are `unclassified`. The scope model does not record enough
+provenance to distinguish captured names, runtime bindings, and names inserted
+by dynamic operations such as `assign()`. A name without an own syntactic site
+therefore has no declaration span, even if an enclosing scope or package import
+has the same name. Static package imports remain available in the file's
+`imports` map.
 
 `declaration.kind` is `"formal"`, `"first_assignment"`, or `"unavailable"`.
-`declaration.span` is a span or `null`. For a captured name, the site comes
-from the nearest recorded enclosing scope that declares it. Synthetic,
-missing, empty, or invalid declaration spans become `null`.
+`declaration.span` is a span or `null`. `first_assignment` means the first
+syntactic assignment in this scope, not the first executed assignment.
+Synthetic, missing, empty, or invalid declaration spans become `null`.
 `declaration.defines_final_value` is always `"not_established"`.
 
 `origin` contains:
 
-- `function_alias_target`: the checker's semantic callee name, or `null`.
-- `imported_from`: a package name when the workspace resolver supplies one,
-  or `null`.
+- `callee_alias`: raw checker metadata with `target` (a name) and
+  `resolution: "not_established"`, or `null`.
 - `list_derived`: whether the checker marks the binding as list-derived.
 - `default_parameter_derived`: whether its type came from a parameter default.
 
-These fields are snapshot metadata. An alias target is a name, not a resolved
-cross-file symbol ID or a safe rename target.
+These fields are snapshot metadata. Callee-alias metadata can remain on a
+binding with a non-function type, such as an integer copied from a name that
+shadows a package function. It does not establish that a value is callable,
+that the name resolves to a particular definition, or that a rename is safe.
 
 ### Types
 

--- a/docs/facts.md
+++ b/docs/facts.md
@@ -1,0 +1,230 @@
+# Structured analysis facts
+
+[Getting started](../README.md) · [Usage](usage.md) · [Configuration](configuration.md)
+
+`ry dump-facts` exports versioned JSON for tools that need structured types and
+analysis context. It uses the same configuration, file discovery, package
+resolution, and scope capture as `ry dump-types`. It does not run the analyzed
+R code or load its packages through R.
+
+```sh
+ry dump-facts R/ --format json > facts.json
+```
+
+Use `--project-root DIR` to set the analysis root for files outside an R package.
+Each package still uses its nearest enclosing `DESCRIPTION` directory. The
+first input anchors `ry.toml` discovery, as it does for `dump-types`.
+
+## Scope snapshots
+
+Every exported scope and binding has `snapshot_kind: "scope_exit"`. Types
+describe the state at the end of the recorded scope body. There is no
+`--position` option and no type-at-reference or resolved-symbol contract.
+
+For example:
+
+```r
+x <- 1L
+y <- x
+x <- "later"
+```
+
+The top-level snapshot describes `x` as character and `y` as integer. The
+`declaration` for `x` points to its first assignment, `x <- 1L`. This span does
+not establish which assignment produced its final value, or what type `x`
+had when R evaluated `y <- x`.
+
+The checker analyzes nested functions using a copy of the enclosing analysis
+scope. That scope can include project facts collected before the body is walked.
+Anonymous function arguments are usually analyzed without recording their
+scopes. Named functions inside those arguments can still have records. A
+missing record means that ry did not export that fact; it does not prove that
+a scope or binding does not exist.
+
+## Schema version 1
+
+The top-level JSON object contains:
+
+| Field | Meaning |
+| --- | --- |
+| `schema_version` | Integer `1`. Consumers must check this before reading facts. |
+| `producer` | ry `version` and `executable_hash`. |
+| `snapshot_kind` | `"scope_exit"`. |
+| `coordinates` | Encoding and position conventions below. |
+| `configuration` | Effective config, its root, and environment profile roots. |
+| `contexts` | Per-project analysis identities and their inputs. |
+| `discovery` | Whether size/depth limits omitted input, with truncation details. |
+| `files` | Analyzed files, their source hashes, context IDs, and scopes. |
+
+Consumers must treat absent fields as unavailable evidence. `null` represents
+an unavailable optional value, such as an unrecorded declaration span.
+An empty array is a known empty collection only when its enclosing object's
+`kind` establishes that knowledge.
+
+### Files and scopes
+
+A file has `path` (an absolute canonical path), `source_hash`, `context_id`,
+`scopes`, and `imports`. `imports` maps names to package names from static
+workspace resolution. These names need not appear in captured lexical bindings;
+the mapping does not establish resolution at a reference. The source hash covers the exact UTF-8 file bytes, including
+line endings. ry rejects a non-UTF-8 file instead of returning byte offsets
+into transcoded text. After removing identical input paths, it rejects distinct paths that resolve
+to the same canonical file.
+
+A scope has `kind` (`"top"` or `"function"`), `name` (string or `null`),
+`snapshot_kind`, `span`, `data_mask_unknown`, `search_path_unknown`, and
+`bindings`. The uncertainty flags come directly from the checker. They can
+be true even when some bindings have concrete types. They do not enumerate
+all sources of uncertainty in R.
+
+A binding has:
+
+| Field | Meaning |
+| --- | --- |
+| `name` | The binding's name in this scope snapshot. |
+| `kind` | `"param"`, `"local"`, `"closed_over"`, or `"imported"`. |
+| `snapshot_kind` | `"scope_exit"`. |
+| `type` | The structured type below. |
+| `declaration` | A source site and its role, when available. |
+| `origin` | Available alias, import, and derivation information. |
+
+A reassigned formal is `local`. A `closed_over` binding comes from the
+captured enclosing scope. `imported` covers top-level bindings supplied by
+the analysis environment, including runtime globals declared in config.
+
+`declaration.kind` is `"formal"`, `"first_assignment"`, or `"unavailable"`.
+`declaration.span` is a span or `null`. For a captured name, the site comes
+from the nearest recorded enclosing scope that declares it. Synthetic,
+missing, empty, or invalid declaration spans become `null`.
+`declaration.defines_final_value` is always `"not_established"`.
+
+`origin` contains:
+
+- `function_alias_target`: the checker's semantic callee name, or `null`.
+- `imported_from`: a package name when the workspace resolver supplies one,
+  or `null`.
+- `list_derived`: whether the checker marks the binding as list-derived.
+- `default_parameter_derived`: whether its type came from a parameter default.
+
+These fields are snapshot metadata. An alias target is a name, not a resolved
+cross-file symbol ID or a safe rename target.
+
+### Types
+
+Each type is an object with `kind: "r_type"` and the following fields:
+
+| Field | Shape |
+| --- | --- |
+| `mode` | `logical`, `integer`, `double`, `complex`, `character`, `raw`, `list`, `null`, `function`, `opaque`, or `union`. |
+| `length` | `{"kind":"known","value":N}` or `{"kind":"unknown"}`. |
+| `class` | `kind` (`known` or `unknown`), ordered `names`, `capacity: 4`, and `may_be_truncated`. |
+| `columns` | `{"kind":"unknown"}` or an object with `kind` (`complete` or `partial`), `entries`, and `locally_constructed`. |
+| `members` | `{"kind":"not_applicable"}`, `{"kind":"unknown"}`, or `{"kind":"known","types":[...]}`. |
+| `function` | `{"kind":"not_applicable"}`, `{"kind":"unknown"}`, or the partial signature below. |
+
+`opaque` means the storage mode is unknown; other fields may still carry
+information. A known empty class list means no explicit class. The checker
+stores at most four class names. At capacity, `may_be_truncated` is true
+because it cannot establish whether the original vector was longer.
+
+Column entries have `key` and a recursive `type`. Order and duplicate keys
+are preserved. A key is the checker's schema key, not necessarily a literal
+field name. For unnamed list elements, the checker uses synthetic keys such
+as `[[1]]`. A literal field named `[[1]]` can have the same key; the type model
+does not retain enough provenance to distinguish these cases. Do not use a
+schema key alone as evidence for a named-field edit. `complete` with `entries: []` is a known empty schema;
+`partial` with `entries: []` establishes no columns but allows others;
+`unknown` has no schema evidence. `locally_constructed` is the checker's
+construction marker, not a guarantee that later operations cannot change it.
+
+Union `members.types` contains recursively structured alternatives. A function
+with a recorded signature has:
+
+```json
+{
+  "kind": "partial",
+  "params": [],
+  "parameters_complete": false,
+  "return_type": {
+    "kind": "r_type",
+    "mode": "integer",
+    "length": {"kind": "known", "value": 1},
+    "class": {"kind": "known", "names": [], "capacity": 4, "may_be_truncated": false},
+    "columns": {"kind": "unknown"},
+    "members": {"kind": "not_applicable"},
+    "function": {"kind": "not_applicable"}
+  }
+}
+```
+
+`params` holds ordered parameter types where available. It does not encode a
+complete named-formal contract, defaults, or R argument matching. An empty
+`params` array does not establish that a function accepts no arguments.
+The export has no NA facts because the checker does not model them.
+
+### Source spans
+
+A source-backed span has this shape:
+
+```json
+{"bytes": [0, 2], "start": [1, 1], "end": [1, 2]}
+```
+
+`bytes` is a zero-based, half-open UTF-8 byte range. Slice the original source
+as `source[start_byte:end_byte]` after checking its hash. Declaration spans
+cover the raw source token: a backtick-quoted name includes its backticks,
+while the binding's `name` contains the decoded name. `start` and `end`
+are one-based `[line, column]` pairs. Columns count Unicode scalar values;
+a tab counts as one character, not a display-width expansion. Lines advance
+at LF, so CRLF bytes remain part of the source and byte ranges.
+
+Function scope spans cover the function literal when the original AST has
+that site. The top-level span covers the file. A scope synthesized during
+analysis can have `span: null`. No span establishes a resolved symbol identity.
+
+### Cache identities and ordering
+
+All hashes use SHA-256 and have a `sha256:` prefix. `producer.executable_hash`
+covers the running binary, so rebuilding ry can invalidate facts without a
+version change. It also identifies the embedded typeshed contents.
+
+Each context has an `id` and an `inputs` object. The ID hashes the compact JSON
+encoding of `inputs`, with sorted object keys. Inputs include:
+
+- the canonical resolution root and producer identity;
+- the hash of effective configuration, including environment profile roots;
+- bundled typeshed source metadata, its build identity, and a hash of all
+  successfully loaded custom stub content after overrides;
+- canonical paths and source hashes for every analyzed file in the group;
+- a hash of the resolved workspace maps and sets supplied to the checker,
+  including imports, attached packages, serialized bindings, and S3 methods;
+- effective built-in environment bindings for every analyzed file, including
+  Shiny classification triggered by unselected `app.R`, `server.R`, or `ui.R`;
+- degraded-scope reports from workspace resolution.
+
+Use the file path, source hash, and context ID together. A change to another
+file, a custom stub, or static package metadata can change a file's facts
+without changing its own source hash. Paths are local identities, not IDs
+that remain stable when a project moves. These hashes describe the resolved
+inputs for this run; they are not a filesystem watcher or a promise that R's
+runtime environment matches the static model.
+
+Files sort by canonical path; contexts by ID; scopes by byte start, byte end,
+then kind; bindings by name. JSON object keys sort lexically. Union alternatives
+sort by their compact structured JSON. Class names, columns, and parameter
+types retain their meaningful order. No timestamps appear in the output.
+
+## Failures and incomplete discovery
+
+Diagnostics do not fail the export. Invalid options, missing/unreadable files,
+parse failures, non-UTF-8 input or paths, and invalid configuration return a nonzero
+status without emitting facts. Malformed custom stubs follow the shared
+loader's policy: warn on stderr and use the valid stubs. Context identity
+covers the stubs actually used.
+
+Size and depth limits set `discovery.complete` to false and list the omitted
+files or directories. Config exclusions and normal package discovery rules
+still apply. Hitting `index.max-files` fails the export because filesystem
+traversal order cannot establish a deterministic subset. Narrow the input or
+raise the limit. Check discovery completeness before treating an export as a
+census of the requested project.


### PR DESCRIPTION
Implements phase 1 of #233 with `ry dump-facts --format json`. The command exports versioned structured types, scope and declaration spans, uncertainty flags, and analysis context identities through the existing checker pipeline.

For `x <- 1L; y <- x; x <- "later"`, the export labels the character type of `x` as `scope_exit` and its declaration span as `first_assignment`. It does not present that pair as the type or defining assignment at the earlier reference. Bindings without an own syntactic site remain unclassified; imports and callee aliases carry metadata without claiming resolved provenance. Reference facts remain phase 2; #233 stays open.

The [schema reference](https://github.com/sims1253/ry/blob/3d96f44377632eea46074fb1c176bdecfb997ef0/docs/facts.md) documents UTF-8 byte ranges, partial type information, synthetic list keys, and deterministic ordering. Context hashes cover the executable, analyzed sources, effective config and stubs, resolved workspace, and built-in Shiny environment. Invalid UTF-8 and syntax errors fail the export; discovery limits remain explicit. Existing `dump-types` output is preserved.

Validation:

- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `cargo test -p ry-checker --test oracle -- --include-ignored`
- `python3 scripts/test_sync_typeshed.py`

New tests cover repeatability, context invalidation, unknown/partial/empty schemas, reassignment, dynamic `assign()` shadowing, Unicode/tabs/CRLF/backticks, import and alias metadata, data masks, truncated discovery, and source non-execution. The export retains the checker's static-model limits; declaration sites and alias names do not establish resolved symbol identities.
