### PR TITLE
fix(checker): stop S3 lookup at opaque Ops methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,9 @@ All notable changes to ry are documented in this file.
 
 ### Fixed
 
-- Stop S3 operator lookup at the winning base group method, avoiding false
+- Stop S3 operator lookup at the winning group method, avoiding false
   column-access errors when later classes define another operator method.
+  Keep custom opaque method results unknown.
 
 ### Cleanup
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to ry are documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- Stop S3 operator lookup at the winning base group method, avoiding false
+  column-access errors when later classes define another operator method.
+
 ### Cleanup
 
 - Avoid recursive-default warnings for signaling arguments that may be ignored

--- a/crates/ry-checker/src/infer/binop.rs
+++ b/crates/ry-checker/src/infer/binop.rs
@@ -222,10 +222,19 @@ impl Checker {
                         if generic == symbol || !matches!(result.mode, Mode::Opaque) {
                             return Some(result);
                         }
-                        // An opaque group stub still wins dispatch. Stop
-                        // before later classes: the storage-mode rules model
-                        // this base method (including its diagnostics).
-                        return None;
+                        // Only embedded base group methods have storage-mode
+                        // models below. An opaque custom stub still wins over
+                        // later classes, but its result is unknown.
+                        let modeled_base = !self.user_stubs.contains_key("base")
+                            && self
+                                .typeshed
+                                .s3_methods
+                                .contains_key(&(generic.to_owned(), class.to_string()));
+                        return if modeled_base {
+                            None
+                        } else {
+                            Some(RType::unknown())
+                        };
                     }
                     None => {}
                 }

--- a/crates/ry-checker/src/infer/binop.rs
+++ b/crates/ry-checker/src/infer/binop.rs
@@ -222,11 +222,10 @@ impl Checker {
                         if generic == symbol || !matches!(result.mode, Mode::Opaque) {
                             return Some(result);
                         }
-                        // An opaque group stub (every embedded `Ops.*`
-                        // entry) offers no shape: fall through like a
-                        // miss, so the storage-mode rules keep modeling
-                        // these base classes with their own diagnostics
-                        // (`Ops.factor`'s warning, `Ops.Date` arithmetic).
+                        // An opaque group stub still wins dispatch. Stop
+                        // before later classes: the storage-mode rules model
+                        // this base method (including its diagnostics).
+                        return None;
                     }
                     None => {}
                 }

--- a/crates/ry-checker/src/tests/operator_s3_dispatch.rs
+++ b/crates/ry-checker/src/tests/operator_s3_dispatch.rs
@@ -340,3 +340,21 @@ fn unary_factor_arithmetic_warns_and_returns_logical() {
         Some(&RType::new(Mode::Logical, Length::Known(3)))
     );
 }
+
+#[test]
+fn opaque_custom_group_winner_keeps_result_unknown() {
+    let json = stub_file(&[op_method("Ops", "custom", "opaque")]);
+    for (file, attachment) in [("custom.json", "library(custom)\n"), ("base.json", "")] {
+        let source = format!(
+            "{attachment}`+.parent` <- function(e1, e2) 1L\n\
+             `-.parent` <- function(e1, e2) 1L\n\
+             x <- structure(list(), class = c('custom', 'parent'))\n\
+             left <- x + 1\nright <- 1 + x\nnegated <- -x\n"
+        );
+        let (diagnostics, scope) = check_with_stubs(&source, &[(file, &json)]);
+        assert!(diagnostics.is_empty(), "{file}: {diagnostics:?}");
+        for name in ["left", "right", "negated"] {
+            assert_eq!(scope.get(name).map(|ty| ty.mode), Some(Mode::Opaque));
+        }
+    }
+}

--- a/crates/ry-checker/testdata/ok_s3_opaque_group_stops_lookup.R
+++ b/crates/ry-checker/testdata/ok_s3_opaque_group_stops_lookup.R
@@ -1,0 +1,11 @@
+# no-diag
+`+.foo` <- function(e1, e2) "wrong"
+x <- structure(data.frame(a = 1), class = c("data.frame", "foo"))
+# Ops.data.frame wins before lookup reaches the later foo class.
+y <- x + 1
+y$a + 1
+z <- 1 + x
+z$a + 1
+`-.foo` <- function(e1, e2) "wrong"
+w <- -x
+w$a + 1

--- a/crates/ry-checker/testdata/oracle/s3_opaque_group_stops_lookup.R
+++ b/crates/ry-checker/testdata/oracle/s3_opaque_group_stops_lookup.R
@@ -1,0 +1,10 @@
+# oracle: must-pass
+`+.foo` <- function(e1, e2) "wrong"
+x <- structure(data.frame(a = 1), class = c("data.frame", "foo"))
+y <- x + 1
+stopifnot(identical(y$a + 1, 3))
+z <- 1 + x
+stopifnot(identical(z$a + 1, 3))
+`-.foo` <- function(e1, e2) "wrong"
+w <- -x
+stopifnot(identical(w$a + 1, 0))

--- a/crates/ry-checker/tests/snapshots/corpus__checker_fixture_diagnostics.snap
+++ b/crates/ry-checker/tests/snapshots/corpus__checker_fixture_diagnostics.snap
@@ -853,6 +853,8 @@ expression: snapshots
 - diagnostics: []
   fixture: ok_s3_dispatch.R
 - diagnostics: []
+  fixture: ok_s3_opaque_group_stops_lookup.R
+- diagnostics: []
   fixture: ok_s3_operator_absence_arithmetic.R
 - diagnostics: []
   fixture: ok_s4_terra_named_vector.R


### PR DESCRIPTION
When a class vector starts with `data.frame` and a later class defines an operator method, R selects `Ops.data.frame`. ry continued past that opaque stub and inferred the later method's return instead. A string return caused false RY061 errors on valid column access after arithmetic.

Stop lookup when an opaque group stub wins. Use existing base-method inference only for embedded base stubs; custom opaque stubs keep an unknown result. Regression tests cover package stubs and base overrides, which must not emit storage-mode errors. Corpus and R oracle fixtures cover both binary operand orders and unary negation. The baseline produced two false RY061 errors; the fixed corpus passes.

Related to #193. Conflicting-method selection still returns unknown, as documented; this change preserves that conservative behavior.

Validation: the final change passed `cargo test --workspace`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt --all -- --check`, and the complete checker-vs-R oracle matrix. The custom-stub regression and its R runtime witness also pass.
