### PR TITLE
fix(checker): respect captured names in lazy defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to ry are documented in this file.
 
 ### Cleanup
 
+- Avoid RY098 warnings for body-local names captured by qualified `base::quote`,
+  `substitute`, `expression`, and `rlang::expr`/`enexpr` calls in defaults. Keep
+  checking evaluated control arguments and tidy-injection payloads.
 - Resolve S3 operators before inferring data-frame results, so subclass methods
   can return other types and conflicting methods do not retain column schemas.
 - Validate typeshed updates before replacing the vendored snapshot. Failed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to ry are documented in this file.
 ### Cleanup
 
 - Avoid RY098 warnings for body-local names captured by qualified `base::quote`,
-  `substitute`, `expression`, and `rlang::expr`/`enexpr` calls in defaults. Keep
+  `substitute`, `expression`, and `rlang::expr` calls in defaults. Keep
   checking evaluated control arguments and tidy-injection payloads.
 - Resolve S3 operators before inferring data-frame results, so subclass methods
   can return other types and conflicting methods do not retain column schemas.

--- a/crates/ry-checker/src/infer/quoting.rs
+++ b/crates/ry-checker/src/infer/quoting.rs
@@ -474,6 +474,26 @@ impl Checker {
                     self.collect_injection_dependencies(value, &mut dependencies);
                     None
                 }
