### PR TITLE
fix(lsp): version suppression edits for capable clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to ry are documented in this file.
 
 ### Fixed
 
+- Stamp suppression edits with the analyzed document version when the editor
+  supports versioned edits, so it can reject actions after the source changes.
+
 - Stop offering suppression actions for disabled or excluded files. Skip
   computing them when the editor requests other action kinds.
 

--- a/crates/ry-lsp/src/backend.rs
+++ b/crates/ry-lsp/src/backend.rs
@@ -114,6 +114,8 @@ pub(super) struct State {
     /// Whether the client supports `workspace/configuration` pull (then
     /// `didChangeConfiguration` re-pulls instead of parsing the payload).
     supports_workspace_configuration: bool,
+    /// Whether workspace edits can carry the document version they modify.
+    supports_document_changes: bool,
     /// Whether the client supports dynamic registration of
     /// `workspace/didChangeWatchedFiles`.
     supports_did_change_watched_files: bool,

--- a/crates/ry-lsp/src/backend/handlers.rs
+++ b/crates/ry-lsp/src/backend/handlers.rs
@@ -31,6 +31,14 @@ impl LanguageServer for Backend {
             .and_then(|w| w.configuration)
             .unwrap_or(false);
 
+        let supports_document_changes = params
+            .capabilities
+            .workspace
+            .as_ref()
+            .and_then(|workspace| workspace.workspace_edit.as_ref())
+            .and_then(|edit| edit.document_changes)
+            .unwrap_or(false);
+
         let supports_did_change_watched_files = params
             .capabilities
             .workspace
@@ -101,6 +109,7 @@ impl LanguageServer for Backend {
         state.folder_settings = folder_settings;
         state.server_settings = server_settings;
         state.supports_workspace_configuration = supports_workspace_configuration;
+        state.supports_document_changes = supports_document_changes;
         state.supports_did_change_watched_files = supports_did_change_watched_files;
         state.supports_relative_patterns = supports_relative_patterns;
         state.folder_contexts = folder_contexts;
@@ -481,6 +490,20 @@ impl LanguageServer for Backend {
             return Ok(None);
         };
 
+        let versioned_edits = {
+            let state = self.state.lock().await;
+            let Some((version, cached)) = state.parsed.get(&path) else {
+                return Ok(None);
+            };
+            if !Arc::ptr_eq(cached, &file)
+                || state.versions.get(&path) != Some(version)
+                || !state.eligibility_for_path(&path)
+            {
+                return Ok(None);
+            }
+            state.supports_document_changes.then_some(*version)
+        };
+
         // One quick-fix per diagnostic visible at the cursor; helpers skip
         // lines that already carry a suppression.
         let mut actions: CodeActionResponse = Vec::new();
@@ -497,6 +520,28 @@ impl LanguageServer for Backend {
 
         if let Some(action) = make_ignore_file_action(&uri, &file) {
             actions.push(CodeActionOrCommand::CodeAction(action));
+        }
+
+        if let Some(version) = versioned_edits {
+            for action in &mut actions {
+                if let CodeActionOrCommand::CodeAction(action) = action
+                    && let Some(edit) = &mut action.edit
+                    && let Some(changes) = edit.changes.take()
+                {
+                    edit.document_changes = Some(DocumentChanges::Edits(
+                        changes
+                            .into_iter()
+                            .map(|(uri, edits)| TextDocumentEdit {
+                                text_document: OptionalVersionedTextDocumentIdentifier {
+                                    uri,
+                                    version: Some(version),
+                                },
+                                edits: edits.into_iter().map(OneOf::Left).collect(),
+                            })
+                            .collect(),
+                    ));
+                }
+            }
         }
 
         if actions.is_empty() {

--- a/crates/ry-lsp/tests/versioned_suppression_edits.rs
+++ b/crates/ry-lsp/tests/versioned_suppression_edits.rs
@@ -1,0 +1,69 @@
+mod harness;
+
+use harness::{file_uri, join_session, normalize_diagnostics, spawn_session};
+use ry_testkit::FixtureProject;
+use serde_json::{Value, json};
+
+#[test]
+fn suppression_edits_use_the_source_version_when_supported() {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap()
+        .block_on(async {
+            for support in [None, Some(false), Some(true)] {
+                let fixture = FixtureProject::empty().unwrap();
+                let uri = file_uri(&fixture.write_file("main.R", "x <- unknown_name\n").unwrap());
+                let capabilities = support.map_or_else(
+                    || json!({}),
+                    |supported| json!({"workspace": {"workspaceEdit": {"documentChanges": supported}}}),
+                );
+                let (mut session, server) = spawn_session(&[fixture.root()], capabilities, None).await;
+                let mut previous_actions = Value::Null;
+                for (version, source) in [(4, "x <- unknown_name\n"), (5, "longer_name <- unknown_name\n")] {
+                    let mark = session.publication_mark();
+                    if version == 4 {
+                        session.open(&uri, version, source).await.unwrap();
+                    } else {
+                        session.change(&uri, version, json!([{"text": source}])).await.unwrap();
+                    }
+                    let published = session.published_diagnostics_after(&uri, mark).await.unwrap();
+                    let diagnostics = normalize_diagnostics(&published);
+                    let diagnostic = &diagnostics[0];
+                    let actions = session.request("textDocument/codeAction", json!({
+                        "textDocument": {"uri": uri},
+                        "range": diagnostic["range"],
+                        "context": {"diagnostics": [diagnostic]}
+                    })).await.unwrap();
+                    let entries = actions.as_array().unwrap();
+                    assert_eq!(entries.len(), 2, "{actions}");
+                    for (index, action) in entries.iter().enumerate() {
+                        let edits = if support == Some(true) {
+                            assert!(action["edit"].get("changes").is_none(), "{action}");
+                            let changes = action["edit"]["documentChanges"].as_array().unwrap();
+                            assert_eq!(changes.len(), 1);
+                            assert_eq!(changes[0]["textDocument"], json!({"uri": uri, "version": version}));
+                            &changes[0]["edits"]
+                        } else {
+                            assert!(action["edit"].get("documentChanges").is_none(), "{action}");
+                            &action["edit"]["changes"][&uri]
+                        };
+                        assert_eq!(edits.as_array().unwrap().len(), 1);
+                        if index == 0 {
+                            assert_eq!(edits[0]["range"]["end"]["character"], source.trim_end().len());
+                            assert_eq!(edits[0]["newText"], format!("{}  # ry: ignore[RY010]", source.trim_end()));
+                        } else {
+                            assert_eq!(edits[0]["newText"], "# ry: ignore-file\n");
+                        }
+                    }
+                    if version == 5 && support == Some(true) {
+                        // A saved action still names version 4, so the client can
+                        // reject it instead of replacing version 5's longer line.
+                        assert_eq!(previous_actions[0]["edit"]["documentChanges"][0]["textDocument"]["version"], 4);
+                    }
+                    previous_actions = actions;
+                }
+                join_session(session, server).await;
+            }
+        });
+}


### PR DESCRIPTION
Suppression actions replace a whole source line. If the file changes while an action remains open in the editor, an unversioned edit can overwrite newer text. Clients that advertise `workspace.workspaceEdit.documentChanges` now receive line and file suppression edits stamped with the exact analyzed document version, so they can reject stale actions.

Before constructing edits, the handler checks that the parsed source still matches the current open document. Clients without versioned-edit support retain the existing `changes` format.

Validation: suppression behavior, eligibility/kind filtering, and versioned-edit protocol tests pass. The new test covers both suppression actions, edits between document versions, and absent/false/true capability negotiation. Full workspace tests, Clippy with warnings denied, formatting, and the full R oracle matrix (17 tests) pass.
