### PR TITLE
fix(checker): respect S3 dollar reads and writes on classed atomics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,10 +151,6 @@ All notable changes to ry are documented in this file.
 
 ### Fixed
 
-- Keep classed atomic `$` reads and writes conservative when an S3 method may
-  handle the access, including classes attached to a union of payload types.
-  Discard caller facts that the method could change.
-
 - `ry check` now emits an empty JSON/GitLab array or JUnit report when no R
   files are discovered, including when configuration excludes every source.
 
@@ -167,6 +163,10 @@ All notable changes to ry are documented in this file.
 - Decode octal and braced Unicode string escapes, escaped spaces and backticks,
   and UTF-8 byte sequences correctly. Preserve physical escaped newlines and
   retain raw recovery text for malformed or unrepresentable string values.
+
+- Keep classed atomic `$` reads and writes conservative when an S3 method may
+  handle the access, including classes attached to a union of payload types.
+  Discard caller facts that the method could change.
 
 - Report missing format arguments only for proven base `sprintf` and
   `gettextf` calls, avoiding false RY094 warnings for custom functions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,6 +151,10 @@ All notable changes to ry are documented in this file.
 
 ### Fixed
 
+- Keep classed atomic `$` reads and writes conservative when an S3 method may
+  handle the access, including classes attached to a union of payload types.
+  Discard caller facts that the method could change.
+
 - Report an explicit nesting-limit error before deeply nested syntax can
   overflow the parser stack. The limit is 128 tree-sitter syntax levels.
 

--- a/crates/ry-checker/src/infer/index.rs
+++ b/crates/ry-checker/src/infer/index.rs
@@ -34,6 +34,16 @@ fn dollar_receiver_is_definitely_atomic(receiver: &RType) -> bool {
     }
 }
 
+fn dollar_atomic_receiver_may_dispatch(receiver: &RType) -> bool {
+    if receiver.mode == Mode::Union {
+        return receiver
+            .members
+            .as_ref()
+            .is_some_and(|members| members.iter().any(dollar_atomic_receiver_may_dispatch));
+    }
+    atomic_mode(receiver) && receiver.class != ClassVector::empty()
+}
+
 /// A human-readable description of the receiver's mode(s) for the RY061
 /// message. For a single type this is just the mode name; for a union
 /// the member modes are listed so the user can see which types combined.