+                Stmt::If {
+                    cond: Expr::Logical(condition, _),
+                    then,
+                    else_,
+                    span,
+                } => {
+                    let selected = if *condition {
+                        then.as_slice()
+                    } else {
+                        else_.as_deref().unwrap_or_default()
+                    };
+                    self.collect_injection_dependencies(
+                        &Expr::Block {
+                            body: selected.to_vec(),
+                            span: *span,
+                        },
+                        &mut dependencies,
+                    );
+                    None
+                }
                 _ => {
                     // Branches and loops do not establish a guaranteed binding.
                     let _ = walk_stmt(
@@ -521,6 +541,14 @@ impl Checker {
                         ..
                     } = expr.as_ref()
                     {
+                        let payload = match payload.as_ref() {
+                            Expr::UnaryOp {
+                                op: UnaryOpKind::Not,
+                                expr,
+                                ..
+                            } => expr.as_ref(),
+                            other => other,
+                        };
                         self.collect_injection_dependencies(payload, names);
                         return ControlFlow::<(), Descend>::Continue(Descend::Skip);
                     }

--- a/crates/ry-checker/src/infer/quoting.rs
+++ b/crates/ry-checker/src/infer/quoting.rs
@@ -87,8 +87,8 @@ impl Checker {
                 continue;
             }
 
-            let mut references = HashSet::new();
-            collect_executed_identifiers(default, &mut references);
+            let mut references = std::collections::BTreeSet::new();
+            self.collect_executed_identifiers(default, &mut references);
 
             for local in references
                 .iter()
@@ -372,24 +372,109 @@ fn first_executed_identifier(expr: &Expr, wanted: &str) -> Option<Span> {
     }
 }
 
-/// Identifiers the expression evaluates when forced. Skips assignment
-/// targets (R does not evaluate them), `$` subscript idents, and nested
-/// function bodies.
-fn collect_executed_identifiers(expr: &Expr, names: &mut HashSet<String>) {
-    let _ = walk_expr(
-        expr,
-        Walk {
-            assign_targets: false,
-            assign_operands: false,
-            dollar_args: false,
-            fn_bodies: false,
-            ..Walk::ALL
-        },
-        |node: AstNode<'_>, _: usize| -> ControlFlow<(), Descend> {
-            if let AstNode::Expr(Expr::Ident { name, .. }) = node {
-                names.insert(name.clone());
+impl Checker {
+    /// Possible dependencies of a forced default. Only reviewed capture-only
+    /// helpers can suppress their quoted arguments: other quoted-expression
+    /// consumers, such as isolate(), capture and then execute their code.
+    fn collect_executed_identifiers(
+        &self,
+        expr: &Expr,
+        names: &mut std::collections::BTreeSet<String>,
+    ) {
+        let _ = walk_expr(
+            expr,
+            Walk {
+                assign_targets: false,
+                assign_operands: false,
+                dollar_args: false,
+                fn_bodies: false,
+                ..Walk::ALL
+            },
+            |node: AstNode<'_>, _: usize| -> ControlFlow<(), Descend> {
+                if let AstNode::Expr(Expr::Call { func, args, .. }) = node
+                    && let Some(callee) = ident_name(func)
+                    && let Some(capture) = default_capture_mode(callee)
+                    && let Some(signature) = self.resolve_typeshed_sig(callee)
+                {
+                    self.collect_executed_identifiers(func, names);
+                    let bindings = match_params(&signature.params, args);
+                    for (index, argument) in args.iter().enumerate() {
+                        if matches!(
+                            eval_mode_for_arg(&signature, &bindings, index),
+                            Some(EvalMode::QuotedExpression | EvalMode::CapturesPromise)
+                        ) {
+                            if matches!(capture, DefaultCapture::Tidy) {
+                                self.collect_possible_injection_dependencies(
+                                    &argument.value,
+                                    names,
+                                );
+                            }
+                        } else {
+                            self.collect_executed_identifiers(&argument.value, names);
+                        }
+                    }
+                    return ControlFlow::Continue(Descend::Skip);
+                }
+                if let AstNode::Expr(Expr::Ident { name, .. }) = node {
+                    names.insert(name.clone());
+                }
+                ControlFlow::Continue(Descend::Into)
+            },
+        );
+    }
+
+    /// The reviewed rlang helpers process tidy injection while capturing code.
+    /// Retain dependencies of !!, !!!, and {{ }} payloads, including those inside
+    /// quoted function bodies. Like rlang, the walker leaves defaults untouched.
+    fn collect_possible_injection_dependencies(
+        &self,
+        expr: &Expr,
+        names: &mut std::collections::BTreeSet<String>,
+    ) {
+        let _ = walk_expr(expr, Walk::ALL, |node: AstNode<'_>, _: usize| {
+            match node {
+                AstNode::Expr(Expr::UnaryOp {
+                    op: UnaryOpKind::Not,
+                    expr,
+                    ..
+                }) => {
+                    if let Expr::UnaryOp {
+                        op: UnaryOpKind::Not,
+                        expr: payload,
+                        ..
+                    } = expr.as_ref()
+                    {
+                        self.collect_executed_identifiers(payload, names);
+                        return ControlFlow::<(), Descend>::Continue(Descend::Skip);
+                    }
+                }
+                AstNode::Expr(Expr::Block { body, .. }) => {
+                    if let [Stmt::Expr(inner @ Expr::Block { .. })] = body.as_slice() {
+                        self.collect_executed_identifiers(inner, names);
+                        return ControlFlow::Continue(Descend::Skip);
+                    }
+                }
+                _ => {}
             }
             ControlFlow::Continue(Descend::Into)
-        },
-    );
+        });
+    }
+}
+
+#[derive(Clone, Copy)]
+enum DefaultCapture {
+    Literal,
+    Tidy,
+}
+
+// EvalMode describes how an argument is received, not whether the callee
+// later evaluates it. Keep this subset explicit until further helpers have
+// runtime evidence; bquote(), for example, has different escape syntax.
+fn default_capture_mode(name: &str) -> Option<DefaultCapture> {
+    let (package, function) = name.rsplit_once("::")?;
+    match (package.trim_end_matches(':'), function) {
+        ("base", "quote" | "substitute" | "expression") => Some(DefaultCapture::Literal),
+        ("rlang", "expr" | "enexpr") => Some(DefaultCapture::Tidy),
+        _ => None,
+    }
 }

--- a/crates/ry-checker/src/infer/quoting.rs
+++ b/crates/ry-checker/src/infer/quoting.rs
@@ -1,7 +1,7 @@
 //! Forwarded promises and guaranteed evaluation of lazy defaults.
 
 use super::*;
-use ry_core::walk::{AstNode, Descend, Walk, walk_expr, walk_stmts};
+use ry_core::walk::{AstNode, Descend, Walk, walk_expr, walk_stmt, walk_stmts};
 use std::ops::ControlFlow;
 
 /// Walk `stmts` collecting calls inside `caller`'s body that forward its
