### PR TITLE
fix(lsp): respect code action eligibility and kinds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to ry are documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- Stop offering suppression actions for disabled or excluded files. Skip
+  computing them when the editor requests other action kinds.
+
 ### Cleanup
 
 - Avoid recursive-default warnings for signaling arguments that may be ignored

--- a/crates/ry-lsp/src/backend/handlers.rs
+++ b/crates/ry-lsp/src/backend/handlers.rs
@@ -459,7 +459,7 @@ impl LanguageServer for Backend {
         if params.context.only.as_ref().is_some_and(|kinds| {
             !kinds
                 .iter()
-                .any(|kind| kind.as_str().is_empty() || *kind == CodeActionKind::QUICKFIX)
+                .any(|kind| *kind == CodeActionKind::EMPTY || *kind == CodeActionKind::QUICKFIX)
         }) {
             return Ok(None);
         }

--- a/crates/ry-lsp/src/backend/handlers.rs
+++ b/crates/ry-lsp/src/backend/handlers.rs
@@ -456,6 +456,13 @@ impl LanguageServer for Backend {
     }
 
     async fn code_action(&self, params: CodeActionParams) -> LspResult<Option<CodeActionResponse>> {
+        if params.context.only.as_ref().is_some_and(|kinds| {
+            !kinds
+                .iter()
+                .any(|kind| kind.as_str().is_empty() || *kind == CodeActionKind::QUICKFIX)
+        }) {
+            return Ok(None);
+        }
         if !params
             .context
             .diagnostics
@@ -467,6 +474,9 @@ impl LanguageServer for Backend {
         let uri = params.text_document.uri.clone();
         let path = uri_to_path(&uri);
 
+        if !self.state.lock().await.eligibility_for_path(&path) {
+            return Ok(None);
+        }
         let Some((file, _)) = self.parsed_file(&path).await else {
             return Ok(None);
         };

--- a/crates/ry-lsp/tests/code_action_eligibility.rs
+++ b/crates/ry-lsp/tests/code_action_eligibility.rs
@@ -1,0 +1,118 @@
+mod harness;
+
+use harness::{file_uri, join_session, normalize_diagnostics, spawn_session};
+use ry_testkit::FixtureProject;
+use serde_json::{Value, json};
+
+fn request(uri: &str, diagnostic: &Value) -> Value {
+    json!({
+        "textDocument": {"uri": uri},
+        "range": diagnostic["range"],
+        "context": {"diagnostics": [diagnostic]}
+    })
+}
+
+#[test]
+fn suppression_actions_respect_requested_kinds() {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap()
+        .block_on(async {
+            let fixture = FixtureProject::empty().unwrap();
+            let source = "x <- never_bound_here\n";
+            let uri = file_uri(&fixture.write_file("main.R", source).unwrap());
+            let (mut session, server) = spawn_session(&[fixture.root()], json!({}), None).await;
+            let mark = session.publication_mark();
+            session.open(&uri, 1, source).await.unwrap();
+            let published = session
+                .published_diagnostics_after(&uri, mark)
+                .await
+                .unwrap();
+            let diagnostics = normalize_diagnostics(&published);
+            let base = request(&uri, &diagnostics[0]);
+            for (only, expected) in [
+                (None, true),
+                (Some(json!(["quickfix"])), true),
+                (Some(json!([""])), true),
+                (Some(json!(["refactor", "quickfix"])), true),
+                (Some(json!([])), false),
+                (Some(json!(["source.fixAll"])), false),
+                (Some(json!(["refactor"])), false),
+                (Some(json!(["quickfix.custom"])), false),
+            ] {
+                let mut params = base.clone();
+                if let Some(only) = only {
+                    params["context"]["only"] = only;
+                }
+                let actions = session
+                    .request("textDocument/codeAction", params.clone())
+                    .await
+                    .unwrap();
+                if expected {
+                    let actions = actions.as_array().unwrap();
+                    assert_eq!(actions.len(), 2, "{params}");
+                    assert!(actions.iter().all(|action| action["kind"] == "quickfix"));
+                } else {
+                    assert!(actions.is_null(), "{params}: {actions}");
+                }
+            }
+            join_session(session, server).await;
+        });
+}
+
+#[test]
+fn stale_diagnostics_do_not_offer_suppressions_after_disabling_or_excluding() {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap()
+        .block_on(async {
+            for exclude in [false, true] {
+                let fixture = FixtureProject::empty().unwrap();
+                let source = "x <- never_bound_here\n";
+                let uri = file_uri(&fixture.write_file("main.R", source).unwrap());
+                let (mut session, server) = spawn_session(&[fixture.root()], json!({}), None).await;
+                let mark = session.publication_mark();
+                session.open(&uri, 1, source).await.unwrap();
+                let published = session
+                    .published_diagnostics_after(&uri, mark)
+                    .await
+                    .unwrap();
+                let diagnostics = normalize_diagnostics(&published);
+                let params = request(&uri, &diagnostics[0]);
+                let before = session
+                    .request("textDocument/codeAction", params.clone())
+                    .await
+                    .unwrap();
+                assert_eq!(before.as_array().unwrap().len(), 2);
+                let settings = if exclude {
+                    fixture
+                        .write_file("ry.toml", "exclude = [\"main.R\"]\n")
+                        .unwrap();
+                    json!({})
+                } else {
+                    json!({"ry": {"enable": false}})
+                };
+                let mark = session.publication_mark();
+                session
+                    .notify(
+                        "workspace/didChangeConfiguration",
+                        json!({"settings": settings}),
+                    )
+                    .await
+                    .unwrap();
+                let refreshed = session
+                    .published_diagnostics_after(&uri, mark)
+                    .await
+                    .unwrap();
+                assert!(normalize_diagnostics(&refreshed).is_empty(), "{refreshed}");
+                let after = session
+                    .request("textDocument/codeAction", params)
+                    .await
+                    .unwrap();
+                assert!(after.is_null(), "exclude={exclude}: {after}");
+                join_session(session, server).await;
+            }
+        });
+}


### PR DESCRIPTION
After a folder is disabled or a file is excluded, an editor can still send old diagnostics in a code-action request. ry now applies the same eligibility check as diagnostics and inlay hints, so those requests offer no suppression edits.

Requests whose `context.only` excludes quick fixes also return early, avoiding unnecessary parsing and edit construction. The protocol tests cover kind filtering and retained diagnostics across disable/exclude refreshes.

Validation: focused protocol tests, workspace tests, Clippy with warnings denied, formatting, and the full R oracle matrix (17 tests) pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Suppression code actions are now shown only when quick fixes are requested.
  * Suppression actions are no longer offered for disabled or excluded files.
  * Stale suppression diagnostics are cleared after linter settings or file exclusions change.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->