### PR TITLE
ci: track core performance and extension activation

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -70,7 +70,8 @@ jobs:
           with open(os.environ['GITHUB_STEP_SUMMARY'], 'a') as summary:
               summary.write('## Performance measurements\n\n| Metric | Value | Unit |\n|---|---:|---|\n')
               for row in data:
-                  summary.write(f"| {row['name']} | {row['value']:.2f} | {row['unit']} |\n")
+                  value = f"{row['value']:,d}" if row['unit'] == 'bytes' else f"{row['value']:.2f}"
+                  summary.write(f"| {row['name']} | {value} | {row['unit']} |\n")
           PY
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -1,0 +1,159 @@
+name: Performance
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  measure:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    env:
+      CARGO_TERM_COLOR: never
+      RAYON_NUM_THREADS: '2'
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87 # stable
+        with:
+          targets: wasm32-wasip2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
+        with:
+          shared-key: performance
+          workspaces: |
+            . -> target
+            editors/zed -> target
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+      - name: Benchmark core
+        run: |
+          rm -rf target/criterion
+          cargo bench --locked -p ry-checker --bench performance -- --noplot
+      - name: Build CLI and Zed extension
+        run: |
+          cargo build --locked --release -p ry-cli
+          cargo build --locked --release --manifest-path editors/zed/Cargo.toml --target wasm32-wasip2
+      - name: Package VS Code extension without bundled server
+        working-directory: editors/code
+        run: |
+          bun install --frozen-lockfile
+          bun run vsce-package
+      - name: Measure VS Code activation and first diagnostic
+        working-directory: editors/code
+        run: |
+          mkdir -p ../../performance-results
+          xvfb-run -a node test/performance.cjs ../../performance-results/activation.json
+      - name: Collect measurements
+        run: |
+          mkdir -p performance-results
+          python3 scripts/performance/collect.py --activation performance-results/activation.json --output performance-results/results.json
+          {
+            rustc -Vv
+            bun --version
+            uname -a
+            lscpu
+            echo 'RAYON_NUM_THREADS=2'
+          } > performance-results/environment.txt
+          python3 - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+          data = json.loads(Path('performance-results/results.json').read_text())
+          with open(os.environ['GITHUB_STEP_SUMMARY'], 'a') as summary:
+              summary.write('## Performance measurements\n\n| Metric | Value | Unit |\n|---|---:|---|\n')
+              for row in data:
+                  summary.write(f"| {row['name']} | {row['value']:.2f} | {row['unit']} |\n")
+          PY
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: performance-results
+          path: performance-results/
+          if-no-files-found: error
+          retention-days: 14
+
+  report:
+    needs: measure
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    # Only pinned actions and inline reporting commands run with this token.
+    # Builds and dependency installation run in the read-only measure job.
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: performance-results
+          path: ${{ runner.temp }}/performance-results
+      - name: Prepare text-only history branch
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          # ls-remote exits 2 only when the branch does not exist. Network
+          # or authentication errors must fail instead of resetting history.
+          gh auth setup-git
+          status=0
+          git ls-remote --exit-code origin refs/heads/performance-data || status=$?
+          if [ "$status" = 0 ]; then
+            git fetch origin performance-data:performance-data
+          elif [ "$status" = 2 ]; then
+            source_revision=$(git rev-parse HEAD)
+            git switch --orphan performance-data
+            git commit --allow-empty -m 'Initialize performance history'
+            git checkout --detach "$source_revision"
+          else
+            exit "$status"
+          fi
+      - name: Compare measurements and update main history
+        uses: benchmark-action/github-action-benchmark@a7bc2366eda11037936ea57d811a43b3418d3073 # v1.21.0
+        with:
+          name: ry performance
+          tool: customSmallerIsBetter
+          output-file-path: ${{ runner.temp }}/performance-results/results.json
+          gh-pages-branch: performance-data
+          benchmark-data-dir-path: benchmarks
+          skip-fetch-gh-pages: true
+          github-token: ${{ github.token }}
+          auto-push: ${{ github.ref == 'refs/heads/main' }}
+          summary-always: true
+          comment-on-alert: false
+          alert-threshold: '120%'
+          fail-on-alert: false
+          max-items-in-chart: 365
+      - name: Export dashboard
+        if: github.ref == 'refs/heads/main'
+        run: |
+          mkdir -p "$RUNNER_TEMP/performance-site"
+          git archive performance-data benchmarks | tar -x -C "$RUNNER_TEMP/performance-site"
+      - uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4
+        if: github.ref == 'refs/heads/main' && vars.BENCHMARK_PAGES == 'true'
+        with:
+          path: ${{ runner.temp }}/performance-site
+
+  deploy:
+    needs: report
+    if: github.ref == 'refs/heads/main' && vars.BENCHMARK_PAGES == 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}benchmarks/
+    steps:
+      - name: Deploy dashboard
+        id: deployment
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,6 +31,8 @@ packages, or daemon state into later fixtures.
 The [instruction-count corpus guide](docs/corpus/instructions.md) explains
 the fixed performance sample, local measurements, and warn-only CI deltas.
 Run `python3 ecosystem/test-instructions.py` after changing that harness.
