### PR TITLE
Avoid indexing functions without promise captures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,8 @@ All notable changes to ry are documented in this file.
 
 ### Cleanup
 
+- Keep only promise-capturing functions in the collection index, reducing startup
+  allocations without changing capture lookup results.
 - Refine only affected functions after edits, using observed callable reads and
   forwarding or S3 metadata dependencies. Keep diagnostic invalidation conservative.
 - Check corpus package totals against their reviewed findings to catch stale

--- a/crates/ry-checker/src/collect.rs
+++ b/crates/ry-checker/src/collect.rs
@@ -560,18 +560,8 @@ fn is_promise_capture(function: &Expr, dots: bool) -> bool {
             .is_some_and(|signature| signature_captures_promises(signature, dots)),
         // Unqualified names consult the one-time global index below.
         //
-        // Known limitation: the index is built exclusively from the
-        // embedded base and the bundled package stubs, NOT from
-        // user-provided stubs installed via `Checker::set_user_stubs`.
-        // A custom stub that DECLARES a promise-capturing helper is
-        // therefore recognized only when called QUALIFIED
-        // (`mypkg::captures(...)`, which reaches the stub through
-        // `load_package`); an unqualified `captures(...)` call to such a
-        // user-stub helper is treated as an ordinary function. This is a
-        // deliberate trade-off: scoring unqualified names against the
-        // per-checker user stubs would thread an `&Arc<BTreeMap>` through
-        // the entire quoting-analysis call tree for an edge case, so we
-        // document rather than refactor. The qualified path is unaffected.
+        // Collection has no per-checker user stubs. Neither this index
+        // nor the qualified embedded-package lookup above reads them.
         None => promise_capture_index()
             .get(function)
             .is_some_and(|&(single, dots_capture)| if dots { dots_capture } else { single }),
@@ -591,7 +581,8 @@ fn signature_captures_promises(signature: &FunctionSig, dots: bool) -> bool {
 /// function name -> (named-parameter capture, `...` capture), the two
 /// flags `is_promise_capture(function, dots)` selects between — whether
 /// the stub declares `captures_promise` on a named formal, on `...`, or
-/// both. Built lazily on first use; `is_promise_capture` consults it for
+/// both. Functions with neither kind of capture have no entry.
+/// Built lazily on first use; `is_promise_capture` consults it for
 /// unqualified names instead of re-scanning every package's function
 /// table on every call-site check.
 fn promise_capture_index() -> &'static std::collections::HashMap<String, (bool, bool)> {
@@ -601,9 +592,9 @@ fn promise_capture_index() -> &'static std::collections::HashMap<String, (bool, 
         let mut index = std::collections::HashMap::new();
         let mut add_typeshed = |typeshed: &ry_typeshed::Typeshed| {
             for (name, signature) in &typeshed.functions {
-                let flags = index.entry(name.clone()).or_insert((false, false));
                 for (parameter, mode) in &signature.eval {
                     if *mode == EvalMode::CapturesPromise {
+                        let flags = index.entry(name.clone()).or_insert((false, false));
                         if parameter == "..." {
                             flags.1 = true;
                         } else {


### PR DESCRIPTION
The promise-capture index currently allocates a key for every embedded function, including functions whose two capture flags are both false. Insert entries only when capture metadata is present: 10 keys instead of 1,707 in the current inventory. An absent entry already returns false for either lookup, and captures with the same name still combine across packages.

Also correct the nearby comment: qualified calls do not read per-checker user stubs either.

Validation: all CI checks pass, including both pinned corpora. Formatting and independent source review pass. Local workspace tests passed the checker and CLI suites, then exposed an LSP startup race in `environment_paths_are_anchored_globs_in_both_frontends`: the first publication can precede installation of workspace bindings. A focused rerun passed and a second LSP run reproduced it. The startup race is independently reproduced on unchanged main `4eb045b` by test commit `e8caa75` (first publication incorrectly reports RY010 while initial indexing is held). The fixture does not use the capture index. Its startup fix is in [PR #275](https://github.com/sims1253/ry/pull/275), where the full LSP suite now passes. No full local-workspace pass is claimed.

A matched fresh-process profile on purrr `481e829f297fd4315b386518215157f361475ad0` (`R/`, two Rayon workers, installed-library discovery disabled) produced byte-identical JSON diagnostics. Against parent `9df07ad`, Callgrind instructions fell from 1,642,758,107 to 1,638,782,648 (0.24%); DHAT total allocated bytes fell from 107,930,646 to 107,793,171, and retained bytes fell by 83,393. This is a small startup saving in this measured workload. Both binaries used `cargo build --locked --release -p ry-cli` on the same machine.

Profile commands: `RAYON_NUM_THREADS=2 RY_NO_INSTALLED_LIBRARIES=1 valgrind --tool=callgrind <binary> check --output-format json --exit-zero <purrr>/R`, repeated with `--tool=dhat`. The source tree was extracted from the exact git revision into an isolated directory.
