### PR TITLE
fix(parser): keep comments out of executable expressions

### DIFF
--- a/crates/ry-checker/src/reference_facts.rs
+++ b/crates/ry-checker/src/reference_facts.rs
@@ -588,6 +588,29 @@ mod tests {
     }
 
     #[test]
+    fn comments_do_not_end_a_supported_reference_prefix() {
+        let source = "# header\nx <- 1L\n# before read\ny <- x\n# before function\nf <- function() {\n# local\nz <- 2L\nz\n# tail\n}\n# end\n";
+        let captured = facts(source);
+        assert_eq!(captured.references.len(), 2);
+        for reference in &captured.references {
+            assert_eq!(reference.resolution, ReferenceResolution::Resolved);
+            assert_eq!(
+                reference.type_at_reference.as_ref().unwrap().mode,
+                Mode::Integer
+            );
+            assert_eq!(
+                &source[reference.span.start..reference.span.end],
+                reference.name
+            );
+        }
+        let opaque = facts("x <- 1L\n# harmless\nmutate()\nx");
+        assert_eq!(
+            named(&opaque, "x")[0].resolution,
+            ReferenceResolution::Unsupported
+        );
+    }
+
+    #[test]
     fn fixed_reference_panel_preserves_counts_and_inference() {
         let panel: serde_json::Value = serde_json::from_str(include_str!(
             "../../../docs/corpus/reference-prefix-panel.json"

--- a/crates/ry-checker/src/tests/functions_classes.rs
+++ b/crates/ry-checker/src/tests/functions_classes.rs
@@ -1,6 +1,15 @@
 use super::*;
 
 #[test]
+fn trailing_comments_preserve_function_return_types() {
+    let (diagnostics, scope) = check_with_scope(
+        "# header\nf <- function() {\n1L\n# return value above\n}\ng <- function() {\n'word' # inline\n# another comment\n}\nvalue <- f()\nbad <- g() + 1L\n",
+    );
+    assert_eq!(scope.get("value").unwrap().mode, Mode::Integer);
+    assert_eq!(diagnostics.iter().filter(|d| d.code == "RY040").count(), 1);
+}
+
+#[test]
 fn closure_factory_infers_inner_return() {
     // `make_counter <- function() { function() { 1L } }` produces a
     // function whose `fn_sig.return_type` is itself a function with

--- a/crates/ry-core/src/parser.rs
+++ b/crates/ry-core/src/parser.rs
@@ -326,6 +326,9 @@ impl RParser {
 
     fn lower_expr(&self, n: Node, src: &str) -> Option<Expr> {
         match n.kind() {
+            // Comments have their own SourceFile metadata for suppressions and
+            // tooling. They are not expressions in the executable AST.
+            "comment" => None,
             "true" => Some(Expr::Logical(true, self.span(n))),
             "false" => Some(Expr::Logical(false, self.span(n))),
             "null" => Some(Expr::Null(self.span(n))),
@@ -393,7 +396,10 @@ impl RParser {
             "function_definition" => self.lower_function_literal(n, src),
             "parenthesized_expression" => {
                 let mut cur = n.walk();
-                if let Some(ch) = n.named_children(&mut cur).next() {
+                if let Some(ch) = n
+                    .named_children(&mut cur)
+                    .find(|child| child.kind() != "comment")
+                {
                     return self.lower_expr(ch, src);
                 }
                 None
@@ -1063,6 +1069,69 @@ mod tests {
     fn parses_simple_assignment() {
         let f = parse("x <- 1L\n");
         assert_eq!(f.stmts.len(), 1);
+    }
+
+    #[test]
+    fn comments_stay_in_metadata_without_becoming_statements() {
+        let source = "# header\nx <- 1L # inline\n{ # block\nx\n# block tail\n}\nf <- function() { # function\n1L\n# function tail\n}\n";
+        let file = parse(source);
+        assert!(file.parse_errors.is_empty());
+        assert_eq!(file.source, source);
+        assert_eq!(file.stmts.len(), 3, "{:?}", file.stmts);
+        let Stmt::Assign {
+            value: Expr::Function { body, .. },
+            ..
+        } = &file.stmts[2]
+        else {
+            panic!("expected function assignment");
+        };
+        assert!(matches!(body.as_slice(), [Stmt::Expr(Expr::Integer(1, _))]));
+        assert_eq!(file.comments.len(), 6);
+        for comment in &file.comments {
+            let line = source.lines().nth(comment.line).unwrap();
+            assert_eq!(&line[comment.col..comment.col + 1], "#");
+            assert_eq!(&line[comment.col + 1..], comment.body);
+        }
+        let only_comments = parse("# first\n# second\n");
+        assert!(only_comments.stmts.is_empty());
+        assert_eq!(only_comments.comments.len(), 2);
+    }
+
+    #[test]
+    fn comments_inside_parentheses_do_not_replace_the_expression() {
+        let file = parse(
+            "x <- (\n# before\n1L\n# after\n)\ny <- list(\n# argument\n2L, z = (\n# nested\n3L\n))\n",
+        );
+        assert!(file.parse_errors.is_empty());
+        assert!(matches!(
+            &file.stmts[0],
+            Stmt::Assign {
+                value: Expr::Integer(1, _),
+                ..
+            }
+        ));
+        let Stmt::Assign {
+            value: Expr::Call { args, .. },
+            ..
+        } = &file.stmts[1]
+        else {
+            panic!("expected list call");
+        };
+        assert_eq!(args.len(), 2);
+        assert!(matches!(args[1].value, Expr::Integer(3, _)));
+        assert_eq!(file.comments.len(), 4);
+    }
+
+    #[test]
+    fn ignoring_comments_preserves_strings_and_unsupported_expressions() {
+        let file = parse("'# not a comment'\n1i\n# real comment\n");
+        assert!(file.parse_errors.is_empty());
+        assert!(
+            matches!(&file.stmts[0], Stmt::Expr(Expr::String(value, _)) if value == "# not a comment")
+        );
+        assert!(matches!(&file.stmts[1], Stmt::Expr(Expr::Unknown(_))));
+        assert_eq!(file.stmts.len(), 2);
+        assert_eq!(file.comments.len(), 1);
     }
 
     #[test]


### PR DESCRIPTION
A comment after a function’s last expression became an unknown executable statement. For example, `f <- function() { 1L # explanation\n }` lost its integer return type; comments also interrupted reference facts and could replace a parenthesized expression.

Keep comments in source metadata for suppressions and tooling, and omit them from the executable AST. Parentheses skip comment nodes when selecting their expression.

Validation: full workspace tests, Clippy with warnings denied, formatting, and all 17 R oracle tests pass. New parser, return-inference, and reference-fact regressions pass; restoring the old parser makes both checker regressions fail. The full 62-package Posit corpus and the ecosystem snapshots are unchanged.
