### PR TITLE
Reject suppression requests with stale diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to ry are documented in this file.
 
 ### Fixed
 
+- Reject suppression requests that reuse stale diagnostics when the editor
+  supports preserving diagnostic data.
+
 - Stamp suppression edits with the analyzed document version when the editor
   supports versioned edits, so it can reject actions after the source changes.
 

--- a/crates/ry-lsp/src/backend.rs
+++ b/crates/ry-lsp/src/backend.rs
@@ -8,7 +8,8 @@
 mod handlers;
 
 use crate::diagnostics::{
-    diagnostic_to_lsp, diagnostic_to_lsp_with_source, make_ignore_action, make_ignore_file_action,
+    diagnostic_origin, diagnostic_to_lsp, diagnostic_to_lsp_with_source, make_ignore_action,
+    make_ignore_file_action,
 };
 use crate::hints::collect_inlay_hints;
 use crate::positions::{byte_offset_to_point, position_to_byte_offset};
@@ -116,6 +117,8 @@ pub(super) struct State {
     supports_workspace_configuration: bool,
     /// Whether workspace edits can carry the document version they modify.
     supports_document_changes: bool,
+    /// Whether the client preserves diagnostic data in code-action requests.
+    supports_diagnostic_data: bool,
     /// Whether the client supports dynamic registration of
     /// `workspace/didChangeWatchedFiles`.
     supports_did_change_watched_files: bool,
@@ -814,7 +817,7 @@ impl Backend {
         // the lock, then drop it before checking so a slow check doesn't
         // block other LSP requests (e.g. didOpen of a second file). Only
         // eligible documents' versions are snapshotted.
-        let (doc_versions, requested_is_eligible) = {
+        let (doc_versions, requested_is_eligible, supports_diagnostic_data) = {
             let state = self.state.lock().await;
             (
                 state
@@ -830,6 +833,7 @@ impl Backend {
                     })
                     .collect::<Vec<_>>(),
                 state.eligibility_for_path(&path),
+                state.supports_diagnostic_data,
             )
         };
         if !requested_is_eligible {
@@ -940,6 +944,8 @@ impl Backend {
             }
         }
 
+        let diagnostic_versions: HashMap<_, _> = doc_versions.into_iter().collect();
+
         // Publish per-file diagnostics through the folder's
         // filter/confidence/exclude/baseline state. The partition carried
         // the owning context through the check, so publication uses the
@@ -1002,9 +1008,18 @@ impl Backend {
                     .filter(|diagnostic| {
                         !file_level && !ry_checker::is_suppressed(diagnostic, &suppressions)
                     })
-                    .map(|diagnostic| match source_text {
-                        Some(text) => diagnostic_to_lsp_with_source(&diagnostic, text),
-                        None => diagnostic_to_lsp(diagnostic),
+                    .map(|diagnostic| {
+                        let mut diagnostic = match source_text {
+                            Some(text) => diagnostic_to_lsp_with_source(&diagnostic, text),
+                            None => diagnostic_to_lsp(diagnostic),
+                        };
+                        if supports_diagnostic_data
+                            && let Some(version) = diagnostic_versions.get(&diagnostic_path)
+                        {
+                            diagnostic.data =
+                                Some(diagnostic_origin(&diagnostic_path, *version, generation));
+                        }
+                        diagnostic
                     })
                     .collect();
                 let diagnostic_uri = if diagnostic_path == path {

--- a/crates/ry-lsp/src/backend/handlers.rs
+++ b/crates/ry-lsp/src/backend/handlers.rs
@@ -31,6 +31,14 @@ impl LanguageServer for Backend {
             .and_then(|w| w.configuration)
             .unwrap_or(false);
 
+        let supports_diagnostic_data = params
+            .capabilities
+            .text_document
+            .as_ref()
+            .and_then(|document| document.publish_diagnostics.as_ref())
+            .and_then(|diagnostics| diagnostics.data_support)
+            .unwrap_or(false);
+
         let supports_document_changes = params
             .capabilities
             .workspace
@@ -110,6 +118,7 @@ impl LanguageServer for Backend {
         state.server_settings = server_settings;
         state.supports_workspace_configuration = supports_workspace_configuration;
         state.supports_document_changes = supports_document_changes;
+        state.supports_diagnostic_data = supports_diagnostic_data;
         state.supports_did_change_watched_files = supports_did_change_watched_files;
         state.supports_relative_patterns = supports_relative_patterns;
         state.folder_contexts = folder_contexts;
@@ -490,7 +499,7 @@ impl LanguageServer for Backend {
             return Ok(None);
         };
 
-        let versioned_edits = {
+        let (versioned_edits, required_origin) = {
             let state = self.state.lock().await;
             let Some((version, cached)) = state.parsed.get(&path) else {
                 return Ok(None);
@@ -501,18 +510,35 @@ impl LanguageServer for Backend {
             {
                 return Ok(None);
             }
-            state.supports_document_changes.then_some(*version)
+            (
+                state.supports_document_changes.then_some(*version),
+                state
+                    .supports_diagnostic_data
+                    .then(|| diagnostic_origin(&path, *version, state.diag_generation)),
+            )
         };
+
+        let diagnostics: Vec<_> = params
+            .context
+            .diagnostics
+            .iter()
+            .filter(|diagnostic| diagnostic.source.as_deref() == Some("ry"))
+            .filter(|diagnostic| {
+                required_origin
+                    .as_ref()
+                    .is_none_or(|origin| diagnostic.data.as_ref() == Some(origin))
+            })
+            .collect();
+        // Stale ranges must not suppress unrelated current lines. Requiring
+        // preserved data is safe only for clients that negotiated it.
+        if diagnostics.is_empty() {
+            return Ok(None);
+        }
 
         // One quick-fix per diagnostic visible at the cursor; helpers skip
         // lines that already carry a suppression.
         let mut actions: CodeActionResponse = Vec::new();
-        for diag in params
-            .context
-            .diagnostics
-            .iter()
-            .filter(|diag| diag.source.as_deref() == Some("ry"))
-        {
+        for diag in diagnostics {
             if let Some(action) = make_ignore_action(&uri, diag, &file) {
                 actions.push(CodeActionOrCommand::CodeAction(action));
             }

--- a/crates/ry-lsp/src/diagnostics.rs
+++ b/crates/ry-lsp/src/diagnostics.rs
@@ -17,6 +17,12 @@ use tower_lsp::lsp_types::{
 
 use crate::positions::{byte_offset_to_position, line_start};
 
+/// Identify the document and analysis snapshot that produced a diagnostic.
+/// Clients advertising diagnostic data support preserve this in code actions.
+pub(super) fn diagnostic_origin(path: &str, version: i32, generation: u64) -> serde_json::Value {
+    serde_json::json!({"ry": {"path": path, "version": version, "generation": generation}})
+}
+
 /// Convert a `ry_checker::Diagnostic` to an LSP `Diagnostic` using the
 /// span's pre-resolved `line` / `col` and a single-character range. Used
 /// as a fallback (tests, missing source text); the production

--- a/crates/ry-lsp/tests/stale_diagnostic_actions.rs
+++ b/crates/ry-lsp/tests/stale_diagnostic_actions.rs
@@ -1,0 +1,77 @@
+mod harness;
+
+use harness::{file_uri, join_session, normalize_diagnostics, spawn_session};
+use ry_testkit::FixtureProject;
+use serde_json::{Value, json};
+
+#[test]
+fn suppression_requests_reject_stale_diagnostic_origins_when_supported() {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap()
+        .block_on(async {
+            for support in [None, Some(false), Some(true)] {
+                let fixture = FixtureProject::empty().unwrap();
+                let uri = file_uri(&fixture.write_file("main.R", "x <- unknown_name\n").unwrap());
+                let capabilities = support.map_or_else(
+                    || json!({}),
+                    |supported| json!({"textDocument": {"publishDiagnostics": {"dataSupport": supported}}}),
+                );
+                let (mut session, server) = spawn_session(&[fixture.root()], capabilities, None).await;
+                let mark = session.publication_mark();
+                session.open(&uri, 4, "x <- unknown_name\n").await.unwrap();
+                let first = session.published_diagnostics_after(&uri, mark).await.unwrap();
+                let old_diagnostic = normalize_diagnostics(&first).remove(0);
+
+                let mark = session.publication_mark();
+                session.change(&uri, 5, json!([{"text": "unrelated <- 1L\nx <- unknown_name\n"}])).await.unwrap();
+                let second = session.published_diagnostics_after(&uri, mark).await.unwrap();
+                let current_diagnostic = normalize_diagnostics(&second).remove(0);
+                let request = |diagnostics: Vec<Value>| json!({
+                    "textDocument": {"uri": uri},
+                    "range": current_diagnostic["range"],
+                    "context": {"diagnostics": diagnostics}
+                });
+                let stale_actions = session.request("textDocument/codeAction", request(vec![old_diagnostic.clone()])).await.unwrap();
+                if support == Some(true) {
+                    assert!(stale_actions.is_null(), "{stale_actions}");
+                    assert_eq!(current_diagnostic["data"]["ry"]["version"], 5);
+                    for data in [None, Some(json!({"invalid": true}))] {
+                        let mut malformed = current_diagnostic.clone();
+                        malformed.as_object_mut().unwrap().remove("data");
+                        if let Some(data) = data {
+                            malformed["data"] = data;
+                        }
+                        let actions = session.request("textDocument/codeAction", request(vec![malformed])).await.unwrap();
+                        assert!(actions.is_null(), "{actions}");
+                    }
+                    let mixed = session.request("textDocument/codeAction", request(vec![old_diagnostic, current_diagnostic.clone()])).await.unwrap();
+                    assert_eq!(mixed.as_array().unwrap().len(), 2, "{mixed}");
+                    assert_eq!(mixed[0]["edit"]["changes"][&uri][0]["range"]["start"]["line"], 1);
+                } else {
+                    // Legacy clients never promised to preserve diagnostic data.
+                    assert_eq!(stale_actions.as_array().unwrap().len(), 2);
+                    assert!(current_diagnostic.get("data").is_none());
+                }
+                let actions = session.request("textDocument/codeAction", request(vec![current_diagnostic.clone()])).await.unwrap();
+                assert_eq!(actions.as_array().unwrap().len(), 2, "{actions}");
+                assert_eq!(actions[0]["edit"]["changes"][&uri][0]["newText"], "x <- unknown_name  # ry: ignore[RY010]");
+
+                if support == Some(true) {
+                    // A settings reload changes analysis without changing text.
+                    let mark = session.publication_mark();
+                    session.notify("workspace/didChangeConfiguration", json!({"settings": {"ry": {"enable": true}}})).await.unwrap();
+                    let refreshed = session.published_diagnostics_after(&uri, mark).await.unwrap();
+                    let refreshed_diagnostic = normalize_diagnostics(&refreshed).remove(0);
+                    assert_eq!(refreshed_diagnostic["data"]["ry"]["version"], 5);
+                    assert_ne!(refreshed_diagnostic["data"], current_diagnostic["data"]);
+                    let stale = session.request("textDocument/codeAction", request(vec![current_diagnostic.clone()])).await.unwrap();
+                    assert!(stale.is_null(), "{stale}");
+                    let fresh = session.request("textDocument/codeAction", request(vec![refreshed_diagnostic])).await.unwrap();
+                    assert_eq!(fresh.as_array().unwrap().len(), 2, "{fresh}");
+                }
+                join_session(session, server).await;
+            }
+        });
+}


### PR DESCRIPTION
A suppression request can reuse a diagnostic after an edit moves its source line. The server then offers to suppress an unrelated current line. When the editor advertises `publishDiagnostics.dataSupport`, attach the document path, version, and analysis generation to diagnostics and require that origin to match before offering suppression actions. Settings or dependency changes also invalidate old diagnostics without requiring a text edit.

Clients that do not promise to preserve diagnostic data retain their existing behavior. This complements #251: that PR protects saved edits after an action is computed; this change rejects stale diagnostics when computing a new action.

Validation: protocol tests cover moved lines, stale/current mixtures, missing or malformed metadata, configuration reloads, and absent/false/true capability negotiation. The test fails against the parent implementation by offering a suppression on the unrelated line. All local gates pass: workspace tests, clippy with warnings denied, formatting, and all 17 R oracle tests. Independent review found no blockers.

Depends on #251, now merged.