@@ -391,6 +391,30 @@ impl Checker {
                 ..Walk::ALL
             },
             |node: AstNode<'_>, _: usize| -> ControlFlow<(), Descend> {
+                // Prune only code being evaluated. The separate capture walker
+                // must still find injections under quoted, unreachable branches.
+                match node {
+                    AstNode::Expr(Expr::If {
+                        cond, then, else_, ..
+                    }) if matches!(cond.as_ref(), Expr::Logical(_, _)) => {
+                        if matches!(cond.as_ref(), Expr::Logical(true, _)) {
+                            self.collect_executed_identifiers(then, names);
+                        } else if let Some(otherwise) = else_ {
+                            self.collect_executed_identifiers(otherwise, names);
+                        }
+                        return ControlFlow::Continue(Descend::Skip);
+                    }
+                    AstNode::Expr(Expr::BinOp { lhs, op, .. })
+                        if matches!(
+                            (op, lhs.as_ref()),
+                            (BinOpKind::AndAnd, Expr::Logical(false, _))
+                                | (BinOpKind::OrOr, Expr::Logical(true, _))
+                        ) =>
+                    {
+                        return ControlFlow::Continue(Descend::Skip);
+                    }
+                    _ => {}
+                }
                 if let AstNode::Expr(Expr::Call { func, args, .. }) = node
                     && let Some(callee) = ident_name(func)
                     && let Some(capture) = default_capture_mode(callee)
@@ -423,6 +447,59 @@ impl Checker {
         );
     }
 
+    fn collect_injection_dependencies(
+        &self,
+        expr: &Expr,
+        names: &mut std::collections::BTreeSet<String>,
+    ) {
+        let Expr::Block { body, .. } = expr else {
+            self.collect_executed_identifiers(expr, names);
+            return;
+        };
+        let mut established = std::collections::BTreeSet::new();
+        for statement in body {
+            let mut dependencies = std::collections::BTreeSet::new();
+            let assigned = match statement {
+                Stmt::Assign { target, value, .. } => {
+                    // R evaluates the RHS before establishing the local binding.
+                    self.collect_injection_dependencies(value, &mut dependencies);
+                    if let Expr::Ident { name, .. } = target {
+                        Some(name)
+                    } else {
+                        self.collect_executed_identifiers(target, &mut dependencies);
+                        None
+                    }
+                }
+                Stmt::Expr(value) => {
+                    self.collect_injection_dependencies(value, &mut dependencies);
+                    None
+                }
+                _ => {
+                    // Branches and loops do not establish a guaranteed binding.
+                    let _ = walk_stmt(
+                        statement,
+                        Walk {
+                            fn_bodies: false,
+                            ..Walk::ALL
+                        },
+                        |node: AstNode<'_>, _: usize| -> ControlFlow<(), Descend> {
+                            if let AstNode::Expr(value) = node {
+                                self.collect_executed_identifiers(value, &mut dependencies);
+                                return ControlFlow::Continue(Descend::Skip);
+                            }
+                            ControlFlow::Continue(Descend::Into)
+                        },
+                    );
+                    None
+                }
+            };
+            names.extend(dependencies.difference(&established).cloned());
+            if let Some(name) = assigned {
+                established.insert(name.clone());
+            }
+        }
+    }
+
     /// The reviewed rlang helpers process tidy injection while capturing code.
     /// Retain dependencies of !!, !!!, and {{ }} payloads, including those inside
     /// quoted function bodies. Like rlang, the walker leaves defaults untouched.
@@ -444,13 +521,13 @@ impl Checker {
                         ..
                     } = expr.as_ref()
                     {
-                        self.collect_executed_identifiers(payload, names);
+                        self.collect_injection_dependencies(payload, names);
                         return ControlFlow::<(), Descend>::Continue(Descend::Skip);
                     }
                 }
                 AstNode::Expr(Expr::Block { body, .. }) => {
                     if let [Stmt::Expr(inner @ Expr::Block { .. })] = body.as_slice() {
-                        self.collect_executed_identifiers(inner, names);
+                        self.collect_injection_dependencies(inner, names);
                         return ControlFlow::Continue(Descend::Skip);
                     }
                 }

