### PR TITLE
fix(checker): match captured actuals to helper formals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ All notable changes to ry are documented in this file.
 
 ### Fixed
 
+- Match promise-capture helpers by formal argument when collecting wrapper
+  evaluation modes. Recognize qualified base helpers and keep their environment
+  arguments, and explicit rlang controls, separate from captured expressions.
+
 - Preserve omitted call arguments and their names without shifting later
   arguments. Calls and indexes now share missing-position handling. The public
   `ry-core` AST adds `Expr::Missing(Span)`; consumers with exhaustive expression

--- a/crates/ry-checker/src/collect.rs
+++ b/crates/ry-checker/src/collect.rs
@@ -586,14 +586,28 @@ fn capture_signature_arguments(signature: &FunctionSig, args: &[Arg], captured: 
         .iter()
         .map(|a| a.name.as_deref().map(semantic_argument_name))
         .collect();
-    let matched = match_argument_names(&params, names.iter().copied());
+    // A forwarded dots expression expands to zero or more actuals, not one
+    // concrete positional slot. Match only explicit actuals here; the proof
+    // below separately limits which bindings survive the unknown expansion.
+    let explicit: Vec<_> = args
+        .iter()
+        .enumerate()
+        .filter(|(_, arg)| !matches!(&arg.value, Expr::Ident { name, .. } if name == "..."))
+        .map(|(index, _)| index)
+        .collect();
+    let matched = match_argument_names(&params, explicit.iter().map(|&index| names[index]));
+    let mut param_for_arg = vec![None; args.len()];
+    for (&index, formal) in explicit.iter().zip(&matched.param_for_arg) {
+        param_for_arg[index] = *formal;
+    }
     let end = matched.dots.unwrap_or(params.len());
     let exact: Vec<_> = params.iter().map(|p| names.contains(&Some(*p))).collect();
     // The general matcher tolerates malformed calls. A capture proof cannot
     // borrow its fallback for duplicate bindings or ambiguous partial names.
     let mut occupied = vec![false; params.len()];
-    for (index, name) in names.iter().enumerate() {
-        if let Some(formal) = matched.param_for_arg[index] {
+    for &index in &explicit {
+        let name = &names[index];
+        if let Some(formal) = param_for_arg[index] {
             if occupied[formal] {
                 return;
             }
@@ -615,7 +629,7 @@ fn capture_signature_arguments(signature: &FunctionSig, args: &[Arg], captured: 
                 if candidates.len() > 1
                     || candidates
                         .first()
-                        .is_some_and(|formal| matched.param_for_arg[index] != Some(*formal))
+                        .is_some_and(|formal| param_for_arg[index] != Some(*formal))
                 {
                     return;
                 }
@@ -625,6 +639,9 @@ fn capture_signature_arguments(signature: &FunctionSig, args: &[Arg], captured: 
     let forwarded = args
         .iter()
         .any(|arg| matches!(&arg.value, Expr::Ident { name, .. } if name == "..."));
+    let all_capture = params
+        .iter()
+        .all(|param| signature.eval.get(*param) == Some(&EvalMode::CapturesPromise));
     for (index, arg) in args.iter().enumerate() {
         // Preserve the existing blanket forwarding approximation: a wrapper's
         // `...` remains quoting when passed to a capturing dots formal. Runtime
@@ -637,10 +654,15 @@ fn capture_signature_arguments(signature: &FunctionSig, args: &[Arg], captured: 
             });
             continue;
         }
-        if matches!(arg.value, Expr::Missing(_)) || (forwarded && end != 0) {
+        let exact_capture = names[index].is_some_and(|name| params.contains(&name));
+        // Exact tags cannot change their formal in a successful call. An
+        // all-capture signature cannot move a value to an ordinary formal.
+        if matches!(arg.value, Expr::Missing(_))
+            || (forwarded && end != 0 && !exact_capture && !all_capture)
+        {
             continue;
         }
-        if let Some(formal) = matched.param_for_arg[index].or(matched.dots) {
+        if let Some(formal) = param_for_arg[index].or(matched.dots) {
             captured[index] |=
                 signature.eval.get(params[formal]) == Some(&EvalMode::CapturesPromise);
         }
@@ -1134,6 +1156,11 @@ mod collect_walker_tests {
             "substitute(en=list(), ex=p)",
             "rlang::enquos(p, .named=FALSE)",
             "rlang::enquos(tag=p, .named=FALSE)",
+            "rlang::enquo(p, ...)",
+            "rlang::enquo(..., p)",
+            "rlang::enquo(ar=p, ...)",
+            "rlang::enquo(arg=p, ...)",
+            "delayedAssign(x='held', value=p, ...)",
         ] {
             let checker = collect(&format!("f <- function(p) {call}"));
             let param = &checker.fn_table.fns["f"].params[0];
@@ -1154,6 +1181,8 @@ mod collect_walker_tests {
         }
         for call in [
             "delayedAssign(p, 1L)",
+            "delayedAssign('held', p, ...)",
+            "delayedAssign('held', val=p, ...)",
             "base::delayedAssign('held', 1L, eval.env=p)",
             "base::delayedAssign('held', 1L, assign.env=p)",
             "base::delayedAssign('held', 1L, p)",

--- a/crates/ry-checker/src/collect.rs
+++ b/crates/ry-checker/src/collect.rs
@@ -434,9 +434,6 @@ fn parameter_is_quoted(body: &[Stmt], params: &[Param], parameter: &str) -> bool
         .any(|statement| stmt_any(statement, &captures_all_arguments))
         || (params.iter().any(|formal| formal.name == parameter)
             && (body.iter().any(quotes)
-                // Variadic promise-capture helpers capture the promises
-                // stored in `...`; there is no single argument to match
-                // syntactically.
                 || (parameter == "..." && body.iter().any(captures_promise)))
             // Promise-capture helpers only make a promise safe to pass
             // unevaluated when that promise is not also used normally in
@@ -502,14 +499,10 @@ fn quotes_parameter(expression: &Expr, parameter: &str) -> bool {
     let Expr::Call { func, args, .. } = expression else {
         return false;
     };
-    (matches!(ident_name(func).map(bare_name), Some("substitute"))
-        && args
-            .first()
-            .is_some_and(|argument| is_parameter(&argument.value, parameter)))
-        || (is_single_promise_capture(func)
-            && args
-                .first()
-                .is_some_and(|argument| is_parameter(&argument.value, parameter)))
+    captured_arguments(func, args)
+        .iter()
+        .zip(args)
+        .any(|(capture, arg)| *capture && is_parameter(&arg.value, parameter))
         || (matches!(ident_name(func).map(bare_name), Some("bquote"))
             && args
                 .iter()
@@ -522,11 +515,10 @@ fn captures_promise_parameter(expression: &Expr, parameter: &str) -> bool {
     let Expr::Call { func, args, .. } = expression else {
         return false;
     };
-    (is_single_promise_capture(func)
-        && args
-            .first()
-            .is_some_and(|argument| is_parameter(&argument.value, parameter)))
-        || (is_dots_promise_capture(func) && parameter == "...")
+    captured_arguments(func, args)
+        .iter()
+        .zip(args)
+        .any(|(capture, arg)| *capture && is_parameter(&arg.value, parameter))
 }
 
 /// Whether any use of `parameter` in `body` reads it as an ordinary value,
@@ -539,93 +531,153 @@ fn parameter_has_normal_use(body: &[Stmt], parameter: &str) -> bool {
     uses.normal
 }
 
-/// Whether a package stub declares this callee as a promise-capture helper.
-/// Collection happens before ordinary call-site resolution, so bare names are
-/// recognized from the loaded stub inventory rather than lexical scope.
-///
-/// Unqualified names resolve against a one-time global index built from the
-/// embedded base and package stubs, so each call-site check is a single map
-/// lookup instead of a scan of the whole package inventory.
-fn is_promise_capture(function: &Expr, dots: bool) -> bool {
+/// Classify actuals using only the capturing formals of embedded signatures.
+/// Bare names retain the existing inventory union, without lexical resolution.
+/// Neither this index nor qualified lookup reads per-checker user stubs.
+fn captured_arguments(function: &Expr, args: &[Arg]) -> Vec<bool> {
     let Some(name) = ident_name(function) else {
-        return false;
+        return Vec::new();
     };
-    let (package, function) = name
-        .rsplit_once("::")
-        .map(|(package, function)| (Some(package.trim_end_matches(':')), function))
-        .unwrap_or((None, name));
-    match package {
-        Some(package) => ry_typeshed::load_package(package)
-            .and_then(|typeshed| typeshed.functions.get(function))
-            .is_some_and(|signature| signature_captures_promises(signature, dots)),
-        // Unqualified names consult the one-time global index below.
-        //
-        // Collection has no per-checker user stubs. Neither this index
-        // nor the qualified embedded-package lookup above reads them.
-        None => promise_capture_index()
-            .get(function)
-            .is_some_and(|&(single, dots_capture)| if dots { dots_capture } else { single }),
+    if let Some((package, name)) = name.rsplit_once("::") {
+        let package = package.trim_end_matches(':');
+        let typeshed = if package == "base" {
+            ry_typeshed::load_base_cached().ok()
+        } else {
+            ry_typeshed::load_package(package)
+        };
+        if let Some(signature) = typeshed.and_then(|db| db.functions.get(name))
+            && signature
+                .eval
+                .values()
+                .any(|mode| *mode == EvalMode::CapturesPromise)
+        {
+            let mut captured = vec![false; args.len()];
+            capture_signature_arguments(signature, args, &mut captured);
+            return captured;
+        }
+    } else if let Some(signatures) = promise_capture_index().get(name) {
+        let mut captured = vec![false; args.len()];
+        for signature in signatures {
+            capture_signature_arguments(signature, args, &mut captured);
+        }
+        return captured;
+    }
+    Vec::new()
+}
+
+fn capture_signature_arguments(signature: &FunctionSig, args: &[Arg], captured: &mut [bool]) {
+    if !signature
+        .eval
+        .values()
+        .any(|mode| *mode == EvalMode::CapturesPromise)
+    {
+        return;
+    }
+    // Recovery spellings do not prove R argument names. Exact and partial
+    // matching otherwise share the ordinary call matcher's occupancy map.
+    if args
+        .iter()
+        .any(|arg| arg.name.as_deref().is_some_and(|name| name.contains('\\')))
+    {
+        return;
+    }
+    let params: Vec<_> = signature.params.iter().map(|p| p.name.as_str()).collect();
+    let names: Vec<_> = args
+        .iter()
+        .map(|a| a.name.as_deref().map(semantic_argument_name))
+        .collect();
+    let matched = match_argument_names(&params, names.iter().copied());
+    let end = matched.dots.unwrap_or(params.len());
+    let exact: Vec<_> = params.iter().map(|p| names.contains(&Some(*p))).collect();
+    // The general matcher tolerates malformed calls. A capture proof cannot
+    // borrow its fallback for duplicate bindings or ambiguous partial names.
+    let mut occupied = vec![false; params.len()];
+    for (index, name) in names.iter().enumerate() {
+        if let Some(formal) = matched.param_for_arg[index] {
+            if occupied[formal] {
+                return;
+            }
+            occupied[formal] = true;
+        } else if matched.dots.is_none() {
+            return;
+        }
+        if let Some(name) = name {
+            if name.is_empty() {
+                return;
+            }
+            if !params.contains(name) {
+                let candidates: Vec<_> = params[..end]
+                    .iter()
+                    .enumerate()
+                    .filter(|(i, p)| !exact[*i] && p.starts_with(name))
+                    .map(|(i, _)| i)
+                    .collect();
+                if candidates.len() > 1
+                    || candidates
+                        .first()
+                        .is_some_and(|formal| matched.param_for_arg[index] != Some(*formal))
+                {
+                    return;
+                }
+            }
+        }
+    }
+    let forwarded = args
+        .iter()
+        .any(|arg| matches!(&arg.value, Expr::Ident { name, .. } if name == "..."));
+    for (index, arg) in args.iter().enumerate() {
+        // Preserve the existing blanket forwarding approximation: a wrapper's
+        // `...` remains quoting when passed to a capturing dots formal. Runtime
+        // names can still bind normal controls (e.g. enquos(.named=...)); the
+        // boolean collected mode cannot represent that per-actual distinction.
+        // Explicit control actuals are matched normally below.
+        if matches!(&arg.value, Expr::Ident { name, .. } if name == "...") {
+            captured[index] |= matched.dots.is_some_and(|formal| {
+                signature.eval.get(params[formal]) == Some(&EvalMode::CapturesPromise)
+            });
+            continue;
+        }
+        if matches!(arg.value, Expr::Missing(_)) || (forwarded && end != 0) {
+            continue;
+        }
+        if let Some(formal) = matched.param_for_arg[index].or(matched.dots) {
+            captured[index] |=
+                signature.eval.get(params[formal]) == Some(&EvalMode::CapturesPromise);
+        }
     }
 }
 
-/// Whether `signature` declares a promise-capturing parameter: a `...`
-/// capture when `dots` is set, otherwise a named-parameter capture.
-fn signature_captures_promises(signature: &FunctionSig, dots: bool) -> bool {
-    signature
-        .eval
-        .iter()
-        .any(|(parameter, mode)| *mode == EvalMode::CapturesPromise && (parameter == "...") == dots)
-}
-
-/// One-time global index over the embedded base and package stubs:
-/// function name -> (named-parameter capture, `...` capture), the two
-/// flags `is_promise_capture(function, dots)` selects between — whether
-/// the stub declares `captures_promise` on a named formal, on `...`, or
-/// both. Functions with neither kind of capture have no entry.
-/// Built lazily on first use; `is_promise_capture` consults it for
-/// unqualified names instead of re-scanning every package's function
-/// table on every call-site check.
-fn promise_capture_index() -> &'static std::collections::HashMap<String, (bool, bool)> {
-    static INDEX: std::sync::OnceLock<std::collections::HashMap<String, (bool, bool)>> =
-        std::sync::OnceLock::new();
+/// Sparse one-time inventory: only signatures with capture metadata allocate
+/// an entry. Multiple packages with the same bare name retain their union.
+fn promise_capture_index() -> &'static std::collections::HashMap<String, Vec<&'static FunctionSig>>
+{
+    static INDEX: std::sync::OnceLock<
+        std::collections::HashMap<String, Vec<&'static FunctionSig>>,
+    > = std::sync::OnceLock::new();
     INDEX.get_or_init(|| {
-        let mut index = std::collections::HashMap::new();
-        let mut add_typeshed = |typeshed: &ry_typeshed::Typeshed| {
+        let mut index: std::collections::HashMap<String, Vec<&'static FunctionSig>> =
+            std::collections::HashMap::new();
+        let mut add = |typeshed: &'static ry_typeshed::Typeshed| {
             for (name, signature) in &typeshed.functions {
-                for (parameter, mode) in &signature.eval {
-                    if *mode == EvalMode::CapturesPromise {
-                        let flags = index.entry(name.clone()).or_insert((false, false));
-                        if parameter == "..." {
-                            flags.1 = true;
-                        } else {
-                            flags.0 = true;
-                        }
-                    }
+                if signature
+                    .eval
+                    .values()
+                    .any(|mode| *mode == EvalMode::CapturesPromise)
+                {
+                    index.entry(name.clone()).or_default().push(signature);
                 }
             }
         };
         if let Ok(base) = ry_typeshed::load_base_cached() {
-            add_typeshed(base);
+            add(base);
         }
         for package in ry_typeshed::known_packages() {
             if let Some(typeshed) = ry_typeshed::load_package(package) {
-                add_typeshed(typeshed);
+                add(typeshed);
             }
         }
         index
     })
-}
-
-/// Whether the callee is a stub-declared promise-capture helper for a
-/// single named formal.
-fn is_single_promise_capture(function: &Expr) -> bool {
-    is_promise_capture(function, false)
-}
-
-/// Whether the callee is a stub-declared promise-capture helper for the
-/// `...` dots argument.
-fn is_dots_promise_capture(function: &Expr) -> bool {
-    is_promise_capture(function, true)
 }
 
 /// Whether a `.(parameter)` unquote anywhere inside the expression —
@@ -728,18 +780,13 @@ fn collect_parameter_uses_in_stmt(statement: &Stmt, parameter: &str, uses: &mut 
                 AstNode::Expr(Expr::Call { func, args, .. }) => {
                     let bare = ident_name(func).map(bare_name);
                     let probes_promise = matches!(bare, Some("missing"));
-                    let defuses_direct_argument = is_single_promise_capture(func)
-                        || is_dots_promise_capture(func)
-                        || matches!(bare, Some("match.call" | "substitute"));
-                    if probes_promise || defuses_direct_argument {
-                        for argument in args {
-                            if matches!(&argument.value, Expr::Ident { name, .. } if name == parameter)
-                            {
-                                if defuses_direct_argument {
-                                    uses.defused = true;
-                                }
-                                classified.push(&argument.value);
-                            }
+                    let captured = captured_arguments(func, args);
+                    for (index, argument) in args.iter().enumerate() {
+                        let defused = captured.get(index).copied().unwrap_or(false)
+                            || matches!(bare, Some("match.call"));
+                        if (probes_promise || defused) && is_parameter(&argument.value, parameter) {
+                            uses.defused |= defused;
+                            classified.push(&argument.value);
                         }
                     }
                 }
@@ -817,22 +864,23 @@ fn first_parameter_use_in_expr(expression: &Expr, parameter: &str) -> Option<Fir
     match expression {
         Expr::Ident { name, .. } => (name == parameter).then_some(FirstParameterUse::Normal),
         Expr::Call { func, args, .. } => {
-            let defuses_direct_argument = is_single_promise_capture(func)
-                || is_dots_promise_capture(func)
-                || matches!(
-                    ident_name(func).map(bare_name),
-                    Some("substitute" | "match.call" | "bquote")
-                );
-            if defuses_direct_argument
-                && args.iter().any(|argument| {
-                    matches!(&argument.value, Expr::Ident { name, .. } if name == parameter)
-                })
-            {
-                return Some(FirstParameterUse::Defused);
-            }
+            let captured = captured_arguments(func, args);
             first_parameter_use_in_expr(func, parameter).or_else(|| {
-                args.iter()
-                    .find_map(|argument| first_parameter_use_in_expr(&argument.value, parameter))
+                // Actual order is not promise force order. A normal use in
+                // another actual must dominate a captured occurrence.
+                conservative_branch_use(args.iter().enumerate().map(|(index, argument)| {
+                    if is_parameter(&argument.value, parameter)
+                        && (captured.get(index).copied().unwrap_or(false)
+                            || matches!(
+                                ident_name(func).map(bare_name),
+                                Some("match.call" | "bquote")
+                            ))
+                    {
+                        Some(FirstParameterUse::Defused)
+                    } else {
+                        first_parameter_use_in_expr(&argument.value, parameter)
+                    }
+                }))
             })
         }
         Expr::BinOp { lhs, rhs, .. } => first_parameter_use_in_expr(lhs, parameter)
@@ -1074,6 +1122,72 @@ mod collect_walker_tests {
         let mut checker = Checker::new("collect_walker_test.R");
         checker.collect_file_fns(&file);
         checker
+    }
+
+    #[test]
+    fn capture_actuals_follow_specific_formals() {
+        for call in [
+            "delayedAssign('held', p)",
+            "base::delayedAssign(value=p, x='held')",
+            "base:::delayedAssign(val=p, x='held')",
+            "base::substitute(env=list(), expr=p)",
+            "substitute(en=list(), ex=p)",
+            "rlang::enquos(p, .named=FALSE)",
+            "rlang::enquos(tag=p, .named=FALSE)",
+        ] {
+            let checker = collect(&format!("f <- function(p) {call}"));
+            let param = &checker.fn_table.fns["f"].params[0];
+            assert!(param.quoting && param.defused, "{call}: {param:?}");
+            assert_eq!(
+                parameter_uses(call, "p"),
+                ParameterUses {
+                    defused: true,
+                    normal: false
+                },
+                "{call}"
+            );
+            assert_eq!(
+                first_use(call, "p"),
+                Some(FirstParameterUse::Defused),
+                "{call}"
+            );
+        }
+        for call in [
+            "delayedAssign(p, 1L)",
+            "base::delayedAssign('held', 1L, eval.env=p)",
+            "base::delayedAssign('held', 1L, assign.env=p)",
+            "base::delayedAssign('held', 1L, p)",
+            "substitute(expr=foo, env=p)",
+            "base::substitute(en=p, ex=foo)",
+            "substitute(e=p)",
+            "substitute(expr=p, expr=p)",
+            "rlang::enquos(.named=p)",
+            "rlang::enquos(.ignore_empty=p)",
+            "base::substitute(expr=p, env=p)",
+            "base::substitute(env=p, expr=p)",
+        ] {
+            let checker = collect(&format!("f <- function(p) {call}"));
+            let param = &checker.fn_table.fns["f"].params[0];
+            assert!(!param.quoting && !param.defused, "{call}: {param:?}");
+            assert!(parameter_uses(call, "p").normal, "{call}");
+            assert_eq!(
+                first_use(call, "p"),
+                Some(FirstParameterUse::Normal),
+                "{call}"
+            );
+        }
+    }
+
+    #[test]
+    fn capture_inventory_remains_sparse() {
+        let index = promise_capture_index();
+        assert!(index.contains_key("substitute"));
+        assert!(!index.contains_key("mean"));
+        assert!(index.values().flatten().all(|sig| {
+            sig.eval
+                .values()
+                .any(|mode| *mode == EvalMode::CapturesPromise)
+        }));
     }
 
     /// A closure has its own formals: a same-named formal shadows the

--- a/crates/ry-checker/src/collect.rs
+++ b/crates/ry-checker/src/collect.rs
@@ -573,12 +573,28 @@ fn capture_signature_arguments(signature: &FunctionSig, args: &[Arg], captured: 
     {
         return;
     }
+    let all_capture = signature
+        .params
+        .iter()
+        .all(|param| signature.eval.get(&param.name) == Some(&EvalMode::CapturesPromise));
     // Recovery spellings do not prove R argument names. Exact and partial
     // matching otherwise share the ordinary call matcher's occupancy map.
     if args
         .iter()
         .any(|arg| arg.name.as_deref().is_some_and(|name| name.contains('\\')))
     {
+        // This does not validate escaped names. In any successful call to an
+        // all-capture signature, no explicit actual can move to normal
+        // evaluation. Preserve that fact without changing call diagnostics.
+        if all_capture {
+            for (index, arg) in args.iter().enumerate() {
+                if !matches!(arg.value, Expr::Missing(_))
+                    && !matches!(&arg.value, Expr::Ident { name, .. } if name == "...")
+                {
+                    captured[index] = true;
+                }
+            }
+        }
         return;
     }
     let params: Vec<_> = signature.params.iter().map(|p| p.name.as_str()).collect();
@@ -639,9 +655,6 @@ fn capture_signature_arguments(signature: &FunctionSig, args: &[Arg], captured: 
     let forwarded = args
         .iter()
         .any(|arg| matches!(&arg.value, Expr::Ident { name, .. } if name == "..."));
-    let all_capture = params
-        .iter()
-        .all(|param| signature.eval.get(*param) == Some(&EvalMode::CapturesPromise));
     for (index, arg) in args.iter().enumerate() {
         // Preserve the existing blanket forwarding approximation: a wrapper's
         // `...` remains quoting when passed to a capturing dots formal. Runtime
@@ -1160,6 +1173,7 @@ mod collect_walker_tests {
             "rlang::enquo(..., p)",
             "rlang::enquo(ar=p, ...)",
             "rlang::enquo(arg=p, ...)",
+            r"rlang::enquo(`\x61rg`=p)",
             "delayedAssign(x='held', value=p, ...)",
         ] {
             let checker = collect(&format!("f <- function(p) {call}"));
@@ -1184,6 +1198,7 @@ mod collect_walker_tests {
             "delayedAssign('held', p, ...)",
             "delayedAssign('held', val=p, ...)",
             "base::delayedAssign('held', 1L, eval.env=p)",
+            r"base::delayedAssign('held', 1L, `\x65val.env`=p)",
             "base::delayedAssign('held', 1L, assign.env=p)",
             "base::delayedAssign('held', 1L, p)",
             "substitute(expr=foo, env=p)",

--- a/crates/ry-checker/src/tests/quoting_data_mask.rs
+++ b/crates/ry-checker/src/tests/quoting_data_mask.rs
@@ -1460,3 +1460,13 @@ fn forwarded_dots_keep_exact_and_all_capture_actuals_quoted() {
         );
     }
 }
+
+#[test]
+fn escaped_names_of_all_capture_helpers_add_no_eager_wrapper_diagnostic() {
+    let diagnostics = check(r"f <- function(p) rlang::enquo(`\x61rg`=p); f(unbound_capture)");
+    let mut codes: Vec<_> = diagnostics.iter().map(|d| d.code).collect();
+    codes.sort();
+    // The ordinary matcher still sees the recovery spelling. Preserve its
+    // existing diagnostics, without adding RY010 at the valid wrapper call.
+    assert_eq!(codes, ["RY090", "RY091"]);
+}

--- a/crates/ry-checker/src/tests/quoting_data_mask.rs
+++ b/crates/ry-checker/src/tests/quoting_data_mask.rs
@@ -1409,3 +1409,35 @@ fn forwarded_data_mask_dots_do_not_use_lexical_column_types() {
     let source = "wrap <- function(data, ...) dplyr::summarise(data, ...)\nx <- list(1)\nwrap(data.frame(x = 1), result = mean(x))";
     assert!(check(source).is_empty(), "{:?}", check(source));
 }
+
+#[test]
+fn wrapper_capture_modes_follow_the_matched_helper_formal() {
+    for body in [
+        "base::delayedAssign(val=p, x='held')",
+        "base::substitute(en=list(), ex=p)",
+        "rlang::enquos(item=p, .named=FALSE)",
+    ] {
+        let diagnostics = check(&format!("f <- function(p) {body}; f(unbound_capture)"));
+        assert!(
+            !diagnostics
+                .iter()
+                .any(|d| d.code == "RY010" && d.message.contains("unbound_capture")),
+            "{body}: {diagnostics:?}"
+        );
+    }
+    for body in [
+        "base::delayedAssign(p, 1L)",
+        "base::delayedAssign('held', 1L, eval.env=p)",
+        "base::delayedAssign('held', 1L, assign.env=p)",
+        "base::substitute(env=p, expr=1L)",
+        "rlang::enquos(.named=p)",
+    ] {
+        let diagnostics = check(&format!("f <- function(p) {body}; f(unbound_control)"));
+        assert!(
+            diagnostics
+                .iter()
+                .any(|d| d.code == "RY010" && d.message.contains("unbound_control")),
+            "{body}: {diagnostics:?}"
+        );
+    }
+}

--- a/crates/ry-checker/src/tests/quoting_data_mask.rs
+++ b/crates/ry-checker/src/tests/quoting_data_mask.rs
@@ -1441,3 +1441,22 @@ fn wrapper_capture_modes_follow_the_matched_helper_formal() {
         );
     }
 }
+
+#[test]
+fn forwarded_dots_keep_exact_and_all_capture_actuals_quoted() {
+    for body in [
+        "rlang::enquo(p, ...)",
+        "rlang::enquo(..., p)",
+        "rlang::enquo(ar=p, ...)",
+        "rlang::enquo(arg=p, ...)",
+        "delayedAssign(x='held', value=p, ...)",
+    ] {
+        let diagnostics = check(&format!("f <- function(p, ...) {body}; f(unbound_capture)"));
+        assert!(
+            !diagnostics
+                .iter()
+                .any(|d| d.code == "RY010" && d.message.contains("unbound_capture")),
+            "{body}: {diagnostics:?}"
+        );
+    }
+}

--- a/crates/ry-checker/testdata/oracle/capture_formal_matching.R
+++ b/crates/ry-checker/testdata/oracle/capture_formal_matching.R
@@ -1,0 +1,27 @@
+# oracle: must-pass
+# Capturing one formal does not make the helper's environment controls lazy.
+value_capture <- function(p) {
+  base::delayedAssign(val = p, x = "held")
+  TRUE
+}
+stopifnot(value_capture(stop("value was forced")))
+expr_capture <- function(p) base::substitute(en = list(), ex = p)
+stopifnot(identical(expr_capture(unbound_capture), quote(p)))
+
+forces <- function(f) {
+  error <- tryCatch(f(stop("normal argument forced")), error = identity)
+  stopifnot(inherits(error, "error"))
+  stopifnot(identical(conditionMessage(error), "normal argument forced"))
+}
+forces(function(p) base::delayedAssign(p, 1L))
+forces(function(p) base::delayedAssign("held", 1L, eval.env = p))
+forces(function(p) base::delayedAssign("held", 1L, assign.env = p))
+forces(function(p) base::substitute(expr = x, env = p))
+stopifnot(inherits(tryCatch(base::substitute(e = x), error = identity), "error"))
+
+if (requireNamespace("rlang", quietly = TRUE)) {
+  dots_capture <- function(p) rlang::enquos(p, .named = FALSE)
+  stopifnot(length(dots_capture(unbound_capture)) == 1L)
+  forces(function(p) rlang::enquos(.named = p))
+  forces(function(p) rlang::enquos(.ignore_empty = p))
+}

--- a/crates/ry-checker/testdata/oracle/capture_formal_matching.R
+++ b/crates/ry-checker/testdata/oracle/capture_formal_matching.R
@@ -25,3 +25,20 @@ if (requireNamespace("rlang", quietly = TRUE)) {
   forces(function(p) rlang::enquos(.named = p))
   forces(function(p) rlang::enquos(.ignore_empty = p))
 }
+
+exact_forward <- function(p, ...) delayedAssign(x = "held", value = p, ...)
+stopifnot(is.null(exact_forward(unbound_capture)))
+if (requireNamespace("rlang", quietly = TRUE)) {
+  leading_forward <- function(p, ...) rlang::enquo(..., p)
+  stopifnot(rlang::is_quosure(leading_forward(unbound_capture)))
+  positional_forward <- function(p, ...) rlang::enquo(p, ...)
+  partial_forward <- function(p, ...) rlang::enquo(ar = p, ...)
+  stopifnot(rlang::is_quosure(positional_forward(unbound_capture)))
+  stopifnot(rlang::is_quosure(partial_forward(unbound_capture)))
+}
+# Unknown named dots can change positional occupancy in a mixed signature.
+# Supplying value moves the positional p from value to the normal eval.env.
+mixed_forward <- function(p, ...) delayedAssign("held", p, ...)
+error <- tryCatch(mixed_forward(stop("normal forwarded control"), value = 1L), error = identity)
+stopifnot(inherits(error, "error"))
+stopifnot(identical(conditionMessage(error), "normal forwarded control"))

--- a/crates/ry-checker/testdata/oracle/capture_formal_matching.R
+++ b/crates/ry-checker/testdata/oracle/capture_formal_matching.R
@@ -15,6 +15,7 @@ forces <- function(f) {
 }
 forces(function(p) base::delayedAssign(p, 1L))
 forces(function(p) base::delayedAssign("held", 1L, eval.env = p))
+forces(function(p) base::delayedAssign("held", 1L, `\x65val.env` = p))
 forces(function(p) base::delayedAssign("held", 1L, assign.env = p))
 forces(function(p) base::substitute(expr = x, env = p))
 stopifnot(inherits(tryCatch(base::substitute(e = x), error = identity), "error"))
@@ -42,3 +43,8 @@ mixed_forward <- function(p, ...) delayedAssign("held", p, ...)
 error <- tryCatch(mixed_forward(stop("normal forwarded control"), value = 1L), error = identity)
 stopifnot(inherits(error, "error"))
 stopifnot(identical(conditionMessage(error), "normal forwarded control"))
+
+if (requireNamespace("rlang", quietly = TRUE)) {
+  escaped_name <- function(p) rlang::enquo(`\x61rg` = p)
+  stopifnot(rlang::is_quosure(escaped_name(unbound_capture)))
+}

--- a/crates/ry-typeshed/src/lib.rs
+++ b/crates/ry-typeshed/src/lib.rs
@@ -1905,7 +1905,7 @@ mod tests {
     #[test]
     fn typeshed_preserves_embedded_schema_version() {
         let t = load_base().expect("loads");
-        assert_eq!(t.version, "0.0.6");
+        assert_eq!(t.version, "0.0.7");
         assert_eq!(t.schema_version.as_deref(), Some("2"));
     }
 

--- a/crates/ry-typeshed/vendor/SOURCE
+++ b/crates/ry-typeshed/vendor/SOURCE
@@ -1,4 +1,4 @@
 repository: https://github.com/sims1253/r-typeshed
-commit: 35fdc4ade9b4f2e35bd73f3169402444a0d4e469
+commit: f87bf6c3c0384814b96b45af0370995238aded18
 tree-state: clean
-stubs-sha256: 8b2407f50fd0263b7273fbdc9e110a5b34577f534c8deeb4e63e70b9433626b5
+stubs-sha256: 736a527d68c635d08fa8ac6a52f3320bf5a61d9b71f08ada68dad44c5a30f580

--- a/crates/ry-typeshed/vendor/base/base.json
+++ b/crates/ry-typeshed/vendor/base/base.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "2",
   "package": "base",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "globals": {
     "ambient": [
       "..deparseOpts",
@@ -3506,7 +3506,9 @@
     "delayedAssign": {
       "params": [
         "x",
-        "value"
+        "value",
+        "eval.env",
+        "assign.env"
       ],
       "eval": {
         "value": "captures_promise"
@@ -7011,7 +7013,8 @@
     },
     "substitute": {
       "params": [
-        "expr"
+        "expr",
+        "env"
       ],
       "eval": {
         "expr": "captures_promise"


### PR DESCRIPTION
Collect wrapper evaluation modes from the actual argument matched to each `captures_promise` formal. Previously, any named capture formal made the first actual look captured, and two other collection paths treated every actual as defused. For example, `delayedAssign("held", p)` should capture `p`, while `delayedAssign(p, 1L)` evaluates it as the target name.

The four collection consumers now share formal-specific classification, including named reordering, partial matching, and qualified base helpers. Normal environment arguments and explicit rlang controls stay separate from captured expressions. A normal use in another actual dominates capture without assuming lexical argument order is force order. The sparse inventory introduced by #273 remains sparse.

Vendors the complete base helper formals from [r-typeshed #25](https://github.com/sims1253/r-typeshed/pull/25), commit f87bf6c. Merge that reviewed prerequisite first.

Boundaries:

- Bare names still use the existing embedded-inventory union; collection does not resolve lexical callee identity or read user stubs.
- Forwarded dots retain the existing blanket capture approximation. Runtime names may bind normal controls; this change handles explicit controls without introducing false diagnostics for ordinary forwarding wrappers.
- Unknown dots expansion preserves exact-named capture and signatures whose every formal captures. Mixed positional/partial occupancy stays conservative.
- Escaped names stay opaque for mixed signatures. All-capture signatures retain their capture fact without validating the name; existing RY090/RY091 diagnostics remain unchanged.

Validation on final d32ef7a: full workspace tests (including 596 checker library tests), Clippy with warnings denied, formatting, all 17 R oracle tests, and both default and full 62-package Posit corpus checks passed. The two pinned corpus checks ran serially in an independent cache and produced zero report drift; Posit retained all 687 readable message identities. Live R witnesses cover capture versus normal environment/control forcing, exact/partial/leading-dots matching, and escaped argument names.

Cost check against main d9902bc, using fresh hermetic processes and two Rayon workers: 200 capture wrappers added 1.05% instructions and 1.38% allocated bytes. Pinned purrr had negligible instruction change (-0.08%) and +0.05% allocated bytes. Diagnostic JSON was byte-identical across all profile runs; these are instruction/allocation measurements, not wall-time claims.

Hold merge until final checks and independent review complete. Pullfrog currently reports an external provider quota limit; no provider configuration has been changed.

