### PR TITLE
docs: reconcile historical audit counts across evidence pages

### DIFF
--- a/docs/corpus/0.9-release-evidence.md
+++ b/docs/corpus/0.9-release-evidence.md
@@ -2,7 +2,9 @@
 
 These results describe the audit at commit
 `ec702b587f2ab5a78f64182654d2b1865b44adb0`. The live ledgers and reports
-change as fixes land; the counts below preserve that audit's results.
+change as fixes land; the counts below preserve that audit's results. The
+[archived ledger](https://github.com/sims1253/ry/blob/941981428b76c43a078179b3b1619209b9802f17/docs/corpus/posit-0.9.0.json)
+contains the findings and labels used here.
 
 ## Corpus provenance
 
@@ -149,11 +151,11 @@ shrinking bound is gated.
    (148779b). A future plan must specify a complete `CollectedFile`
    round trip before wiring a cache.
 
-2. **Precision**: 5.08% overall (4.20% `R/`). The dominant FP source is RY010
-   (476 FP — imported/generated/data bindings that exist at runtime). This
+2. **Precision**: 6.06% overall (4.20% `R/`). The dominant FP source is RY010
+   (472 FP — imported/generated/data bindings that exist at runtime). This
    is a design decision (no runtime binding resolution), not a regression.
 
-3. **RY032 parameter-vector heuristic**: 48 FP. Policy decided that
+3. **RY032 parameter-vector heuristic**: 47 FP. Policy decided that
    unknown parameter length is not evidence that `&&`/`||` discards elements.
    The R7 literal-lift report confirms RY032 as param-unreachable.
 

--- a/docs/corpus/0.9-release-evidence.md
+++ b/docs/corpus/0.9-release-evidence.md
@@ -4,7 +4,8 @@ These results describe the audit at commit
 `ec702b587f2ab5a78f64182654d2b1865b44adb0`. The live ledgers and reports
 change as fixes land; the counts below preserve that audit's results. The
 [archived ledger](https://github.com/sims1253/ry/blob/941981428b76c43a078179b3b1619209b9802f17/docs/corpus/posit-0.9.0.json)
-contains the findings and labels used here.
+contains the findings and labels used here. Counts below are recomputed from
+its finding records; its package summaries contain stale counts.
 
 ## Corpus provenance
 
@@ -16,7 +17,7 @@ contains the findings and labels used here.
 | Source reports | `ecosystem/reports/posit.*.root.txt` |
 | Source SHA-256 | `602fe749c12cfb2217d96fdb82a93634907a4f1d4f9507a27abb51d5209fb7e7` |
 | ry commit | `ec702b587f2ab5a78f64182654d2b1865b44adb0` (audited head) |
-| Full-tier check | `ecosystem/run.sh --check --tier full` — 709 identities match |
+| Full-tier check | `ecosystem/run.sh --check --tier full` — 709 finding records |
 | Drift detection | `ecosystem/test-drift-detection.sh` — PASS |
 | Label falsification | `ecosystem/test-posit-label-falsification.sh` — PASS |
 
@@ -35,12 +36,18 @@ contains the findings and labels used here.
 | Original 0.8.0 TP | 34 |
 | Surviving original TP | 31 |
 | TP retention | 91.18% |
-| New TP (corpus audit) | 6 |
-| Packages with ≥1 diagnostic | 39 / 62 |
+| New unique TP (corpus audit) | 10 |
+| Packages with ≥1 diagnostic | 38 / 62 |
 
 The 3 resolved original TP are intentional bad-code fixtures in lintr and
 styler test suites — not production-source defects. All 31 surviving original
-TP are unchanged. The 6 new TP were individually reviewed at source during the audit response.
+TP retain their labels. The snapshot has 10 new unique TP locations. Two
+RY091 locations in dbplyr appear twice in the ledger, giving 43 TP records
+but 41 unique TP identities (31 surviving + 10 new). Overall there are
+709 records and 707 unique identities. The precision above preserves the
+record-based audit totals. An identity is `(package, code, path, line, column)`.
+Retention is compared with the
+[archived 0.8 ledger](https://github.com/sims1253/ry/blob/bf48af302670ba5113290ad7b328264ad7ca6201/docs/corpus/posit-0.8.0.json).
 
 **Gate:** `ecosystem/run.sh --check --manifest ecosystem/posit-packages.txt
 --ledger docs/corpus/posit-0.9.0.json --tier full`.
@@ -53,7 +60,7 @@ TP are unchanged. The 6 new TP were individually reviewed at source during the a
 | RY001 | 29 | 6 | 23 |
 | RY002 | 3 | 0 | 3 |
 | RY010 | 476 | 4 | 472 |
-| RY030 | 25 | 0 | 25 |
+| RY030 | 1 | 0 | 1 |
 | RY031 | 2 | 0 | 2 |
 | RY032 | 48 | 1 | 47 |
 | RY033 | 41 | 6 | 35 |
@@ -64,8 +71,8 @@ TP are unchanged. The 6 new TP were individually reviewed at source during the a
 | RY070 | 8 | 2 | 6 |
 | RY080 | 2 | 0 | 2 |
 | RY090 | 4 | 0 | 4 |
-| RY091 | 5 | 1 | 4 |
-| RY092 | 3 | 0 | 3 |
+| RY091 | 11 | 7 | 4 |
+| RY092 | 2 | 0 | 2 |
 | RY093 | 4 | 4 | 0 |
 | RY098 | 1 | 0 | 1 |
 | RY100 | 4 | 4 | 0 |

--- a/docs/corpus/rule-evidence-0.9.md
+++ b/docs/corpus/rule-evidence-0.9.md
@@ -2,7 +2,9 @@
 
 This records the rule audit at commit
 `ec702b587f2ab5a78f64182654d2b1865b44adb0`: 709 Posit findings, including
-43 true positives and 666 false positives. The tables preserve that audit;
+43 true-positive records and 666 false-positive records. Two TP identities
+appear twice; see the [snapshot counting notes](0.9-release-evidence.md#final-precision-and-tp-retention).
+The tables preserve that audit;
 use the live corpus ledgers and oracle tests for current results.
 
 The audit combined the corpus, semantic-claim oracle, probes, literal-to-parameter
@@ -74,7 +76,7 @@ determines the verdict.
 | `RY010` unbound-variable | 4/472 | yes | `unbound_variable_claim.R` | n/a (syntactic) | - | - | keep | Core reachability check; 4 TP / 472 FP. High FP from cross-file resolution gaps addressed by workspace resolution. |
 | `RY020` unary-minus-type | 0/0 | yes | `unary_minus_type_claim.R` | lift-reachable | - | - | keep | Valid claim; 0 corpus findings. Lift-reachable through scalar defaults. |
 | `RY021` unary-not-type | 0/0 | yes | `unary_not_type_claim.R` | lift-reachable | - | - | keep | Valid claim; 0 corpus findings. Lift-reachable through scalar defaults. |
-| `RY030` invalid-comparison | 0/25 | yes | `invalid_comparison_claim.R` | param-unreachable | - | - | keep | Valid claim; 0 TP / 25 FP. Parameter-unreachable (triggering types are non-scalar). FP from typeshed coverage gaps. |
+| `RY030` invalid-comparison | 0/1 | yes | `invalid_comparison_claim.R` | param-unreachable | - | - | keep | Valid claim; 0 TP / 1 FP. Parameter-unreachable (triggering types are non-scalar). FP from typeshed coverage gaps. |
 | `RY031` invalid-logical-op | 0/2 | yes | `invalid_logical_op_claim.R` | lift-reachable | - | - | keep | Valid claim; 0 TP / 2 FP. Known gap in inconsistent_superassignment.R. Lift-reachable through scalar defaults. |
 | `RY032` scalar-logical-length | 1/47 | yes | `unknown_short_circuit_parameter.R` | param-unreachable | piloted | yes | keep | Standing-case policy: 1 TP / 47 FP. Fires on non-literal parameter-dependent expressions (47 FP in corpus) but policy determined unknown parameter length is not actionable. R7 confirms param-unreachable for c() defaults. |
 | `RY033` comparison-mode-mismatch | 6/35 | yes | `comparison_mode_mismatch_claim.R` | lift-reachable | - | - | keep | Valid claim; 6 TP / 35 FP. Lift-reachable through scalar defaults. |
@@ -88,8 +90,8 @@ determines the verdict.
 | `RY070` call-non-function | 2/6 | yes | `call_non_function.R` | n/a (syntactic) | - | - | keep | Valid claim; 2 TP / 6 FP. |
 | `RY080` map-return-type-mismatch | 0/2 | yes | `map_return_type_claim.R` | n/a (syntactic) | - | - | keep | Valid claim; 0 TP / 2 FP. Requires purrr typeshed. |
 | `RY090` unknown-argument | 0/4 | yes | `unknown_argument.R` | n/a (syntactic) | - | yes | keep | Valid syntactic claim; 0 TP / 4 FP. |
-| `RY091` missing-required-argument | 1/4 | yes | `missing_required_argument.R` | n/a (syntactic) | - | - | keep | Valid claim; 1 TP / 4 FP. |
-| `RY092` argument-type-mismatch | 0/3 | yes | `argument_type_mismatch.R` | n/a (syntactic) | - | - | keep | Valid claim; 0 TP / 3 FP. |
+| `RY091` missing-required-argument | 7/4 | yes | `missing_required_argument.R` | n/a (syntactic) | - | - | keep | Valid claim; 7 TP / 4 FP. |
+| `RY092` argument-type-mismatch | 0/2 | yes | `argument_type_mismatch.R` | n/a (syntactic) | - | - | keep | Valid claim; 0 TP / 2 FP. |
 | `RY093` comparison-inside-length | 4/0 | yes | `comparison_inside_length_claim.R` | consistent | piloted | yes | keep | Valid claim; 4 TP / 0 FP. Consistent under R7 lifting (syntactic). Mutation pilot passed. |
 | `RY094` printf-argument-count | 0/0 | yes | `printf_argument_count_claim.R` | n/a (syntactic) | - | - | keep | Valid claim; 0 corpus findings. |
 | `RY096` hasarg-non-formal | 0/0 | yes | `hasarg_non_formal_claim.R` | n/a (syntactic) | - | - | keep | Valid claim; 0 corpus findings. |
@@ -126,5 +128,5 @@ Code-level verdicts are enforced by `crates/ry-checker/tests/rule_evidence.rs`:
 - R7 coverage: every rule is classified (lift-reachable, param-unreachable,
   consistent, or n/a).
 - Mutation pilot: 4 rule families piloted (RY032, RY040, RY093, RY103).
-- Corpus values are identity counts from the hermetic ledger.
+- Corpus values count finding records in the archived hermetic ledger.
 - Verdicts: 33 keep, 1 default-off (RY003), 0 retire (RY095 retired during the audit response).

--- a/docs/editor-defaults.md
+++ b/docs/editor-defaults.md
@@ -6,9 +6,9 @@ See the [extension guide](../editors/code/README.md) for setup and settings.
 
 ## Corpus baseline
 
-The 0.9 corpus baseline is measured and gated in
+The historical 0.9 corpus audit is recorded in
 [docs/corpus/0.9-release-evidence.md](corpus/0.9-release-evidence.md):
-709 findings, 43 true positives, 666 false positives, 6.06% overall
+709 finding records, 43 true positives, 666 false positives, 6.06% overall
 precision. The corpus is dominated by RY010 (unbound-variable) false
 positives from imported, generated, and data bindings that exist at
 runtime.
@@ -29,7 +29,7 @@ list. Codes, names, severities, and defaults mirror
 | RY003 (numeric-condition) | info | Disabled | Default-off | 0 corpus findings. Valid claim, but style advice. |
 | RY010 (unbound-variable) | warning | Enabled | Keep | 4 true positives / 472 false positives. Largest source of false positives; also catches real bugs. |
 | RY020 (unary-minus-type) | error | Enabled | Keep | 0 true positives / 0 false positives in the corpus. Verified by an oracle fixture; scalar parameter defaults can trigger it. |
-| RY030 (invalid-comparison) | error | Enabled | Keep | 0 true positives / 25 false positives. False positives come from typeshed coverage gaps. |
+| RY030 (invalid-comparison) | error | Enabled | Keep | 0 true positives / 1 false positive. The false positive comes from a typeshed coverage gap. |
 | RY032 (scalar-logical-length) | warning | Enabled | Keep | 1 true positive / 47 false positives. Fires on non-literal parameter-dependent expressions. |
 | RY040 (invalid-arithmetic) | error | Enabled | Keep | 0 true positives / 23 false positives. False positives come from typeshed coverage gaps. |
 | RY090 (unknown-argument) | warning | Enabled | Keep | 0 true positives / 4 false positives. Valid syntactic claim. |


### PR DESCRIPTION
The historical 0.9 audit mixed counts from different snapshots. Reconcile the release table, rule verdict table, and editor-default evidence with finding records in the pinned archived ledger. Correct the package count and distinguish the ledger’s 709 records from its 707 unique identities: two RY091 true-positive locations occur twice.

Retention against the archived 0.8 ledger is 31 of 34 original true positives, plus 10 new unique true positives (41 unique TP identities, 43 TP records). Link both archives and label editor evidence as historical.

Validation: recomputed every release and rule-table row from the archived finding records; independently compared original TP identities and package coverage; `git diff --check` passed. Documentation only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the 0.9 corpus audit evidence with recomputed finding, identity, package, and rule-verdict counts.
  - Clarified duplicate finding records and their effect on totals.
  - Revised the rule audit snapshot to distinguish TP/FP records from identities and updated completeness details.
  - Updated remaining-known-gap precision figures and false-positive counts.
  - Refreshed editor defaults documentation with corrected RY030 evidence and baseline wording.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->