### PR TITLE
fix(ci): validate corpus package diagnostic totals

### DIFF
--- a/.github/workflows/ecosystem.yml
+++ b/.github/workflows/ecosystem.yml
@@ -93,6 +93,8 @@ jobs:
             ecosystem-${{ runner.os }}-
       - name: Build release binary
         run: cargo build --release --locked -p ry-cli --bin ry
+      - name: Test ledger validation
+        run: python3 ecosystem/test-check-ledger.py
       - name: "Validate ledger summary consistency"
         run: python3 ecosystem/check-ledger.py docs/corpus/posit-0.9.0.json docs/corpus/tidyverse-0.7.1.json
       - name: Check Posit corpus

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ All notable changes to ry are documented in this file.
 
 ### Cleanup
 
+- Check corpus package totals against their reviewed findings to catch stale
+  summary counts in CI.
+
 - Show editor type hints from each assignment, including function locals,
   rather than applying the file's final binding type to earlier assignments.
   Refresh cached hints when local stubs change.

--- a/ecosystem/check-ledger.py
+++ b/ecosystem/check-ledger.py
@@ -9,6 +9,7 @@ Asserts:
     categories no finding carries must be 0)
   - every audit_group_counts entry equals the actual audit group count,
     likewise
+  - each optional package diagnostic count equals its findings count
 
 Comparing per key over the union of summary and observed labels rejects
 what per-key loops over the observed labels alone miss: a negative entry
@@ -75,13 +76,27 @@ def check_ledger(path: str) -> int:
     actual_groups = Counter(f.get("audit_group") for f in findings)
     compare_summary("audit_group_counts", group_counts, actual_groups, errors)
 
+    # Historical ledgers may omit per-package summaries. When a count is
+    # supplied, it describes findings, including repeated diagnostic identities.
+    package_counts = Counter(f.get("package") for f in findings)
+    for package in data.get("packages", []):
+        if "diagnostics" not in package:
+            continue
+        name = package["name"]
+        expected = package_counts[name]
+        if package["diagnostics"] != expected:
+            errors.append(
+                f"packages[{name!r}].diagnostics ({package['diagnostics']}) "
+                f"!= actual count ({expected})"
+            )
+
     if errors:
         print(f"FAIL: {path}")
         for e in errors:
             print(f"  {e}")
         return 1
 
-    print(f"OK: {path} — {n} findings, classification and audit group sums match")
+    print(f"OK: {path} — {n} findings, summary counts match")
     return 0
 
 

--- a/ecosystem/check-ledger.py
+++ b/ecosystem/check-ledger.py
@@ -10,6 +10,7 @@ Asserts:
   - every audit_group_counts entry equals the actual audit group count,
     likewise
   - each optional package diagnostic count equals its findings count
+  - findings belong to declared packages when a package summary is present
 
 Comparing per key over the union of summary and observed labels rejects
 what per-key loops over the observed labels alone miss: a negative entry
@@ -79,6 +80,10 @@ def check_ledger(path: str) -> int:
     # Historical ledgers may omit per-package summaries. When a count is
     # supplied, it describes findings, including repeated diagnostic identities.
     package_counts = Counter(f.get("package") for f in findings)
+    if "packages" in data:
+        declared_packages = {package["name"] for package in data["packages"]}
+        for name in sorted(set(package_counts) - declared_packages, key=repr):
+            errors.append(f"findings package {name!r} is absent from packages")
     for package in data.get("packages", []):
         if "diagnostics" not in package:
             continue

--- a/ecosystem/test-check-ledger.py
+++ b/ecosystem/test-check-ledger.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+import copy
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+class LedgerPackageCountsTest(unittest.TestCase):
+    def setUp(self):
+        self.ledger = {
+            "packages": [
+                {"name": "alpha", "diagnostics": 2},
+                {"name": "beta", "diagnostics": 1},
+                {"name": "empty", "diagnostics": 0},
+            ],
+            "findings": [
+                {"package": package, "label": "false_positive", "audit_group": "reviewed"}
+                for package in ["alpha", "alpha", "beta"]
+            ],
+            "classification": {"false_positive": 3},
+            "audit_group_counts": {"reviewed": 3},
+        }
+
+    def check(self, ledger):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "ledger.json"
+            path.write_text(json.dumps(ledger))
+            return subprocess.run(
+                [sys.executable, str(Path(__file__).with_name("check-ledger.py")), str(path)],
+                capture_output=True, text=True, check=False,
+            )
+
+    def test_matching_counts_include_repeated_findings_and_zero_packages(self):
+        result = self.check(self.ledger)
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+
+    def test_stale_package_counts_fail_even_if_the_total_is_unchanged(self):
+        for counts in [(3, 1, 0), (2, 0, 0), (2, 1, 1), (1, 2, 0)]:
+            with self.subTest(counts=counts):
+                ledger = copy.deepcopy(self.ledger)
+                for package, count in zip(ledger["packages"], counts):
+                    package["diagnostics"] = count
+                result = self.check(ledger)
+                self.assertEqual(result.returncode, 1, result.stdout + result.stderr)
+                self.assertIn("packages[", result.stdout)
+                self.assertIn("!= actual count", result.stdout)
+
+    def test_historical_ledgers_can_omit_package_counts(self):
+        for package in self.ledger["packages"]:
+            package.pop("diagnostics")
+        result = self.check(self.ledger)
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+
+    def test_a_partly_populated_summary_still_validates_declared_counts(self):
+        self.ledger["packages"][0].pop("diagnostics")
+        self.ledger["packages"][1]["diagnostics"] = 7
+        result = self.check(self.ledger)
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("packages['beta'].diagnostics (7) != actual count (1)", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ecosystem/test-check-ledger.py
+++ b/ecosystem/test-check-ledger.py
@@ -61,6 +61,17 @@ class LedgerPackageCountsTest(unittest.TestCase):
         self.assertEqual(result.returncode, 1)
         self.assertIn("packages['beta'].diagnostics (7) != actual count (1)", result.stdout)
 
+    def test_findings_must_belong_to_a_declared_package(self):
+        self.ledger["packages"].pop(1)
+        result = self.check(self.ledger)
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("findings package 'beta' is absent from packages", result.stdout)
+
+    def test_omitted_package_summary_remains_optional(self):
+        self.ledger.pop("packages")
+        result = self.check(self.ledger)
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
The Posit audit found six package totals that no longer matched their findings, even though the classification and audit-group totals passed validation. For example, gt reported 110 diagnostics while its findings array contained 89 before the corpus update in #250.

Validate every declared package diagnostic count against the findings array. Repeated findings count separately, and historical ledgers may still omit package counts. Findings must belong to a declared package when a package summary is present. CI now runs six regression tests covering accurate counts, stale counts, total-preserving swaps, missing packages, and optional summaries.

Validation: all six tests pass; the refreshed Posit ledger (707 findings) and historical tidyverse ledger (127 findings) pass. Mutation testing confirms the old validator misses the stale-count cases.

Stacked on #250, which refreshes the stale corpus totals.