+The [performance tracking guide](docs/performance.md) covers core timings,
+extension activation, package sizes, and the historical dashboard.
 
 ## Fixture conventions
 

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -24,7 +24,7 @@ against the latest recorded `main` result. The first run establishes a baseline.
 A slowdown or size increase above 20% is advisory; it does not fail the workflow.
 The existing performance budget and scaling tests in `CI` remain enforced.
 
-Only runs on `main` push history to the separate `performance-data` branch.
+Runs on `main` write history to the separate `performance-data` branch.
 Manual runs on other branches compare without publishing history. The workflow
 does not post comments. The history contains numeric measurements and
 commit metadata in `benchmarks/data.js`, plus a static chart page. No executables,

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -1,0 +1,86 @@
+# Performance tracking
+
+The `Performance` workflow runs on pushes to `main` and manual requests. The full
+suite does not run on PR pushes; existing CI budget tests provide the cheaper
+PR checks. It measures:
+
+- Core parsing, checking, branch handling, and incremental edits with the existing
+  `ry-checker` Criterion suite. Reports use mean time in nanoseconds and include
+  the confidence interval.
+- Release CLI executable size.
+- VS Code activation and activation-to-first-diagnostic latency, plus
+  JavaScript bundle size and VSIX size without the bundled server.
+- Release Zed WASM size.
+
+Extension sizes measure distribution cost. Zed runtime latency and memory use
+are not measured. The incremental core benchmarks model part of the
+LSP workload but do not exercise an editor or the JSON-RPC transport.
+
+## Reading results
+
+Each run writes a measurement table to its GitHub Actions summary and uploads
+`results.json` and `environment.txt` as a 14-day artifact. The report job compares
+against the latest recorded `main` result. The first run establishes a baseline.
+A slowdown or size increase above 20% is advisory; it does not fail the workflow.
+The existing performance budget and scaling tests in `CI` remain enforced.
+
+Only runs on `main` push history to the separate `performance-data` branch.
+Manual runs on other branches compare without publishing history. The workflow
+does not post comments. The history contains numeric measurements and
+commit metadata in `benchmarks/data.js`, plus a static chart page. No executables,
+VSIX packages, WASM files, or Criterion sample files enter git history.
+The chart retains the latest 365 runs; older revisions remain in the history
+branch as small text diffs.
+
+The workflow uses Ubuntu 24.04 and two Rayon workers. Rust stable, the runner
+image, and other tools can change over time; the environment artifact records
+Rust, Bun, and CPU details. Hosted runner noise and toolchain changes can affect
+results. Confirm a suspected regression with repeated measurements on the same
+machine before treating it as a code regression. Changes to benchmark fixtures
+also change the workload and require care when comparing results.
+
+## Enable the public dashboard
+
+1. In repository **Settings → Pages**, select **GitHub Actions** as the source.
+2. Add the repository Actions variable `BENCHMARK_PAGES` with value `true`.
+3. Run `Performance` on `main`, or push a change to `main`.
+
+The dashboard will be at `https://sims1253.github.io/ry/benchmarks/`.
+History and run summaries work before Pages is enabled. The deployment publishes
+the performance site as the repository's Pages site; coordinate this setting if
+another workflow already owns that site. No personal access token is needed.
+
+Charts and comparisons use
+[github-action-benchmark](https://github.com/benchmark-action/github-action-benchmark),
+pinned to a release commit in the workflow.
+
+## VS Code activation
+
+The benchmark starts five fresh VS Code 1.90.2 extension hosts with separate
+profiles and empty workspaces. This fixed version matches the extension's
+minimum supported editor series. It explicitly activates the compiled extension
+and records the median time, with the minimum and maximum as the range.
+Each host uses the locally built release server through `ry.path`.
+
+Activation ends before the extension's deferred server startup. A second metric
+therefore measures from activation start until the server reports `RY040` for
+`x <- 1 + "a"`. A missing diagnostic fails the benchmark. This includes binary
+resolution, server startup, document opening, and the first check. Editor launch
+and downloading VS Code are outside both timers. These are fresh-process
+measurements with potentially warm OS caches, not cold-disk startup timings.
+
+## Run locally
+
+```sh
+RAYON_NUM_THREADS=2 cargo bench --locked -p ry-checker --bench performance -- --noplot
+cargo build --locked --release -p ry-cli
+rustup target add wasm32-wasip2
+cargo build --locked --release --manifest-path editors/zed/Cargo.toml --target wasm32-wasip2
+(cd editors/code && bun install --frozen-lockfile && bun run vsce-package)
+(cd editors/code && xvfb-run -a node test/performance.cjs /tmp/ry-activation.json)
+python3 scripts/performance/collect.py --activation /tmp/ry-activation.json --output /tmp/ry-performance.json
+```
+
+Use a clean checkout without `editors/code/bundled/bin/ry` when measuring the VSIX
+without a server. Remove `target/criterion` before running a changed benchmark
+suite so deleted benchmarks do not remain in the local report.

--- a/editors/code/test/performance.cjs
+++ b/editors/code/test/performance.cjs
@@ -1,0 +1,131 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { performance } = require("node:perf_hooks");
+
+// Invoked inside a fresh extension host by @vscode/test-electron.
+exports.run = async () => {
+  const vscode = require("vscode");
+  const extension = vscode.extensions.getExtension("sims1253.ry");
+  assert.ok(extension, "ry extension is available");
+  assert.equal(extension.isActive, false, "ry must not activate before timing");
+  assert.equal(vscode.workspace.isTrusted, true);
+
+  const start = performance.now();
+  await extension.activate();
+  const activation = performance.now() - start;
+
+  // activate() schedules server startup, so also measure useful readiness.
+  // A real diagnostic ensures a failed server cannot look like a speedup.
+  const uri = vscode.Uri.joinPath(
+    vscode.workspace.workspaceFolders[0].uri,
+    "activation.R",
+  );
+  let subscription;
+  let timer;
+  const diagnostic = new Promise((resolve, reject) => {
+    subscription = vscode.languages.onDidChangeDiagnostics(() => {
+      if (
+        vscode.languages
+          .getDiagnostics(uri)
+          .some((item) => String(item.code) === "RY040")
+      ) {
+        resolve(performance.now() - start);
+      }
+    });
+    timer = setTimeout(
+      () => reject(new Error("No RY040 diagnostic within 30 seconds")),
+      30000,
+    );
+  });
+  // Attach the rejection handler before opening the document.
+  const ready = (async () => {
+    try {
+      await vscode.workspace.fs.writeFile(uri, Buffer.from('x <- 1 + "a"\n'));
+      const document = await vscode.workspace.openTextDocument(uri);
+      await vscode.window.showTextDocument(document);
+    } catch (error) {
+      clearTimeout(timer);
+      subscription.dispose();
+      throw error;
+    }
+  })();
+  try {
+    const [firstDiagnostic] = await Promise.all([diagnostic, ready]);
+    fs.writeFileSync(
+      process.env.RY_PERFORMANCE_SAMPLE,
+      JSON.stringify({ activation, firstDiagnostic, vscode: vscode.version }),
+    );
+  } finally {
+    clearTimeout(timer);
+    subscription.dispose();
+  }
+};
+
+async function main() {
+  const { downloadAndUnzipVSCode, runTests } = require("@vscode/test-electron");
+  // Fix the host version so editor upgrades do not silently shift the baseline.
+  const version = "1.90.2";
+  const binary = path.resolve(__dirname, "../../../target/release/ry");
+  assert.ok(fs.existsSync(binary), "build the release ry binary first");
+  const destination = process.argv[2];
+  assert.ok(destination, "pass an output JSON path");
+  const executable = await downloadAndUnzipVSCode(version);
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "ry-performance-"));
+  const samples = [];
+  try {
+    for (let index = 0; index < 5; index++) {
+      const directory = path.join(root, String(index));
+      const workspace = path.join(directory, "workspace");
+      const output = path.join(directory, "sample.json");
+      fs.mkdirSync(path.join(workspace, ".vscode"), { recursive: true });
+      fs.writeFileSync(
+        path.join(workspace, ".vscode/settings.json"),
+        JSON.stringify({ "ry.path": [binary] }),
+      );
+      await runTests({
+        vscodeExecutablePath: executable,
+        extensionDevelopmentPath: path.resolve(__dirname, ".."),
+        extensionTestsPath: __filename,
+        extensionTestsEnv: { RY_PERFORMANCE_SAMPLE: output },
+        launchArgs: [
+          workspace,
+          "--user-data-dir",
+          path.join(directory, "profile"),
+          "--extensions-dir",
+          path.join(directory, "extensions"),
+          "--skip-welcome",
+          "--skip-release-notes",
+          "--no-sandbox",
+          "--disable-gpu",
+          "--disable-updates",
+        ],
+      });
+      samples.push(JSON.parse(fs.readFileSync(output, "utf8")));
+    }
+    const results = [
+      ["vscode/activation", "activation"],
+      ["vscode/activation-to-first-diagnostic", "firstDiagnostic"],
+    ].map(([name, key]) => {
+      const values = samples.map((sample) => sample[key]).sort((a, b) => a - b);
+      assert.ok(values.every((value) => Number.isFinite(value) && value > 0));
+      return {
+        name,
+        unit: "ms",
+        value: values[2],
+        range: `${values[0].toFixed(2)}–${values[4].toFixed(2)}`,
+        extra: `VS Code ${version}; median of 5 fresh hosts; samples: ${values.join(", ")}`,
+      };
+    });
+    fs.writeFileSync(destination, JSON.stringify(results, null, 2) + "\n");
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+}
+
+if (require.main === module)
+  main().catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  });

