### PR TITLE
fix(parser): honor R integer literal storage limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ All notable changes to ry are documented in this file.
 
 ### Fixed
 
+- Parse exponent and hexadecimal integer literals with their values, and use
+  double storage when an `L`-suffixed value exceeds R's integer range.
+
 - Infer double results for primitive division and powers of integers. Reject
   complex remainder and integer division only when both operands are nonempty.
 - Match `structure()` payloads through `.Data`, preserve class and list-column

--- a/crates/ry-checker/testdata/oracle/integer_literal_modes.R
+++ b/crates/ry-checker/testdata/oracle/integer_literal_modes.R
@@ -1,0 +1,13 @@
+# oracle: must-pass
+# R keeps an L suffix only when the value fits its integer storage.
+decimal <- 1e5L
+hexadecimal <- 0x10L
+largest <- 2147483647L
+wide <- 2147483648L
+rounded <- 9007199254740993L
+fractional <- 1.5L
+wide_hexadecimal <- 0x80000000L
+stopifnot(identical(decimal, 100000L), identical(hexadecimal, 16L),
+          typeof(largest) == "integer", typeof(wide) == "double",
+          identical(rounded, 9007199254740992), identical(fractional, 1.5),
+          identical(wide_hexadecimal, 2147483648))

--- a/crates/ry-core/src/parser.rs
+++ b/crates/ry-core/src/parser.rs
@@ -340,16 +340,26 @@ impl RParser {
                 let raw = text(n, src)?;
                 let stripped = raw.trim_end_matches('L').trim_end_matches('l');
                 let span = self.span(n);
-                // Integer literals that don't fit `i64` (e.g. `1e5L`,
-                // `0x10L` for non-hex, very large values) must NOT vanish
-                // via `?`-propagation and take the enclosing statement
-                // with them. Fall back to a double, then to `Unknown`.
-                if let Ok(v) = stripped.parse::<i64>() {
-                    Some(Expr::Integer(v, span))
-                } else if let Ok(d) = stripped.parse::<f64>() {
-                    Some(Expr::Double(d, span))
+                // L requests R's 32-bit integer storage. Fractional and
+                // out-of-range values remain doubles, even with this suffix.
+                let value = if let Some(hex) = stripped
+                    .strip_prefix("0x")
+                    .or_else(|| stripped.strip_prefix("0X"))
+                {
+                    u64::from_str_radix(hex, 16).ok().map(|value| value as f64)
                 } else {
-                    Some(Expr::Unknown(span))
+                    stripped.parse::<f64>().ok()
+                };
+                match value {
+                    Some(value)
+                        if (0.0..=i32::MAX as f64).contains(&value) && value.fract() == 0.0 =>
+                    {
+                        Some(Expr::Integer(value as i64, span))
+                    }
+                    Some(value) => Some(Expr::Double(value, span)),
+                    // Unsupported numeric spellings must preserve the enclosing
+                    // statement rather than disappear through ? propagation.
+                    None => Some(Expr::Unknown(span)),
                 }
             }
             "float" | "nan" | "inf" => {

--- a/crates/ry-core/tests/parser_correctness.rs
+++ b/crates/ry-core/tests/parser_correctness.rs
@@ -97,6 +97,37 @@ fn failed_integer_literal_does_not_drop_statement() {
     );
 }
 
+#[test]
+fn integer_suffix_uses_r_storage_range_and_value() {
+    for (source, expected) in [
+        ("1e5L", 100000),
+        ("0x10L", 16),
+        ("2147483647L", 2147483647),
+        ("1.0L", 1),
+    ] {
+        let file = parse(source);
+        assert!(
+            matches!(&file.stmts[..], [Stmt::Expr(Expr::Integer(value, _))] if *value == expected),
+            "{source}: {:?}",
+            file.stmts
+        );
+    }
+    for (source, expected) in [
+        ("2147483648L", 2147483648.0),
+        ("9007199254740993L", 9007199254740992.0),
+        ("1.5L", 1.5),
+        ("0x80000000L", 2147483648.0),
+        ("1e100L", 1e100),
+    ] {
+        let file = parse(source);
+        assert!(
+            matches!(&file.stmts[..], [Stmt::Expr(Expr::Double(value, _))] if *value == expected),
+            "{source}: {:?}",
+            file.stmts
+        );
+    }
+}
+
 /// Regression: `lower_braced_as_stmt` keeps
 /// only the last statement of a top-level `{ ... }` block. All statements
 /// must be preserved.

--- a/crates/ry-core/tests/parser_correctness.rs
+++ b/crates/ry-core/tests/parser_correctness.rs
@@ -82,19 +82,23 @@ fn star_star_is_pow() {
     assert!(pow, "2 ** 3 must lower to Pow; got {:?}", file.stmts);
 }
 
-/// Regression: integer literals that fail `i64` parse (`1e5L`,
-/// `0x10L`) return `None`, and `?`-propagation in `lower_binary` /
-/// `try_lower_assign` silently deletes the whole enclosing statement. The
-/// statement must NOT vanish: `n <- 1e5L` and `m <- n + 1` must both survive.
+/// Unsupported numeric spellings must not drop their enclosing statement.
 #[test]
 fn failed_integer_literal_does_not_drop_statement() {
-    let file = parse("n <- 1e5L\nm <- n + 1\n");
+    let file = parse("n <- 0x1p2L\nm <- n + 1\n");
     assert_eq!(
         file.stmts.len(),
         2,
         "both statements must be preserved; got {:?}",
         file.stmts
     );
+    assert!(matches!(
+        &file.stmts[0],
+        Stmt::Assign {
+            value: Expr::Unknown(_),
+            ..
+        }
+    ));
 }
 
 #[test]


### PR DESCRIPTION
`1e5L` was parsed as a double, while `2147483648L` was parsed as an integer. R uses integer storage only when an `L`-suffixed value is whole and fits its integer range.

Parse the value before choosing storage, including ordinary hexadecimal integer literals such as `0x10L`. Preserve unsupported spellings as unknown expressions so their enclosing statements survive.

Validation: core tests pass; the new parser regression fails before the fix. Live R confirms exponent notation, hexadecimal values, the integer boundary, fractional values, and rounding above exact double precision. A matching R oracle fixture is included. Full workspace, Clippy, formatting, and all 17 R oracle tests pass. The full 62-package Posit corpus and ecosystem reports are unchanged. This PR builds on #259.
