### PR TITLE
feat(facts): preserve ordered writes and proven prefixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to ry are documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- Export reference identities across ordinary literal/copy reassignments and
+  retain proven reads before opaque statements. The schema-2 reference
+  capability is now `same_file_ordered_prefix`; coverage remains partial.
+
 ### Fixed
 
 - Stop S3 operator lookup at the winning group method, avoiding false

--- a/crates/ry-checker/src/reference_facts.rs
+++ b/crates/ry-checker/src/reference_facts.rs
@@ -759,6 +759,7 @@ mod tests {
     fn deferred_functions_and_formal_writes_do_not_gain_prefix_evidence() {
         for source in [
             "f <- function() { x <- 1L; x }; mutate()",
+            "f <- function() { x <- 1L; x }; f <- function() { 2L }",
             "f <- function(p) { p <- 1L; p }",
             "f <- function(p) { p; p <- 1L; p }",
             "f <- function() { x <- 1L; x }; if (flag) mutate()",

--- a/crates/ry-checker/src/reference_facts.rs
+++ b/crates/ry-checker/src/reference_facts.rs
@@ -123,15 +123,19 @@ impl ReferenceCapture {
         inherited_unsupported: bool,
     ) {
         let mut unsafe_scope = inherited_unsupported;
+        let mut spellings = HashMap::<String, String>::new();
         let mut writes = HashMap::<String, usize>::new();
+        let mut formals = HashSet::new();
         let mut declarations = Vec::new();
-        let mut excluded_targets = HashSet::new();
         let mut references = Vec::new();
         let mut functions = Vec::new();
         let mut defaults = Vec::new();
         for param in params {
             if let Some(key) = ordinary_spelling(&param.name) {
-                *writes.entry(key.to_string()).or_default() += 1;
+                if !formals.insert(key.to_string()) {
+                    unsafe_scope = true;
+                }
+                spellings.insert(key.to_string(), param.name.clone());
             } else {
                 unsafe_scope = true;
             }
@@ -141,7 +145,12 @@ impl ReferenceCapture {
                 ..param.span
             };
             if source.get(span.start..span.end) == Some(param.name.as_str()) {
-                declarations.push((param.name.clone(), span, ReferenceDefinitionKind::Formal));
+                declarations.push((
+                    param.name.clone(),
+                    span,
+                    ReferenceDefinitionKind::Formal,
+                    true,
+                ));
             } else {
                 unsafe_scope = true;
             }
@@ -149,77 +158,110 @@ impl ReferenceCapture {
                 defaults.push(Stmt::Expr(default.clone()));
             }
         }
-        let _ = walk_stmts(
-            stmts,
-            Walk {
-                dollar_args: false,
-                assign_operands: false,
-                ..Walk::ALL
-            },
-            |node, _| {
-                match node {
-                    AstNode::Stmt(Stmt::Assign { target, value, .. }) => {
-                        if let Expr::Ident { name, span } = target {
-                            excluded_targets.insert(*span);
-                            if let Some(key) = ordinary_spelling(name) {
-                                *writes.entry(key.to_string()).or_default() += 1;
+        let mut supported_prefix = true;
+        for statement in stmts {
+            let mut unsupported_statement = false;
+            let mut statement_declarations = Vec::new();
+            let mut statement_references = Vec::new();
+            let mut excluded_targets = HashSet::new();
+            let _ = walk_stmts(
+                std::slice::from_ref(statement),
+                Walk {
+                    dollar_args: false,
+                    assign_operands: false,
+                    ..Walk::ALL
+                },
+                |node, _| {
+                    match node {
+                        AstNode::Stmt(Stmt::Assign { target, value, .. }) => {
+                            if let Expr::Ident { name, span } = target {
+                                excluded_targets.insert(*span);
+                                if let Some(key) = ordinary_spelling(name) {
+                                    // Equivalent spellings and writes to formals
+                                    // remain outside the ordinary-local contract.
+                                    if formals.contains(key)
+                                        || spellings.get(key).is_some_and(|raw| raw != name)
+                                    {
+                                        unsafe_scope = true;
+                                    }
+                                    spellings.insert(key.to_string(), name.clone());
+                                    let count = writes.entry(key.to_string()).or_default();
+                                    *count += 1;
+                                    if *count > 1 && matches!(value, Expr::Function { .. }) {
+                                        unsupported_statement = true;
+                                    }
+                                } else {
+                                    unsafe_scope = true;
+                                }
+                                statement_declarations.push((
+                                    name.clone(),
+                                    *span,
+                                    ReferenceDefinitionKind::Assignment,
+                                ));
+                                // Only certify ordinary left assignment from
+                                // source tokens; the AST drops some operators.
+                                let rhs = span_of(value);
+                                let operator = source.get(span.end..rhs.start).map(str::trim);
+                                if !matches!(operator, Some("<-" | "=")) || !simple_value(value) {
+                                    unsupported_statement = true;
+                                }
                             } else {
-                                unsafe_scope = true;
+                                unsupported_statement = true;
                             }
-                            declarations.push((
-                                name.clone(),
-                                *span,
-                                ReferenceDefinitionKind::Assignment,
-                            ));
-                            // The small AST drops some assignment operators. Only
-                            // certify ordinary left assignment from source tokens.
-                            let rhs = span_of(value);
-                            let operator = source.get(span.end..rhs.start).map(str::trim);
-                            if !matches!(operator, Some("<-" | "=")) || !simple_value(value) {
-                                unsafe_scope = true;
+                        }
+                        AstNode::Stmt(Stmt::FunctionDef { params, body, span })
+                        | AstNode::Expr(Expr::Function { params, body, span }) => {
+                            functions.push((params.clone(), body.clone(), *span));
+                            return ControlFlow::<(), Descend>::Continue(Descend::Skip);
+                        }
+                        AstNode::Stmt(
+                            Stmt::If { .. }
+                            | Stmt::For { .. }
+                            | Stmt::While { .. }
+                            | Stmt::Return { .. },
+                        ) => unsupported_statement = true,
+                        AstNode::Expr(Expr::Ident { name, span }) => {
+                            if ordinary_spelling(name).is_none() {
+                                unsupported_statement = true;
                             }
-                        } else {
-                            unsafe_scope = true;
+                            if !excluded_targets.contains(span)
+                                && Self::source_backed(source, *span)
+                            {
+                                statement_references.push((name.clone(), *span));
+                            }
                         }
+                        AstNode::Expr(
+                            Expr::Call { .. }
+                            | Expr::BinOp { .. }
+                            | Expr::UnaryOp { .. }
+                            | Expr::Index { .. }
+                            | Expr::If { .. }
+                            | Expr::Unknown(_),
+                        ) => unsupported_statement = true,
+                        _ => {}
                     }
-                    AstNode::Stmt(Stmt::FunctionDef { params, body, span })
-                    | AstNode::Expr(Expr::Function { params, body, span }) => {
-                        functions.push((params.clone(), body.clone(), *span));
-                        return ControlFlow::<(), Descend>::Continue(Descend::Skip);
-                    }
-                    AstNode::Stmt(
-                        Stmt::If { .. }
-                        | Stmt::For { .. }
-                        | Stmt::While { .. }
-                        | Stmt::Return { .. },
-                    ) => unsafe_scope = true,
-                    AstNode::Expr(Expr::Ident { name, span }) => {
-                        if ordinary_spelling(name).is_none() {
-                            unsafe_scope = true;
-                        }
-                        if !excluded_targets.contains(span) && Self::source_backed(source, *span) {
-                            references.push((name.clone(), *span));
-                        }
-                    }
-                    AstNode::Expr(
-                        Expr::Call { .. }
-                        | Expr::BinOp { .. }
-                        | Expr::UnaryOp { .. }
-                        | Expr::Index { .. }
-                        | Expr::If { .. }
-                        | Expr::Unknown(_),
-                    ) => unsafe_scope = true,
-                    _ => {}
-                }
-                ControlFlow::Continue(Descend::Into)
-            },
-        );
-        unsafe_scope |= writes.values().any(|count| *count != 1);
+                    ControlFlow::Continue(Descend::Into)
+                },
+            );
+            // Reject the entire opaque statement, including earlier children.
+            // This boundary makes no argument/subexpression ordering claims.
+            supported_prefix &= !unsupported_statement;
+            declarations.extend(
+                statement_declarations
+                    .into_iter()
+                    .map(|(name, span, kind)| (name, span, kind, supported_prefix)),
+            );
+            references.extend(
+                statement_references
+                    .into_iter()
+                    .map(|(name, span)| (name, span, supported_prefix)),
+            );
+        }
         if !unsafe_scope {
             self.eligible_scopes.insert(owner);
-            declarations.sort_by_key(|(_, span, _)| (span.start, span.end));
-            for (name, span, kind) in declarations {
-                if !Self::source_backed(source, span) {
+            declarations.sort_by_key(|(_, span, _, _)| (span.start, span.end));
+            for (name, span, kind, eligible) in declarations {
+                if !eligible || !Self::source_backed(source, span) {
                     continue;
                 }
                 let id = DefinitionId(self.definitions.len() as u32);
@@ -233,7 +275,8 @@ impl ReferenceCapture {
                 self.declarations.insert(span, id);
             }
         }
-        for (name, span) in references {
+        for (name, span, eligible) in references {
+            let eligible = eligible && !unsafe_scope;
             self.occurrences.entry(span).or_insert(Occurrence {
                 record: ReferenceRecord {
                     name,
@@ -241,24 +284,31 @@ impl ReferenceCapture {
                     resolution: ReferenceResolution::Unsupported,
                     definition: None,
                     type_at_reference: None,
-                    reason: Some(if unsafe_scope {
-                        "unsupported_scope"
-                    } else {
+                    reason: Some(if eligible {
                         "not_observed"
+                    } else {
+                        "unsupported_scope"
                     }),
                 },
                 owner,
-                eligible: !unsafe_scope,
+                eligible,
                 observed: false,
             });
         }
         // Defaults are lazy expressions, not the function's runtime contract.
-        // Their references and any nested functions remain unsupported.
         if !defaults.is_empty() {
             self.inventory_scope(source, owner, &[], &defaults, true);
         }
         for (params, body, span) in functions {
-            self.inventory_scope(source, span, &params, &body, unsafe_scope);
+            // A body can run after the enclosing prefix has ended. Its textual
+            // definition position cannot make later enclosing effects safe.
+            self.inventory_scope(
+                source,
+                span,
+                &params,
+                &body,
+                unsafe_scope || !supported_prefix,
+            );
         }
     }
 
@@ -278,7 +328,7 @@ impl ReferenceCapture {
     }
 }
 
-// Canonical spelling is used ONLY to reject multiple syntactic writes and
+// Canonical spelling is used ONLY to reject equivalent mixed spellings and
 // unsupported names. The semantic lookup and provenance retain the checker's
 // raw names. Escaped names need a full R decoder and are outside this subset.
 fn ordinary_spelling(name: &str) -> Option<&str> {
@@ -538,6 +588,214 @@ mod tests {
     }
 
     #[test]
+    fn fixed_reference_panel_preserves_counts_and_inference() {
+        let panel: serde_json::Value = serde_json::from_str(include_str!(
+            "../../../docs/corpus/reference-prefix-panel.json"
+        ))
+        .unwrap();
+        let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+        let mut sources: Vec<_> = panel["cases"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|case| {
+                (
+                    case["name"].as_str().unwrap().to_string(),
+                    case["source"].as_str().unwrap().to_string(),
+                    case["references"].as_u64().unwrap() as usize,
+                    case["resolved"].as_u64().unwrap() as usize,
+                )
+            })
+            .collect();
+        for case in panel["files"].as_array().unwrap() {
+            let path = case["path"].as_str().unwrap();
+            sources.push((
+                path.to_string(),
+                std::fs::read_to_string(root.join(path)).unwrap(),
+                case["references"].as_u64().unwrap() as usize,
+                case["resolved"].as_u64().unwrap() as usize,
+            ));
+        }
+        for (name, source, references, resolved) in sources {
+            let file = file(&source);
+            let mut plain = Checker::new("refs.R");
+            let (plain_diagnostics, plain_scope) = plain.check_with_scope(&file);
+            let mut captured = Checker::new("refs.R");
+            captured.enable_reference_capture();
+            let (captured_diagnostics, captured_scope) = captured.check_with_scope(&file);
+            assert_eq!(plain_scope.bindings, captured_scope.bindings, "{name}");
+            assert_eq!(
+                format!("{plain_diagnostics:?}"),
+                format!("{captured_diagnostics:?}"),
+                "{name}"
+            );
+            let facts = captured.take_reference_facts();
+            assert_eq!(facts.references.len(), references, "{name}");
+            assert_eq!(
+                facts
+                    .references
+                    .iter()
+                    .filter(|read| read.resolution == ReferenceResolution::Resolved)
+                    .count(),
+                resolved,
+                "{name}"
+            );
+            captured.check(&file);
+            assert_eq!(
+                format!("{facts:?}"),
+                format!("{:?}", captured.take_reference_facts()),
+                "{name}"
+            );
+        }
+    }
+
+    #[test]
+    fn ordered_reassignments_keep_each_read_at_its_installed_definition() {
+        let source = "x <- 1L\nx\ny <- x\nx <- x\nx\nx <- 'later'\nx\ny\n";
+        let facts = facts(source);
+        let reads = named(&facts, "x");
+        assert_eq!(reads.len(), 5);
+        assert!(
+            reads
+                .iter()
+                .all(|read| read.resolution == ReferenceResolution::Resolved)
+        );
+        assert_eq!(reads[0].definition, reads[1].definition);
+        assert_eq!(reads[1].definition, reads[2].definition);
+        assert_ne!(reads[2].definition, reads[3].definition);
+        assert_ne!(reads[3].definition, reads[4].definition);
+        for read in &reads[..4] {
+            assert_eq!(read.type_at_reference.as_ref().unwrap().mode, Mode::Integer);
+        }
+        assert_eq!(
+            reads[4].type_at_reference.as_ref().unwrap().mode,
+            Mode::Character
+        );
+        let copied = named(&facts, "y")[0];
+        assert_eq!(copied.resolution, ReferenceResolution::Resolved);
+        assert_ne!(copied.definition, reads[0].definition);
+        assert_eq!(
+            copied.type_at_reference.as_ref().unwrap().mode,
+            Mode::Integer
+        );
+    }
+
+    #[test]
+    fn opaque_statements_preserve_only_the_proven_prefix() {
+        for opaque in [
+            "mutate()",
+            "base::identity(1L)",
+            "x + 1L",
+            "if (flag) mutate()",
+            "z <- { x; mutate() }",
+        ] {
+            let source = format!("x <- 1L\nx\n{opaque}\nx <- 2L\nx\n");
+            let facts = facts(&source);
+            let reads = named(&facts, "x");
+            assert_eq!(
+                reads[0].resolution,
+                ReferenceResolution::Resolved,
+                "{source}: {facts:?}"
+            );
+            assert_eq!(
+                reads[0].type_at_reference.as_ref().unwrap().mode,
+                Mode::Integer
+            );
+            for read in &reads[1..] {
+                assert_eq!(
+                    read.resolution,
+                    ReferenceResolution::Unsupported,
+                    "{source}: {facts:?}"
+                );
+                assert!(read.definition.is_none() && read.type_at_reference.is_none());
+            }
+            assert_eq!(facts.definitions.len(), 1, "no later definition: {facts:?}");
+        }
+        let facts = facts("mutate()\nx <- 1L\nx\n");
+        assert_eq!(
+            named(&facts, "x")[0].resolution,
+            ReferenceResolution::Unsupported
+        );
+    }
+
+    #[test]
+    fn prefix_changes_do_not_rewrite_an_earlier_fact() {
+        let original = facts("x <- 1L\ny <- x\n");
+        for suffix in [
+            "mutate()\ny\n",
+            "base::identity(x)\ny\n",
+            "if (flag) mutate()\ny\n",
+        ] {
+            let extended = facts(&format!("x <- 1L\ny <- x\n{suffix}"));
+            let before = &original.references[0];
+            let after = &extended.references[0];
+            assert_eq!(before.span, after.span);
+            assert_eq!(before.definition, after.definition);
+            assert_eq!(before.type_at_reference, after.type_at_reference);
+            assert_eq!(after.resolution, ReferenceResolution::Resolved);
+        }
+    }
+
+    #[test]
+    fn reassignment_does_not_recover_after_formal_or_unknown_reads() {
+        for source in [
+            "f <- function(p) { x <- 1L; x; p; x <- 2L; x }",
+            "x <- 1L; x; unknown_name; x <- 2L; x",
+        ] {
+            let facts = facts(source);
+            let reads = named(&facts, "x");
+            assert_eq!(reads[0].resolution, ReferenceResolution::Resolved);
+            assert_eq!(reads[1].resolution, ReferenceResolution::Unsupported);
+            assert!(reads[1].definition.is_none() && reads[1].type_at_reference.is_none());
+        }
+        let facts = facts("f <- function(p) { x <- 1L; x; p; x }");
+        assert_eq!(
+            named(&facts, "p")[0].resolution,
+            ReferenceResolution::Resolved
+        );
+    }
+
+    #[test]
+    fn deferred_functions_and_formal_writes_do_not_gain_prefix_evidence() {
+        for source in [
+            "f <- function() { x <- 1L; x }; mutate()",
+            "f <- function(p) { p <- 1L; p }",
+            "f <- function(p) { p; p <- 1L; p }",
+            "f <- function() { x <- 1L; x }; if (flag) mutate()",
+            "f <- function() { x <- 1L; x }; base::identity(1L)",
+        ] {
+            let facts = facts(source);
+            assert!(
+                facts
+                    .references
+                    .iter()
+                    .all(|read| read.resolution == ReferenceResolution::Unsupported),
+                "{source}: {facts:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn ordered_shadowing_keeps_unicode_sites_separate() {
+        let source = "`空 白` <- 1L\n`空 白`\nf <- function() { `空 白` <- 'local'; `空 白`; `空 白` <- FALSE; `空 白` }\n`空 白`\n";
+        let facts = facts(source);
+        let reads = named(&facts, "`空 白`");
+        assert_eq!(reads.len(), 4);
+        assert_eq!(reads[0].definition, reads[3].definition);
+        assert_ne!(reads[0].definition, reads[1].definition);
+        assert_ne!(reads[1].definition, reads[2].definition);
+        for (read, mode) in
+            reads
+                .iter()
+                .zip([Mode::Integer, Mode::Character, Mode::Logical, Mode::Integer])
+        {
+            assert_eq!(read.resolution, ReferenceResolution::Resolved);
+            assert_eq!(read.type_at_reference.as_ref().unwrap().mode, mode);
+            assert_eq!(&source[read.span.start..read.span.end], "`空 白`");
+        }
+    }
+
+    #[test]
     fn reference_capture_uses_the_semantic_write_and_lookup() {
         let source = "x <- 1L\ny <- x\nz <- y\n";
         let facts = facts(source);
@@ -563,9 +821,8 @@ mod tests {
     }
 
     #[test]
-    fn reference_capture_rejects_reassignment_and_nonordinary_operators() {
+    fn reference_capture_rejects_nonordinary_operators() {
         for source in [
-            "x <- 1L\ny <- x\nx <- 'later'",
             "x := 1L\ny <- x",
             "1L ->> x\ny <- x",
             "x <<- 1L\ny <- x",

--- a/crates/ry-cli/src/facts.rs
+++ b/crates/ry-cli/src/facts.rs
@@ -438,7 +438,7 @@ pub(crate) fn run_dump_facts(
         result["scope_snapshot_kind"] = json!("scope_exit");
         result["capabilities"] = json!({
             "scope_snapshots": true,
-            "reference_facts": "same_file_straight_line",
+            "reference_facts": "same_file_ordered_prefix",
             "reference_coverage": "partial",
         });
     }

--- a/crates/ry-cli/tests/facts_references.rs
+++ b/crates/ry-cli/tests/facts_references.rs
@@ -87,6 +87,10 @@ fn literal_copy_resolves_to_source_definition_with_reference_type() {
     assert_eq!(output["scope_snapshot_kind"], "scope_exit");
     assert!(output.get("snapshot_kind").is_none());
     assert_eq!(output["capabilities"]["reference_coverage"], "partial");
+    assert_eq!(
+        output["capabilities"]["reference_facts"],
+        "same_file_ordered_prefix"
+    );
     for (fragment, name, definition_start) in [("y <- x", "x", 0), ("z <- y", "y", 8)] {
         let reference = reference_at(&output, source, fragment, name);
         assert_eq!(reference["snapshot_kind"], "reference");
@@ -106,7 +110,9 @@ fn literal_copy_resolves_to_source_definition_with_reference_type() {
 fn later_reassignment_never_lends_its_final_type_to_an_earlier_read() {
     let source = "x <- 1L\ny <- x\nx <- \"later\"\n";
     let output = analyze(source);
-    assert_uncertain(&reference_at(&output, source, "y <- x", "x"));
+    let early = reference_at(&output, source, "y <- x", "x");
+    assert_eq!(early["resolution_status"], "resolved");
+    assert_eq!(early["type_at_reference"]["mode"], "integer");
     let top = output["files"][0]["scopes"]
         .as_array()
         .unwrap()
@@ -219,7 +225,7 @@ fn reference_capture_is_deterministic_opt_in_and_does_not_execute_source() {
     let directory = tempfile::tempdir().unwrap();
     fs::write(
         directory.path().join("case.R"),
-        "x <- 1L\ny <- x\nf <- function(arg = 1L) { copy <- arg; copy }\n",
+        "x <- 1L\ny <- x\nx <- 'later'\ny\nf <- function(arg = 1L) { copy <- arg; copy }\nmutate()\ny\n",
     )
     .unwrap();
     let legacy_before = invoke(directory.path(), false);

--- a/docs/corpus/reference-prefix-panel.json
+++ b/docs/corpus/reference-prefix-panel.json
@@ -1,0 +1,133 @@
+{
+  "baseline_commit": "26654ce",
+  "cases": [
+    {
+      "name": "literal_copy",
+      "source": "x <- 1L\ny <- x\ny\n",
+      "baseline_resolved": 2,
+      "resolved": 2,
+      "references": 2
+    },
+    {
+      "name": "ordered_writes",
+      "source": "x <- 1L\nx\nx <- \"later\"\nx\n",
+      "baseline_resolved": 0,
+      "resolved": 2,
+      "references": 2
+    },
+    {
+      "name": "copy_survives_write",
+      "source": "x <- 1L\ny <- x\nx <- \"later\"\ny\n",
+      "baseline_resolved": 0,
+      "resolved": 2,
+      "references": 2
+    },
+    {
+      "name": "self_copy",
+      "source": "x <- 1L\nx <- x\nx\n",
+      "baseline_resolved": 0,
+      "resolved": 2,
+      "references": 2
+    },
+    {
+      "name": "call_prefix",
+      "source": "x <- 1L\ny <- x\nmutate()\ny\n",
+      "baseline_resolved": 0,
+      "resolved": 1,
+      "references": 3
+    },
+    {
+      "name": "qualified_call_prefix",
+      "source": "x <- 1L\nx\nbase::identity(x)\nx\n",
+      "baseline_resolved": 0,
+      "resolved": 1,
+      "references": 4
+    },
+    {
+      "name": "branch_prefix",
+      "source": "x <- 1L\nx\nif (flag) mutate()\nx\n",
+      "baseline_resolved": 0,
+      "resolved": 1,
+      "references": 4
+    },
+    {
+      "name": "opaque_first",
+      "source": "mutate()\nx <- 1L\nx\n",
+      "baseline_resolved": 0,
+      "resolved": 0,
+      "references": 2
+    },
+    {
+      "name": "formal_barrier",
+      "source": "f <- function(p) { x <- 1L; x; p; x <- 2L; x }\n",
+      "baseline_resolved": 0,
+      "resolved": 2,
+      "references": 3
+    },
+    {
+      "name": "unknown_barrier",
+      "source": "x <- 1L\nx\nunknown_name\nx <- 2L\nx\n",
+      "baseline_resolved": 0,
+      "resolved": 1,
+      "references": 3
+    },
+    {
+      "name": "deferred_function",
+      "source": "f <- function() { x <- 1L; x }\nmutate()\n",
+      "baseline_resolved": 0,
+      "resolved": 0,
+      "references": 2
+    },
+    {
+      "name": "unicode_shadowing",
+      "source": "`空 白` <- 1L\n`空 白`\nf <- function() { `空 白` <- \"local\"; `空 白`; `空 白` <- FALSE; `空 白` }\n`空 白`\n",
+      "baseline_resolved": 2,
+      "resolved": 4,
+      "references": 4
+    },
+    {
+      "name": "equivalent_spellings",
+      "source": "x <- 1L\n`x` <- \"later\"\ny <- x\n",
+      "baseline_resolved": 0,
+      "resolved": 0,
+      "references": 1
+    },
+    {
+      "name": "formal_write",
+      "source": "f <- function(p) { p <- 1L; p }\n",
+      "baseline_resolved": 0,
+      "resolved": 0,
+      "references": 1
+    },
+    {
+      "name": "opaque_subexpression",
+      "source": "x <- 1L\nx\nz <- { x; mutate() }\nx\n",
+      "baseline_resolved": 0,
+      "resolved": 1,
+      "references": 4
+    }
+  ],
+  "files": [
+    {
+      "path": "crates/ry-checker/testdata/vendor/glue/R/quoting.R",
+      "source_hash": "sha256:2821ef735bb44a1b37af3a38b49de4252470b16168fecab0672abec65897bf3f",
+      "references": 6,
+      "baseline_resolved": 0,
+      "resolved": 0
+    },
+    {
+      "path": "crates/ry-checker/testdata/vendor/purrr/R/adverb-possibly.R",
+      "source_hash": "sha256:9a41704fb43684ed561fb02e4f9e1182894460fc858c3c2dc555007afbffda25",
+      "references": 14,
+      "baseline_resolved": 0,
+      "resolved": 0
+    },
+    {
+      "path": "crates/ry-checker/testdata/vendor/purrr/R/imap.R",
+      "source_hash": "sha256:afdd6b8fbfc9540e4adc67c862ce9526d8524a07e7560026b6e94b56924ea4e4",
+      "references": 68,
+      "baseline_resolved": 0,
+      "resolved": 0
+    }
+  ]
+}

--- a/docs/corpus/reference-prefixes.md
+++ b/docs/corpus/reference-prefixes.md
@@ -1,0 +1,39 @@
+# Ordered reference coverage
+
+The [fixed panel](reference-prefix-panel.json) measures the ordered-write and
+proven-prefix extensions to schema-2 reference facts. It contains 15 authored
+cases and three existing vendored R files. The real files were selected before
+measurement and are pinned by source hash. This is a regression panel, not a
+representative estimate of R code coverage.
+
+The baseline uses the reference implementation at `26654ce`. Each source was
+checked independently with `ry dump-facts case.R --references`, using the same
+source for the baseline and candidate binaries. Counts include exported read
+records; they do not count all possible runtime reads.
+
+| Source group | Exported reads | Baseline resolved | Ordered-prefix resolved | Gain |
+| --- | ---: | ---: | ---: | ---: |
+| 15 authored cases | 39 | 4 | 19 | 15 |
+| 3 vendored files | 88 | 0 | 0 | 0 |
+
+The vendored files are glue's `R/quoting.R` and purrr's `R/adverb-possibly.R`
+and `R/imap.R`. Their reads remain unavailable under the current restrictions.
+The gain in this panel comes entirely from the authored cases. It does not
+establish useful coverage for general editor navigation.
+
+The panel records the source text of each authored case, repository paths and
+hashes for the vendored files, and both sets of counts. The checker test pins
+the candidate counts, verifies deterministic capture, and compares types and
+diagnostics with reference capture disabled:
+
+```sh
+cargo test -p ry-checker fixed_reference_panel_preserves_counts_and_inference
+```
+
+For a CLI comparison, write an authored case's `source` to `case.R`, or copy a
+vendored file to that path. Run both binaries on it with `dump-facts case.R
+--references`. Count file reference records whose `resolution_status` is
+`resolved`. Keep the input sources fixed when comparing versions.
+
+The [reference contract](../facts.md#reference-facts-schema-version-2) describes
+the remaining statement, promise, and deferred-function barriers.

--- a/docs/facts.md
+++ b/docs/facts.md
@@ -52,13 +52,18 @@ ry dump-facts R/ --references > facts.json
 `dump-types` keeps its own output format. Reference capture runs alongside
 scope capture in the same project check, without changing diagnostic inference.
 
+The `reference_facts` capability is `"same_file_ordered_prefix"`. Consumers
+that accepted only `"same_file_straight_line"` must opt into this broader
+contract. The schema version remains 2; IDs are still local to one file and
+analysis snapshot, and coverage remains partial.
+
 Schema 2 keeps the scope and binding snapshots below. At the root it replaces
 `snapshot_kind` with `scope_snapshot_kind: "scope_exit"` and adds:
 
 ```json
 "capabilities": {
   "scope_snapshots": true,
-  "reference_facts": "same_file_straight_line",
+  "reference_facts": "same_file_ordered_prefix",
   "reference_coverage": "partial"
 }
 ```
@@ -85,11 +90,14 @@ Each reference contains:
 | `type_at_reference` | A structured type, or `null` when resolution is not established. |
 | `reason` | The checker's explanation for missing evidence, or `null`. |
 
-The checker supports a conservative subset of straight-line, same-file code:
-literal assignments, copies of established bindings, and a function's own
-formals and locals. A copy gets its own definition ID and carries the source
-binding's established type. A formal has unknown type even when it has a
-default. R callers can supply a different value. Reading a formal can force
+The checker supports a conservative subset of same-file code: literal
+assignments, copies of established bindings, and a function's own formals and
+locals. Ordinary literal/copy reassignments to non-formal locals get a distinct
+definition ID for each write. A read uses the definition installed at that
+point, after the preceding assignment's RHS has been analyzed. A copy gets its
+own definition ID and keeps the source binding's established type.
+
+A formal has unknown type even when it has a default. R callers can supply a different value. Reading a formal can force
 caller or default code that changes the frame. After that read, the checker
 discards binding identities for the rest of the scope, including nested
 functions analyzed from it. A fresh assignment cannot restore that evidence.
@@ -109,16 +117,26 @@ names, dots arguments, escaped names, syntax-primitive names, and reassignment
 through equivalent plain/backtick spellings are excluded. A differently
 spelled read cannot resolve by matching a decoded name.
 
-Eligibility applies to a whole lexical scope. Calls, operators, indexing,
-control flow, nonstandard evaluation, or reassignment anywhere in that scope
-make its references unsupported, including reads before that operation. Nested
-functions inherit this restriction. Default expressions and reads captured
-from enclosing scopes are unsupported. Unresolved, ambiguous, and
-unsupported records have no definition ID or type. A missing record is also
+Calls, operators, indexing, control flow, nonstandard evaluation, and other
+unsupported statements end the supported prefix. The entire statement and
+its suffix remain unsupported, including fresh literal assignments. Earlier
+proven reads retain their definition IDs and types. This does not establish
+evaluation order inside an unsupported expression. Top-level braces that the
+parser flattens into a statement sequence follow that sequence.
+
+Mixed equivalent spellings, writes to formals, and unsupported declaration
+names still exclude the whole lexical scope. Nested function bodies remain
+unsupported if their enclosing scope contains an opaque statement, even after
+the function's definition: those bodies can run later. Default expressions and
+reads captured from enclosing scopes are unsupported. Unresolved, ambiguous,
+and unsupported records have no definition ID or type. A missing record is also
 unavailable evidence: the export does not promise to enumerate every possible
 runtime read. Check the status of each record. A concrete scope-exit type
 cannot fill a gap in reference evidence, and a resolved reference alone does
 not establish that a rename or other edit is safe.
+
+See the [fixed coverage panel](corpus/reference-prefixes.md) for measured
+changes and unchanged real-source cases.
 
 ## Schema version 1
 


### PR DESCRIPTION
Reference reads now resolve to the ordinary literal/copy assignment installed at that point, with a distinct definition ID per write. For `x <- 1L; x; x <- "later"; x`, the reads resolve to different definitions with integer and character types. A copy retains its own identity and type after the source binding changes.

An unsupported statement ends the supported prefix without discarding earlier proven reads. The whole statement and its suffix remain unavailable. Existing promise/unknown-read barriers persist; formal writes, mixed equivalent spellings, default expressions, and deferred bodies under opaque enclosing scopes remain conservative. No navigation or rename capability is added.

Schema 2 now advertises `reference_facts: "same_file_ordered_prefix"` instead of `"same_file_straight_line"`, documented for strict consumers. The fixed panel measures 4→19 resolved reads among 39 authored-case records, and 0→0 among 88 records in three pinned vendored files. All observed gain is in the authored cases.

Validation: 18 focused checker tests and 12 CLI reference tests pass. The panel also checks deterministic reuse and unchanged inference/diagnostics with capture disabled. Full workspace tests, Clippy with warnings denied, formatting, and the full R oracle matrix (17 tests) pass after rebasing onto current main.

Closes #246. Closes #247.