@@ -94,6 +104,13 @@ impl Checker {
         }
         match kind {
             IndexKind::Dollar => {
+                // `$` dispatches on classed atomic values. The pooled method
+                // table cannot prove which method applies here, its return
+                // type, or its writes to the caller.
+                if dollar_atomic_receiver_may_dispatch(&bt) {
+                    scope.invalidate_unknown_effects();
+                    return RType::unknown();
+                }
                 // RY061: `$` on an atomic vector is a runtime error in R
                 // ("$ operator is invalid for atomic vectors"). Only flag
                 // when we're confident the type is atomic (not opaque,

--- a/crates/ry-checker/src/infer/index.rs
+++ b/crates/ry-checker/src/infer/index.rs
@@ -34,7 +34,7 @@ fn dollar_receiver_is_definitely_atomic(receiver: &RType) -> bool {
     }
 }
 
-fn dollar_atomic_receiver_may_dispatch(receiver: &RType) -> bool {
+pub(super) fn dollar_atomic_receiver_may_dispatch(receiver: &RType) -> bool {
     if receiver.mode == Mode::Union {
         // structure() can attach the dispatch class to the union itself.
         return receiver.class != ClassVector::empty()

--- a/crates/ry-checker/src/infer/index.rs
+++ b/crates/ry-checker/src/infer/index.rs
@@ -36,10 +36,12 @@ fn dollar_receiver_is_definitely_atomic(receiver: &RType) -> bool {
 
 fn dollar_atomic_receiver_may_dispatch(receiver: &RType) -> bool {
     if receiver.mode == Mode::Union {
-        return receiver
-            .members
-            .as_ref()
-            .is_some_and(|members| members.iter().any(dollar_atomic_receiver_may_dispatch));
+        // structure() can attach the dispatch class to the union itself.
+        return receiver.class != ClassVector::empty()
+            || receiver
+                .members
+                .as_ref()
+                .is_some_and(|members| members.iter().any(dollar_atomic_receiver_may_dispatch));
     }
     atomic_mode(receiver) && receiver.class != ClassVector::empty()
 }

--- a/crates/ry-checker/src/infer/mod.rs
+++ b/crates/ry-checker/src/infer/mod.rs
@@ -1463,6 +1463,12 @@ impl Checker {
             let _ = self.infer(base, scope);
             return true;
         };
+        if matches!(kind, IndexKind::Dollar) && index::dollar_atomic_receiver_may_dispatch(&base_t)
+        {
+            // `$<-` may replace the whole value and write to its caller.
+            scope.invalidate_unknown_effects();
+            return true;
+        }
         if matches!(kind, IndexKind::Single) {
             let names = args
                 .first()

--- a/crates/ry-checker/src/tests/type_inference.rs
+++ b/crates/ry-checker/src/tests/type_inference.rs
@@ -1156,6 +1156,42 @@ fn dollar_on_list_no_warning() {
 }
 
 #[test]
+fn dollar_on_classed_atomic_values_keeps_dispatch_opaque() {
+    for value in [
+        "structure(1L, class='widget')",
+        "structure('payload', class='widget')",
+        "if (runif(1) > 0.5) structure(1L, class='widget') else 'plain'",
+    ] {
+        let (diags, scope) = check_with_scope(&format!(
+            "`$.widget` <- function(x, name) list(value=2L); x <- {value}; out <- x$field; out$value + 1L"
+        ));
+        assert!(
+            diags.iter().all(|d| !matches!(d.code, "RY061" | "RY040")),
+            "{value}: {diags:?}"
+        );
+        assert_eq!(scope.get("out").unwrap().mode, Mode::Opaque, "{value}");
+    }
+}
+
+#[test]
+fn dollar_on_classed_atomic_values_invalidates_caller_effects() {
+    let diags = check(
+        "`$.widget` <- function(x, name) { assign('marker', 1L, envir=parent.frame()); 2L }; f <- function() { marker <- 'before'; x <- structure(1L, class='widget'); out <- x$field; marker + 1L }; f()",
+    );
+    assert!(
+        diags.iter().all(|d| !matches!(d.code, "RY061" | "RY040")),
+        "{diags:?}"
+    );
+}
+
+#[test]
+fn dollar_on_classed_atomic_values_does_not_require_a_collected_method() {
+    let (diags, scope) = check_with_scope("x <- structure(1L, class='external'); out <- x$field");
+    assert!(diags.iter().all(|d| d.code != "RY061"), "{diags:?}");
+    assert_eq!(scope.get("out").unwrap().mode, Mode::Opaque);
+}
+
+#[test]
 fn dollar_on_data_frame_no_warning() {
     let diags = check("val <- mtcars$mpg\n");
     assert!(diags.iter().all(|d| d.code != "RY061"), "got {:?}", diags);

--- a/crates/ry-checker/src/tests/type_inference.rs
+++ b/crates/ry-checker/src/tests/type_inference.rs
@@ -1203,6 +1203,24 @@ fn dollar_on_union_with_outer_class_invalidates_caller_effects() {
 }
 
 #[test]
+fn dollar_assignment_on_classed_atomic_values_preserves_uncertainty() {
+    for value in [
+        "structure(1L,class='widget')",
+        "structure(if(flag) 1L else 'payload',class='widget')",
+    ] {
+        let diags = check(&format!(
+            "`$<-.widget` <- function(x,name,value) {{ assign('marker',1L,envir=parent.frame()); list(saved=value) }}; f <- function(flag) {{ marker <- 'before'; x <- {value}; x$field <- 3L; marker+1L; x$saved }}; f(TRUE); f(FALSE)"
+        ));
+        assert!(
+            diags.iter().all(|d| !matches!(d.code, "RY061" | "RY040")),
+            "{value}: {diags:?}"
+        );
+    }
+    let diags = check("x <- 1L; x$field <- 3L");
+    assert!(diags.iter().any(|d| d.code == "RY061"), "{diags:?}");
+}
+
+#[test]
 fn dollar_on_data_frame_no_warning() {
     let diags = check("val <- mtcars$mpg\n");
     assert!(diags.iter().all(|d| d.code != "RY061"), "got {:?}", diags);

--- a/crates/ry-checker/src/tests/type_inference.rs
+++ b/crates/ry-checker/src/tests/type_inference.rs
@@ -1192,6 +1192,17 @@ fn dollar_on_classed_atomic_values_does_not_require_a_collected_method() {
 }
 
 #[test]
+fn dollar_on_union_with_outer_class_invalidates_caller_effects() {
+    let diags = check(
+        "`$.widget` <- function(x,name) { assign('marker',1L,envir=parent.frame()); 2L }; f <- function(flag) { marker <- 'before'; x <- structure(if(flag) 1L else 'payload',class='widget'); out <- x$field; marker+1L }; f(TRUE); f(FALSE)",
+    );
+    assert!(
+        diags.iter().all(|d| !matches!(d.code, "RY061" | "RY040")),
+        "{diags:?}"
+    );
+}
+
+#[test]
 fn dollar_on_data_frame_no_warning() {
     let diags = check("val <- mtcars$mpg\n");
     assert!(diags.iter().all(|d| d.code != "RY061"), "got {:?}", diags);

--- a/crates/ry-checker/testdata/ok_dollar_assign_classed_atomic.R
+++ b/crates/ry-checker/testdata/ok_dollar_assign_classed_atomic.R
@@ -1,0 +1,5 @@
+# no-diag
+`$<-.ry_dollar_widget` <- function(x, name, value) list(saved = value)
+x <- structure(1L, class = "ry_dollar_widget")
+x$field <- 3L
+x$saved + 1L

--- a/crates/ry-checker/testdata/ok_dollar_classed_atomic.R
+++ b/crates/ry-checker/testdata/ok_dollar_classed_atomic.R
@@ -1,0 +1,5 @@
+# no-diag
+`$.ry_dollar_widget` <- function(x, name) list(value = 2L)
+x <- structure(1L, class = "ry_dollar_widget")
+result <- x$field
+result$value + 1L

--- a/crates/ry-checker/testdata/oracle/dollar_assign_classed_effects.R
+++ b/crates/ry-checker/testdata/oracle/dollar_assign_classed_effects.R
@@ -1,0 +1,21 @@
+# oracle: must-pass
+# Replacement dispatch can replace the entire value and write to its caller.
+`$<-.ry_dollar_write` <- function(x, name, value) {
+  assign("marker", 1L, envir = parent.frame())
+  list(saved = value)
+}
+write_scalar <- function() {
+  marker <- "before"
+  x <- structure(1L, class = "ry_dollar_write")
+  x$field <- 3L
+  stopifnot(identical(x$saved, 3L), identical(marker + 1L, 2L))
+}
+write_union <- function(flag) {
+  marker <- "before"
+  x <- structure(if (flag) 1L else "payload", class = "ry_dollar_write")
+  x$field <- 3L
+  stopifnot(identical(x$saved, 3L), identical(marker + 1L, 2L))
+}
+write_scalar()
+write_union(TRUE)
+write_union(FALSE)

--- a/crates/ry-checker/testdata/oracle/dollar_classed_atomic.R
+++ b/crates/ry-checker/testdata/oracle/dollar_classed_atomic.R
@@ -1,0 +1,6 @@
+# oracle: must-pass
+# An atomic payload can dispatch `$` to an S3 method with an arbitrary result.
+`$.ry_dollar_widget` <- function(x, name) list(value = 2L)
+x <- structure(1L, class = "ry_dollar_widget")
+result <- x$field
+stopifnot(identical(result$value, 2L))

--- a/crates/ry-checker/testdata/oracle/dollar_classed_atomic_effects.R
+++ b/crates/ry-checker/testdata/oracle/dollar_classed_atomic_effects.R
@@ -1,0 +1,13 @@
+# oracle: must-pass
+# The method can write to the caller even when the payload and field are literal.
+`$.ry_dollar_effects` <- function(x, name) {
+  assign("marker", 1L, envir = parent.frame())
+  2L
+}
+read_field <- function() {
+  marker <- "before"
+  x <- structure(1L, class = "ry_dollar_effects")
+  result <- x$field
+  stopifnot(identical(result, 2L), identical(marker + 1L, 2L))
+}
+read_field()

--- a/crates/ry-checker/testdata/oracle/dollar_classed_union_effects.R
+++ b/crates/ry-checker/testdata/oracle/dollar_classed_union_effects.R
@@ -1,0 +1,13 @@
+# oracle: must-pass
+# structure() attaches a class to the whole union, not to each possible payload.
+`$.ry_dollar_union` <- function(x, name) {
+  assign("marker", 1L, envir = parent.frame())
+  2L
+}
+read_union <- function(flag) {
+  marker <- "before"
+  x <- structure(if (flag) 1L else "payload", class = "ry_dollar_union")
+  result <- x$field
+  marker + 1L
+}
+stopifnot(identical(read_union(TRUE), 2L), identical(read_union(FALSE), 2L))

--- a/crates/ry-checker/tests/snapshots/corpus__checker_fixture_diagnostics.snap
+++ b/crates/ry-checker/tests/snapshots/corpus__checker_fixture_diagnostics.snap
@@ -689,6 +689,8 @@ expression: snapshots
 - diagnostics: []
   fixture: ok_divisible_recycling.R
 - diagnostics: []
+  fixture: ok_dollar_assign_classed_atomic.R
+- diagnostics: []
   fixture: ok_dollar_classed_atomic.R
 - diagnostics: []
   fixture: ok_dollar_missing_list.R

--- a/crates/ry-checker/tests/snapshots/corpus__checker_fixture_diagnostics.snap
+++ b/crates/ry-checker/tests/snapshots/corpus__checker_fixture_diagnostics.snap
@@ -689,6 +689,8 @@ expression: snapshots
 - diagnostics: []
   fixture: ok_divisible_recycling.R
 - diagnostics: []
+  fixture: ok_dollar_classed_atomic.R
+- diagnostics: []
   fixture: ok_dollar_missing_list.R
 - diagnostics: []
   fixture: ok_dots_absorb_unknown_argument.R

--- a/crates/ry-core/src/types.rs
+++ b/crates/ry-core/src/types.rs
@@ -370,8 +370,8 @@ pub struct RType {
     /// closures).
     pub fn_sig: Option<Arc<FunctionSignature>>,
     /// Members of a union type (`mode == Mode::Union`). `None` for all
-    /// non-union types. Members are bare atomic shapes (class/columns/
-    /// fn_sig cleared); the union owns those dimensions. Built by `join`
+    /// non-union types. Members retain their class, columns, and function
+    /// signature; the union can also carry its own metadata. Built by `join`
     /// when two incompatible branches merge (e.g. `if (p) 1L else "a"`),
     /// capped at `MAX_UNION_MEMBERS` (beyond the cap, join collapses to
     /// `RType::unknown()`).

--- a/crates/ry-core/src/walk.rs
+++ b/crates/ry-core/src/walk.rs
@@ -195,7 +195,7 @@ fn expr_step<B>(
         }
         Expr::BinOp { op, lhs, rhs, .. } => {
             let assignment = matches!(op, BinOpKind::Assign | BinOpKind::SuperAssign);
-            if !(assignment && !policy.assign_operands) {
+            if !assignment || policy.assign_operands {
                 expr_step(lhs, policy, fn_depth, visit)?;
             }
             expr_step(rhs, policy, fn_depth, visit)?;
@@ -205,7 +205,7 @@ fn expr_step<B>(
             base, kind, args, ..
         } => {
             expr_step(base, policy, fn_depth, visit)?;
-            if !(*kind == IndexKind::Dollar && !policy.dollar_args) {
+            if *kind != IndexKind::Dollar || policy.dollar_args {
                 for argument in args {
                     expr_step(&argument.value, policy, fn_depth, visit)?;
                 }


### PR DESCRIPTION
R allows S3 `$` and `$<-` methods on atomic payloads. ry reported RY061 solely from the payload mode, and could keep stale caller facts after a method wrote through `assign(..., envir = parent.frame())`.

Keep reads and writes unknown when a classed atomic receiver may dispatch. This includes classes attached to a whole union or one of its members. Invalidate caller facts and the replacement target because the method can change either. Existing plain-atomic diagnostics remain unchanged.

Regression tests reproduce the original false RY061 and stale RY040 before the fixes. Four fresh-R oracle fixtures cover custom return values, caller writes, scalar replacement, and both branches of a classed union. Existing plain-atomic and plain-union controls remain covered. The union-member documentation now matches the metadata retained by the implementation.

Validation: workspace tests, Clippy with warnings denied, formatting, and the complete checker-versus-R oracle matrix. Vendored package snapshots remain unchanged. Added a changelog entry and corpus fixtures.
