### PR TITLE
perf(infer): reduce expression-if scope allocation

### DIFF
--- a/crates/ry-checker/benches/performance.rs
+++ b/crates/ry-checker/benches/performance.rs
@@ -151,6 +151,37 @@ fn check_branch_scopes(c: &mut Criterion) {
     group.finish();
 }
 
+/// Expression arms discard bindings and need only one live child scope at a time.
+fn check_if_expression_scopes(c: &mut Criterion) {
+    let mut group = c.benchmark_group("check_if_expression_scopes");
+    for bindings in [128, 1024] {
+        for with_else in [false, true] {
+            let mut source = String::from("f <- function(flag) {\n");
+            for i in 0..bindings {
+                source.push_str(&format!("x{i} <- {i}L\n"));
+            }
+            source.push_str("result <- ");
+            for _ in 0..24 {
+                source.push_str("if (flag) (");
+            }
+            source.push_str("x0");
+            for _ in 0..24 {
+                source.push_str(if with_else { ") else 0L" } else { ")" });
+            }
+            source.push_str("\nresult\n}\nf(TRUE)\n");
+            let file = RParser::new().unwrap().parse("if_expr.R", &source).unwrap();
+            let arm = if with_else { "two_arms" } else { "one_arm" };
+            group.bench_with_input(BenchmarkId::new(arm, bindings), &file, |b, file| {
+                b.iter(|| {
+                    let mut checker = Checker::new("if_expr.R");
+                    black_box(checker.check(black_box(file)));
+                });
+            });
+        }
+    }
+    group.finish();
+}
+
 /// Guards need only one continuation, even in a scope with many unrelated names.
 fn check_selected_branch_scopes(c: &mut Criterion) {
     let mut group = c.benchmark_group("check_selected_branch_scopes");
@@ -408,7 +439,7 @@ criterion_group! {
         .sample_size(20)
         .warm_up_time(Duration::from_secs(1))
         .measurement_time(Duration::from_secs(3));
-    targets = parse_large, check_project_glue, check_single_synthetic, check_branch_scopes, check_selected_branch_scopes,
+    targets = parse_large, check_project_glue, check_single_synthetic, check_branch_scopes, check_selected_branch_scopes, check_if_expression_scopes,
               warm_edit_dependent, warm_edit_leaf, warm_edit_library,
               lsp_edit_sim, warm_edit_sparse_callers
 }

--- a/crates/ry-checker/src/infer/pipe.rs
+++ b/crates/ry-checker/src/infer/pipe.rs
@@ -274,17 +274,24 @@ impl Checker {
         // expression-position assignment is rare and merging here would
         // require plumbing owned branch scopes back to the caller.
         let narrowing = self.extract_type_narrowing(cond, scope);
-        let (mut then_scope, mut else_scope, _narrowed) = apply_narrowing(scope, &narrowing);
-        let then_t = self.infer(then, &mut then_scope);
-        let else_t = match else_ {
-            Some(e) => self.infer(e, &mut else_scope),
-            None => RType::new(Mode::Null, Length::Zero),
+        // Expression arms do not merge bindings. Drop each child before
+        // creating its sibling, and avoid a child for an absent else arm.
+        // Delay propagating effects until both arms have seen the same base.
+        let mut infer_arm = |expr, branch| {
+            let mut child = scope.clone();
+            apply_narrowing_branch(&mut child, &narrowing, branch);
+            let ty = self.infer(expr, &mut child);
+            (ty, child.ops_environment_unknown, child.effects_unknown)
+        };
+        let (then_t, then_ops, then_effects) = infer_arm(then, NarrowingBranch::Then);
+        let (else_t, else_ops, else_effects) = match else_ {
+            Some(e) => infer_arm(e, NarrowingBranch::Else),
+            None => (RType::new(Mode::Null, Length::Zero), false, false),
         };
         scope.literal_functions.clear();
         scope.plain_ops_vectors.clear();
-        scope.ops_environment_unknown |=
-            then_scope.ops_environment_unknown || else_scope.ops_environment_unknown;
-        scope.effects_unknown |= then_scope.effects_unknown || else_scope.effects_unknown;
+        scope.ops_environment_unknown |= then_ops || else_ops;
+        scope.effects_unknown |= then_effects || else_effects;
         then_t.join(else_t)
     }
 
@@ -342,5 +349,68 @@ impl Checker {
             return RType::unknown();
         }
         join_all(types.into_iter())
+    }
+}
+
+#[cfg(test)]
+mod if_expression_scope_tests {
+    use super::*;
+    use ry_core::RParser;
+
+    fn infer_expression(source: &str, scope: &mut Scope) -> RType {
+        let file = RParser::new().unwrap().parse("test.R", source).unwrap();
+        let Stmt::Assign { value, .. } = &file.stmts[0] else {
+            panic!("expected an expression assignment");
+        };
+        let Expr::If {
+            cond, then, else_, ..
+        } = value
+        else {
+            panic!("expected an if expression");
+        };
+        Checker::new("test.R").infer_if_expr(cond, then, else_, scope)
+    }
+
+    #[test]
+    fn sibling_expression_arms_share_the_original_binding() {
+        let mut scope = Scope::default();
+        scope.insert("x", RType::scalar(Mode::Integer));
+        let ty = infer_expression("result <- if (TRUE) (x <- 'changed') else x", &mut scope);
+        assert_eq!(ty.mode, Mode::Union);
+        let members = ty.members.unwrap();
+        assert!(members.iter().any(|ty| ty.mode == Mode::Integer));
+        assert!(members.iter().any(|ty| ty.mode == Mode::Character));
+        assert_eq!(scope.get("x").unwrap().mode, Mode::Integer);
+    }
+
+    #[test]
+    fn absent_else_joins_null_and_keeps_existing_effects() {
+        for effects_unknown in [false, true] {
+            let mut scope = Scope {
+                effects_unknown,
+                ops_environment_unknown: effects_unknown,
+                ..Scope::default()
+            };
+            let ty = infer_expression("result <- if (TRUE) 1L", &mut scope);
+            assert_eq!(ty.mode, Mode::Union);
+            let members = ty.members.unwrap();
+            assert!(members.iter().any(|ty| ty.mode == Mode::Integer));
+            assert!(members.iter().any(|ty| ty.mode == Mode::Null));
+            assert_eq!(scope.effects_unknown, effects_unknown);
+            assert_eq!(scope.ops_environment_unknown, effects_unknown);
+        }
+    }
+
+    #[test]
+    fn effects_from_either_expression_arm_reach_the_parent() {
+        for source in [
+            "result <- if (TRUE) unknown_call()",
+            "result <- if (TRUE) unknown_call() else 1L",
+            "result <- if (TRUE) 1L else unknown_call()",
+        ] {
+            let mut scope = Scope::default();
+            infer_expression(source, &mut scope);
+            assert!(scope.ops_environment_unknown, "{source}");
+        }
     }
 }

