### PR TITLE
fix(parser): reject excessive syntax nesting before AST conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,6 +151,9 @@ All notable changes to ry are documented in this file.
 
 ### Fixed
 
+- Report an explicit nesting-limit error before deeply nested syntax can
+  overflow the parser stack. The limit is 128 tree-sitter syntax levels.
+
 - Compute data-frame column types after scalar arithmetic instead of copying
   their input types. Keep classed column results unknown when methods may run.
 

--- a/crates/ry-core/src/parser.rs
+++ b/crates/ry-core/src/parser.rs
@@ -951,15 +951,15 @@ fn utf8_char_len(b: u8) -> usize {
     }
 }
 
+// Keep recursive lowering within an ordinary 2 MiB Rust worker stack.
+const MAX_SYNTAX_DEPTH: usize = 128;
+
 /// Collect every `comment` node in the tree, returning `(line, body)`
 /// pairs in source order. The body is the text AFTER the leading `#`
 /// (untrimmed). These are the ONLY lexically-real comments -- a `#`
 /// that appears inside a string literal is part of the string, not a
 /// comment, so the suppression parser must consume this list rather
 /// than scanning source lines for `#`.
-// Keep recursive lowering within an ordinary 2 MiB Rust worker stack.
-const MAX_SYNTAX_DEPTH: usize = 128;
-
 fn collect_comments(
     root: tree_sitter::Node,
     src: &str,

--- a/crates/ry-core/src/parser.rs
+++ b/crates/ry-core/src/parser.rs
@@ -62,6 +62,8 @@ impl RParser {
                 message: "parser returned no tree".into(),
             })?;
         let root = tree.root_node();
+        // Check nesting before recursive lowering (and eventual AST drop).
+        let comments = collect_comments(root, src)?;
         let tree = tree.clone(); // Clone for return value; root borrows the original.
         let mut stmts = Vec::new();
         let mut cursor = root.walk();
@@ -80,7 +82,6 @@ impl RParser {
             }
         }
         let parse_errors = collect_parse_errors(root);