--- a/crates/ry-checker/src/infer/quoting.rs
+++ b/crates/ry-checker/src/infer/quoting.rs
@@ -499,6 +499,9 @@ impl Checker {
                     let _ = walk_stmt(
                         statement,
                         Walk {
+                            assign_targets: false,
+                            assign_operands: false,
+                            dollar_args: false,
                             fn_bodies: false,
                             ..Walk::ALL
                         },

--- a/crates/ry-checker/src/infer/quoting.rs
+++ b/crates/ry-checker/src/infer/quoting.rs
@@ -579,7 +579,7 @@ fn default_capture_mode(name: &str) -> Option<DefaultCapture> {
     let (package, function) = name.rsplit_once("::")?;
     match (package.trim_end_matches(':'), function) {
         ("base", "quote" | "substitute" | "expression") => Some(DefaultCapture::Literal),
-        ("rlang", "expr" | "enexpr") => Some(DefaultCapture::Tidy),
+        ("rlang", "expr") => Some(DefaultCapture::Tidy),
         _ => None,
     }
 }

--- a/crates/ry-checker/src/tests/packages_typeshed.rs
+++ b/crates/ry-checker/src/tests/packages_typeshed.rs
@@ -606,3 +606,84 @@ fn qualified_deferring_calls_do_not_force_lazy_defaults() {
         assert_eq!(fired, expect_ry098, "{note}: {diags:?}");
     }
 }
+
+#[test]
+fn lazy_default_dependencies_respect_qualified_defusing_metadata() {
+    for (default, warned) in [
+        ("base::quote(body_value)", false),
+        ("base::quote(!!body_value)", false),
+        ("base::quote(function() !!body_value)", false),
+        ("base::expression({{ body_value }})", false),
+        ("base:::quote(expr = body_value)", false),
+        ("base::substitute(body_value)", false),
+        ("base::expression(body_value, body_value + 1L)", false),
+        ("rlang::expr(body_value)", false),
+        ("rlang::enexpr(body_value)", false),
+        ("rlang::expr(function() body_value)", false),
+        ("rlang::expr(!!base::quote(body_value))", false),
+        ("rlang::expr(list(!!1L, body_value))", false),
+        ("base::identity(body_value)", true),
+        ("base::bquote(.(body_value))", true),
+        ("base::bquote(list(..(body_value)), splice = TRUE)", true),
+        ("shiny::isolate(body_value)", true),
+        ("base::substitute(other, env = body_value)", true),
+        ("rlang::expr(!!body_value)", true),
+        ("rlang::expr(list(!!!body_value))", true),
+        ("rlang::expr({{ body_value }})", true),
+        ("rlang::expr(function() !!body_value)", true),
+        ("rlang::expr(function(arg = !!body_value) arg)", false),
+        ("unknownpkg::capture(body_value)", true),
+        ("capture(body_value)", true),
+    ] {
+        let source =
+            format!("f <- function(x = {default}) {{ out <- x; body_value <- 1L; out }}\n");
+        let diagnostics = check(&source);
+        assert_eq!(
+            diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.code == "RY098"),
+            warned,
+            "{default}: {diagnostics:?}"
+        );
+    }
+    let diagnostics = check(
+        "quote <- function(expr) expr\nf <- function(x = quote(body_value)) { out <- x; body_value <- 1L; out }\n",
+    );
+    assert!(
+        diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code == "RY098")
+    );
+}
+
+#[test]
+fn lazy_default_multiple_dependencies_have_deterministic_diagnostics() {
+    let diagnostics = check("f <- function(x = z + a) { out <- x; z <- 1L; a <- 2L; out }\n");
+    let diagnostic = diagnostics
+        .iter()
+        .find(|diagnostic| diagnostic.code == "RY098")
+        .unwrap();
+    assert!(diagnostic.message.contains("`a`"), "{diagnostic:?}");
+}
+
+#[test]
+fn quoted_metadata_alone_does_not_suppress_lazy_default_dependencies() {
+    let (diagnostics, _) = check_with_stubs(
+        "f <- function(x = custom::run(body_value)) { out <- x; body_value <- 1L; out }\n",
+        &[(
+            "custom.json",
+            r#"{
+            "schema_version": "2", "package": "custom", "version": "test",
+            "functions": {"run": {
+                "params": ["expr"], "eval": {"expr": "quoted_expression"},
+                "return": {"mode": "opaque", "length": "unknown"}
+            }}
+        }"#,
+        )],
+    );
+    assert!(
+        diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code == "RY098")
+    );
+}

