### PR TITLE
feat(cli): export conservative facts at references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@ suppression actions — and fixes a parser panic plus several editor issues.
 
 - `ry dump-facts` exports versioned structured types, scope-exit snapshots,
   UTF-8 source spans, and analysis context hashes for downstream tools.
+  Add `--references` for conservative same-file reference facts, explicit
+  resolution status, and source definition IDs in schema 2.
   See the [facts schema](docs/facts.md). Existing `dump-types` output is unchanged.
 
 - Zed verifies downloaded server executables against published SHA-256 sidecars

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ See the [VS Code / Positron guide](editors/code/README.md) for settings and the
 
 - [Usage](docs/usage.md): package handling, data masking, CI, and editors.
 - [Inferred types](docs/types.md): inspect bindings with `ry dump-types`.
-- [Structured facts](docs/facts.md): versioned types and source spans for tooling.
+- [Structured facts](docs/facts.md): versioned scope snapshots and opt-in reference facts for tooling.
 - [Rules](docs/rules.md): diagnostic codes and default severities.
   Run `ry explain rule RY040` for one rule or `ry explain rule` for all rules.
 - [Changelog](CHANGELOG.md): release notes and upgrade guidance.

--- a/crates/ry-checker/src/infer/mod.rs
+++ b/crates/ry-checker/src/infer/mod.rs
@@ -185,6 +185,8 @@ impl Checker {
         }
         match s {
             Stmt::Assign { target, value, .. } => {
+                let reference_type_known =
+                    self.capture_references && self.reference_value_known(value, scope);
                 let scope_marked_origin = expression_has_list_origin(value, scope);
                 let vt = self.infer(value, scope);
                 // The value keeps list origin whenever its inferred mode
@@ -196,6 +198,14 @@ impl Checker {
                 if self.try_assign_value(target, value, vt, scope)
                     && let Some(name) = binding_name(target)
                 {
+                    if self.capture_references {
+                        self.install_reference_definition(
+                            scope,
+                            name,
+                            span_of(target),
+                            reference_type_known,
+                        );
+                    }
                     if value_has_list_origin {
                         scope.mark_list_origin(name.to_string());
                     }
@@ -395,6 +405,7 @@ impl Checker {
         scope: &Scope,
     ) {
         let mut fn_scope = scope.clone();
+        self.start_reference_scope(&mut fn_scope, span);
         if let Some(captures) = self.deferred_captures.last() {
             for capture in captures {
                 if fn_scope.get(capture).is_none() {
@@ -428,6 +439,15 @@ impl Checker {
                 fn_scope.insert_parameter_default(p.name.clone(), t);
             } else {
                 fn_scope.insert_parameter(p.name.clone(), t);
+            }
+        }
+        if self.capture_references {
+            for p in params {
+                let declaration_span = Span {
+                    end: p.span.start + p.name.len(),
+                    ..p.span
+                };
+                self.install_reference_definition(&mut fn_scope, &p.name, declaration_span, false);
             }
         }
         self.deferred_captures.push(assigned);
@@ -1457,6 +1477,183 @@ impl Checker {
         }
     }
 
+    // Keep reference observation after every exit from the existing value
+    // lookup ladder. Calls retain their distinct function-lookup path.
+    fn infer_identifier(&mut self, name: &str, span: &Span, scope: &mut Scope) -> RType {
+        let mut found_lexical = false;
+        let mut unresolved = false;
+        let result = (|| match scope.get(name) {
+            Some(t) => {
+                found_lexical = true;
+                let is_lexical_binding_under_unknown_mask = scope.data_mask_unknown
+                    && scope.get(crate::nse::DATA_MASK_ACTIVE).is_some()
+                    && scope
+                        .get(&format!("{}{name}", crate::nse::DATA_MASK_ENV_PREFIX))
+                        .is_some()
+                    && scope
+                        .get(&format!("{}{name}", crate::nse::DATA_MASK_COLUMN_PREFIX))
+                        .is_none();
+                if is_lexical_binding_under_unknown_mask {
+                    RType::unknown()
+                } else {
+                    t.clone()
+                }
+            }
+            None => {
+                // A defused/data-mask scope resolves its names against
+                // an environment ry cannot enumerate (a data mask, or
+                // the closure a quoting helper splices the block
+                // into — withr's `wrap()` even re-derives its formals
+                // via `formals(fun) <- formals(f)`). The lexical arm
+                // above already treats that as shadowing; the same
+                // reasoning demotes the search-path function-value
+                // rungs below, so a bare `append` inside a defused
+                // block types as unknown instead of borrowing
+                // `base::append`'s function type.
+                let under_unknown_data_mask =
+                    scope.data_mask_unknown && scope.get(crate::nse::DATA_MASK_ACTIVE).is_some();
+                // Typed package values take precedence over existence-only
+                // import bindings so constants retain their declared type.
+                if let Some(value_type) = self.resolve_typeshed_value(name) {
+                    return value_type;
+                }
+                if self.external_bindings.contains(name) {
+                    return RType::unknown();
+                }
+                if self.external_bindings.iter().any(|binding| {
+                    binding
+                        .strip_prefix(ry_workspace::packages::NATIVE_ROUTINE_PREFIX_SENTINEL)
+                        .is_some_and(|prefix| {
+                            name.strip_prefix(prefix)
+                                .is_some_and(|rest| !rest.is_empty())
+                        })
+                }) {
+                    return RType::unknown();
+                }
+                // Known typeshed function used as a value (e.g.
+                // `sapply(x, sqrt)` passes `sqrt` as a bare
+                // identifier)? Return an opaque function value
+                // rather than flagging it as unbound. The higher-
+                // order call handlers resolve the signature when
+                // the callback is invoked.
+                //
+                // Skipped under an unknown data mask: the mask may
+                // shadow the search path, so the name is unknown
+                // there rather than a base function value.
+                if !under_unknown_data_mask && self.typeshed.functions.contains_key(name) {
+                    return RType::scalar(Mode::Function);
+                }
+                // A function from a loaded package (e.g. purrr's
+                // `map` used as a value) resolves to a function too.
+                // Equally shadowable by an unknown mask.
+                if !under_unknown_data_mask
+                    && self.bare_loaded.iter().any(|pkg| {
+                        self.package_is_known(pkg)
+                            && self
+                                .package_typeshed(pkg)
+                                .map(|t| t.functions.contains_key(name))
+                                .unwrap_or(false)
+                    })
+                {
+                    return RType::scalar(Mode::Function);
+                }
+                // User-defined function in the FnTable used as a
+                // value? Same treatment.
+                if !under_unknown_data_mask && self.fn_table.fns.contains_key(name) {
+                    return RType::scalar(Mode::Function);
+                }
+                // Cross-file variable defined in another file of
+                // the project (or a top-level assignment later in
+                // this same file)? Return opaque rather than
+                // flagging it as unbound. Without this, multi-file
+                // projects like ggplot2 (where `GeomRect <-
+                // ggproto(...)` is a CALL, not a function literal)
+                // generate hundreds of false-positive RY010
+                // warnings for references to symbols defined in
+                // sibling files.
+                if self.known_vars.contains(name) {
+                    return RType::unknown();
+                }
+                if !under_unknown_data_mask
+                    && self
+                        .typeshed
+                        .globals
+                        .ambient_functions
+                        .iter()
+                        .any(|function| function == name)
+                {
+                    // Value-position uses of ambient functions are
+                    // overwhelmingly legitimate higher-order idioms
+                    // (`lapply(x, enc2utf8)`, `do.call(rbind, z)`), so
+                    // resolve silently as a function value. The typo
+                    // class (`col`, `oldClass` misused as data) is still
+                    // caught downstream when the function type flows
+                    // into comparisons or arithmetic (RY030/RY033).
+                    return RType::scalar(Mode::Function);
+                }
+                // Existence-only standard and ambient globals are a
+                // fallback after typed datasets, functions, and project
+                // bindings so inventory overlap cannot erase precision.
+                if self
+                    .typeshed
+                    .globals
+                    .ambient
+                    .iter()
+                    .any(|global| global == name)
+                {
+                    return RType::unknown();
+                }
+                // Namespace-qualified reference (`pkg::name`),
+                // including the bare reexport pattern
+                // (`rlang::set_names` or `magrittr::`%>%`` in
+                // statement position) and qualified values
+                // (`x <- S7::class_any`). We don't model other
+                // packages' export tables, so we treat these as
+                // opaque cross-package references and never emit
+                // RY010. The `contains("::")` test matches both
+                // `::` and `:::`.
+                if name.contains("::") {
+                    return RType::unknown();
+                }
+                // Special/operator names referenced via backticks
+                // (e.g. `` `%+%` ``, `` `+` ``) or bare operator
+                // symbols. The parser preserves the surrounding
+                // backticks in the identifier name, so a leading
+                // backtick is the primary signal. These are commonly
+                // user-defined operators or package reexports that
+                // we cannot resolve against any scope, typeshed, or
+                // FnTable -- suppressing RY010 here avoids
+                // false positives on code like ggplot2's `` `%+%` ``
+                // operator. We return opaque rather than flagging.
+                if name.starts_with('`') || name.contains('%') || is_operator_symbol(name) {
+                    return RType::unknown();
+                }
+                if scope.data_mask_unknown || scope.search_path_unknown {
+                    return RType::unknown();
+                }
+                unresolved = true;
+                self.emit(
+                    Severity::Warning,
+                    *span,
+                    "RY010",
+                    format!("variable `{}` is not bound in this scope", name),
+                );
+                RType::unknown()
+            }
+        })();
+        if self.capture_references {
+            self.observe_reference(
+                name,
+                *span,
+                scope,
+                found_lexical.then_some(&result),
+                unresolved,
+            );
+            self.finish_reference_read(name, scope);
+        }
+        result
+    }
+
     /// Infer the type of an expression, emitting diagnostics for misuse.
     pub(crate) fn infer(&mut self, e: &Expr, scope: &mut Scope) -> RType {
         // `infer_pipe` has already inferred the expression it injects into
@@ -1472,163 +1669,7 @@ impl Checker {
             Expr::String(_, _) => RType::scalar(Mode::Character),
             Expr::Null(_) => RType::new(Mode::Null, Length::Zero),
             Expr::Na(t, _) => t.clone(),
-            Expr::Ident { name, span } => match scope.get(name) {
-                Some(t) => {
-                    let is_lexical_binding_under_unknown_mask = scope.data_mask_unknown
-                        && scope.get(crate::nse::DATA_MASK_ACTIVE).is_some()
-                        && scope
-                            .get(&format!("{}{name}", crate::nse::DATA_MASK_ENV_PREFIX))
-                            .is_some()
-                        && scope
-                            .get(&format!("{}{name}", crate::nse::DATA_MASK_COLUMN_PREFIX))
-                            .is_none();
-                    if is_lexical_binding_under_unknown_mask {
-                        RType::unknown()
-                    } else {
-                        t.clone()
-                    }
-                }
-                None => {
-                    // A defused/data-mask scope resolves its names against
-                    // an environment ry cannot enumerate (a data mask, or
-                    // the closure a quoting helper splices the block
-                    // into — withr's `wrap()` even re-derives its formals
-                    // via `formals(fun) <- formals(f)`). The lexical arm
-                    // above already treats that as shadowing; the same
-                    // reasoning demotes the search-path function-value
-                    // rungs below, so a bare `append` inside a defused
-                    // block types as unknown instead of borrowing
-                    // `base::append`'s function type.
-                    let under_unknown_data_mask = scope.data_mask_unknown
-                        && scope.get(crate::nse::DATA_MASK_ACTIVE).is_some();
-                    // Typed package values take precedence over existence-only
-                    // import bindings so constants retain their declared type.
-                    if let Some(value_type) = self.resolve_typeshed_value(name) {
-                        return value_type;
-                    }
-                    if self.external_bindings.contains(name) {
-                        return RType::unknown();
-                    }
-                    if self.external_bindings.iter().any(|binding| {
-                        binding
-                            .strip_prefix(ry_workspace::packages::NATIVE_ROUTINE_PREFIX_SENTINEL)
-                            .is_some_and(|prefix| {
-                                name.strip_prefix(prefix)
-                                    .is_some_and(|rest| !rest.is_empty())
-                            })
-                    }) {
-                        return RType::unknown();
-                    }
-                    // Known typeshed function used as a value (e.g.
-                    // `sapply(x, sqrt)` passes `sqrt` as a bare
-                    // identifier)? Return an opaque function value
-                    // rather than flagging it as unbound. The higher-
-                    // order call handlers resolve the signature when
-                    // the callback is invoked.
-                    //
-                    // Skipped under an unknown data mask: the mask may
-                    // shadow the search path, so the name is unknown
-                    // there rather than a base function value.
-                    if !under_unknown_data_mask && self.typeshed.functions.contains_key(name) {
-                        return RType::scalar(Mode::Function);
-                    }
-                    // A function from a loaded package (e.g. purrr's
-                    // `map` used as a value) resolves to a function too.
-                    // Equally shadowable by an unknown mask.
-                    if !under_unknown_data_mask
-                        && self.bare_loaded.iter().any(|pkg| {
-                            self.package_is_known(pkg)
-                                && self
-                                    .package_typeshed(pkg)
-                                    .map(|t| t.functions.contains_key(name))
-                                    .unwrap_or(false)
-                        })
-                    {
-                        return RType::scalar(Mode::Function);
-                    }
-                    // User-defined function in the FnTable used as a
-                    // value? Same treatment.
-                    if !under_unknown_data_mask && self.fn_table.fns.contains_key(name) {
-                        return RType::scalar(Mode::Function);
-                    }
-                    // Cross-file variable defined in another file of
-                    // the project (or a top-level assignment later in
-                    // this same file)? Return opaque rather than
-                    // flagging it as unbound. Without this, multi-file
-                    // projects like ggplot2 (where `GeomRect <-
-                    // ggproto(...)` is a CALL, not a function literal)
-                    // generate hundreds of false-positive RY010
-                    // warnings for references to symbols defined in
-                    // sibling files.
-                    if self.known_vars.contains(name) {
-                        return RType::unknown();
-                    }
-                    if !under_unknown_data_mask
-                        && self
-                            .typeshed
-                            .globals
-                            .ambient_functions
-                            .iter()
-                            .any(|function| function == name)
-                    {
-                        // Value-position uses of ambient functions are
-                        // overwhelmingly legitimate higher-order idioms
-                        // (`lapply(x, enc2utf8)`, `do.call(rbind, z)`), so
-                        // resolve silently as a function value. The typo
-                        // class (`col`, `oldClass` misused as data) is still
-                        // caught downstream when the function type flows
-                        // into comparisons or arithmetic (RY030/RY033).
-                        return RType::scalar(Mode::Function);
-                    }
-                    // Existence-only standard and ambient globals are a
-                    // fallback after typed datasets, functions, and project
-                    // bindings so inventory overlap cannot erase precision.
-                    if self
-                        .typeshed
-                        .globals
-                        .ambient
-                        .iter()
-                        .any(|global| global == name)
-                    {
-                        return RType::unknown();
-                    }
-                    // Namespace-qualified reference (`pkg::name`),
-                    // including the bare reexport pattern
-                    // (`rlang::set_names` or `magrittr::`%>%`` in
-                    // statement position) and qualified values
-                    // (`x <- S7::class_any`). We don't model other
-                    // packages' export tables, so we treat these as
-                    // opaque cross-package references and never emit
-                    // RY010. The `contains("::")` test matches both
-                    // `::` and `:::`.
-                    if name.contains("::") {
-                        return RType::unknown();
-                    }
-                    // Special/operator names referenced via backticks
-                    // (e.g. `` `%+%` ``, `` `+` ``) or bare operator
-                    // symbols. The parser preserves the surrounding
-                    // backticks in the identifier name, so a leading
-                    // backtick is the primary signal. These are commonly
-                    // user-defined operators or package reexports that
-                    // we cannot resolve against any scope, typeshed, or
-                    // FnTable -- suppressing RY010 here avoids
-                    // false positives on code like ggplot2's `` `%+%` ``
-                    // operator. We return opaque rather than flagging.
-                    if name.starts_with('`') || name.contains('%') || is_operator_symbol(name) {
-                        return RType::unknown();
-                    }
-                    if scope.data_mask_unknown || scope.search_path_unknown {
-                        return RType::unknown();
-                    }
-                    self.emit(
-                        Severity::Warning,
-                        *span,
-                        "RY010",
-                        format!("variable `{}` is not bound in this scope", name),
-                    );
-                    RType::unknown()
-                }
-            },
+            Expr::Ident { name, span } => self.infer_identifier(name, span, scope),
             Expr::BinOp { op, lhs, rhs, span } => {
                 // Pipes need structural access to `rhs` (to build a
                 // desugared call), so they bypass `infer_binop`'s

--- a/crates/ry-checker/src/lib.rs
+++ b/crates/ry-checker/src/lib.rs
@@ -20,7 +20,12 @@ mod higher_order;
 mod infer;
 mod nse;
 pub mod project;
+mod reference_facts;
 mod resolve;
+pub use reference_facts::{
+    DefinitionId, ReferenceDefinition, ReferenceDefinitionKind, ReferenceFacts, ReferenceRecord,
+    ReferenceResolution,
+};
 pub mod rules;
 pub mod semantic_lists;
 
@@ -282,6 +287,7 @@ pub fn builtin_environment_bindings(path: &str) -> &'static [&'static str] {
 /// A single scope's binding table.
 #[derive(Debug, Clone, Default)]
 pub struct Scope {
+    pub(crate) reference_provenance: Option<Box<reference_facts::ScopeProvenance>>,
     pub bindings: HashMap<String, RType>,
     /// Names whose current binding was installed by flow narrowing rather
     /// than an R assignment. `insert` clears this marker, so branch merging
@@ -319,6 +325,9 @@ impl Scope {
 
     pub fn insert(&mut self, name: impl Into<String>, t: RType) {
         let name = name.into();
+        if let Some(provenance) = self.reference_provenance.as_mut() {
+            provenance.invalidate(&name);
+        }
         self.function_aliases.remove(&name);
         self.lexical_functions.remove(&name);
         self.list_origin_bindings.remove(&name);
@@ -332,6 +341,9 @@ impl Scope {
         // Preserve parameter, default-parameter, and list-origin markers;
         // clear function aliases and lexical-function markers, then mark narrowed.
         let name = name.into();
+        if let Some(provenance) = self.reference_provenance.as_mut() {
+            provenance.invalidate(&name);
+        }
         self.function_aliases.remove(&name);
         self.lexical_functions.remove(&name);
         self.bindings.insert(name.clone(), t);
@@ -348,6 +360,9 @@ impl Scope {
         // Preserve lexical-function and list-origin markers; clear function
         // aliases and narrowing, then set both parameter markers.
         let name = name.into();
+        if let Some(provenance) = self.reference_provenance.as_mut() {
+            provenance.invalidate(&name);
+        }
         self.function_aliases.remove(&name);
         self.narrowed_bindings.remove(&name);
         self.bindings.insert(name.clone(), t);
@@ -714,6 +729,8 @@ pub struct Checker {
     // signature-building walks (the same walker in discarding mode) from
     // double-capturing a body.
     capture_scopes: bool,
+    capture_references: bool,
+    reference_capture: Option<Box<reference_facts::ReferenceCapture>>,
     scope_records: Vec<ScopeRecord>,
 }
 
@@ -835,6 +852,8 @@ impl Checker {
             enclosing_formals: Vec::new(),
             pipe_argument_types: HashMap::new(),
             capture_scopes: false,
+            capture_references: false,
+            reference_capture: None,
             scope_records: Vec::new(),
         }
     }
@@ -945,6 +964,10 @@ impl Checker {
         self.source.clone_from(&file.source);
         self.emit_parse_errors(file);
         let mut scope = self.top_level_scope();
+        if self.capture_references {
+            self.reference_capture = Some(Box::new(reference_facts::ReferenceCapture::new(file)));
+            self.start_reference_scope(&mut scope, whole_file_span(&file.source));
+        }
         for s in &file.stmts {
             self.check_stmt(s, &mut scope);
         }

--- a/crates/ry-checker/src/project.rs
+++ b/crates/ry-checker/src/project.rs
@@ -26,6 +26,14 @@ use ry_typeshed::Typeshed;
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::Arc;
 
+struct FileEmission {
+    index: usize,
+    path: String,
+    diagnostics: Vec<Diagnostic>,
+    scopes: Vec<crate::ScopeRecord>,
+    references: crate::ReferenceFacts,
+}
+
 /// A multi-file R project. Functions defined in any file are visible
 /// to all other files. The fixpoint loop refines returns across the
 /// whole project at once.
@@ -113,6 +121,8 @@ pub struct Project {
     /// When true, pass-3 emitters snapshot each file's lexical scopes.
     /// Off by default; see [`Checker::enable_scope_capture`].
     capture_scopes: bool,
+    capture_references: bool,
+    reference_facts: Vec<(String, crate::ReferenceFacts)>,
     /// Scope records from the most recent emission, one entry per
     /// re-emitted file. Files served from the incremental cache keep no
     /// records, so a cold `check()` (which emits every file) is the
@@ -251,6 +261,18 @@ impl Project {
     /// called before it.
     pub fn take_scope_records(&mut self) -> Vec<(String, Vec<crate::ScopeRecord>)> {
         std::mem::take(&mut self.scope_records)
+    }
+
+    /// Capture reference facts for every file on each subsequent check.
+    /// This bypasses the diagnostic cache so the snapshot is complete.
+    pub fn enable_reference_capture(&mut self) {
+        self.capture_references = true;
+        self.reference_facts.clear();
+    }
+
+    /// Take the reference facts from the most recent check.
+    pub fn take_reference_facts(&mut self) -> Vec<(String, crate::ReferenceFacts)> {
+        std::mem::take(&mut self.reference_facts)
     }
 
     /// Install runtime package stubs. User packages, including `base`,
@@ -636,13 +658,14 @@ impl Project {
             .files
             .iter()
             .enumerate()
-            .filter(|(_, (path, _))| must_emit.contains(path.as_str()))
+            .filter(|(_, (path, _))| self.capture_references || must_emit.contains(path.as_str()))
             .map(|(i, _)| i)
             .collect();
         self.emit_count = emit_indices.len();
         let capture_scopes = self.capture_scopes;
+        let capture_references = self.capture_references;
 
-        let per_file: Vec<(usize, String, Vec<Diagnostic>, Vec<crate::ScopeRecord>)> = emit_indices
+        let per_file: Vec<FileEmission> = emit_indices
             .par_iter()
             .map(|&i| {
                 let (path, file) = &self.files[i];
@@ -674,9 +697,19 @@ impl Project {
                 if capture_scopes {
                     emitter.enable_scope_capture();
                 }
+                if capture_references {
+                    emitter.enable_reference_capture();
+                }
                 emitter.emit_diagnostics(file);
                 let records = emitter.take_scope_records();
-                (i, path.clone(), emitter.take_diagnostics(), records)
+                let references = emitter.take_reference_facts();
+                FileEmission {
+                    index: i,
+                    path: path.clone(),
+                    diagnostics: emitter.take_diagnostics(),
+                    scopes: records,
+                    references,
+                }
             })
             .collect();
 
@@ -702,13 +735,25 @@ impl Project {
         if capture_scopes {
             self.scope_records = per_file
                 .iter_mut()
-                .map(|(_, path, _, records)| (path.clone(), std::mem::take(records)))
+                .map(|emission| (emission.path.clone(), std::mem::take(&mut emission.scopes)))
+                .collect();
+        }
+
+        if capture_references {
+            self.reference_facts = per_file
+                .iter_mut()
+                .map(|emission| {
+                    (
+                        emission.path.clone(),
+                        std::mem::take(&mut emission.references),
+                    )
+                })
                 .collect();
         }
 
         let mut emitted_map: HashMap<usize, (String, Vec<Diagnostic>)> = per_file
             .into_iter()
-            .map(|(i, p, d, _)| (i, (p, d)))
+            .map(|emission| (emission.index, (emission.path, emission.diagnostics)))
             .collect();
 
         for (i, (path, _)) in self.files.iter().enumerate() {

--- a/crates/ry-checker/src/reference_facts.rs
+++ b/crates/ry-checker/src/reference_facts.rs
@@ -742,10 +742,6 @@ mod tests {
             format!("{plain_diagnostics:?}"),
             format!("{captured_diagnostics:?}")
         );
-        assert_eq!(
-            std::mem::size_of::<Option<Box<ScopeProvenance>>>(),
-            std::mem::size_of::<usize>()
-        );
     }
 
     #[test]

--- a/crates/ry-checker/src/reference_facts.rs
+++ b/crates/ry-checker/src/reference_facts.rs
@@ -1,0 +1,777 @@
+//! Optional, deliberately narrow reference facts from the diagnostic walk.
+//!
+//! The inventory rejects syntax; it does not resolve names. Only a binding
+//! installed by the semantic walk can supply a definition to a reference.
+
+use std::collections::{HashMap, HashSet};
+use std::ops::ControlFlow;
+
+use ry_core::ast::{Expr, Param, SourceFile, Stmt};
+use ry_core::walk::{AstNode, Descend, Walk, walk_stmts};
+use ry_core::{RType, Span};
+
+use crate::infer::span_of;
+use crate::{Checker, Scope, whole_file_span};
+
+/// File-local identity, valid only within one returned facts snapshot.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct DefinitionId(pub u32);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReferenceDefinitionKind {
+    Assignment,
+    Formal,
+}
+
+/// A declaration installed by the diagnostic walk, with original-source spans.
+#[derive(Debug, Clone)]
+pub struct ReferenceDefinition {
+    pub id: DefinitionId,
+    pub name: String,
+    pub scope_span: Span,
+    pub span: Span,
+    pub kind: ReferenceDefinitionKind,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReferenceResolution {
+    Resolved,
+    Ambiguous,
+    Unresolved,
+    Unsupported,
+}
+
+/// An original-source value occurrence, never a scope-exit snapshot.
+#[derive(Debug, Clone)]
+pub struct ReferenceRecord {
+    pub name: String,
+    pub span: Span,
+    pub resolution: ReferenceResolution,
+    pub definition: Option<DefinitionId>,
+    pub type_at_reference: Option<RType>,
+    pub reason: Option<&'static str>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct ReferenceFacts {
+    pub definitions: Vec<ReferenceDefinition>,
+    pub references: Vec<ReferenceRecord>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct BindingProvenance {
+    definition: DefinitionId,
+    owner: Span,
+    type_known: bool,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct ScopeProvenance {
+    owner: Span,
+    after_unsafe_read: bool,
+    bindings: HashMap<String, BindingProvenance>,
+}
+
+impl ScopeProvenance {
+    pub(crate) fn invalidate(&mut self, name: &str) {
+        self.bindings.remove(name);
+    }
+}
+
+#[derive(Debug)]
+struct Occurrence {
+    record: ReferenceRecord,
+    owner: Span,
+    eligible: bool,
+    observed: bool,
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct ReferenceCapture {
+    definitions: Vec<ReferenceDefinition>,
+    declarations: HashMap<Span, DefinitionId>,
+    installed: HashSet<DefinitionId>,
+    occurrences: HashMap<Span, Occurrence>,
+    eligible_scopes: HashSet<Span>,
+}
+
+impl ReferenceCapture {
+    pub(crate) fn new(file: &SourceFile) -> Self {
+        let mut capture = Self::default();
+        capture.inventory_scope(
+            &file.source,
+            whole_file_span(&file.source),
+            &[],
+            &file.stmts,
+            !file.parse_errors.is_empty(),
+        );
+        capture
+    }
+
+    fn source_backed(source: &str, span: Span) -> bool {
+        span.start < span.end && source.get(span.start..span.end).is_some()
+    }
+
+    // This pass only inventories declarations/occurrences and rejects unsafe
+    // scopes. It never matches a reference spelling to a declaration.
+    fn inventory_scope(
+        &mut self,
+        source: &str,
+        owner: Span,
+        params: &[Param],
+        stmts: &[Stmt],
+        inherited_unsupported: bool,
+    ) {
+        let mut unsafe_scope = inherited_unsupported;
+        let mut writes = HashMap::<String, usize>::new();
+        let mut declarations = Vec::new();
+        let mut excluded_targets = HashSet::new();
+        let mut references = Vec::new();
+        let mut functions = Vec::new();
+        let mut defaults = Vec::new();
+        for param in params {
+            if let Some(key) = ordinary_spelling(&param.name) {
+                *writes.entry(key.to_string()).or_default() += 1;
+            } else {
+                unsafe_scope = true;
+            }
+            // Param.span includes its default. Its name is the raw source token.
+            let span = Span {
+                end: param.span.start + param.name.len(),
+                ..param.span
+            };
+            if source.get(span.start..span.end) == Some(param.name.as_str()) {
+                declarations.push((param.name.clone(), span, ReferenceDefinitionKind::Formal));
+            } else {
+                unsafe_scope = true;
+            }
+            if let Some(default) = &param.default {
+                defaults.push(Stmt::Expr(default.clone()));
+            }
+        }
+        let _ = walk_stmts(
+            stmts,
+            Walk {
+                dollar_args: false,
+                assign_operands: false,
+                ..Walk::ALL
+            },
+            |node, _| {
+                match node {
+                    AstNode::Stmt(Stmt::Assign { target, value, .. }) => {
+                        if let Expr::Ident { name, span } = target {
+                            excluded_targets.insert(*span);
+                            if let Some(key) = ordinary_spelling(name) {
+                                *writes.entry(key.to_string()).or_default() += 1;
+                            } else {
+                                unsafe_scope = true;
+                            }
+                            declarations.push((
+                                name.clone(),
+                                *span,
+                                ReferenceDefinitionKind::Assignment,
+                            ));
+                            // The small AST drops some assignment operators. Only
+                            // certify ordinary left assignment from source tokens.
+                            let rhs = span_of(value);
+                            let operator = source.get(span.end..rhs.start).map(str::trim);
+                            if !matches!(operator, Some("<-" | "=")) || !simple_value(value) {
+                                unsafe_scope = true;
+                            }
+                        } else {
+                            unsafe_scope = true;
+                        }
+                    }
+                    AstNode::Stmt(Stmt::FunctionDef { params, body, span })
+                    | AstNode::Expr(Expr::Function { params, body, span }) => {
+                        functions.push((params.clone(), body.clone(), *span));
+                        return ControlFlow::<(), Descend>::Continue(Descend::Skip);
+                    }
+                    AstNode::Stmt(
+                        Stmt::If { .. }
+                        | Stmt::For { .. }
+                        | Stmt::While { .. }
+                        | Stmt::Return { .. },
+                    ) => unsafe_scope = true,
+                    AstNode::Expr(Expr::Ident { name, span }) => {
+                        if ordinary_spelling(name).is_none() {
+                            unsafe_scope = true;
+                        }
+                        if !excluded_targets.contains(span) && Self::source_backed(source, *span) {
+                            references.push((name.clone(), *span));
+                        }
+                    }
+                    AstNode::Expr(
+                        Expr::Call { .. }
+                        | Expr::BinOp { .. }
+                        | Expr::UnaryOp { .. }
+                        | Expr::Index { .. }
+                        | Expr::If { .. }
+                        | Expr::Unknown(_),
+                    ) => unsafe_scope = true,
+                    _ => {}
+                }
+                ControlFlow::Continue(Descend::Into)
+            },
+        );
+        unsafe_scope |= writes.values().any(|count| *count != 1);
+        if !unsafe_scope {
+            self.eligible_scopes.insert(owner);
+            declarations.sort_by_key(|(_, span, _)| (span.start, span.end));
+            for (name, span, kind) in declarations {
+                if !Self::source_backed(source, span) {
+                    continue;
+                }
+                let id = DefinitionId(self.definitions.len() as u32);
+                self.definitions.push(ReferenceDefinition {
+                    id,
+                    name,
+                    scope_span: owner,
+                    span,
+                    kind,
+                });
+                self.declarations.insert(span, id);
+            }
+        }
+        for (name, span) in references {
+            self.occurrences.entry(span).or_insert(Occurrence {
+                record: ReferenceRecord {
+                    name,
+                    span,
+                    resolution: ReferenceResolution::Unsupported,
+                    definition: None,
+                    type_at_reference: None,
+                    reason: Some(if unsafe_scope {
+                        "unsupported_scope"
+                    } else {
+                        "not_observed"
+                    }),
+                },
+                owner,
+                eligible: !unsafe_scope,
+                observed: false,
+            });
+        }
+        // Defaults are lazy expressions, not the function's runtime contract.
+        // Their references and any nested functions remain unsupported.
+        if !defaults.is_empty() {
+            self.inventory_scope(source, owner, &[], &defaults, true);
+        }
+        for (params, body, span) in functions {
+            self.inventory_scope(source, span, &params, &body, unsafe_scope);
+        }
+    }
+
+    fn finish(self) -> ReferenceFacts {
+        let mut references: Vec<_> = self.occurrences.into_values().map(|o| o.record).collect();
+        references.sort_by_key(|r| (r.span.start, r.span.end));
+        let mut definitions: Vec<_> = self
+            .definitions
+            .into_iter()
+            .filter(|d| self.installed.contains(&d.id))
+            .collect();
+        definitions.sort_by_key(|d| (d.span.start, d.span.end));
+        ReferenceFacts {
+            definitions,
+            references,
+        }
+    }
+}
+
+// Canonical spelling is used ONLY to reject multiple syntactic writes and
+// unsupported names. The semantic lookup and provenance retain the checker's
+// raw names. Escaped names need a full R decoder and are outside this subset.
+fn ordinary_spelling(name: &str) -> Option<&str> {
+    let quoted = name
+        .strip_prefix('`')
+        .and_then(|name| name.strip_suffix('`'));
+    let key = quoted.unwrap_or(name);
+    if key.contains('\\')
+        || matches!(key, "<-" | "=" | "->" | "{" | "(" | "function")
+        || (quoted.is_none() && key.contains("::"))
+        || key == "..."
+        || key
+            .strip_prefix("..")
+            .is_some_and(|suffix| !suffix.is_empty() && suffix.bytes().all(|b| b.is_ascii_digit()))
+    {
+        None
+    } else {
+        Some(key)
+    }
+}
+
+fn simple_value(expr: &Expr) -> bool {
+    matches!(
+        expr,
+        Expr::Logical(..)
+            | Expr::Integer(..)
+            | Expr::Double(..)
+            | Expr::String(..)
+            | Expr::Null(..)
+            | Expr::Na(..)
+            | Expr::Ident { .. }
+            | Expr::Function { .. }
+    )
+}
+
+impl Checker {
+    /// Opt into conservative reference facts from the final diagnostic walk.
+    pub fn enable_reference_capture(&mut self) {
+        self.capture_references = true;
+    }
+
+    /// Take this file's most recent reference snapshot. Disabled by default.
+    pub fn take_reference_facts(&mut self) -> ReferenceFacts {
+        self.reference_capture
+            .take()
+            .map(|capture| capture.finish())
+            .unwrap_or_default()
+    }
+
+    pub(crate) fn start_reference_scope(&self, scope: &mut Scope, owner: Span) {
+        if self.reference_capture.is_none() || self.discarding {
+            return;
+        }
+        if let Some(provenance) = scope.reference_provenance.as_mut() {
+            provenance.owner = owner;
+        } else {
+            scope.reference_provenance = Some(Box::new(ScopeProvenance {
+                owner,
+                after_unsafe_read: false,
+                bindings: HashMap::new(),
+            }));
+        }
+    }
+
+    pub(crate) fn reference_value_known(&self, value: &Expr, scope: &Scope) -> bool {
+        match value {
+            Expr::Logical(..)
+            | Expr::Integer(..)
+            | Expr::Double(..)
+            | Expr::String(..)
+            | Expr::Null(..)
+            | Expr::Na(..) => true,
+            Expr::Ident { name, .. } => scope.reference_provenance.as_ref().is_some_and(|p| {
+                p.bindings
+                    .get(name)
+                    .is_some_and(|b| b.owner == p.owner && b.type_known)
+            }),
+            _ => false,
+        }
+    }
+
+    pub(crate) fn install_reference_definition(
+        &mut self,
+        scope: &mut Scope,
+        name: &str,
+        span: Span,
+        type_known: bool,
+    ) {
+        if self.discarding {
+            return;
+        }
+        let (Some(capture), Some(provenance)) = (
+            self.reference_capture.as_mut(),
+            scope.reference_provenance.as_mut(),
+        ) else {
+            return;
+        };
+        if provenance.after_unsafe_read || !capture.eligible_scopes.contains(&provenance.owner) {
+            return;
+        }
+        let Some(&definition) = capture.declarations.get(&span) else {
+            return;
+        };
+        let declaration = &capture.definitions[definition.0 as usize];
+        if declaration.scope_span != provenance.owner || declaration.name != name {
+            return;
+        }
+        capture.installed.insert(definition);
+        provenance.bindings.insert(
+            name.to_string(),
+            BindingProvenance {
+                definition,
+                owner: provenance.owner,
+                type_known,
+            },
+        );
+    }
+
+    pub(crate) fn finish_reference_read(&self, name: &str, scope: &mut Scope) {
+        // A formal, inherited, or untracked read may force arbitrary code.
+        // It can mutate this frame or install active bindings for future writes.
+        // Only an ordinary value already installed in this scope is safe.
+        if self.discarding {
+            return;
+        }
+        let formal = scope.is_parameter(name);
+        if let Some(provenance) = scope.reference_provenance.as_mut() {
+            let ordinary_local = provenance
+                .bindings
+                .get(name)
+                .is_some_and(|binding| binding.owner == provenance.owner);
+            if formal || !ordinary_local {
+                provenance.bindings.clear();
+                provenance.after_unsafe_read = true;
+            }
+        }
+    }
+
+    pub(crate) fn observe_reference(
+        &mut self,
+        name: &str,
+        span: Span,
+        scope: &Scope,
+        ty: Option<&RType>,
+        unresolved: bool,
+    ) {
+        if self.discarding {
+            return;
+        }
+        let (Some(capture), Some(provenance)) = (
+            self.reference_capture.as_mut(),
+            scope.reference_provenance.as_ref(),
+        ) else {
+            return;
+        };
+        let Some(occurrence) = capture.occurrences.get_mut(&span) else {
+            return;
+        };
+        if !occurrence.eligible
+            || occurrence.owner != provenance.owner
+            || occurrence.record.name != name
+        {
+            return;
+        }
+        let (resolution, definition, type_at_reference, reason) = if provenance.after_unsafe_read {
+            (
+                ReferenceResolution::Unsupported,
+                None,
+                None,
+                Some("after_unsafe_read"),
+            )
+        } else if scope.data_mask_unknown || scope.search_path_unknown {
+            (
+                ReferenceResolution::Unsupported,
+                None,
+                None,
+                Some("unknown_environment"),
+            )
+        } else if let Some(ty) = ty {
+            match provenance.bindings.get(name) {
+                Some(binding) if binding.owner == provenance.owner => (
+                    ReferenceResolution::Resolved,
+                    Some(binding.definition),
+                    Some(if binding.type_known {
+                        ty.clone()
+                    } else {
+                        RType::unknown()
+                    }),
+                    None,
+                ),
+                Some(_) => (
+                    ReferenceResolution::Unsupported,
+                    None,
+                    None,
+                    Some("deferred_capture"),
+                ),
+                None => (
+                    ReferenceResolution::Unsupported,
+                    None,
+                    None,
+                    Some("untracked_binding"),
+                ),
+            }
+        } else if unresolved {
+            (
+                ReferenceResolution::Unresolved,
+                None,
+                None,
+                Some("unbound_name"),
+            )
+        } else {
+            (
+                ReferenceResolution::Unsupported,
+                None,
+                None,
+                Some("untracked_lookup"),
+            )
+        };
+        if occurrence.observed
+            && (occurrence.record.resolution != resolution
+                || occurrence.record.definition != definition
+                || occurrence.record.type_at_reference != type_at_reference)
+        {
+            occurrence.record.resolution = ReferenceResolution::Ambiguous;
+            occurrence.record.definition = None;
+            occurrence.record.type_at_reference = None;
+            occurrence.record.reason = Some("conflicting_observations");
+        } else if !occurrence.observed {
+            occurrence.record.resolution = resolution;
+            occurrence.record.definition = definition;
+            occurrence.record.type_at_reference = type_at_reference;
+            occurrence.record.reason = reason;
+        }
+        occurrence.observed = true;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Project;
+    use ry_core::{Mode, RParser};
+
+    fn file(source: &str) -> SourceFile {
+        RParser::new().unwrap().parse("refs.R", source).unwrap()
+    }
+
+    fn facts(source: &str) -> ReferenceFacts {
+        let mut checker = Checker::new("refs.R");
+        checker.enable_reference_capture();
+        checker.check(&file(source));
+        checker.take_reference_facts()
+    }
+
+    fn named<'a>(facts: &'a ReferenceFacts, name: &str) -> Vec<&'a ReferenceRecord> {
+        facts.references.iter().filter(|r| r.name == name).collect()
+    }
+
+    #[test]
+    fn reference_capture_uses_the_semantic_write_and_lookup() {
+        let source = "x <- 1L\ny <- x\nz <- y\n";
+        let facts = facts(source);
+        assert_eq!(facts.references.len(), 2);
+        for reference in &facts.references {
+            assert_eq!(reference.resolution, ReferenceResolution::Resolved);
+            assert_eq!(
+                reference.type_at_reference.as_ref().unwrap().mode,
+                Mode::Integer
+            );
+            let definition = facts
+                .definitions
+                .iter()
+                .find(|d| Some(d.id) == reference.definition)
+                .unwrap();
+            assert_eq!(definition.name, reference.name);
+            assert!(definition.span.end < reference.span.start);
+            assert_eq!(
+                &source[definition.span.start..definition.span.end],
+                definition.name
+            );
+        }
+    }
+
+    #[test]
+    fn reference_capture_rejects_reassignment_and_nonordinary_operators() {
+        for source in [
+            "x <- 1L\ny <- x\nx <- 'later'",
+            "x := 1L\ny <- x",
+            "1L ->> x\ny <- x",
+            "x <<- 1L\ny <- x",
+            "x <- 1L\ny <- x + 1L",
+        ] {
+            let facts = facts(source);
+            assert!(!facts.references.is_empty(), "{source}");
+            assert!(
+                facts
+                    .references
+                    .iter()
+                    .all(|r| r.resolution == ReferenceResolution::Unsupported
+                        && r.definition.is_none()
+                        && r.type_at_reference.is_none()),
+                "{source}: {facts:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn reference_capture_rejects_aliased_and_special_spellings() {
+        for source in [
+            "x <- 1L\n`x` <- 'later'\ny <- x",
+            "x <- 1L\n`\\x78` <- 'later'\ny <- x",
+            "base::x <- 1L\ny <- base::x",
+            "f <- function(...) { x <- 1L; x }",
+            "`<-` <- function(a, b) NULL\nx <- 1L\ny <- x",
+        ] {
+            let facts = facts(source);
+            assert!(!facts.references.is_empty(), "{source}");
+            assert!(
+                facts
+                    .references
+                    .iter()
+                    .all(|r| r.resolution == ReferenceResolution::Unsupported
+                        && r.definition.is_none()
+                        && r.type_at_reference.is_none()),
+                "{source}: {facts:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn reference_capture_untracked_reads_are_permanent_effect_barriers() {
+        for source in [
+            "x <- 1L\ny <- missing_unlikely\nz <- x",
+            "x <- 1L\ny <- sqrt\nz <- x",
+            "outer <- 1L\nf <- function() { x <- 1L; y <- outer; z <- x }",
+            "f <- function(p) { y <- p; x <- 1L; x }",
+        ] {
+            let facts = facts(source);
+            let later = named(&facts, "x").last().copied().unwrap();
+            assert_eq!(
+                later.resolution,
+                ReferenceResolution::Unsupported,
+                "{source}: {facts:?}"
+            );
+            assert!(later.definition.is_none() && later.type_at_reference.is_none());
+        }
+    }
+
+    #[test]
+    fn reference_capture_formal_identity_does_not_assert_default_type() {
+        let source = "x <- 'outer'\nf <- function(x = 1L) { copied <- x; copied }";
+        let facts = facts(source);
+        let formal_read = named(&facts, "x")[0];
+        assert_eq!(formal_read.resolution, ReferenceResolution::Resolved);
+        assert_eq!(formal_read.type_at_reference, Some(RType::unknown()));
+        let definition = facts
+            .definitions
+            .iter()
+            .find(|d| Some(d.id) == formal_read.definition)
+            .unwrap();
+        assert_eq!(definition.kind, ReferenceDefinitionKind::Formal);
+        assert_eq!(&source[definition.span.start..definition.span.end], "x");
+        let copy = named(&facts, "copied")[0];
+        assert_eq!(copy.resolution, ReferenceResolution::Unsupported);
+        assert_eq!(copy.type_at_reference, None);
+    }
+
+    #[test]
+    fn reference_capture_formal_force_invalidates_earlier_bindings() {
+        for source in [
+            "f <- function(p) { x <- 1L; y <- p; z <- x }",
+            "f <- function(p = { x <- 'changed'; 1L }) { x <- 1L; y <- p; z <- x }",
+        ] {
+            let facts = facts(source);
+            let formal = named(&facts, "p")[0];
+            assert_eq!(formal.resolution, ReferenceResolution::Resolved);
+            assert_eq!(formal.type_at_reference, Some(RType::unknown()));
+            let after = named(&facts, "x").last().copied().unwrap();
+            assert_eq!(after.resolution, ReferenceResolution::Unsupported);
+            assert!(after.definition.is_none() && after.type_at_reference.is_none());
+        }
+    }
+
+    #[test]
+    fn reference_capture_outer_and_forward_bindings_are_not_local_definitions() {
+        let facts = facts("x <- 'outer'\nf <- function() { before <- x; x <- 1L; after <- x }");
+        let reads = named(&facts, "x");
+        assert_eq!(reads.len(), 2);
+        assert_eq!(reads[0].resolution, ReferenceResolution::Unsupported);
+        assert_eq!(reads[0].reason, Some("deferred_capture"));
+        assert_eq!(reads[1].resolution, ReferenceResolution::Unsupported);
+        assert!(reads[1].type_at_reference.is_none());
+        let facts = self::facts("before <- later\nlater <- 1L\nmissing_name_unlikely");
+        assert_eq!(
+            named(&facts, "later")[0].resolution,
+            ReferenceResolution::Unsupported
+        );
+        assert_eq!(
+            named(&facts, "missing_name_unlikely")[0].resolution,
+            ReferenceResolution::Unsupported
+        );
+        assert_eq!(
+            self::facts("missing_name_unlikely").references[0].resolution,
+            ReferenceResolution::Unresolved
+        );
+    }
+
+    #[test]
+    fn reference_capture_unsafe_wrappers_reach_nested_occurrences() {
+        for source in [
+            "quote(function(p) { x <- 1L; x })",
+            "with(data, function(p) p)",
+            "data |> f(function(p) p)",
+            "if (condition) { f <- function(p) p }",
+            "f <- function(p = function(q) q) p",
+        ] {
+            let facts = facts(source);
+            assert!(!facts.references.is_empty(), "{source}");
+            for reference in &facts.references {
+                // The last p in the final fixture is a supported own formal.
+                if source.starts_with("f <-") && reference.name == "p" {
+                    continue;
+                }
+                assert_eq!(
+                    reference.resolution,
+                    ReferenceResolution::Unsupported,
+                    "{source}: {facts:?}"
+                );
+                assert!(reference.definition.is_none() && reference.type_at_reference.is_none());
+            }
+        }
+    }
+
+    #[test]
+    fn reference_capture_project_refreshes_even_when_diagnostics_are_cached() {
+        let mut project = Project::new();
+        project.add_file("refs.R".into(), file("x <- 1L\ny <- x"));
+        project.check();
+        project.enable_reference_capture();
+        project.check();
+        let first = project.take_reference_facts();
+        assert_eq!(first.len(), 1);
+        assert_eq!(first[0].1.references.len(), 1);
+        project.check();
+        let second = project.take_reference_facts();
+        assert_eq!(format!("{first:?}"), format!("{second:?}"));
+    }
+
+    #[test]
+    fn reference_capture_does_not_change_types_or_diagnostics() {
+        let file = file("f <- function(x = 1L) { y <- x; y }\nf()\ny <- unknown_name");
+        let mut plain = Checker::new("refs.R");
+        let (plain_diagnostics, plain_scope) = plain.check_with_scope(&file);
+        assert!(plain_scope.reference_provenance.is_none());
+        assert!(plain.take_reference_facts().references.is_empty());
+        let mut captured = Checker::new("refs.R");
+        captured.enable_reference_capture();
+        let (captured_diagnostics, captured_scope) = captured.check_with_scope(&file);
+        assert_eq!(plain_scope.bindings, captured_scope.bindings);
+        assert_eq!(
+            format!("{plain_diagnostics:?}"),
+            format!("{captured_diagnostics:?}")
+        );
+        assert_eq!(
+            std::mem::size_of::<Option<Box<ScopeProvenance>>>(),
+            std::mem::size_of::<usize>()
+        );
+    }
+
+    #[test]
+    fn reference_capture_conflicting_observations_fail_closed() {
+        let source = file("x <- 1L\nx");
+        let mut checker = Checker::new("refs.R");
+        checker.enable_reference_capture();
+        let (_, scope) = checker.check_with_scope(&source);
+        let Stmt::Expr(Expr::Ident { span, .. }) = &source.stmts[1] else {
+            unreachable!()
+        };
+        checker.observe_reference(
+            "x",
+            *span,
+            &scope,
+            Some(&RType::scalar(Mode::Character)),
+            false,
+        );
+        let facts = checker.take_reference_facts();
+        assert_eq!(
+            facts.references[0].resolution,
+            ReferenceResolution::Ambiguous
+        );
+        assert!(
+            facts.references[0].definition.is_none()
+                && facts.references[0].type_at_reference.is_none()
+        );
+    }
+}

--- a/crates/ry-cli/src/check.rs
+++ b/crates/ry-cli/src/check.rs
@@ -70,6 +70,19 @@ pub fn check_project(input: CheckInput) -> CheckOutput {
 pub fn check_project_with_scope_capture(
     input: CheckInput,
 ) -> Vec<(String, Vec<ry_checker::ScopeRecord>)> {
+    check_project_with_facts_capture(input, false).scopes
+}
+
+pub(crate) struct CapturedFacts {
+    pub scopes: Vec<(String, Vec<ry_checker::ScopeRecord>)>,
+    pub references: Vec<(String, ry_checker::ReferenceFacts)>,
+}
+
+/// Capture scope snapshots and optional reference evidence in one project check.
+pub(crate) fn check_project_with_facts_capture(
+    input: CheckInput,
+    references: bool,
+) -> CapturedFacts {
     let mut project = apply_workspace(
         ry_checker::Project::new(),
         input.workspace.as_ref(),
@@ -79,8 +92,14 @@ pub fn check_project_with_scope_capture(
         project.add_file_arc(path.clone(), Arc::clone(file));
     }
     project.enable_scope_capture();
+    if references {
+        project.enable_reference_capture();
+    }
     project.check();
-    project.take_scope_records()
+    CapturedFacts {
+        scopes: project.take_scope_records(),
+        references: project.take_reference_facts(),
+    }
 }
 
 /// Install the workspace metadata onto a fresh project. Shared by

--- a/crates/ry-cli/src/facts.rs
+++ b/crates/ry-cli/src/facts.rs
@@ -202,10 +202,46 @@ fn export_scopes(file: &SourceFile, mut records: Vec<ScopeRecord>) -> Vec<Value>
     scopes
 }
 
+fn export_references(file: &SourceFile, facts: ry_checker::ReferenceFacts) -> (Value, Value) {
+    use ry_checker::{ReferenceDefinitionKind, ReferenceResolution};
+    let definitions: Vec<_> = facts
+        .definitions
+        .into_iter()
+        .map(|definition| {
+            json!({
+                "id": definition.id.0,
+                "name": definition.name,
+                "kind": match definition.kind {
+                    ReferenceDefinitionKind::Assignment => "assignment",
+                    ReferenceDefinitionKind::Formal => "formal",
+                },
+                "scope_span": source_span(&file.source, definition.scope_span),
+                "span": source_span(&file.source, definition.span),
+            })
+        })
+        .collect();
+    let references: Vec<_> = facts.references.into_iter().map(|reference| json!({
+        "name": reference.name,
+        "span": source_span(&file.source, reference.span),
+        "snapshot_kind": "reference",
+        "resolution_status": match reference.resolution {
+            ReferenceResolution::Resolved => "resolved",
+            ReferenceResolution::Ambiguous => "ambiguous",
+            ReferenceResolution::Unresolved => "unresolved",
+            ReferenceResolution::Unsupported => "unsupported",
+        },
+        "definition_id": reference.definition.map(|id| id.0),
+        "type_at_reference": reference.type_at_reference.as_ref().map(facts_types::export_type),
+        "reason": reference.reason,
+    })).collect();
+    (json!(definitions), json!(references))
+}
+
 pub(crate) fn run_dump_facts(
     files: Vec<PathBuf>,
     project_root: Option<PathBuf>,
     format: &str,
+    references: bool,
 ) -> Result<ExitCode> {
     if format != "json" {
         return Err(miette::miette!(
@@ -352,9 +388,9 @@ pub(crate) fn run_dump_facts(
         contexts.push(json!({"id": context_id, "inputs": context}));
         let imported = workspace.imported_bindings.clone();
         let group_files = input.files.clone();
-        let mut captures: HashMap<_, _> = check::check_project_with_scope_capture(input)
-            .into_iter()
-            .collect();
+        let facts = check::check_project_with_facts_capture(input, references);
+        let mut captures: HashMap<_, _> = facts.scopes.into_iter().collect();
+        let mut reference_captures: HashMap<_, _> = facts.references.into_iter().collect();
         for (path, file) in group_files {
             if builtin_environments[sources[&path]["path"].as_str().expect("canonical path")]
                 != ry_checker::builtin_environment_bindings(&path)
@@ -364,19 +400,26 @@ pub(crate) fn run_dump_facts(
                 ));
             }
             let records = captures.remove(&path).unwrap_or_default();
-            exported.push(json!({
+            let mut exported_file = json!({
                 "path": sources[&path]["path"],
                 "source_hash": sources[&path]["source_hash"],
                 "context_id": context_id,
                 "scopes": export_scopes(&file, records),
                 "imports": imported.get(&path).map(|imports| imports.iter().collect::<BTreeMap<_,_>>()).unwrap_or_default(),
-            }));
+            });
+            if references {
+                let facts = reference_captures.remove(&path).unwrap_or_default();
+                let (definitions, records) = export_references(&file, facts);
+                exported_file["definitions"] = definitions;
+                exported_file["references"] = records;
+            }
+            exported.push(exported_file);
         }
     }
     exported.sort_by(|a, b| a["path"].as_str().cmp(&b["path"].as_str()));
     contexts.sort_by(|a, b| a["id"].as_str().cmp(&b["id"].as_str()));
     truncations.sort_by_key(Value::to_string);
-    let result = json!({
+    let mut result = json!({
         "schema_version": 1,
         "producer": build,
         "snapshot_kind": "scope_exit",
@@ -386,6 +429,19 @@ pub(crate) fn run_dump_facts(
         "discovery": {"complete": truncations.is_empty(), "truncations": truncations},
         "files": exported,
     });
+    if references {
+        result["schema_version"] = json!(2);
+        result
+            .as_object_mut()
+            .expect("facts object")
+            .remove("snapshot_kind");
+        result["scope_snapshot_kind"] = json!("scope_exit");
+        result["capabilities"] = json!({
+            "scope_snapshots": true,
+            "reference_facts": "same_file_straight_line",
+            "reference_coverage": "partial",
+        });
+    }
     println!(
         "{}",
         serde_json::to_string_pretty(&result).into_diagnostic()?

--- a/crates/ry-cli/src/main.rs
+++ b/crates/ry-cli/src/main.rs
@@ -195,7 +195,7 @@ enum Cmd {
         #[arg(long = "position", value_name = "LINE:COL", value_parser = dump::parse_dump_position)]
         positions: Vec<(usize, usize)>,
     },
-    /// Export versioned structured facts at scope exit, as JSON.
+    /// Export versioned structured analysis facts as JSON.
     DumpFacts {
         /// R files or directories to analyze.
         #[arg(required = true)]
@@ -206,6 +206,9 @@ enum Cmd {
         /// Output format. Only `json` is supported.
         #[arg(long, value_name = "FORMAT", default_value = "json")]
         format: String,
+        /// Include conservative reference facts using schema version 2.
+        #[arg(long)]
+        references: bool,
     },
     /// Start the language server. Speaks the Language Server Protocol
     /// (LSP) over stdio, publishing type-check diagnostics for open R
@@ -310,7 +313,8 @@ fn main() -> Result<ExitCode> {
             files,
             project_root,
             format,
-        } => facts::run_dump_facts(files, project_root, &format),
+            references,
+        } => facts::run_dump_facts(files, project_root, &format, references),
         Cmd::Server { log_level } => {
             // The LSP server reads JSON-RPC from stdin and writes
             // JSON-RPC to stdout. CRITICAL: any tracing or log output

--- a/crates/ry-cli/tests/facts_references.rs
+++ b/crates/ry-cli/tests/facts_references.rs
@@ -1,0 +1,312 @@
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::Path;
+use std::process::{Command, Output};
+
+use serde_json::{Value, json};
+
+fn invoke(directory: &Path, references: bool) -> Output {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_ry"));
+    command
+        .current_dir(directory)
+        .args(["dump-facts", "case.R"]);
+    if references {
+        command.arg("--references");
+    }
+    command.output().unwrap()
+}
+
+fn parse(output: &Output) -> Value {
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    serde_json::from_slice(&output.stdout).unwrap()
+}
+
+fn analyze(source: &str) -> Value {
+    let directory = tempfile::tempdir().unwrap();
+    fs::write(directory.path().join("case.R"), source).unwrap();
+    parse(&invoke(directory.path(), true))
+}
+
+fn reference_at(output: &Value, source: &str, fragment: &str, token: &str) -> Value {
+    let fragment_start = source.find(fragment).unwrap();
+    let token_start = fragment_start + fragment.find(token).unwrap();
+    let expected = json!([token_start, token_start + token.len()]);
+    let matching: Vec<_> = output["files"][0]["references"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter(|reference| reference["span"]["bytes"] == expected)
+        .collect();
+    assert_eq!(
+        matching.len(),
+        1,
+        "expected one reference to {token} in {fragment}: {output}"
+    );
+    matching[0].clone()
+}
+
+fn definition<'a>(output: &'a Value, reference: &Value) -> &'a Value {
+    let id = reference["definition_id"]
+        .as_u64()
+        .expect("resolved definition ID");
+    output["files"][0]["definitions"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|definition| definition["id"] == id)
+        .unwrap()
+}
+
+fn assert_uncertain(reference: &Value) {
+    assert!(
+        matches!(
+            reference["resolution_status"].as_str(),
+            Some("unsupported" | "unresolved" | "ambiguous")
+        ),
+        "{reference}"
+    );
+    assert!(reference["definition_id"].is_null(), "{reference}");
+    assert!(reference["type_at_reference"].is_null(), "{reference}");
+    assert!(
+        reference["reason"]
+            .as_str()
+            .is_some_and(|reason| !reason.is_empty()),
+        "{reference}"
+    );
+}
+
+#[test]
+fn literal_copy_resolves_to_source_definition_with_reference_type() {
+    let source = "x <- 1L\ny <- x\nz <- y\n";
+    let output = analyze(source);
+    assert_eq!(output["schema_version"], 2);
+    assert_eq!(output["scope_snapshot_kind"], "scope_exit");
+    assert!(output.get("snapshot_kind").is_none());
+    assert_eq!(output["capabilities"]["reference_coverage"], "partial");
+    for (fragment, name, definition_start) in [("y <- x", "x", 0), ("z <- y", "y", 8)] {
+        let reference = reference_at(&output, source, fragment, name);
+        assert_eq!(reference["snapshot_kind"], "reference");
+        assert_eq!(reference["resolution_status"], "resolved");
+        assert_eq!(reference["type_at_reference"]["mode"], "integer");
+        let definition = definition(&output, &reference);
+        assert_eq!(definition["name"], name);
+        assert_eq!(definition["kind"], "assignment");
+        assert_eq!(
+            definition["span"]["bytes"],
+            json!([definition_start, definition_start + 1])
+        );
+    }
+}
+
+#[test]
+fn later_reassignment_never_lends_its_final_type_to_an_earlier_read() {
+    let source = "x <- 1L\ny <- x\nx <- \"later\"\n";
+    let output = analyze(source);
+    assert_uncertain(&reference_at(&output, source, "y <- x", "x"));
+    let top = output["files"][0]["scopes"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|scope| scope["kind"] == "top")
+        .unwrap();
+    let final_x = top["bindings"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|binding| binding["name"] == "x")
+        .unwrap();
+    assert_eq!(final_x["type"]["mode"], "character");
+    assert_eq!(top["snapshot_kind"], "scope_exit");
+}
+
+#[test]
+fn own_formals_resolve_unknown_but_default_derived_copies_fail_closed() {
+    let source = "x <- 1L\nf <- function(x = 1L) {\n  copy <- x\n  copy\n}\n";
+    let output = analyze(source);
+    let formal_read = reference_at(&output, source, "copy <- x", "x");
+    assert_eq!(formal_read["resolution_status"], "resolved");
+    assert_eq!(formal_read["type_at_reference"]["mode"], "opaque");
+    let formal = definition(&output, &formal_read);
+    assert_eq!(formal["kind"], "formal");
+    let formal_start = source.find("x = 1L").unwrap();
+    assert_eq!(
+        formal["span"]["bytes"],
+        json!([formal_start, formal_start + 1])
+    );
+    let copied_read = reference_at(&output, source, "  copy\n}", "copy");
+    assert_uncertain(&copied_read);
+}
+
+#[test]
+fn function_locals_are_supported_but_outer_captures_and_early_reads_are_not() {
+    let source = "outer <- 1L\nf <- function() {\n  local <- 1L\n  copy <- local\n  outer\n}\n";
+    let output = analyze(source);
+    let local = reference_at(&output, source, "copy <- local", "local");
+    assert_eq!(local["resolution_status"], "resolved");
+    assert_eq!(local["type_at_reference"]["mode"], "integer");
+    assert_uncertain(&reference_at(&output, source, "  outer\n}", "outer"));
+
+    // R may resolve the first x to the outer value; the later local x does not
+    // identify that read even though it is the only assignment in this body.
+    let source = "x <- \"outer\"\nf <- function() {\n  copy <- x\n  x <- 1L\n  copy\n}\n";
+    let output = analyze(source);
+    assert_uncertain(&reference_at(&output, source, "copy <- x", "x"));
+    let source = "copy <- missing\nmissing <- 1L\n";
+    let output = analyze(source);
+    assert_uncertain(&reference_at(&output, source, "copy <- missing", "missing"));
+}
+
+#[test]
+fn dynamic_import_control_flow_and_ordinary_calls_fail_closed() {
+    for source in [
+        "x <- 1L\nassign(\"x\", \"later\")\ny <- x\n",
+        "x <- 1L\nlibrary(stats)\ny <- x\n",
+        "x <- 1L\nif (flag) x <- \"later\"\ny <- x\n",
+        "x <- 1L\nbase::identity(1L)\ny <- x\n",
+        "x <- 1L\ny <- x + 1L\n",
+    ] {
+        let output = analyze(source);
+        assert_uncertain(&reference_at(&output, source, "y <- x", "x"));
+    }
+}
+
+#[test]
+fn unsafe_wrappers_do_not_make_nested_function_reads_look_lexical() {
+    for source in [
+        "quoted <- quote(function(x) x)\n",
+        "masked <- with(data, function(x) x)\n",
+        "piped <- data |> identity(function(x) x)\n",
+        "wrapped <- identity(function(x) x)\n",
+    ] {
+        let output = analyze(source);
+        assert_uncertain(&reference_at(&output, source, " x)", "x"));
+    }
+}
+
+#[test]
+fn utf8_backticks_tabs_and_crlf_have_exact_nonduplicated_reference_spans() {
+    let source =
+        "`空 白` <- 1L\r\n結果 <- `空 白`\r\nf <- function(λ) {\r\n\tcopy <- λ\r\n\tcopy\r\n}\r\n";
+    let output = analyze(source);
+    let quoted = reference_at(&output, source, "結果 <- `空 白`", "`空 白`");
+    assert_eq!(quoted["name"], "`空 白`");
+    assert_eq!(quoted["resolution_status"], "resolved");
+    let formal = reference_at(&output, source, "copy <- λ", "λ");
+    assert_eq!(formal["resolution_status"], "resolved");
+    assert_eq!(formal["span"]["start"], json!([4, 10]));
+    let references = output["files"][0]["references"].as_array().unwrap();
+    let mut seen = BTreeSet::new();
+    for reference in references {
+        let range = reference["span"]["bytes"].as_array().unwrap();
+        let start = range[0].as_u64().unwrap() as usize;
+        let end = range[1].as_u64().unwrap() as usize;
+        assert!(
+            seen.insert((start, end)),
+            "duplicate reference: {reference}"
+        );
+        let token = &source[start..end];
+        let name = reference["name"].as_str().unwrap();
+        assert!(token == name || token == format!("`{name}`"));
+    }
+}
+
+#[test]
+fn reference_capture_is_deterministic_opt_in_and_does_not_execute_source() {
+    let directory = tempfile::tempdir().unwrap();
+    fs::write(
+        directory.path().join("case.R"),
+        "x <- 1L\ny <- x\nf <- function(arg = 1L) { copy <- arg; copy }\n",
+    )
+    .unwrap();
+    let legacy_before = invoke(directory.path(), false);
+    let first = invoke(directory.path(), true);
+    let second = invoke(directory.path(), true);
+    let legacy_after = invoke(directory.path(), false);
+    let legacy = parse(&legacy_before);
+    let current = parse(&first);
+    parse(&second);
+    parse(&legacy_after);
+    assert_eq!(first.stdout, second.stdout);
+    assert_eq!(legacy_before.stdout, legacy_after.stdout);
+    assert_eq!(legacy["schema_version"], 1);
+    assert!(legacy["files"][0].get("references").is_none());
+    assert!(legacy["files"][0].get("definitions").is_none());
+    assert_eq!(legacy["files"][0]["scopes"], current["files"][0]["scopes"]);
+    let references = current["files"][0]["references"].as_array().unwrap();
+    let spans: BTreeSet<_> = references
+        .iter()
+        .map(|reference| reference["span"]["bytes"].to_string())
+        .collect();
+    assert_eq!(
+        spans.len(),
+        references.len(),
+        "inference revisits duplicated reference records"
+    );
+
+    fs::write(
+        directory.path().join("case.R"),
+        "writeLines(\"executed\", \"execution-marker\")\nx <- 1L\ny <- x\n",
+    )
+    .unwrap();
+    parse(&invoke(directory.path(), true));
+    assert!(!directory.path().join("execution-marker").exists());
+}
+
+#[test]
+fn forcing_a_default_can_change_a_previous_local_binding() {
+    let source =
+        "f <- function(p = { x <- \"changed\"; 1L }) {\n  x <- 1L\n  y <- p\n  z <- x\n}\n";
+    let output = analyze(source);
+    assert_uncertain(&reference_at(&output, source, "z <- x", "x"));
+
+    let source = "f <- function(p) { x <- 1L; y <- p; z <- x }\n";
+    let output = analyze(source);
+    let formal = reference_at(&output, source, "y <- p", "p");
+    assert_eq!(formal["resolution_status"], "resolved");
+    assert_eq!(formal["type_at_reference"]["mode"], "opaque");
+    assert_uncertain(&reference_at(&output, source, "z <- x", "x"));
+
+    // The promise can install an active binding before the literal assignment,
+    // so a fresh assignment cannot restore ordinary-binding certainty.
+    let source = "f <- function(p) { y <- p; x <- 1L; z <- x }\n";
+    let output = analyze(source);
+    assert_uncertain(&reference_at(&output, source, "z <- x", "x"));
+}
+
+#[test]
+fn nonlocal_and_special_assignment_operators_do_not_define_ordinary_locals() {
+    for source in [
+        "f <- function() { 1L ->> x; y <- x }\n",
+        "f <- function() { x <<- 1L; y <- x }\n",
+        "x := 1L\ny <- x\n",
+    ] {
+        let output = analyze(source);
+        assert_uncertain(&reference_at(&output, source, "y <- x", "x"));
+    }
+}
+
+#[test]
+fn unsupported_outer_reads_cannot_preserve_later_local_type_certainty() {
+    // An outer active-binding getter can mutate the current frame while read.
+    let source = "f <- function() { local <- 1L; copy <- outer; result <- local }\n";
+    let output = analyze(source);
+    assert_uncertain(&reference_at(&output, source, "copy <- outer", "outer"));
+    assert_uncertain(&reference_at(&output, source, "result <- local", "local"));
+}
+
+#[test]
+fn equivalent_identifier_spellings_and_syntax_rebinding_fail_closed() {
+    for source in [
+        "x <- 1L\n`x` <- \"later\"\ny <- x\n",
+        "x <- 1L\n`\\x78` <- \"later\"\ny <- x\n",
+        "x <- 1L\nbase::x <- 2L\ny <- x\n",
+        "`<-` <- function(...) NULL\nx <- 1L\ny <- x\n",
+    ] {
+        let output = analyze(source);
+        assert_uncertain(&reference_at(&output, source, "y <- x", "x"));
+    }
+}

--- a/docs/facts.md
+++ b/docs/facts.md
@@ -19,7 +19,8 @@ first input anchors `ry.toml` discovery, as it does for `dump-types`.
 
 Every exported scope and binding has `snapshot_kind: "scope_exit"`. Types
 describe the state at the end of the recorded scope body. There is no
-`--position` option and no type-at-reference or resolved-symbol contract.
+`--position` option. Schema 1 has no type-at-reference or resolved-symbol
+contract. Add `--references` for the bounded reference facts in schema 2.
 
 For example:
 
@@ -40,6 +41,84 @@ Anonymous function arguments are usually analyzed without recording their
 scopes. Named functions inside those arguments can still have records. A
 missing record means that ry did not export that fact; it does not prove that
 a scope or binding does not exist.
+
+## Reference facts (schema version 2)
+
+```sh
+ry dump-facts R/ --references > facts.json
+```
+
+`--references` selects schema 2. Without this flag, `dump-facts` emits schema 1.
+`dump-types` keeps its own output format. Reference capture runs alongside
+scope capture in the same project check, without changing diagnostic inference.
+
+Schema 2 keeps the scope and binding snapshots below. At the root it replaces
+`snapshot_kind` with `scope_snapshot_kind: "scope_exit"` and adds:
+
+```json
+"capabilities": {
+  "scope_snapshots": true,
+  "reference_facts": "same_file_straight_line",
+  "reference_coverage": "partial"
+}
+```
+
+Each file also has `definitions` and `references`. A definition contains `id`,
+`name`, `kind` (`"assignment"` or `"formal"`), `span`, and `scope_span`.
+The span identifies the source definition; the scope span identifies its
+lexical scope. Reference and definition names retain the checker's raw
+spelling, including backticks; these are not canonical R symbol names.
+Use the reference-to-definition ID for identity, not a join by name.
+IDs are local to this file and analysis snapshot. Join them
+only within the same file, source hash, and context ID. Unchanged inputs
+produce deterministic output. IDs carry no identity outside that snapshot;
+do not reuse them after its source hash or context ID changes.
+
+Each reference contains:
+
+| Field | Meaning |
+| --- | --- |
+| `name`, `span` | The read name and its source token. |
+| `snapshot_kind` | `"reference"`; evidence at this read, not scope exit. |
+| `resolution_status` | `"resolved"`, `"ambiguous"`, `"unresolved"`, or `"unsupported"`. |
+| `definition_id` | An ID in this file's `definitions`, or `null`. |
+| `type_at_reference` | A structured type, or `null` when resolution is not established. |
+| `reason` | The checker's explanation for missing evidence, or `null`. |
+
+The checker supports a conservative subset of straight-line, same-file code:
+literal assignments, copies of established bindings, and a function's own
+formals and locals. A copy gets its own definition ID and carries the source
+binding's established type. A formal has unknown type even when it has a
+default. R callers can supply a different value. Reading a formal can force
+caller or default code that changes the frame. After that read, the checker
+discards binding identities for the rest of the scope, including nested
+functions analyzed from it. A fresh assignment cannot restore that evidence.
+The formal read itself may resolve with unknown type, but a copy made from
+that read and later reads remain unsupported. Reads without an established
+own-scope assignment value, including outer, external, and unresolved names,
+apply the same barrier.
+
+For example, in `x <- 1L; y <- x; y`, the read of `x` resolves to its assignment
+with integer type. The read of `y` resolves to the copy assignment with the
+same type.
+
+The supported subset assumes ordinary initial bindings. It does not certify
+behavior under arbitrary ambient active bindings. Consistently spelled
+backtick names without escapes are supported. Unquoted namespace-qualified
+names, dots arguments, escaped names, syntax-primitive names, and reassignment
+through equivalent plain/backtick spellings are excluded. A differently
+spelled read cannot resolve by matching a decoded name.
+
+Eligibility applies to a whole lexical scope. Calls, operators, indexing,
+control flow, nonstandard evaluation, or reassignment anywhere in that scope
+make its references unsupported, including reads before that operation. Nested
+functions inherit this restriction. Default expressions and reads captured
+from enclosing scopes are unsupported. Unresolved, ambiguous, and
+unsupported records have no definition ID or type. A missing record is also
+unavailable evidence: the export does not promise to enumerate every possible
+runtime read. Check the status of each record. A concrete scope-exit type
+cannot fill a gap in reference evidence, and a resolved reference alone does
+not establish that a rename or other edit is safe.
 
 ## Schema version 1
 
@@ -183,14 +262,15 @@ A source-backed span has this shape:
 `bytes` is a zero-based, half-open UTF-8 byte range. Slice the original source
 as `source[start_byte:end_byte]` after checking its hash. Declaration spans
 cover the raw source token: a backtick-quoted name includes its backticks,
-while the binding's `name` contains the decoded name. `start` and `end`
+while `name` retains the checker's spelling. `start` and `end`
 are one-based `[line, column]` pairs. Columns count Unicode scalar values;
 a tab counts as one character, not a display-width expansion. Lines advance
 at LF, so CRLF bytes remain part of the source and byte ranges.
 
 Function scope spans cover the function literal when the original AST has
 that site. The top-level span covers the file. A scope synthesized during
-analysis can have `span: null`. No span establishes a resolved symbol identity.
+analysis can have `span: null`. A span alone establishes no resolved symbol
+identity; schema 2 uses explicit reference-to-definition IDs for that evidence.
 
 ### Cache identities and ordering
 
@@ -219,7 +299,9 @@ that remain stable when a project moves. These hashes describe the resolved
 inputs for this run; they are not a filesystem watcher or a promise that R's
 runtime environment matches the static model.
 
-Files sort by canonical path; contexts by ID; scopes by byte start, byte end,
+Reference records sort by byte start and end. Definitions retain the checker's
+deterministic declaration order. Files sort by canonical path; contexts by ID;
+scopes by byte start, byte end,
 then kind; bindings by name. JSON object keys sort lexically. Union alternatives
 sort by their compact structured JSON. Class names, columns, and parameter
 types retain their meaningful order. No timestamps appear in the output.

--- a/docs/facts.md
+++ b/docs/facts.md
@@ -299,9 +299,9 @@ that remain stable when a project moves. These hashes describe the resolved
 inputs for this run; they are not a filesystem watcher or a promise that R's
 runtime environment matches the static model.
 
-Reference records sort by byte start and end. Definitions retain the checker's
-deterministic declaration order. Files sort by canonical path; contexts by ID;
-scopes by byte start, byte end,
+References and definitions sort by byte start and end. Definition IDs retain
+the checker's allocation order, so IDs need not increase through the array.
+Files sort by canonical path; contexts by ID; scopes by byte start, byte end,
 then kind; bindings by name. JSON object keys sort lexically. Union alternatives
 sort by their compact structured JSON. Class names, columns, and parameter
 types retain their meaningful order. No timestamps appear in the output.


### PR DESCRIPTION
Completes the initial reference-facts phase of #233 with `ry dump-facts --references`. This opt-in output uses schema 2; default schema 1 and `dump-types` stay compatible.

For `x <- 1L; y <- x`, the reference to `x` carries integer type and the ID of its actual assignment. Later reassignment makes the scope unsupported instead of lending the reference its scope-exit type. Definition IDs come from checker writes and references from the existing identifier lookup; the exporter does no name resolution.

The supported subset is deliberately small: ordinary same-file literal assignments, local copies, and own-formal identity with unknown type. Calls, operators, control flow, reassignment, and captured outer bindings remain unsupported. Reading a formal or untracked binding permanently invalidates later evidence in that scope, since a promise or active binding can change it. Schema 2 documents these limits and keeps reference facts separate from scope-exit snapshots.

Validation:

- 1,106 workspace tests, including 11 checker capture tests and 12 CLI reference test groups.
- Strict Clippy, formatting, and all 17 R oracle tests.
- Direct R checks for promise effects, active bindings, equivalent identifier spellings, and assignment syntax.
- Tests for deterministic output, exact Unicode spans, compatibility, cache refresh, conflicting observations, and no execution of analyzed source.

- Capture-disabled benchmarks across ten controls found no consistent material regression. Reversing run order reduced one initial 3.5% shift to below 1%.

Fixes #233.

Combined validation with #241: 1,107 workspace tests, all 17 R oracle tests, strict Clippy, and formatting pass in an isolated build directory.