-        let comments = collect_comments(root, src);
         Ok((
             SourceFile {
                 path: path.to_string(),
@@ -956,10 +957,24 @@ fn utf8_char_len(b: u8) -> usize {
 /// that appears inside a string literal is part of the string, not a
 /// comment, so the suppression parser must consume this list rather
 /// than scanning source lines for `#`.
-fn collect_comments(root: tree_sitter::Node, src: &str) -> Vec<crate::ast::Comment> {
+// Keep recursive lowering within an ordinary 2 MiB Rust worker stack.
+const MAX_SYNTAX_DEPTH: usize = 128;
+
+fn collect_comments(
+    root: tree_sitter::Node,
+    src: &str,
+) -> Result<Vec<crate::ast::Comment>, ParseError> {
     let mut out = Vec::new();
-    let mut stack: Vec<tree_sitter::Node> = vec![root];
-    while let Some(node) = stack.pop() {
+    let mut stack = vec![(root, 0_usize)];
+    while let Some((node, depth)) = stack.pop() {
+        if depth > MAX_SYNTAX_DEPTH {
+            let position = node.start_position();
+            return Err(ParseError::TreeSitter {
+                line: position.row + 1,
+                col: position.column + 1,
+                message: format!("source exceeds ry's syntax nesting limit of {MAX_SYNTAX_DEPTH}"),
+            });
+        }
         if node.kind() == "comment" {
             let pos = node.start_position();
             let line = pos.row;
@@ -973,11 +988,11 @@ fn collect_comments(root: tree_sitter::Node, src: &str) -> Vec<crate::ast::Comme
         }
         let mut child_cursor = node.walk();
         for child in node.children(&mut child_cursor) {
-            stack.push(child);
+            stack.push((child, depth + 1));
         }
     }
     out.sort_by_key(|c| c.line);
-    out
+    Ok(out)
 }
 
 /// Walk the parse tree and collect spans of `ERROR` and `MISSING` nodes.
@@ -1065,6 +1080,55 @@ mod tests {
     fn parse(src: &str) -> SourceFile {
         let mut p = RParser::new().expect("parser init");
         p.parse("test.R", src).expect("parse ok")
+    }
+
+    #[test]
+    fn syntax_depth_limit_protects_small_stacks_and_parser_reuse() {
+        std::thread::Builder::new()
+            .stack_size(2 * 1024 * 1024)
+            .spawn(|| {
+                let mut parser = RParser::new().unwrap();
+                for source in [
+                    format!("{}1", "-".repeat(96)),
+                    format!("{}1", "1+".repeat(96)),
+                    format!("{}1{}", "f(".repeat(40), ")".repeat(40)),
+                    format!("{}1{}", "{".repeat(96), "}".repeat(96)),
+                    format!("{}1", "if (TRUE) ".repeat(40)),
+                    format!("{}1", "function() ".repeat(40)),
+                    format!("f({})", vec!["1"; 10_000].join(",")),
+                ] {
+                    let file = parser.parse("ordinary.R", &source).unwrap();
+                    assert!(file.parse_errors.is_empty());
+                    drop(file);
+                }
+                for source in [
+                    format!("{}1", "-".repeat(512)),
+                    format!("{}1", "1+".repeat(512)),
+                    format!("{}1{}", "f(".repeat(512), ")".repeat(512)),
+                    format!("{}1{}", "{".repeat(512), "}".repeat(512)),
+                    format!("{}1", "if (TRUE) ".repeat(512)),
+                    format!("{}1", "function() ".repeat(512)),
+                ] {
+                    let source = format!("# before\n{source}");
+                    let error = parser.parse("deep.R", &source).unwrap_err();
+                    match error {
+                        super::ParseError::TreeSitter { line, col, message } => {
+                            assert_eq!(line, 2);
+                            assert!(col > 0 && col <= source.len());
+                            assert_eq!(message, "source exceeds ry's syntax nesting limit of 128");
+                        }
+                    }
+                    let recovered = parser
+                        .parse("next.R", "# retained\nx <- 1 # trailing")
+                        .unwrap();
+                    assert!(recovered.parse_errors.is_empty());
+                    assert_eq!(recovered.stmts.len(), 1);
+                    assert_eq!(recovered.comments.len(), 2);
+                }
+            })
+            .unwrap()
+            .join()
+            .unwrap();
     }
 
     #[test]

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -185,6 +185,12 @@ vim.lsp.start({
 
 ## Known limits
 
+ry rejects source whose tree-sitter syntax tree exceeds 128 nested levels,
+with a parser error that identifies ry’s nesting limit and the source location.
+This protects recursive analysis on ordinary worker-thread stacks; it is not
+an R language limit. Flat files and wide argument lists are not limited by
+this bound.
+
 When both operator operands have different S3 methods, ry can follow a
 `chooseOpsMethod` returning literal `TRUE` or `FALSE` when the current scope
 proves both methods and the chooser values in top-level code using ordinary

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -188,8 +188,8 @@ vim.lsp.start({
 ry rejects source whose tree-sitter syntax tree exceeds 128 nested levels,
 with a parser error that identifies ry’s nesting limit and the source location.
 This protects recursive analysis on ordinary worker-thread stacks; it is not
-an R language limit. Flat files and wide argument lists are not limited by
-this bound.
+an R language limit. The bound measures syntax-tree depth, not line count or
+file size; wide argument lists remain allowed.
 
 When both operator operands have different S3 methods, ry can follow a
 `chooseOpsMethod` returning literal `TRUE` or `FALSE` when the current scope


### PR DESCRIPTION
Deep syntax can overflow the stack while converting tree-sitter nodes to the AST. Check depth during the iterative comment walk before conversion, and reject syntax deeper than 128 levels with an error at the source position. Wide argument lists remain allowed. Document this ry limit.

Validation: workspace tests, Clippy, formatting, and 17 R-oracle tests pass. Regression coverage uses a 2 MiB stack and checks accepted input, rejected nesting, and parser reuse. Parser fuzzing completed 137,463 runs in 301 seconds. Fresh pinned corpus comparisons against d9902bc found no output changes across 64 default and 124 extended package-root/R checks.

Integration `ad7a641` includes main through #281. Formatting, diff checks, and all 33 parser tests pass after integration. The corpus and fuzz results above precede the inherited string-decoder changes.