--- a/crates/ry-checker/src/tests/packages_typeshed.rs
+++ b/crates/ry-checker/src/tests/packages_typeshed.rs
@@ -633,6 +633,14 @@ fn lazy_default_dependencies_respect_qualified_defusing_metadata() {
         ("rlang::expr(function() !!body_value)", true),
         ("rlang::expr(function(arg = !!body_value) arg)", false),
         (
+            "rlang::expr(function() !!{ if (FALSE) body_value; 1L })",
+            false,
+        ),
+        (
+            "rlang::expr(function() list(!!!{ body_value <- list(1L); body_value }))",
+            false,
+        ),
+        (
             "rlang::expr(function() !!{ body_value; body_value <- 1L })",
             true,
         ),

--- a/crates/ry-checker/src/tests/packages_typeshed.rs
+++ b/crates/ry-checker/src/tests/packages_typeshed.rs
@@ -633,6 +633,22 @@ fn lazy_default_dependencies_respect_qualified_defusing_metadata() {
         ("rlang::expr(function() !!body_value)", true),
         ("rlang::expr(function(arg = !!body_value) arg)", false),
         (
+            "rlang::expr(function() !!{ for (i in 1:2) body_value <- 1L; 1L })",
+            false,
+        ),
+        (
+            "rlang::expr(function() !!{ for (i in 1:2) other <- body_value; 1L })",
+            true,
+        ),
+        (
+            "rlang::expr(function() !!{ if (unknown) body_value <- 1L; 1L })",
+            false,
+        ),
+        (
+            "rlang::expr(function() !!{ if (unknown) other <- body_value; 1L })",
+            true,
+        ),
+        (
             "rlang::expr(function() !!{ if (FALSE) body_value; 1L })",
             false,
         ),

--- a/crates/ry-checker/src/tests/packages_typeshed.rs
+++ b/crates/ry-checker/src/tests/packages_typeshed.rs
@@ -618,7 +618,7 @@ fn lazy_default_dependencies_respect_qualified_defusing_metadata() {
         ("base::substitute(body_value)", false),
         ("base::expression(body_value, body_value + 1L)", false),
         ("rlang::expr(body_value)", false),
-        ("rlang::enexpr(body_value)", false),
+        ("rlang::enexpr(body_value)", true),
         ("rlang::expr(function() body_value)", false),
         ("rlang::expr(!!base::quote(body_value))", false),
         ("rlang::expr(list(!!1L, body_value))", false),

--- a/crates/ry-checker/src/tests/packages_typeshed.rs
+++ b/crates/ry-checker/src/tests/packages_typeshed.rs
@@ -632,6 +632,35 @@ fn lazy_default_dependencies_respect_qualified_defusing_metadata() {
         ("rlang::expr({{ body_value }})", true),
         ("rlang::expr(function() !!body_value)", true),
         ("rlang::expr(function(arg = !!body_value) arg)", false),
+        (
+            "rlang::expr(function() !!{ body_value; body_value <- 1L })",
+            true,
+        ),
+        (
+            "rlang::expr(function() !!{ body_value <- body_value + 1L; body_value })",
+            true,
+        ),
+        (
+            "rlang::expr(function() !!{ body_value <- 1L; body_value })",
+            false,
+        ),
+        (
+            "rlang::expr(function() !!(if (FALSE) body_value else 1L))",
+            false,
+        ),
+        (
+            "rlang::expr(function() !!(if (TRUE) 1L else body_value))",
+            false,
+        ),
+        ("rlang::expr(function() !!(FALSE && body_value))", false),
+        ("rlang::expr(function() !!(TRUE || body_value))", false),
+        ("rlang::expr(function() !!(TRUE && body_value))", true),
+        ("rlang::expr(function() !!(FALSE || body_value))", true),
+        (
+            "rlang::expr(function() !!(if (unknown) body_value else 1L))",
+            true,
+        ),
+        ("rlang::expr(function() if (FALSE) !!body_value)", true),
         ("unknownpkg::capture(body_value)", true),
         ("capture(body_value)", true),
     ] {

--- a/crates/ry-checker/testdata/ok_quoted_default_dependencies.R
+++ b/crates/ry-checker/testdata/ok_quoted_default_dependencies.R
@@ -1,0 +1,36 @@
+# no-diag
+quoted <- function(x = base::quote(body_value)) {
+  out <- x
+  body_value <- 1L
+  out
+}
+named <- function(x = base:::quote(expr = body_value)) {
+  out <- x
+  body_value <- 1L
+  out
+}
+substituted <- function(x = base::substitute(body_value)) {
+  out <- x
+  body_value <- 1L
+  out
+}
+expressions <- function(x = base::expression(body_value, body_value + 1L)) {
+  out <- x
+  body_value <- 1L
+  out
+}
+captured <- function(x = rlang::expr(body_value)) {
+  out <- x
+  body_value <- 1L
+  out
+}
+injected_quote <- function(x = rlang::expr(!!base::quote(body_value))) {
+  out <- x
+  body_value <- 1L
+  out
+}
+quoted_default <- function(x = rlang::expr(function(arg = !!body_value) arg)) {
+  out <- x
+  body_value <- 1L
+  out
+}

--- a/crates/ry-checker/testdata/oracle/injected_default_dependencies.R
+++ b/crates/ry-checker/testdata/oracle/injected_default_dependencies.R
@@ -55,9 +55,14 @@ quoted_unreachable <- function(x = rlang::expr(function() if (FALSE) !!body_valu
   body_value <- 1L
   out
 }
+promise_capture <- function(x = rlang::enexpr(body_value)) {
+  out <- x
+  body_value <- 1L
+  out
+}
 for (fn in list(ordinary, substitution_environment, injected, spliced, embraced,
                 quoted_function, bquoted, bquote_spliced, read_before_assignment,
-                read_in_assignment, quoted_unreachable)) {
+                read_in_assignment, quoted_unreachable, promise_capture)) {
   result <- tryCatch(fn(), error = function(error) error)
   stopifnot(inherits(result, "error"))
 }

--- a/crates/ry-checker/testdata/oracle/injected_default_dependencies.R
+++ b/crates/ry-checker/testdata/oracle/injected_default_dependencies.R
@@ -1,0 +1,47 @@
+# oracle: must-warn RY098
+# oracle-claim: RY098
+ordinary <- function(x = base::identity(body_value)) {
+  out <- x
+  body_value <- 1L
+  out
+}
+substitution_environment <- function(x = base::substitute(other, env = body_value)) {
+  out <- x
+  body_value <- list()
+  out
+}
+injected <- function(x = rlang::expr(!!body_value)) {
+  out <- x
+  body_value <- 1L
+  out
+}
+spliced <- function(x = rlang::expr(list(!!!body_value))) {
+  out <- x
+  body_value <- list()
+  out
+}
+embraced <- function(x = rlang::expr({{ body_value }})) {
+  out <- x
+  body_value <- 1L
+  out
+}
+quoted_function <- function(x = rlang::expr(function() !!body_value)) {
+  out <- x
+  body_value <- 1L
+  out
+}
+bquoted <- function(x = base::bquote(.(body_value))) {
+  out <- x
+  body_value <- 1L
+  out
+}
+bquote_spliced <- function(x = base::bquote(list(..(body_value)), splice = TRUE)) {
+  out <- x
+  body_value <- list()
+  out
+}
+for (fn in list(ordinary, substitution_environment, injected, spliced, embraced,
+                quoted_function, bquoted, bquote_spliced)) {
+  result <- tryCatch(fn(), error = function(error) error)
+  stopifnot(inherits(result, "error"))
+}

--- a/crates/ry-checker/testdata/oracle/injected_default_dependencies.R
+++ b/crates/ry-checker/testdata/oracle/injected_default_dependencies.R
@@ -40,8 +40,24 @@ bquote_spliced <- function(x = base::bquote(list(..(body_value)), splice = TRUE)
   body_value <- list()
   out
 }
+read_before_assignment <- function(x = rlang::expr(function() !!{ body_value; body_value <- 1L })) {
+  out <- x
+  body_value <- 1L
+  out
+}
+read_in_assignment <- function(x = rlang::expr(function() !!{ body_value <- body_value + 1L; body_value })) {
+  out <- x
+  body_value <- 1L
+  out
+}
+quoted_unreachable <- function(x = rlang::expr(function() if (FALSE) !!body_value)) {
+  out <- x
+  body_value <- 1L
+  out
+}
 for (fn in list(ordinary, substitution_environment, injected, spliced, embraced,
-                quoted_function, bquoted, bquote_spliced)) {
+                quoted_function, bquoted, bquote_spliced, read_before_assignment,
+                read_in_assignment, quoted_unreachable)) {
   result <- tryCatch(fn(), error = function(error) error)
   stopifnot(inherits(result, "error"))
 }

--- a/crates/ry-checker/testdata/oracle/quoted_default_dependencies.R
+++ b/crates/ry-checker/testdata/oracle/quoted_default_dependencies.R
@@ -93,3 +93,10 @@ pruned_statement <- function(x = rlang::expr(function() !!{ if (FALSE) body_valu
   out
 }
 stopifnot(identical(pruned_statement(), quote(function() 1L)))
+
+loop_target <- function(x = rlang::expr(function() !!{ for (i in 1:2) body_value <- 1L; 1L })) {
+  out <- x
+  body_value <- 1L
+  out
+}
+stopifnot(identical(loop_target(), quote(function() 1L)))

--- a/crates/ry-checker/testdata/oracle/quoted_default_dependencies.R
+++ b/crates/ry-checker/testdata/oracle/quoted_default_dependencies.R
@@ -79,3 +79,17 @@ payload_binding <- function(x = rlang::expr(function() !!{ body_value <- 1L; bod
   out
 }
 stopifnot(identical(payload_binding(), quote(function() 1L)))
+
+splice_binding <- function(x = rlang::expr(function() list(!!!{ body_value <- list(1L); body_value }))) {
+  out <- x
+  body_value <- 1L
+  out
+}
+stopifnot(identical(splice_binding(), quote(function() list(1L))))
+
+pruned_statement <- function(x = rlang::expr(function() !!{ if (FALSE) body_value; 1L })) {
+  out <- x
+  body_value <- 1L
+  out
+}
+stopifnot(identical(pruned_statement(), quote(function() 1L)))

--- a/crates/ry-checker/testdata/oracle/quoted_default_dependencies.R
+++ b/crates/ry-checker/testdata/oracle/quoted_default_dependencies.R
@@ -1,0 +1,49 @@
+# oracle: must-pass
+quoted <- function(x = base::quote(body_value)) {
+  out <- x
+  body_value <- 1L
+  out
+}
+named <- function(x = base:::quote(expr = body_value)) {
+  out <- x
+  body_value <- 1L
+  out
+}
+substituted <- function(x = base::substitute(body_value)) {
+  out <- x
+  body_value <- 1L
+  out
+}
+expressions <- function(x = base::expression(body_value, body_value + 1L)) {
+  out <- x
+  body_value <- 1L
+  out
+}
+captured <- function(x = rlang::expr(body_value)) {
+  out <- x
+  body_value <- 1L
+  out
+}
+injected_quote <- function(x = rlang::expr(!!base::quote(body_value))) {
+  out <- x
+  body_value <- 1L
+  out
+}
+for (fn in list(quoted, named, substituted, captured, injected_quote)) {
+  stopifnot(identical(fn(), quote(body_value)))
+}
+stopifnot(identical(expressions(), expression(body_value, body_value + 1L)))
+
+quoted_default <- function(x = rlang::expr(function(arg = !!body_value) arg)) {
+  out <- x
+  body_value <- 1L
+  out
+}
+stopifnot(identical(quoted_default(), quote(function(arg = !!body_value) arg)))
+
+literal_bangs <- function(x = base::quote(function() !!body_value)) {
+  out <- x
+  body_value <- 1L
+  out
+}
+stopifnot(identical(literal_bangs(), quote(function() !!body_value)))

--- a/crates/ry-checker/testdata/oracle/quoted_default_dependencies.R
+++ b/crates/ry-checker/testdata/oracle/quoted_default_dependencies.R
@@ -47,3 +47,35 @@ literal_bangs <- function(x = base::quote(function() !!body_value)) {
   out
 }
 stopifnot(identical(literal_bangs(), quote(function() !!body_value)))
+
+pruned_if <- function(x = rlang::expr(function() !!(if (FALSE) body_value else 1L))) {
+  out <- x
+  body_value <- 1L
+  out
+}
+pruned_else <- function(x = rlang::expr(function() !!(if (TRUE) 1L else body_value))) {
+  out <- x
+  body_value <- 1L
+  out
+}
+pruned_and <- function(x = rlang::expr(function() !!(FALSE && body_value))) {
+  out <- x
+  body_value <- 1L
+  out
+}
+pruned_or <- function(x = rlang::expr(function() !!(TRUE || body_value))) {
+  out <- x
+  body_value <- 1L
+  out
+}
+stopifnot(identical(pruned_if(), quote(function() 1L)))
+stopifnot(identical(pruned_else(), quote(function() 1L)))
+stopifnot(identical(pruned_and(), quote(function() FALSE)))
+stopifnot(identical(pruned_or(), quote(function() TRUE)))
+
+payload_binding <- function(x = rlang::expr(function() !!{ body_value <- 1L; body_value })) {
+  out <- x
+  body_value <- 1L
+  out
+}
+stopifnot(identical(payload_binding(), quote(function() 1L)))

--- a/crates/ry-checker/tests/snapshots/corpus__checker_fixture_diagnostics.snap
+++ b/crates/ry-checker/tests/snapshots/corpus__checker_fixture_diagnostics.snap
@@ -807,6 +807,8 @@ expression: snapshots
 - diagnostics: []
   fixture: ok_qualified_nse_aes.R
 - diagnostics: []
+  fixture: ok_quoted_default_dependencies.R
+- diagnostics: []
   fixture: ok_quoted_formula_symbols.R
 - diagnostics: []
   fixture: ok_r6_class_body_bindings.R


### PR DESCRIPTION
RY098 warns when a default captures a name that the body assigns later, even though forcing the default only returns quoted code:

```r
f <- function(x = base::quote(body_value)) {
  out <- x
  body_value <- 1L
  out
}
```

This is now clean; R returns the symbol `body_value`. Replacing `base::quote` with `base::identity` still warns, and R errors because `body_value` has not been assigned.

The dependency collector uses argument matching and eval metadata for an explicit set of qualified capture-only helpers: base `quote`, `substitute`, and `expression`, plus rlang `expr`. The list is necessary because `quoted_expression` describes capture, not whether the callee later executes the code. Other callees, including masked names, `bquote`, `shiny::isolate`, `rlang::enexpr`, and custom quoting metadata, retain conservative traversal. Evaluated control arguments and tidy-injection payloads remain dependencies. Literal branches and short-circuit operands are pruned in evaluated expressions; quoted syntax still undergoes injection. Straight-line payload assignments are processed after their right-hand sides, so reads before assignment still warn. Diagnostic selection is deterministic when several body-local names occur.

Partial follow-up to #196; the broader guaranteed-force walker remains open. No stub or upstream changes.

Validation: table-driven checker tests, corpus fixtures/snapshot, two R oracle fixtures, full workspace tests, Clippy, formatting, and the full R oracle matrix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of lazy default expressions that capture names through qualified quoting and expression helpers.
  - Reduced false-positive RY098 warnings while continuing to flag genuinely forced-before-assignment dependencies.
  - Improved analysis of conditional branches, short-circuit expressions, assignments, function bodies, and tidy-injection expressions.
  - Made diagnostics deterministic when multiple lazy-default dependencies are present.

- **Tests**
  - Added comprehensive coverage for quoted, captured, injected, nested, and unreachable default-expression scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->