### PR TITLE
docs: record scope journal experiment tradeoffs

### DIFF
--- a/docs/corpus/README.md
+++ b/docs/corpus/README.md
@@ -30,6 +30,8 @@ audit records summarized in [`pre-governance-measurement.md`](pre-governance-mea
 
 The [instruction baseline](instructions-baseline.json) records the fixed performance
 sample. See the [measurement guide](instructions.md) for local runs and CI deltas.
+The [scope journal experiment](scope-journal-experiment.md) records sparse and
+dense branch tradeoffs for issue #130.
 
 ## Parser invariant evidence
 

--- a/docs/corpus/scope-journal-experiment.json
+++ b/docs/corpus/scope-journal-experiment.json
@@ -1,0 +1,133 @@
+{
+  "commit": "6cb70fa98b109edf70b7d384b8bd1be73a944443",
+  "rustc": "rustc 1.98.1 (48a229cea 2026-09-01)",
+  "valgrind": "valgrind-3.25.1",
+  "settings": {
+    "rayon_threads": 1,
+    "no_installed_libraries": true
+  },
+  "inputs": {
+    "sparse": {
+      "sha256": "3f0919104342b5f19a5d144e1dd36dee98239cb2bf3b8787ee4d536cac67e564",
+      "files": 1
+    },
+    "dense": {
+      "sha256": "811323d0932294376dff2f8e80eecddc55b1770efad0b6d3e8cf54e3b302e654",
+      "files": 1
+    },
+    "alternating": {
+      "sha256": "5146b6c11182f912733bf0e1f17e01a1f87b01da3ffe9eb39d6c9b6907d006ae",
+      "files": 1
+    },
+    "corpus": {
+      "sha256": "4073671d4b5cf883da6823ae6e33523d3c16bec7546460ef9c672407e3e61ea1",
+      "files": 240
+    }
+  },
+  "measurements": [
+    {
+      "workload": "sparse",
+      "tool": "callgrind",
+      "journal": false,
+      "instructions": 199206416
+    },
+    {
+      "workload": "sparse",
+      "tool": "callgrind",
+      "journal": true,
+      "instructions": 104834824
+    },
+    {
+      "workload": "sparse",
+      "tool": "dhat",
+      "journal": false,
+      "allocated_bytes": 67538807,
+      "peak_live_bytes": 23701232
+    },
+    {
+      "workload": "sparse",
+      "tool": "dhat",
+      "journal": true,
+      "allocated_bytes": 22557812,
+      "peak_live_bytes": 10821396
+    },
+    {
+      "workload": "dense",
+      "tool": "callgrind",
+      "journal": false,
+      "instructions": 1631017829
+    },
+    {
+      "workload": "dense",
+      "tool": "callgrind",
+      "journal": true,
+      "instructions": 1583017500
+    },
+    {
+      "workload": "dense",
+      "tool": "dhat",
+      "journal": false,
+      "allocated_bytes": 185605709,
+      "peak_live_bytes": 50665765
+    },
+    {
+      "workload": "dense",
+      "tool": "dhat",
+      "journal": true,
+      "allocated_bytes": 143622599,
+      "peak_live_bytes": 45266945
+    },
+    {
+      "workload": "alternating",
+      "tool": "callgrind",
+      "journal": false,
+      "instructions": 1831214239
+    },
+    {
+      "workload": "alternating",
+      "tool": "callgrind",
+      "journal": true,
+      "instructions": 2329137758
+    },
+    {
+      "workload": "alternating",
+      "tool": "dhat",
+      "journal": false,
+      "allocated_bytes": 240455233,
+      "peak_live_bytes": 50668360
+    },
+    {
+      "workload": "alternating",
+      "tool": "dhat",
+      "journal": true,
+      "allocated_bytes": 295895701,
+      "peak_live_bytes": 43718900
+    },
+    {
+      "workload": "corpus",
+      "tool": "callgrind",
+      "journal": false,
+      "instructions": 198082220
+    },
+    {
+      "workload": "corpus",
+      "tool": "callgrind",
+      "journal": true,
+      "instructions": 197405701
+    },
+    {
+      "workload": "corpus",
+      "tool": "dhat",
+      "journal": false,
+      "allocated_bytes": 30985357,
+      "peak_live_bytes": 12213406
+    },
+    {
+      "workload": "corpus",
+      "tool": "dhat",
+      "journal": true,
+      "allocated_bytes": 30756840,
+      "peak_live_bytes": 12213406
+    }
+  ]
+}

--- a/docs/corpus/scope-journal-experiment.md
+++ b/docs/corpus/scope-journal-experiment.md
@@ -1,0 +1,87 @@
+# Scope journal experiment
+
+The journal prototype stays outside production. It cuts work on wide scopes with
+sparse branch writes, but dense branches that alternate inferred types remain
+slower. The ordinary fixture corpus gains too little to justify the extra state
+and mutation paths. [Issue #130](https://github.com/sims1253/ry/issues/130) remains
+open.
+
+This follows the [#225 investigation](https://github.com/sims1253/ry/issues/130#issuecomment-5560333325),
+which retained cheaper branch merging and rejected whole-map copy-on-write.
+This experiment keeps the public `Scope` maps and journals mutations instead.
+A snapshot stores the log position and scalar flags; rollback replays the log.
+Branch merging reads mutation-derived deltas rather than scanning full maps.
+Clones start with an empty journal. Binding markers, aliases, reachability and
+reference provenance are included.
+
+The first version saved sparse allocations but added about 22% dense instructions.
+Moving old types into undo entries, using smaller marker records and borrowing
+branch views reduced that cost only slightly. The final version also skips
+assignments that leave every tracked binding fact unchanged. That helps repeated
+writes of the same type; the alternating-type control exposes the remaining cost.
+
+## Measurement
+
+The [final source and harness](https://github.com/sims1253/ry/tree/6cb70fa98b109edf70b7d384b8bd1be73a944443/experiments/scope-journal)
+are pinned at `6cb70fa98b109edf70b7d384b8bd1be73a944443`, based on `e67fb55`.
+Only statement `if` branches use the experiment; other scope clones remain.
+The same release binary runs with
+`RY_SCOPE_JOURNAL=0` and `1`, one Rayon thread and installed R libraries disabled.
+Rust is 1.98.1; Valgrind is 3.25.1 on Linux x86-64.
+
+Each synthetic file has 1,024 bindings and 24 nested branches. Sparse branches
+write one name each. Dense branches write every name; the alternating variant
+switches between integer and character at each depth. The corpus runs each of
+240 top-level checker fixtures independently. Parsing occurs before the timed
+check, but Callgrind counts the whole process, including parsing and diagnostic
+formatting. These are instruction counts, not wall-time speedups or the fixed
+package instruction ledger.
+
+| Workload | Clone instructions | Journal instructions | Change |
+| :-- | --: | --: | --: |
+| Sparse writes | 199,206,416 | 104,834,824 | -47.37% |
+| Dense, same type | 1,631,017,829 | 1,583,017,500 | -2.94% |
+| Dense, alternating types | 1,831,214,239 | 2,329,137,758 | +27.19% |
+| 240-file corpus | 198,082,220 | 197,405,701 | -0.34% |
+
+| Workload | Clone allocations (MB) | Journal allocations (MB) | Change |
+| :-- | --: | --: | --: |
+| Sparse writes | 67.54 | 22.56 | -66.60% |
+| Dense, same type | 185.61 | 143.62 | -22.62% |
+| Dense, alternating types | 240.46 | 295.90 | +23.06% |
+| 240-file corpus | 30.99 | 30.76 | -0.74% |
+
+Sparse peak live heap falls from 23.70 to 10.82 MB; alternating dense peak falls
+from 50.67 to 43.72 MB. Corpus peak stays at 12.21 MB. Exact totals, input hashes
+and settings are in [the recorded results](scope-journal-experiment.json).
+
+The reports match byte for byte between modes. Small count differences between
+runs remain possible because of randomized hashing and paths. The disabled mode
+still contains dormant journal plumbing, so these numbers compare strategies
+inside the prototype, not two released versions.
+
+The prototype passed workspace tests with the journal enabled, including scope
+and reference-fact coverage, plus Clippy, rustfmt and the full R oracle matrix.
+A nested-snapshot test checks marker/scalar rollback and independent clone logs.
+
+## Reproduce
+
+Fetch the experiment branch and use a separate checkout:
+
+```sh
+git fetch origin experiment/scope-journal
+git worktree add --detach /tmp/ry-scope-journal 6cb70fa98b109edf70b7d384b8bd1be73a944443
+cd /tmp/ry-scope-journal
+python3 experiments/scope-journal/profile.py \
+  --out /tmp/ry-scope-profile --tools callgrind dhat
+```
+
+The output directory must be new. The script builds with locked dependencies,
+records input SHA-256 hashes and tool versions, preserves raw profiles, and
+checks diagnostic equality. `results.json` contains exact allocation and
+instruction totals. DHAT totals are cumulative allocations; its peak is live
+heap, not process RSS.
+
+A future design should improve dense writes and ordinary workloads before it
+replaces the current storage. Persistent collections would need their own
+lookup-cost and public-API review; they were not measured here.


### PR DESCRIPTION
Record the scope-journal experiment for #130 so its sparse wins and dense costs remain reproducible. The final prototype cuts sparse instructions by 47.37%, but alternating-type dense writes add 27.19%; the ordinary fixture corpus improves only 0.34%. The production storage stays unchanged and #130 remains open.

The note includes exact counts, allocation and peak-heap results, input hashes, source/tool pins, and a command that rebuilds the preserved experiment branch. It also records the prior COW rejection and the limits of this focused comparison.

Validation: the preserved runner completed all four workloads with Callgrind and DHAT and checked byte-identical diagnostics in both modes. The final prototype passed workspace tests with journal snapshots enabled, Clippy, rustfmt and the full R oracle matrix. Documentation links, JSON and diff checks pass.
