### PR TITLE
fix(lsp): show inferred types at each assignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to ry are documented in this file.
 
 ### Cleanup
 
+- Show editor type hints from each assignment, including function locals,
+  rather than applying the file's final binding type to earlier assignments.
+  Refresh cached hints when local stubs change.
+
 - Avoid recursive-default warnings for signaling arguments that may be ignored
   or evaluated conditionally.
 

--- a/crates/ry-checker/src/infer/mod.rs
+++ b/crates/ry-checker/src/infer/mod.rs
@@ -1156,6 +1156,16 @@ impl Checker {
         {
             return false;
         }
+        if !self.discarding
+            && let Some(types) = &mut self.assignment_types
+            && let Expr::Ident { name, span } = target
+            && self.source.get(span.start..span.end) == Some(name.as_str())
+        {
+            types
+                .entry(*span)
+                .and_modify(|previous| *previous = previous.clone().join(vt.clone()))
+                .or_insert_with(|| vt.clone());
+        }
         self.assign_target(target, vt, scope);
         true
     }

--- a/crates/ry-checker/src/lib.rs
+++ b/crates/ry-checker/src/lib.rs
@@ -732,6 +732,8 @@ pub struct Checker {
     capture_references: bool,
     reference_capture: Option<Box<reference_facts::ReferenceCapture>>,
     scope_records: Vec<ScopeRecord>,
+    // Assignment-site types for editor hints, captured only on request.
+    assignment_types: Option<HashMap<Span, RType>>,
 }
 
 impl Checker {
@@ -757,8 +759,7 @@ impl Checker {
     }
 
     // Check a file and return both diagnostics and the final top-level
-    // scope. Used by the LSP server's scope cache: the scope maps variable
-    // names to their inferred types, feeding inlay hint lookups.
+    // scope. This snapshot describes scope exit, not individual assignments.
     pub fn check_with_scope(&mut self, file: &SourceFile) -> (Vec<Diagnostic>, Scope) {
         self.run_passes(file);
         // Emit parse errors after the collection/refinement passes (both
@@ -855,6 +856,7 @@ impl Checker {
             capture_references: false,
             reference_capture: None,
             scope_records: Vec::new(),
+            assignment_types: None,
         }
     }
 
@@ -958,10 +960,13 @@ impl Checker {
     // Pass 3: emit diagnostics for this file using the refined tables.
     // Diagnostics are appended to `self.diagnostics`; clear that vec
     // first if you want only this file's diagnostics. Returns the final
-    // top-level scope (also what `check_with_scope` hands to the LSP).
+    // top-level scope (also returned by `check_with_scope`).
     pub(crate) fn emit_diagnostics(&mut self, file: &SourceFile) -> Scope {
         self.path = file.path.clone();
         self.source.clone_from(&file.source);
+        if let Some(types) = &mut self.assignment_types {
+            types.clear();
+        }
         self.emit_parse_errors(file);
         let mut scope = self.top_level_scope();
         if self.capture_references {
@@ -996,6 +1001,26 @@ impl Checker {
     /// [`enable_scope_capture`](Self::enable_scope_capture) was called.
     pub fn take_scope_records(&mut self) -> Vec<ScopeRecord> {
         std::mem::take(&mut self.scope_records)
+    }
+
+    /// Capture inferred types at identifier assignments during the diagnostic
+    /// walk. Types describe the assigned value, not the scope's final state.
+    /// Coverage follows that walk; unknown types and unvisited code can be absent.
+    pub fn enable_assignment_capture(&mut self) {
+        self.assignment_types = Some(HashMap::new());
+    }
+
+    /// Take assignment types from the latest check, sorted by source position.
+    /// Repeated observations of one source site are joined. This is inference
+    /// evidence, not a guarantee about execution or symbol identity.
+    pub fn take_assignment_types(&mut self) -> Vec<(Span, RType)> {
+        let mut records: Vec<_> = self
+            .assignment_types
+            .as_mut()
+            .map(|types| types.drain().collect())
+            .unwrap_or_default();
+        records.sort_by_key(|(span, _)| (span.start, span.end));
+        records
     }
 
     // Snapshot one completed function-body scope. Called at the end of

--- a/crates/ry-checker/tests/assignment_types.rs
+++ b/crates/ry-checker/tests/assignment_types.rs
@@ -1,0 +1,32 @@
+use ry_checker::Checker;
+use ry_core::{Mode, RParser};
+
+#[test]
+fn assignment_capture_is_optional_and_preserves_diagnostics() {
+    let mut parser = RParser::new().unwrap();
+    let file = parser
+        .parse("test.R", "x <- 1L\nx <- \"later\"\ny <- x + 1L\n")
+        .unwrap();
+    let mut plain = Checker::new("test.R");
+    let expected = plain.check(&file).to_vec();
+    assert!(!expected.is_empty());
+    assert!(plain.take_assignment_types().is_empty());
+
+    let mut captured = Checker::new("test.R");
+    captured.enable_assignment_capture();
+    assert_eq!(captured.check(&file), expected);
+    let types = captured.take_assignment_types();
+    assert_eq!(types.len(), 3);
+    assert_eq!(types[0].1.mode, Mode::Integer);
+    assert_eq!(types[1].1.mode, Mode::Character);
+    assert!(captured.take_assignment_types().is_empty());
+
+    // Starting another check also drops records the caller did not take.
+    captured.check(&file);
+    let second = parser.parse("next.R", "z <- FALSE\n").unwrap();
+    captured.check(&second);
+    let types = captured.take_assignment_types();
+    assert_eq!(types.len(), 1);
+    assert_eq!(types[0].1.mode, Mode::Logical);
+    assert_eq!(&second.source[types[0].0.start..types[0].0.end], "z");
+}

--- a/crates/ry-lsp/src/backend.rs
+++ b/crates/ry-lsp/src/backend.rs
@@ -2,7 +2,7 @@
 //! document cache / debounce machinery.
 //!
 //! All request handlers read the cached parse (`State::parsed`) and the
-//! cached single-file scope (`State::scopes`); diagnostics are debounced
+//! cached assignment hints (`State::hints`); diagnostics are debounced
 //! via `schedule_diagnostics`.
 
 mod handlers;
@@ -46,6 +46,12 @@ pub(super) struct Backend {
     pub(super) state: Arc<Mutex<State>>,
 }
 
+struct CachedHints {
+    version: i32,
+    stubs: Arc<std::collections::BTreeMap<String, ry_typeshed::Typeshed>>,
+    hints: Vec<InlayHint>,
+}
+
 #[derive(Default)]
 pub(super) struct State {
     /// Open documents: path -> current source text. Keeping every open
@@ -61,9 +67,8 @@ pub(super) struct State {
     /// `Send` but `RParser` is not, so the parser is constructed per
     /// request and only the result is cached.
     parsed: HashMap<String, (i32, Arc<SourceFile>)>,
-    /// path -> (version, top-level Scope). Cached for inlay hints;
-    /// invalidated by `update_doc` alongside the parse cache.
-    scopes: HashMap<String, (i32, ry_checker::Scope)>,
+    /// Hints belong to one document version and loaded stub snapshot.
+    hints: HashMap<String, CachedHints>,
     /// Workspace-wide debounce generation; see `schedule_diagnostics`.
     diag_generation: u64,
     /// Index generation stamp, bumped each time `spawn_background_index`
@@ -381,14 +386,14 @@ impl State {
         }
     }
 
-    /// Drop the cached parse and scope for `path`, mirroring the
+    /// Drop the cached parse and hints for `path`, mirroring the
     /// cache-invalidation half of `Backend::update_doc`. Test-only;
     /// lets the cache acceptance test simulate a `did_change` on a bare
     /// `State` without a `tower_lsp::Client`.
     #[cfg(test)]
     pub(super) fn invalidate_parse(&mut self, path: &str) {
         self.parsed.remove(path);
-        self.scopes.remove(path);
+        self.hints.remove(path);
     }
 
     /// Open / replace a document at `version`, mirroring the doc-store
@@ -639,9 +644,9 @@ impl Backend {
         let mut state = self.state.lock().await;
         state.docs.insert(path.clone(), text);
         state.versions.insert(path.clone(), version);
-        // Invalidate the cached parse and scope; the next read repopulates.
+        // Invalidate the cached parse and hints; the next read repopulates.
         state.parsed.remove(&path);
-        state.scopes.remove(&path);
+        state.hints.remove(&path);
     }
 
     /// Return the current AST for `path` together with the exact source
@@ -705,49 +710,60 @@ impl Backend {
         }
     }
 
-    /// Return the top-level `Scope` for `path`, reusing the cached
-    /// `check_with_scope` result when its version matches. Returns `None`
-    /// when the document is not open or parsing fails.
-    async fn scope_for(&self, path: &str) -> Option<ry_checker::Scope> {
+    /// Return hints from one current parse and its assignment-site inference.
+    async fn hints_for(&self, path: &str) -> Option<Vec<InlayHint>> {
         {
             let state = self.state.lock().await;
+            let stubs = state
+                .folder_context_for_path(path)
+                .map(|ctx| &ctx.stubs)
+                .unwrap_or(&state.user_stubs);
             if let Some(version) = state.versions.get(path).copied()
-                && let Some((cached_v, scope)) = state.scopes.get(path)
-                && *cached_v == version
+                && let Some(cached) = state.hints.get(path)
+                && cached.version == version
+                && Arc::ptr_eq(&cached.stubs, stubs)
             {
-                return Some(scope.clone());
+                return Some(cached.hints.clone());
             }
         }
-        let (file, _) = self.parsed_file(path).await?;
+        let (file, text) = self.parsed_file(path).await?;
         let mut checker = ry_checker::Checker::new(path);
         let user_stubs = {
             let state = self.state.lock().await;
-            // The owning folder's stubs for single-file checks.
             state
                 .folder_context_for_path(path)
                 .map(|ctx| Arc::clone(&ctx.stubs))
                 .unwrap_or_else(|| Arc::clone(&state.user_stubs))
         };
-        checker.set_user_stubs(user_stubs);
-        let (_, scope) = checker.check_with_scope(&file);
-        // Cache only when the parse behind this scope is still current
-        // (Arc identity + version match in the parse cache). One post-check
-        // suffices: `record_parse` only ever installs Arc/version pairings
-        // stamped against the then-current document version.
-        {
-            let mut state = self.state.lock().await;
-            let current_version = state.parsed.get(path).and_then(|(cached_version, cached)| {
+        checker.set_user_stubs(Arc::clone(&user_stubs));
+        checker.enable_assignment_capture();
+        checker.check(&file);
+        let hints = collect_inlay_hints(&checker.take_assignment_types(), &text);
+        let mut state = self.state.lock().await;
+        let current_stubs = state
+            .folder_context_for_path(path)
+            .map(|ctx| &ctx.stubs)
+            .unwrap_or(&state.user_stubs);
+        if !Arc::ptr_eq(current_stubs, &user_stubs) {
+            return None;
+        }
+        let version = state
+            .parsed
+            .get(path)
+            .and_then(|(cached_version, cached)| {
                 (Arc::ptr_eq(cached, &file)
                     && state.versions.get(path).copied() == Some(*cached_version))
                 .then_some(*cached_version)
-            });
-            if let Some(version) = current_version {
-                state
-                    .scopes
-                    .insert(path.to_string(), (version, scope.clone()));
-            }
-        }
-        Some(scope)
+            })?;
+        state.hints.insert(
+            path.to_string(),
+            CachedHints {
+                version,
+                stubs: user_stubs,
+                hints: hints.clone(),
+            },
+        );
+        Some(hints)
     }
 
     /// Pull `ry` settings per folder scope via `workspace/configuration`:

--- a/crates/ry-lsp/src/backend/handlers.rs
+++ b/crates/ry-lsp/src/backend/handlers.rs
@@ -262,7 +262,7 @@ impl LanguageServer for Backend {
             state.disk_files.retain(|p, _| !under_removed_root(p));
             state.trees.retain(|p, _| !under_removed_root(p));
             state.parsed.retain(|p, _| !under_removed_root(p));
-            state.scopes.retain(|p, _| !under_removed_root(p));
+            state.hints.retain(|p, _| !under_removed_root(p));
 
             // Rebuild folder contexts from the surviving + added roots
             // through the shared builder used at initialize.
@@ -371,7 +371,7 @@ impl LanguageServer for Backend {
             state.docs.remove(&path);
             state.versions.remove(&path);
             state.parsed.remove(&path);
-            state.scopes.remove(&path);
+            state.hints.remove(&path);
             state.trees.remove(&path);
             // Invalidate any in-flight debounced publish for this file.
             state.diag_generation = state.diag_generation.wrapping_add(1);
@@ -427,17 +427,10 @@ impl LanguageServer for Backend {
             }
         }
 
-        // On parse failure return `None` (no hints) rather than erroring,
-        // so the editor shows nothing instead of a broken state.
-        let Some((file, text)) = self.parsed_file(&path).await else {
+        let Some(mut hints) = self.hints_for(&path).await else {
             return Ok(None);
         };
 
-        let Some(scope) = self.scope_for(&path).await else {
-            return Ok(None);
-        };
-
-        let mut hints = collect_inlay_hints(&file, &scope, &text);
         // Filter to the visible range; off-screen hints are dropped.
         hints.retain(|h| {
             let within_start = h.position.line > range.start.line

--- a/crates/ry-lsp/src/hints.rs
+++ b/crates/ry-lsp/src/hints.rs
@@ -1,96 +1,25 @@
-//! Inlay-hint helpers.
+//! Inlay hints from types captured at assignment sites.
 
-use ry_checker::Scope;
-use ry_core::{Expr, SourceFile, Stmt};
+use ry_core::{RType, Span};
 use tower_lsp::lsp_types::{InlayHint, InlayHintKind, InlayHintLabel};
 
 use crate::positions::byte_offset_to_position;
 
-/// Collect `InlayHint`s for every assignment whose target is a bare
-/// identifier with a known (non-opaque) inferred type. The hint is
-/// placed at the end of the identifier name (so the editor renders the
-/// ghost text right after the variable, before the `<-`), and its
-/// label is the inferred type rendered via `RType`'s `Display` impl
-/// (e.g. `: integer<len=1>`).
-///
-/// The walk recurses into `Stmt::FunctionDef` bodies so that local
-/// bindings inside statement-position function literals are annotated
-/// too (the top-level scope may or may not track them; if it doesn't,
-/// the lookup yields `None` and no hint is emitted).
-///
-/// Opaque (`Mode::Opaque`) types are deliberately skipped: they
-/// represent "we don't know" and would only clutter the editor with
-/// unhelpful `: opaque<len=?>?NA?` annotations (the scope's Display
-/// string is noisy for opaque modes). For inlay hints, skipping is
-/// the better UX.
-pub(super) fn collect_inlay_hints(file: &SourceFile, scope: &Scope, text: &str) -> Vec<InlayHint> {
-    let mut hints = Vec::new();
-    for stmt in &file.stmts {
-        collect_inlay_hints_from_stmt(stmt, scope, text, &mut hints);
-    }
-    hints
-}
-
-/// Walk a single statement, appending any inlay hints it contributes
-/// to `hints`. Assignments to a bare identifier become hints (when
-/// the scope has a non-opaque type for the name); function-definition
-/// statements are recursed into so their body bindings are annotated.
-fn collect_inlay_hints_from_stmt(
-    stmt: &Stmt,
-    scope: &Scope,
-    text: &str,
-    hints: &mut Vec<InlayHint>,
-) {
-    match stmt {
-        // Match only bare-identifier targets in this arm. Complex
-        // targets (`df$col <- 1`, `x[1] <- 2`) fall through to
-        // the second `Stmt::Assign` arm below and contribute nothing.
-        Stmt::Assign {
-            target: Expr::Ident { name, span },
-            ..
-        } => {
-            if let Some(t) = scope.get(name) {
-                // Opaque types are skipped; see the rationale on
-                // `collect_inlay_hints`.
-                if matches!(t.mode, ry_core::types::Mode::Opaque) {
-                    return;
-                }
-                // UTF-16 conversion matters here: non-ASCII identifiers
-                // must land the hint past their last code unit.
-                let pos = byte_offset_to_position(text, span.start + name.len());
-                hints.push(InlayHint {
-                    position: pos,
-                    label: InlayHintLabel::String(format!(": {}", t)),
-                    kind: Some(InlayHintKind::TYPE),
-                    tooltip: None,
-                    padding_left: Some(true),
-                    padding_right: None,
-                    text_edits: None,
-                    data: None,
-                });
-            }
-        }
-        // Non-identifier assignment targets (e.g. `x[1] <- 2`,
-        // `df$col <- value`) don't introduce a new name in the
-        // scope, so they contribute no hints.
-        Stmt::Assign { .. } => {}
-        // Recurse into anonymous statement-position function literals
-        // (a bare `function(...) ...` line) so bindings inside them are
-        // annotated too; named functions lower to `Assign` +
-        // `Expr::Function` and only their assignment target is hinted.
-        Stmt::FunctionDef { body, .. } => {
-            for s in body {
-                collect_inlay_hints_from_stmt(s, scope, text, hints);
-            }
-        }
-        // Other statement forms (bare expressions, control flow,
-        // returns) do not introduce named top-level bindings, so they
-        // contribute no hints. We deliberately do NOT recurse into
-        // `if`/`for`/`while` bodies here
-        // because the top-level scope only tracks the file's top
-        // scope; bindings introduced inside control-flow blocks may
-        // not be present in `scope`, and emitting a hint for a name
-        // the scope doesn't know would be wrong.
-        _ => {}
-    }
+/// Render known assignment types at the end of their original identifier.
+/// Unknown types provide no useful annotation, so omit them.
+pub(super) fn collect_inlay_hints(types: &[(Span, RType)], text: &str) -> Vec<InlayHint> {
+    types
+        .iter()
+        .filter(|(_, ty)| !matches!(ty.mode, ry_core::types::Mode::Opaque))
+        .map(|(span, ty)| InlayHint {
+            position: byte_offset_to_position(text, span.end),
+            label: InlayHintLabel::String(format!(": {ty}")),
+            kind: Some(InlayHintKind::TYPE),
+            tooltip: None,
+            padding_left: Some(true),
+            padding_right: None,
+            text_edits: None,
+            data: None,
+        })
+        .collect()
 }

--- a/crates/ry-lsp/src/tests.rs
+++ b/crates/ry-lsp/src/tests.rs
@@ -177,8 +177,9 @@ fn inlay_hints(src: &str) -> Vec<InlayHint> {
     let mut parser = RParser::new().unwrap();
     let file = parser.parse("test.R", src).unwrap();
     let mut checker = ry_checker::Checker::new("test.R");
-    let (_, scope) = checker.check_with_scope(&file);
-    collect_inlay_hints(&file, &scope, src)
+    checker.enable_assignment_capture();
+    checker.check(&file);
+    collect_inlay_hints(&checker.take_assignment_types(), src)
 }
 
 #[test]
@@ -308,6 +309,63 @@ fn inlay_hints_for_function_definition() {
         ),
         other => panic!("expected String label, got {:?}", other),
     }
+}
+
+#[test]
+fn inlay_hints_keep_each_assignments_type() {
+    let hints = inlay_hints("x <- 1L\nx <- \"later\"\ny <- x\nx <- FALSE\n");
+    assert_eq!(hints.len(), 4, "{hints:?}");
+    for (hint, mode) in hints
+        .iter()
+        .zip(["integer", "character", "character", "logical"])
+    {
+        assert!(
+            matches!(&hint.label, InlayHintLabel::String(label) if label.contains(mode)),
+            "{hint:?}"
+        );
+    }
+}
+
+#[test]
+fn inlay_hints_use_the_assignments_lexical_scope() {
+    let hints = inlay_hints("x <- 1L\nf <- function() {\n  x <- \"local\"\n  x\n}\n");
+    assert_eq!(hints.len(), 3, "{hints:?}");
+    assert_eq!(hints[2].position, Position::new(2, 3));
+    assert!(
+        matches!(&hints[2].label, InlayHintLabel::String(label) if label.contains("character"))
+    );
+}
+
+#[test]
+fn inlay_hints_skip_quoted_assignments() {
+    let hints = inlay_hints("base::quote(x <- 1L)\nz <- TRUE\n");
+    assert_eq!(hints.len(), 1, "{hints:?}");
+    assert_eq!(hints[0].position, Position::new(1, 1));
+}
+
+#[test]
+fn inlay_hints_do_not_use_later_mutations() {
+    let hints = inlay_hints("x <- 1L\nclass(x) <- \"special\"\nnames(x) <- \"name\"\n");
+    assert_eq!(hints.len(), 1, "{hints:?}");
+    assert!(
+        matches!(&hints[0].label, InlayHintLabel::String(label) if label == ": integer<len=1>")
+    );
+}
+
+#[test]
+fn inlay_hints_for_nested_assignments_and_unicode() {
+    let hints = inlay_hints("变量 <- other <- 1L\n");
+    assert_eq!(hints.len(), 2, "{hints:?}");
+    assert_eq!(hints[0].position, Position::new(0, 2));
+    assert_eq!(hints[1].position, Position::new(0, 11));
+}
+
+#[test]
+fn inlay_hints_follow_backtick_token_ends() {
+    let hints = inlay_hints("`a b` <- 1L\n`multi\nline` <- FALSE\n");
+    assert_eq!(hints.len(), 2, "{hints:?}");
+    assert_eq!(hints[0].position, Position::new(0, 5));
+    assert_eq!(hints[1].position, Position::new(2, 5));
 }
 
 // ---- code action helpers ----

--- a/crates/ry-lsp/tests/protocol_contract.rs
+++ b/crates/ry-lsp/tests/protocol_contract.rs
@@ -23,6 +23,112 @@ mod harness;
 
 use harness::{Published, file_uri, published_from_cli_value, published_from_lsp, ry_binary};
 
+#[test]
+fn assignment_hints_keep_source_types_across_edits_and_ranges() {
+    let fixture = FixtureProject::empty().unwrap();
+    fixture.write_file("main.R", "").unwrap();
+    let uri = ry_testkit::file_uri(&fixture.path("main.R")).unwrap();
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    runtime.block_on(async {
+        let (mut session, server) =
+            harness::spawn_session(&[fixture.root()], json!({}), None).await;
+        session
+            .open(&uri, 1, "x <- 1L\nx <- \"later\"\n")
+            .await
+            .unwrap();
+        let request = json!({
+            "textDocument": {"uri": uri},
+            "range": {"start": {"line": 0, "character": 0}, "end": {"line": 0, "character": 10}}
+        });
+        for _ in 0..2 {
+            let hints = session
+                .request("textDocument/inlayHint", request.clone())
+                .await
+                .unwrap();
+            assert_eq!(hints.as_array().unwrap().len(), 1, "{hints}");
+            assert_eq!(hints[0]["label"], ": integer<len=1>");
+        }
+        session
+            .notify(
+                "textDocument/didChange",
+                json!({
+                    "textDocument": {"uri": uri, "version": 2},
+                    "contentChanges": [{"text": "x <- FALSE\nx <- 1L\n"}]
+                }),
+            )
+            .await
+            .unwrap();
+        let hints = session
+            .request("textDocument/inlayHint", request)
+            .await
+            .unwrap();
+        assert_eq!(hints.as_array().unwrap().len(), 1, "{hints}");
+        assert_eq!(hints[0]["label"], ": logical<len=1>");
+        harness::join_session(session, server).await;
+    });
+}
+
+#[test]
+fn assignment_hints_refresh_when_local_stubs_change() {
+    let fixture = FixtureProject::empty().unwrap();
+    fixture
+        .write_file("ry.toml", "typeshed = [\"stubs\"]\n")
+        .unwrap();
+    let write_stub =
+        |mode| {
+            fixture.write_file("stubs/localdep.json", serde_json::to_string(&json!({
+            "schema_version": "1", "package": "localdep", "version": "test",
+            "functions": {"value": {"params": [], "return": {"mode": mode, "length": "1"}}}
+        })).unwrap()).unwrap();
+        };
+    write_stub("integer");
+    fixture.write_file("main.R", "").unwrap();
+    let uri = ry_testkit::file_uri(&fixture.path("main.R")).unwrap();
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    runtime.block_on(async {
+        let (mut session, server) =
+            harness::spawn_session(&[fixture.root()], json!({}), None).await;
+        session
+            .open(&uri, 1, "x <- localdep::value()\n")
+            .await
+            .unwrap();
+        let request = json!({
+            "textDocument": {"uri": uri},
+            "range": {"start": {"line": 0, "character": 0}, "end": {"line": 1, "character": 0}}
+        });
+        let hints = session
+            .request("textDocument/inlayHint", request.clone())
+            .await
+            .unwrap();
+        assert_eq!(hints[0]["label"], ": integer<len=1>");
+        // Finish the initial publication before using the config-triggered
+        // publication as proof that the asynchronous reload has completed.
+        session.published_diagnostics_after(&uri, 0).await.unwrap();
+        write_stub("character");
+        let mark = session.publication_mark();
+        session
+            .notify("workspace/didChangeConfiguration", json!({"settings": {}}))
+            .await
+            .unwrap();
+        session
+            .published_diagnostics_after(&uri, mark)
+            .await
+            .unwrap();
+        let hints = session
+            .request("textDocument/inlayHint", request)
+            .await
+            .unwrap();
+        assert_eq!(hints[0]["label"], ": character<len=1>");
+        harness::join_session(session, server).await;
+    });
+}
+
 // ──────────────────────────────────────────────────────────────────────────
 // Shared helpers (adapted from tests/protocol.rs for multi-root support)
 // ──────────────────────────────────────────────────────────────────────────

--- a/editors/code/README.md
+++ b/editors/code/README.md
@@ -3,6 +3,8 @@
 [ry](https://github.com/sims1253/ry) checks R code as you type. The extension
 provides project diagnostics, inlay hints for inferred types, and code actions
 to insert suppression comments. Hints and code actions apply to open documents.
+Type hints describe inferred assignment values, including locals in named
+functions. Unknown types and assignments the checker does not visit are omitted.
 
 ## Installation
 


### PR DESCRIPTION
In `x <- 1L; x <- "later"`, both editor hints used the file's final character type. Capture inferred assignment values during the diagnostic walk so the first hint stays integer. This also supplies hints for locals in named functions and chained assignments, while omitting unknown types and assignments the checker does not visit.

Cache the rendered hints against the document version and loaded stubs. A local stub reload now refreshes hints without requiring an R-file edit. Positions come from the same source snapshot as inference.

Validation: workspace tests, Clippy with warnings denied, formatting, the full R oracle suite, and the full LSP suite passed. Regressions cover reassignment, lexical scopes, quoted code, later mutations, Unicode/backtick positions, checker reuse, source edits, range filtering, and stub reloads. An independent Astra review found no blocking issues.