--- a/crates/ry-core/src/walk.rs
+++ b/crates/ry-core/src/walk.rs
@@ -195,7 +195,7 @@ fn expr_step<B>(
         }
         Expr::BinOp { op, lhs, rhs, .. } => {
             let assignment = matches!(op, BinOpKind::Assign | BinOpKind::SuperAssign);
-            if !(assignment && !policy.assign_operands) {
+            if !assignment || policy.assign_operands {
                 expr_step(lhs, policy, fn_depth, visit)?;
             }
             expr_step(rhs, policy, fn_depth, visit)?;
@@ -205,7 +205,7 @@ fn expr_step<B>(
             base, kind, args, ..
         } => {
             expr_step(base, policy, fn_depth, visit)?;
-            if !(*kind == IndexKind::Dollar && !policy.dollar_args) {
+            if *kind != IndexKind::Dollar || policy.dollar_args {
                 for argument in args {
                     expr_step(&argument.value, policy, fn_depth, visit)?;
                 }

--- a/docs/corpus/if-expression-scopes.json
+++ b/docs/corpus/if-expression-scopes.json
@@ -1,0 +1,69 @@
+{
+  "baseline_revision": "d5414ffe2be45d2f3ead7a804ea7a872c80f6346",
+  "rustc": "rustc 1.96.1 (31fca3adb 2026-06-26)",
+  "valgrind": "valgrind-3.18.1",
+  "environment": {
+    "RY_NO_INSTALLED_LIBRARIES": "1",
+    "RAYON_NUM_THREADS": "1"
+  },
+  "command": "valgrind --tool=dhat --dhat-out-file=PROFILE BINARY check INPUT",
+  "binary_sha256": {
+    "baseline": "e0726e1ba44b541d02bb0fb6de61ce5a62c041de10a1fc2a7a838b05bac42926",
+    "candidate": "d7e5810f2af1a3631049e08f63779d055489e8493f591291fc7718fa14b68df1"
+  },
+  "workloads": {
+    "one": {
+      "baseline": {
+        "allocated_bytes": 68204571,
+        "allocation_blocks": 228633,
+        "peak_live_bytes": 23879204,
+        "peak_live_blocks": 81991,
+        "stdout_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+      },
+      "candidate": {
+        "allocated_bytes": 45344963,
+        "allocation_blocks": 154569,
+        "peak_live_bytes": 16258540,
+        "peak_live_blocks": 57293,
+        "stdout_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+      },
+      "input_sha256": "b97430a87c7eb6fdcfdf1fca1d6768d7e5ff3e84efe4b0f781dad0b503e64987"
+    },
+    "two": {
+      "baseline": {
+        "allocated_bytes": 68180087,
+        "allocation_blocks": 228689,
+        "peak_live_bytes": 23886132,
+        "peak_live_blocks": 82035,
+        "stdout_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+      },
+      "candidate": {
+        "allocated_bytes": 68180095,
+        "allocation_blocks": 228689,
+        "peak_live_bytes": 16266252,
+        "peak_live_blocks": 57339,
+        "stdout_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+      },
+      "input_sha256": "6ad883b151fa19fbf26301e27679bdd9bcabc6a3a0415f352b726e184bac6239"
+    },
+    "corpus": {
+      "baseline": {
+        "allocated_bytes": 167049810,
+        "allocation_blocks": 1318335,
+        "peak_live_bytes": 30425122,
+        "peak_live_blocks": 181568,
+        "stdout_sha256": "8711b196a72870838dcee359b34c2aac654fe09410d15a43d3e6a7ba2d718f25"
+      },
+      "candidate": {
+        "allocated_bytes": 166988530,
+        "allocation_blocks": 1317980,
+        "peak_live_bytes": 30425122,
+        "peak_live_blocks": 181568,
+        "stdout_sha256": "8711b196a72870838dcee359b34c2aac654fe09410d15a43d3e6a7ba2d718f25"
+      },
+      "input": "crates/ry-checker/testdata at baseline_revision; CLI checks 461 files"
+    }
+  },
+  "candidate_change_revision": "fab49527c4e60da278163ad7e07efdfe06eada93",
+  "candidate_source": "baseline_revision plus candidate_change_revision; excludes separate walker-condition cleanup"
+}

--- a/docs/corpus/if-expression-scopes.md
+++ b/docs/corpus/if-expression-scopes.md
@@ -1,0 +1,80 @@
+# Expression-if scope allocation
+
+Expression-form `if` arms now use one child scope at a time. The checker drops
+that child after retaining its type and effect flags. An absent `else` returns
+NULL without cloning a scope. Both explicit arms still see the same parent;
+effect flags propagate only after both arms finish.
+
+This removes an unused narrowing-name set and the absent-else clone. It also
+reduces peak live heap for nested expressions with two explicit arms. Statement
+branches and the public `Scope` API are unchanged. Snapshots still cost O(scope
+size), so [#130](https://github.com/sims1253/ry/issues/130) remains open.
+
+## Measurement
+
+Two isolated release binaries compare baseline `d5414ff` with the scope change
+from `fab4952`. The measurements exclude the separate, equivalent
+walker-condition cleanup required by the local Clippy gate.
+DHAT 3.18.1 measures the complete CLI process, including parsing and output.
+Rust is 1.96.1 on Linux x86-64. Both runs set `RAYON_NUM_THREADS=1` and
+`RY_NO_INSTALLED_LIBRARIES=1`. The synthetic files match the 1,024-binding
+Criterion inputs: 24 nested expression-form conditionals, with either one arm
+or two arms. The corpus command checks 461 files. Diagnostics match byte for
+byte for all three workloads.
+
+| Workload | Baseline allocated bytes | Changed allocated bytes | Change |
+| :-- | --: | --: | --: |
+| No else | 68,204,571 | 45,344,963 | -33.52% |
+| Explicit else | 68,180,087 | 68,180,095 | unchanged |
+| Fixture corpus | 167,049,810 | 166,988,530 | -0.037% |
+
+| Workload | Baseline peak live bytes | Changed peak live bytes | Change |
+| :-- | --: | --: | --: |
+| No else | 23,879,204 | 16,258,540 | -31.91% |
+| Explicit else | 23,886,132 | 16,266,252 | -31.90% |
+| Fixture corpus | 30,425,122 | 30,425,122 | unchanged |
+
+Allocated bytes are cumulative allocations. Peak live bytes are live heap,
+not process RSS. The eight-byte explicit-else difference is negligible; binary
+paths differ between runs. These results do not establish a wall-time speedup.
+The ordinary corpus benefit is small. Exact totals, input hashes, binary hashes,
+and output hashes are in [the measurement record](if-expression-scopes.json).
+
+## Reproduce
+
+Create two worktrees at `d5414ff`. Apply commit `fab4952` to one
+worktree with `git cherry-pick`, leaving out the separate walker cleanup. Build
+both with `cargo build --release --locked -p ry-cli`, and save each binary. Generate the
+two synthetic inputs in a separate output directory:
+
+```python
+from pathlib import Path
+
+for with_else in [False, True]:
+    source = "f <- function(flag) {\n"
+    source += "".join(f"x{i} <- {i}L\n" for i in range(1024))
+    source += "result <- " + "if (flag) (" * 24 + "x0"
+    source += (") else 0L" if with_else else ")") * 24
+    source += "\nresult\n}\nf(TRUE)\n"
+    Path("two.R" if with_else else "one.R").write_text(source)
+```
+
+For each binary and input, run the following command with a distinct profile
+and output path. Also run it with `crates/ry-checker/testdata` as the input,
+from the same worktree for both binaries. Compare each pair of output files.
+The corpus returns status 1 because its fixtures deliberately contain errors.
+
+```sh
+RY_NO_INSTALLED_LIBRARIES=1 RAYON_NUM_THREADS=1 \
+  valgrind --tool=dhat --dhat-out-file=profile.json \
+  /path/to/ry check one.R > diagnostics.txt
+```
+
+The Criterion benchmark covers 128 and 1,024 bindings, with and without `else`:
+
+```sh
+cargo bench -p ry-checker --bench performance -- check_if_expression_scopes
+```
+
+The recorded comparison uses DHAT rather than Criterion elapsed time. Concurrent
+host activity makes elapsed-time comparisons unsuitable for this run.


### PR DESCRIPTION
Expression-form `if` previously kept both cloned scopes alive through both arms and cloned an else scope even when no else existed. Infer each arm in a temporary child, retain its type/effect flags, and release the child before its sibling. Both arms still use the original parent, and effects propagate after both finish.

On 1,024 bindings with 24 nested expressions, DHAT allocations fall 33.52% without an else. Peak live heap falls about 31.9% with or without an explicit else. The 461-file corpus saves only 0.037% of allocated bytes; peak stays unchanged. Diagnostics match byte for byte. These are allocation measurements, not wall-time or RSS claims. Exact totals, hashes, and reproduction are in `docs/corpus/if-expression-scopes.md` and its JSON record.

Adds regression tests for sibling isolation, NULL joins, and effect propagation, plus four Criterion inputs. A separate prerequisite commit simplifies two equivalent walker conditions so the existing code passes current Clippy.

Validation: `cargo test --workspace`; `cargo clippy --workspace --all-targets -- -D warnings`; `cargo fmt --all -- --check`; full R oracle matrix (17 tests); Criterion benchmark smoke run (four inputs).

Related to #130. This is a bounded improvement: scopes still clone, so the O(1)-snapshot acceptance criterion is unmet and #130 remains open.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved type and effect inference for conditional expressions, including more reliable handling of sibling branches and omitted `else` clauses.
  * Prevented bindings from one conditional branch from affecting another.

* **Performance**
  * Reduced temporary scope allocation during conditional-expression checking.

* **Documentation**
  * Added memory-profiling results and reproducible benchmarking guidance for conditional-expression checking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->