### PR TITLE
fix(typeshed): recover snapshot after failed installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ All notable changes to ry are documented in this file.
 - Resolve S3 operators before inferring data-frame results, so subclass methods
   can return other types and conflicting methods do not retain column schemas.
 - Validate typeshed updates before replacing the vendored snapshot. Failed
-  validation leaves the existing stubs and provenance intact.
+  validation leaves the existing stubs and provenance intact. Restore the old
+  snapshot if installation fails or receives a handled interrupt, and retain a
+  recovery copy if restoration fails.
 - Shorten the README and move the inferred-types reference to `docs/types.md`.
 - Infer vector-constructor lengths from size values, including empty defaults
   and fractional sizes. Correct factor arithmetic with NULL and unary minus.

--- a/scripts/sync_typeshed.sh
+++ b/scripts/sync_typeshed.sh
@@ -20,7 +20,36 @@ stubs_sha256=$(
 
 # Validate a staged copy before replacing the last usable snapshot.
 staged=$(mktemp -d "${vendor}.XXXXXX")
-trap 'rm -rf "$staged"' EXIT
+backup=
+installed=false
+cleanup() {
+  status=$?
+  trap - EXIT
+  # Finish recovery if another handled signal arrives during cleanup.
+  trap '' HUP INT TERM
+  if [[ -n "$backup" ]]; then
+    if [[ -e "$backup/snapshot" || -L "$backup/snapshot" ]]; then
+      if [[ "$installed" == true ]]; then
+        rm -rf "$backup"
+      elif { [[ ! -e "$vendor" && ! -L "$vendor" ]] || rm -rf "$vendor"; } \
+        && mv "$backup/snapshot" "$vendor"; then
+        rmdir "$backup"
+        echo "ry: restored the previous typeshed snapshot after installation failed or was interrupted" >&2
+      else
+        echo "ry: could not restore the previous typeshed snapshot; recover it from $backup/snapshot" >&2
+        [[ "$status" != 0 ]] || status=1
+      fi
+    else
+      rmdir "$backup"
+    fi
+  fi
+  rm -rf "$staged"
+  exit "$status"
+}
+trap cleanup EXIT
+trap 'exit 129' HUP
+trap 'exit 130' INT
+trap 'exit 143' TERM
 cp -R "$checkout/stubs/." "$staged/"
 cat > "$staged/SOURCE" <<EOF
 repository: https://github.com/sims1253/r-typeshed
@@ -32,5 +61,12 @@ EOF
 cargo run --manifest-path "$repo_root/Cargo.toml" -p ry-cli -- \
   typeshed validate "$staged"
 
-rm -rf "$vendor"
+# Both directories stay on the same filesystem. Keep the old snapshot until
+# the staged directory is installed; EXIT restores it on a failed move or a
+# handled signal. SIGKILL and power loss can still require manual recovery.
+if [[ -e "$vendor" || -L "$vendor" ]]; then
+  backup=$(mktemp -d "${vendor}.backup.XXXXXX")
+  mv "$vendor" "$backup/snapshot"
+fi
 mv "$staged" "$vendor"
+installed=true

--- a/scripts/test_sync_typeshed.py
+++ b/scripts/test_sync_typeshed.py
@@ -25,6 +25,7 @@ class SyncTypeshedTest(unittest.TestCase):
         stubs.mkdir(parents=True)
         (stubs / "base.json").write_text('{"package": "base"}\n')
         binaries = self.root / "bin"
+        self.binaries = binaries
         binaries.mkdir()
         cargo = binaries / "cargo"
         cargo.write_text("""#!/usr/bin/env bash
@@ -50,13 +51,40 @@ exit "$VALIDATION_STATUS"
     def assert_no_staging_directory(self):
         self.assertEqual(list(self.vendor.parent.glob("vendor.*")), [])
 
+    def assert_old_snapshot(self, path=None):
+        path = self.vendor if path is None else path
+        self.assertEqual((path / "old.json").read_text(), "old snapshot")
+        self.assertEqual((path / "SOURCE").read_text(), "old provenance")
+        self.assertEqual(sorted(p.name for p in path.iterdir()),
+                         ["SOURCE", "old.json"])
+
+    def fail_move(self, mode):
+        move = self.binaries / "mv"
+        move.write_text("""#!/usr/bin/env bash
+set -eu
+if [[ "$MOVE_FAILURE" == backup && "$1" == "$EXPECTED_VENDOR" ]]; then
+  exit 7
+fi
+if [[ "$2" == "$EXPECTED_VENDOR" ]]; then
+  if [[ "${1##*/}" == snapshot ]]; then
+    [[ "$MOVE_FAILURE" != restore ]] || exit 9
+  elif [[ "$MOVE_FAILURE" == interrupt ]]; then
+    "$REAL_MV" "$@"
+    kill -TERM "$PPID"
+    exit 0
+  else
+    exit 7
+  fi
+fi
+exec "$REAL_MV" "$@"
+""")
+        move.chmod(0o755)
+        self.env.update(MOVE_FAILURE=mode, REAL_MV=shutil.which("mv"))
+
     def test_failed_validation_preserves_snapshot_and_provenance(self):
         result = self.run_sync(7)
         self.assertEqual(result.returncode, 7, result.stderr)
-        self.assertEqual((self.vendor / "old.json").read_text(), "old snapshot")
-        self.assertEqual((self.vendor / "SOURCE").read_text(), "old provenance")
-        self.assertEqual(sorted(p.name for p in self.vendor.iterdir()),
-                         ["SOURCE", "old.json"])
+        self.assert_old_snapshot()
         self.assert_no_staging_directory()
 
     def test_success_replaces_snapshot_after_validation(self):
@@ -67,6 +95,40 @@ exit "$VALIDATION_STATUS"
                          (self.checkout / "stubs/base/base.json").read_bytes())
         self.assertIn("stubs-sha256:", (self.vendor / "SOURCE").read_text())
         self.assert_no_staging_directory()
+
+    def test_failed_install_restores_snapshot_and_provenance(self):
+        self.fail_move("install")
+        result = self.run_sync(0)
+        self.assertEqual(result.returncode, 7, result.stderr)
+        self.assertIn("restored the previous typeshed snapshot", result.stderr)
+        self.assert_old_snapshot()
+        self.assert_no_staging_directory()
+
+    def test_failed_backup_move_leaves_existing_snapshot(self):
+        self.fail_move("backup")
+        result = self.run_sync(0)
+        self.assertEqual(result.returncode, 7, result.stderr)
+        self.assert_old_snapshot()
+        self.assert_no_staging_directory()
+
+    def test_term_after_install_move_restores_snapshot(self):
+        self.fail_move("interrupt")
+        result = self.run_sync(0)
+        self.assertEqual(result.returncode, 143, result.stderr)
+        self.assert_old_snapshot()
+        self.assert_no_staging_directory()
+
+    def test_failed_restore_retains_snapshot_and_reports_recovery_path(self):
+        self.fail_move("restore")
+        result = self.run_sync(0)
+        self.assertEqual(result.returncode, 7, result.stderr)
+        backups = list(self.vendor.parent.glob("vendor.backup.*"))
+        self.assertEqual(len(backups), 1)
+        snapshot = backups[0] / "snapshot"
+        self.assert_old_snapshot(snapshot)
+        self.assertIn(f"recover it from {snapshot}", result.stderr)
+        self.assertFalse(self.vendor.exists())
+        self.assertEqual(list(self.vendor.parent.glob("vendor.*")), backups)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Follow-up to #234. After validation, typeshed sync now keeps the old vendor snapshot in a sibling backup until the staged snapshot is installed. A failed move or handled HUP, INT, or TERM restores the old stubs and provenance. If restoration fails, the script keeps the backup and prints its recovery path.

Six Python regressions cover validation failure, successful replacement, backup and install failures, interruption after the install move, and failed recovery. Workspace tests, Clippy, formatting, bash syntax checks, and the full R oracle matrix pass. SIGKILL or power loss can still require manual recovery.