--- a/scripts/performance/collect.py
+++ b/scripts/performance/collect.py
@@ -1,0 +1,54 @@
+"""Collect Criterion estimates and extension sizes without retaining binaries."""
+
+import argparse
+import json
+import math
+from pathlib import Path
+
+
+def collect(root, activation=None):
+    results = []
+    for estimate in sorted((root / 'target/criterion').glob('**/new/estimates.json')):
+        benchmark = json.loads((estimate.parent / 'benchmark.json').read_text())
+        mean = json.loads(estimate.read_text())['mean']
+        value = mean['point_estimate']
+        if not math.isfinite(value) or value <= 0:
+            raise ValueError(f'Invalid estimate: {estimate}')
+        interval = mean['confidence_interval']
+        results.append({
+            'name': f"core/{benchmark['full_id']}",
+            'unit': 'ns',
+            'value': value,
+            'range': f"{interval['lower_bound']:.2f}–{interval['upper_bound']:.2f}",
+        })
+    if not results:
+        raise ValueError('No Criterion estimates found; run the performance benchmark first')
+    for name, path in [
+        ('cli/executable', 'target/release/ry'),
+        ('vscode/javascript', 'editors/code/dist/extension.js'),
+        ('vscode/vsix-without-server', 'editors/code/ry.vsix'),
+        ('zed/wasm', 'editors/zed/target/wasm32-wasip2/release/zed_ry.wasm'),
+    ]:
+        size = (root / path).stat().st_size
+        if size == 0:
+            raise ValueError(f'Empty artifact: {path}')
+        results.append({'name': name, 'unit': 'bytes', 'value': size})
+    if activation is not None:
+        metrics = json.loads(activation.read_text())
+        expected = {'vscode/activation', 'vscode/activation-to-first-diagnostic'}
+        if len(metrics) != 2 or {row['name'] for row in metrics} != expected:
+            raise ValueError('Missing or duplicate activation metrics')
+        for row in metrics:
+            if row['unit'] != 'ms' or not math.isfinite(row['value']) or row['value'] <= 0:
+                raise ValueError('Invalid activation metric')
+        results.extend(metrics)
+    return results
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--root', type=Path, default=Path('.'))
+    parser.add_argument('--activation', type=Path, required=True)
+    parser.add_argument('--output', type=Path, required=True)
+    args = parser.parse_args()
+    args.output.write_text(json.dumps(collect(args.root, args.activation), indent=2) + '\n')

