### PR TITLE
fix(checker): invalidate incremental callback readers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to ry are documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- Refresh incremental diagnostics when a callback changes, including callbacks
+  passed as values and their downstream callers.
+
 ### Cleanup
 
 - Avoid recursive-default warnings for signaling arguments that may be ignored

--- a/crates/ry-checker/src/lib.rs
+++ b/crates/ry-checker/src/lib.rs
@@ -942,11 +942,11 @@ impl Checker {
     pub(crate) fn seed_caller_visible_signatures(
         &mut self,
         seed: &HashMap<String, CallerVisibleSignature>,
-        scope: Option<&HashSet<String>>,
+        scope: &HashSet<String>,
     ) {
         let table = Arc::make_mut(&mut self.fn_table);
         for (name, function) in &mut table.fns {
-            if scope.is_some_and(|scope| scope.contains(name)) {
+            if scope.contains(name) {
                 continue;
             }
             if let Some(signature) = seed.get(name) {

--- a/crates/ry-checker/src/lib.rs
+++ b/crates/ry-checker/src/lib.rs
@@ -926,9 +926,17 @@ impl Checker {
     ///
     /// Only functions that exist in both the current table and the seed map
     /// are updated. Functions new to the table (or absent from the seed)
-    /// keep their pass-1 collection value.
-    pub(crate) fn seed_return_types(&mut self, seed: &HashMap<String, ry_core::RType>) {
+    /// keep their pass-1 collection value. Affected functions also start fresh:
+    /// an old seed can otherwise sustain a newly introduced recursive cycle.
+    pub(crate) fn seed_return_types(
+        &mut self,
+        seed: &HashMap<String, ry_core::RType>,
+        scope: &HashSet<String>,
+    ) {
         for (name, uf) in &self.fn_table.fns {
+            if scope.contains(name) {
+                continue;
+            }
             if let Some(t) = seed.get(name) {
                 Arc::make_mut(&mut self.return_slots).set(uf.return_slot, t.clone());
             }

--- a/crates/ry-checker/src/project.rs
+++ b/crates/ry-checker/src/project.rs
@@ -554,15 +554,18 @@ impl Project {
         );
         refiner.set_loaded(self.loaded.clone());
         refiner.set_user_stubs(Arc::clone(&self.user_stubs));
-        refiner.seed_return_types(&self.prev_fn_returns);
 
         // Scoping: refine only functions whose return type can have
         // changed, rather than the entire project. On the first call or
         // when `loaded` changed, fall back to refining everything.
-        refiner.seed_caller_visible_signatures(&self.prev_fn_signatures, fixpoint_scope.as_ref());
         if let Some(ref scope) = fixpoint_scope {
+            refiner.seed_return_types(&self.prev_fn_returns);
+            refiner.seed_caller_visible_signatures(&self.prev_fn_signatures, scope);
             refiner.run_fixpoint_scoped(scope);
         } else {
+            // Full invalidation starts from fresh collection, like a cold
+            // check. Old metadata can belong to a replaced or shadowed
+            // definition, and recursive returns can preserve an old seed.
             refiner.run_fixpoint();
         }
         let (fn_table, return_slots) = refiner.into_tables();

--- a/crates/ry-checker/src/project.rs
+++ b/crates/ry-checker/src/project.rs
@@ -32,6 +32,7 @@ struct FileEmission {
     diagnostics: Vec<Diagnostic>,
     scopes: Vec<crate::ScopeRecord>,
     references: crate::ReferenceFacts,
+    read_fns: HashSet<String>,
 }
 
 /// A multi-file R project. Functions defined in any file are visible
@@ -106,6 +107,9 @@ pub struct Project {
     /// so the dirty-set computation in `refine_and_emit` can check whether
     /// a file references any function whose return slot changed.
     file_called_fns: HashMap<String, HashSet<String>>,
+    /// Actual callable reads during emission include callbacks and aliases
+    /// absent from syntactic call sites. Names survive return-slot renumbering.
+    file_read_fns: HashMap<String, HashSet<String>>,
     /// Previous pass-2 refined return types, keyed by function name.
     /// Used to seed the next fixpoint iteration so already-converged
     /// entries start from their refined value rather than re-converging
@@ -209,6 +213,7 @@ impl Project {
                 .extend(previous.fn_table.fns.keys().cloned());
         }
         self.file_known_vars.remove(path);
+        self.file_read_fns.remove(path);
         // Removing a file changes the shared function table and pooled
         // known_vars. Conservatively mark all remaining files dirty so
         // callers of the removed file's functions are re-emitted.
@@ -358,6 +363,7 @@ impl Project {
         self.prev_loaded = None;
         self.has_prev_emit = false;
         self.prev_fn_returns.clear();
+        self.file_read_fns.clear();
         self.prev_fn_signatures.clear();
         self.prev_known_vars.clear();
         self.invalidated_fns.clear();
@@ -440,6 +446,11 @@ impl Project {
         {
             return None;
         }
+        // A new callable can resolve a previously unknown callback or alias;
+        // no observed dependency exists for that earlier lookup miss.
+        if self.callable_names_changed() {
+            return None;
+        }
         // Nothing changed → nothing to refine.
         if self.dirty_paths.is_empty() {
             return Some(HashSet::new());
@@ -486,19 +497,34 @@ impl Project {
         Some(affected)
     }
 
+    fn callable_names_changed(&self) -> bool {
+        self.fn_table.fns.len() != self.prev_fn_returns.len()
+            || self
+                .fn_table
+                .fns
+                .keys()
+                .any(|name| !self.prev_fn_returns.contains_key(name))
+    }
+
+    fn file_depends_on(&self, path: &str, affected: &HashSet<String>) -> bool {
+        self.file_called_fns
+            .get(path)
+            .into_iter()
+            .chain(self.file_read_fns.get(path))
+            .flatten()
+            .any(|callee| affected.contains(callee))
+    }
+
     /// Expand a set of changed callees through the cached reverse call graph.
-    /// `FnTable::call_sites` is collected per file, so every function defined
-    /// in a file that calls an affected function is a conservative caller.
+    /// Syntactic calls and observed callable reads are collected per file,
+    /// so every function in a dependent file is a conservative caller.
     /// Repeating to a fixpoint reaches callers in other files transitively.
     fn with_transitive_callers(&self, mut affected: HashSet<String>) -> HashSet<String> {
         let mut changed = true;
         while changed {
             changed = false;
             for (path, collected) in &self.collected_files {
-                let Some(calls) = self.file_called_fns.get(path) else {
-                    continue;
-                };
-                if !calls.iter().any(|callee| affected.contains(callee)) {
+                if !self.file_depends_on(path, &affected) {
                     continue;
                 }
                 for caller in collected.fn_table.fns.keys() {
@@ -607,7 +633,11 @@ impl Project {
         // the incremental dirty set.
         let known_vars_changed = self.prev_known_vars != self.fn_table.known_vars;
         let first_call = !self.has_prev_emit;
-        let must_emit: HashSet<&str> = if first_call || loaded_changed || known_vars_changed {
+        let must_emit: HashSet<&str> = if first_call
+            || loaded_changed
+            || known_vars_changed
+            || self.callable_names_changed()
+        {
             self.files.iter().map(|(p, _)| p.as_str()).collect()
         } else {
             let mut dirty: HashSet<&str> = self.dirty_paths.iter().map(|s| s.as_str()).collect();
@@ -616,11 +646,7 @@ impl Project {
                     continue;
                 }
                 // Does this file call any function whose return type changed?
-                if let Some(called) = self.file_called_fns.get(path)
-                    && called
-                        .iter()
-                        .any(|name| changed_fns.contains(name.as_str()))
-                {
+                if self.file_depends_on(path, &changed_fns) {
                     dirty.insert(path.as_str());
                 }
                 // Conservatively: if any S3/S4 method slot changed, emit
@@ -665,6 +691,13 @@ impl Project {
         let capture_scopes = self.capture_scopes;
         let capture_references = self.capture_references;
 
+        let mut names_by_slot: HashMap<usize, Vec<&String>> = HashMap::new();
+        for (name, function) in &fn_table.fns {
+            names_by_slot
+                .entry(function.return_slot)
+                .or_default()
+                .push(name);
+        }
         let per_file: Vec<FileEmission> = emit_indices
             .par_iter()
             .map(|&i| {
@@ -700,7 +733,21 @@ impl Project {
                 if capture_references {
                     emitter.enable_reference_capture();
                 }
+                *emitter.refinement_reads.get_mut() = Some(Vec::new());
                 emitter.emit_diagnostics(file);
+                let read_slots: HashSet<_> = emitter
+                    .refinement_reads
+                    .get_mut()
+                    .take()
+                    .unwrap()
+                    .into_iter()
+                    .collect();
+                let read_fns = read_slots
+                    .iter()
+                    .filter_map(|slot| names_by_slot.get(slot))
+                    .flatten()
+                    .map(|name| (*name).clone())
+                    .collect();
                 let records = emitter.take_scope_records();
                 let references = emitter.take_reference_facts();
                 FileEmission {
@@ -709,6 +756,7 @@ impl Project {
                     diagnostics: emitter.take_diagnostics(),
                     scopes: records,
                     references,
+                    read_fns,
                 }
             })
             .collect();
@@ -732,6 +780,12 @@ impl Project {
         // Scope records replace the previous emission's; files served
         // from cache contribute none (see `scope_records` on the struct).
         let mut per_file = per_file;
+        for emission in &mut per_file {
+            self.file_read_fns.insert(
+                emission.path.clone(),
+                std::mem::take(&mut emission.read_fns),
+            );
+        }
         if capture_scopes {
             self.scope_records = per_file
                 .iter_mut()

--- a/crates/ry-checker/src/project.rs
+++ b/crates/ry-checker/src/project.rs
@@ -559,7 +559,7 @@ impl Project {
         // changed, rather than the entire project. On the first call or
         // when `loaded` changed, fall back to refining everything.
         if let Some(ref scope) = fixpoint_scope {
-            refiner.seed_return_types(&self.prev_fn_returns);
+            refiner.seed_return_types(&self.prev_fn_returns, scope);
             refiner.seed_caller_visible_signatures(&self.prev_fn_signatures, scope);
             refiner.run_fixpoint_scoped(scope);
         } else {

--- a/crates/ry-checker/tests/project.rs
+++ b/crates/ry-checker/tests/project.rs
@@ -1407,3 +1407,75 @@ fn incremental_callback_removal_and_readdition_match_cold() {
         callback_project(&sources).check()
     );
 }
+
+#[test]
+fn full_invalidation_keeps_fresh_shadowed_signatures() {
+    let operations = [
+        Operation::RepeatedUpdate {
+            file: 2,
+            first: SourceModel::UnrelatedInteger,
+            second: SourceModel::IntegerReturn,
+        },
+        Operation::RemoveThenReadd {
+            file: 1,
+            source: SourceModel::QuotingParameter,
+        },
+        Operation::Update {
+            file: 1,
+            source: SourceModel::ForwardingCaller,
+        },
+        Operation::Add {
+            file: 0,
+            source: SourceModel::DirectCaller,
+        },
+    ];
+    let mut project = Project::new();
+    let mut state = ProjectState::default();
+    for operation in operations {
+        apply_operation(&mut project, &mut state, operation);
+        assert_eq!(project.check_incremental(), cold_check(&state));
+    }
+    assert!(
+        project
+            .check_incremental()
+            .iter()
+            .flat_map(|(_, d)| d)
+            .any(|d| d.code == "RY010")
+    );
+}
+
+#[test]
+fn loaded_change_keeps_fresh_signatures() {
+    let mut sources = vec![
+        ("callee.R", "target <- function(value) substitute(value)"),
+        ("use.R", "target(not_bound)"),
+    ];
+    let mut project = callback_project(&sources);
+    project.check_incremental();
+    sources[0].1 = "library(stats)\ntarget <- function(value) 1L";
+    project.update_file("callee.R".into(), Arc::new(parse("callee.R", sources[0].1)));
+    let incremental = project.check_incremental();
+    assert_eq!(incremental, callback_project(&sources).check());
+    assert!(
+        incremental
+            .iter()
+            .flat_map(|(_, d)| d)
+            .any(|d| d.code == "RY010")
+    );
+}
+
+#[test]
+fn full_invalidation_does_not_seed_recursive_returns() {
+    let mut sources = vec![
+        ("callee.R", "target <- function() 'old'"),
+        ("use.R", "target() + 1"),
+    ];
+    let mut project = callback_project(&sources);
+    project.check_incremental();
+    sources[0].1 = "target <- function() target()\nadded <- function() 1";
+    project.update_file("callee.R".into(), Arc::new(parse("callee.R", sources[0].1)));
+    assert_eq!(
+        project.check_incremental(),
+        callback_project(&sources).check()
+    );
+}

--- a/crates/ry-checker/tests/project.rs
+++ b/crates/ry-checker/tests/project.rs
@@ -1296,3 +1296,114 @@ fn renamed_function_matches_cold_for_transitive_callers() {
 
     assert_eq!(incremental, cold);
 }
+
+fn callback_project(sources: &[(&str, &str)]) -> Project {
+    let mut project = Project::new();
+    for &(path, source) in sources {
+        project.add_file(path.into(), parse(path, source));
+    }
+    project
+}
+
+#[test]
+fn incremental_callback_returns_match_cold_checks() {
+    for callback_use in [
+        "wrapper <- function() lapply(1, leaf)[[1]]",
+        "wrapper <- function() { callback <- leaf; callback(1) }",
+    ] {
+        let mut sources = vec![
+            ("leaf.R", "leaf <- function(x) 1"),
+            ("wrapper.R", callback_use),
+            ("use.R", "wrapper() + 1"),
+            ("direct.R", "lapply(1, leaf)[[1]] + 1"),
+        ];
+        let mut project = callback_project(&sources);
+        assert!(
+            project
+                .check_incremental()
+                .iter()
+                .all(|(_, d)| d.is_empty())
+        );
+        for source in ["leaf <- function(x) 'bad'", "leaf <- function(x) 1"] {
+            sources[0].1 = source;
+            project.update_file("leaf.R".into(), Arc::new(parse("leaf.R", source)));
+            let incremental = project.check_incremental();
+            let cold = callback_project(&sources).check();
+            assert_eq!(incremental, cold, "{callback_use}: {source}");
+            if source.contains("bad") && callback_use.contains("lapply") {
+                for path in ["use.R", "direct.R"] {
+                    assert!(incremental.iter().any(|(p, diagnostics)| {
+                        p == path
+                            && diagnostics
+                                .iter()
+                                .any(|diagnostic| diagnostic.code == "RY040")
+                    }));
+                }
+            }
+            assert_eq!(project.check_incremental(), cold);
+        }
+    }
+}
+
+#[test]
+fn incremental_callback_replacement_drops_stale_reads() {
+    let mut sources = vec![
+        ("leaf.R", "leaf <- function(x) 1"),
+        ("wrapper.R", "wrapper <- function() lapply(1, leaf)[[1]]"),
+        ("use.R", "wrapper() + 1"),
+    ];
+    let mut project = callback_project(&sources);
+    project.check_incremental();
+    sources[1].1 = "wrapper <- function() 1";
+    project.update_file(
+        "wrapper.R".into(),
+        Arc::new(parse("wrapper.R", sources[1].1)),
+    );
+    assert_eq!(
+        project.check_incremental(),
+        callback_project(&sources).check()
+    );
+    sources[0].1 = "leaf <- function(x) 'bad'";
+    project.update_file("leaf.R".into(), Arc::new(parse("leaf.R", sources[0].1)));
+    assert_eq!(
+        project.check_incremental(),
+        callback_project(&sources).check()
+    );
+    assert_eq!(
+        project.emit_count, 1,
+        "replaced callback must not retain its old read"
+    );
+}
+
+#[test]
+fn incremental_callback_removal_and_readdition_match_cold() {
+    let mut sources = vec![
+        ("leaf.R", "leaf <- function(x) 1"),
+        ("wrapper.R", "wrapper <- function() lapply(1, leaf)[[1]]"),
+        ("use.R", "wrapper() + 1"),
+    ];
+    let mut project = callback_project(&sources);
+    project.check_incremental();
+    // Keep the binding name while replacing its callable identity. This
+    // cannot rely on pooled known-variable changes to invalidate readers.
+    for source in ["leaf <- 1", "leaf <- function(x) 'bad'"] {
+        sources[0].1 = source;
+        project.update_file("leaf.R".into(), Arc::new(parse("leaf.R", source)));
+        assert_eq!(
+            project.check_incremental(),
+            callback_project(&sources).check()
+        );
+    }
+    project.remove_file("leaf.R");
+    sources.remove(0);
+    assert_eq!(
+        project.check_incremental(),
+        callback_project(&sources).check()
+    );
+    sources.push(("leaf.R", "leaf <- function(x) 'bad'"));
+    project.update_file("leaf.R".into(), Arc::new(parse("leaf.R", sources[2].1)));
+    assert_eq!(
+        project.check_incremental(),
+        callback_project(&sources).check()
+    );
+}

--- a/crates/ry-checker/tests/project.rs
+++ b/crates/ry-checker/tests/project.rs
@@ -1479,3 +1479,38 @@ fn full_invalidation_does_not_seed_recursive_returns() {
         callback_project(&sources).check()
     );
 }
+
+#[test]
+fn scoped_invalidation_does_not_seed_replaced_recursive_returns() {
+    let mut sources = vec![
+        ("callee.R", "target <- function() 'old'"),
+        ("use.R", "target() + 1"),
+    ];
+    let mut project = callback_project(&sources);
+    project.check_incremental();
+    sources[0].1 = "target <- function() target()";
+    project.update_file("callee.R".into(), Arc::new(parse("callee.R", sources[0].1)));
+    assert_eq!(
+        project.check_incremental(),
+        callback_project(&sources).check()
+    );
+}
+
+#[test]
+fn scoped_invalidation_does_not_seed_mutually_recursive_returns() {
+    let mut sources = vec![
+        (
+            "callee.R",
+            "target <- function() 'old'\nother <- function() 'old'",
+        ),
+        ("use.R", "target() + 1"),
+    ];
+    let mut project = callback_project(&sources);
+    project.check_incremental();
+    sources[0].1 = "target <- function() other()\nother <- function() target()";
+    project.update_file("callee.R".into(), Arc::new(parse("callee.R", sources[0].1)));
+    assert_eq!(
+        project.check_incremental(),
+        callback_project(&sources).check()
+    );
+}


### PR DESCRIPTION
Editing a callback could leave incremental diagnostics stale because the project dependency graph recorded only syntactic calls. For example, changing `leaf` from a numeric return to a string left `wrapper <- function() lapply(1, leaf)[[1]]` and `wrapper() + 1` clean until a cold check reported RY040.

Retain actual callable reads from each file's emission, keyed by function names so slot renumbering cannot corrupt dependencies. Combine these reads with existing call edges for refinement and diagnostic invalidation. Replacement emissions replace old reads; cached emissions retain them. Changes to callable names trigger full invalidation to cover previously unresolved callbacks. Full invalidation, including package-attachment changes, starts from fresh collection without old return/signature seeds so shadowed definitions cannot inherit stale metadata. Scoped checks seed only functions outside the affected set, preventing stale return types from sustaining newly introduced mutual-recursion cycles.

Regression tests compare incremental and cold diagnostics for callback edits, direct callback use, aliases, repeated checks, replacement, removal, and re-addition. The baseline misses two RY040 errors in the main regression. R confirms both expressions error after the callback starts returning a string.

Validation: the final merged head passes workspace tests, Clippy with warnings denied, rustfmt, and the full oracle matrix. All 30 project tests pass, including deterministic shadowed-signature, loaded-change, and direct/mutual-recursion regressions. The generated edit-sequence property also passes with 1,024 cases.

Cold-check overhead probe: identical standalone release builds at `99b6249` and `9946e11`, using `Project::check` on the 60 vendored purrr R files with one Rayon thread, produced 18 diagnostics each. Whole-process Callgrind instructions rose from 885,209,116 to 886,206,695 (+0.113%). Wall-time samples were too noisy to estimate a reliable difference. This is a focused probe, not the corpus instruction-count ledger.

Partial progress on #131: dependencies remain file-granular; selective refinement across edits remains a follow-up.