--- a/scripts/test_performance.py
+++ b/scripts/test_performance.py
@@ -1,0 +1,83 @@
+"""Tests for the compact CI performance report."""
+
+import json
+from pathlib import Path
+import tempfile
+import unittest
+
+from performance.collect import collect
+
+
+class PerformanceReportTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.root = Path(self.temp.name)
+        self.estimate = self.root / 'target/criterion/branch/128/new'
+        self.estimate.mkdir(parents=True)
+        (self.estimate / 'benchmark.json').write_text(json.dumps({'full_id': 'branch/128'}))
+        self.write_estimate(42)
+        for path in (
+            'target/release/ry',
+            'editors/code/dist/extension.js',
+            'editors/code/ry.vsix',
+            'editors/zed/target/wasm32-wasip2/release/zed_ry.wasm',
+        ):
+            artifact = self.root / path
+            artifact.parent.mkdir(parents=True, exist_ok=True)
+            artifact.write_bytes(b'12345')
+
+    def write_estimate(self, value):
+        (self.estimate / 'estimates.json').write_text(json.dumps({
+            'mean': {
+                'point_estimate': value,
+                'confidence_interval': {'lower_bound': 40, 'upper_bound': 44},
+            },
+        }))
+
+    def test_collects_grouped_estimates_and_sizes(self):
+        # Old Criterion baselines must not become additional measurements.
+        old = self.estimate.parent / 'base'
+        old.mkdir()
+        (old / 'estimates.json').write_text('{}')
+        result = collect(self.root)
+        self.assertEqual(len(result), 5)
+        self.assertEqual(result[0]['name'], 'core/branch/128')
+        self.assertEqual(result[0]['value'], 42)
+        self.assertEqual(result[0]['unit'], 'ns')
+        self.assertTrue(all(row['value'] == 5 for row in result[1:]))
+        self.assertTrue(all(row['unit'] == 'bytes' for row in result[1:]))
+
+    def test_missing_benchmark_fails(self):
+        (self.estimate / 'estimates.json').unlink()
+        with self.assertRaisesRegex(ValueError, 'No Criterion estimates'):
+            collect(self.root)
+
+    def test_invalid_estimate_fails(self):
+        for value in (0, -1, float('nan'), float('inf')):
+            with self.subTest(value=value):
+                self.write_estimate(value)
+                with self.assertRaisesRegex(ValueError, 'Invalid estimate'):
+                    collect(self.root)
+
+    def test_activation_metrics_are_included_and_validated(self):
+        activation = self.root / 'activation.json'
+        rows = [
+            {'name': 'vscode/activation', 'unit': 'ms', 'value': 10},
+            {'name': 'vscode/activation-to-first-diagnostic', 'unit': 'ms', 'value': 200},
+        ]
+        activation.write_text(json.dumps(rows))
+        self.assertEqual(collect(self.root, activation)[-2:], rows)
+        rows[1]['name'] = rows[0]['name']
+        activation.write_text(json.dumps(rows))
+        with self.assertRaisesRegex(ValueError, 'Missing or duplicate'):
+            collect(self.root, activation)
+
+    def test_missing_extension_fails(self):
+        (self.root / 'editors/code/ry.vsix').unlink()
+        with self.assertRaises(FileNotFoundError):
+            collect(self.root)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Adds historical performance reporting on pushes to main and manual runs. Existing performance budget tests remain the cheaper PR checks.

The workflow measures core Criterion timings, VS Code activation and time to the first real diagnostic across five fresh extension hosts, and CLI/VS Code/Zed artifact sizes. It compares against the latest main result with advisory regression warnings, retains compact text history on a separate branch, and optionally deploys GitHub Pages charts. Binaries stay out of git history.

Validation: core benchmarks, five real VS Code activation runs, release CLI and Zed builds, VSIX packaging, report unit tests, history bootstrap and repeat-comparison smoke tests, workspace tests, Clippy, formatting, and zizmor passed locally.

To enable the public dashboard, select GitHub Actions as the Pages source and set the repository variable `BENCHMARK_PAGES=true`. Setup and measurement limits are documented in `docs/performance.md`.
