### PR TITLE
fix(checker): allow Math and Summary member fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,6 +151,10 @@ All notable changes to ry are documented in this file.
 
 ### Fixed
 
+- Math and Summary member calls no longer emit RY050 just because an unrelated
+  class has a local group method. Built-ins such as `sum()` and `abs()` can
+  use their default behavior without a class-specific method.
+
 - Report an explicit nesting-limit error before deeply nested syntax can
   overflow the parser stack. The limit is 128 tree-sitter syntax levels.
 

--- a/crates/ry-checker/src/higher_order.rs
+++ b/crates/ry-checker/src/higher_order.rs
@@ -644,6 +644,13 @@ impl Checker {
         cv: &ClassVector,
         span: Span,
     ) -> Option<RType> {
+        // Math/Summary members have built-in fallbacks. An unrelated local
+        // group method cannot make a class-specific method mandatory. Keep
+        // the result opaque: the local inventory cannot rule out registered
+        // methods, and their return types need not match the primitive.
+        if s3_group_generic(generic).is_some() {
+            return Some(RType::unknown());
+        }
         let has_default = generics.iter().any(|candidate| {
             let default_key = ((*candidate).to_string(), "default".to_string());
             self.fn_table.s3_methods.contains_key(&default_key)

--- a/crates/ry-checker/src/higher_order.rs
+++ b/crates/ry-checker/src/higher_order.rs
@@ -644,13 +644,6 @@ impl Checker {
         cv: &ClassVector,
         span: Span,
     ) -> Option<RType> {
-        // Math/Summary members have built-in fallbacks. An unrelated local
-        // group method cannot make a class-specific method mandatory. Keep
-        // the result opaque: the local inventory cannot rule out registered
-        // methods, and their return types need not match the primitive.
-        if s3_group_generic(generic).is_some() {
-            return Some(RType::unknown());
-        }
         let has_default = generics.iter().any(|candidate| {
             let default_key = ((*candidate).to_string(), "default".to_string());
             self.fn_table.s3_methods.contains_key(&default_key)
@@ -670,6 +663,13 @@ impl Checker {
             });
         if !has_known_s3_method {
             return None;
+        }
+        // Math/Summary members have built-in fallbacks. An unrelated local
+        // group method cannot make a class-specific method mandatory. Keep
+        // the result opaque: the local inventory cannot rule out registered
+        // methods, and their return types need not match the primitive.
+        if s3_group_generic(generic).is_some() {
+            return Some(RType::unknown());
         }
         // The generic has no dispatch target for this class. Emit RY050
         // and return opaque so callers don't trip further diagnostics on

--- a/crates/ry-checker/src/tests/data_frames_s3.rs
+++ b/crates/ry-checker/src/tests/data_frames_s3.rs
@@ -155,6 +155,31 @@ fn s3_dispatch_missing_method() {
 }
 
 #[test]
+fn math_summary_members_do_not_require_a_class_method() {
+    for generic in crate::semantic_lists::S3_MATH_GENERICS
+        .iter()
+        .chain(crate::semantic_lists::S3_SUMMARY_GENERICS)
+    {
+        let source = format!(
+            "Math.other <- function(x, ...) 99\n\
+             Summary.other <- function(..., na.rm = FALSE) 99L\n\
+             x <- structure(c(1L, 2L), class = \"widget\")\n\
+             result <- {generic}(x)\n"
+        );
+        let (diagnostics, scope) = check_with_scope(&source);
+        assert!(
+            diagnostics.iter().all(|d| d.code != "RY050"),
+            "{generic} has a built-in fallback: {diagnostics:?}"
+        );
+        assert_eq!(
+            scope.get("result").map(|ty| ty.mode),
+            Some(Mode::Opaque),
+            "a missing local method does not prove absence of registered methods: {generic}"
+        );
+    }
+}
+
+#[test]
 fn s3_dispatch_walks_every_class_before_reporting_a_miss() {
     let diags = check(
         "print.b <- function(x, ...) invisible(x)\n\

--- a/crates/ry-checker/testdata/oracle/math_summary_primitive_fallback.R
+++ b/crates/ry-checker/testdata/oracle/math_summary_primitive_fallback.R
@@ -1,0 +1,11 @@
+# oracle: must-pass
+# Unrelated group methods do not prevent built-in member fallback.
+Summary.other <- function(..., na.rm = FALSE) 99L
+Math.other <- function(x, ...) 99
+x <- structure(c(1L, 2L), class = "widget")
+stopifnot(sum(x) == 3L, prod(x) == 2, max(x) == 2L, min(x) == 1L)
+stopifnot(all(x), any(x), identical(as.numeric(range(x)), c(1, 2)))
+stopifnot(identical(as.numeric(abs(x)), c(1, 2)))
+stopifnot(identical(as.numeric(sqrt(x)), sqrt(c(1, 2))))
+tab <- structure(c(2L, 1L), dim = 2L, class = "table")
+stopifnot(sum(tab) == 3L)


### PR DESCRIPTION
Calls such as `sum(structure(1:2, class = "widget"))` and `abs()` wrongly emit RY050 when an unrelated local Summary/Math method exists. These built-ins have default behavior without a class-specific method. Keep the existing unknown result on this path and suppress the false missing-method warning.

Tests cover every modeled Math/Summary member, retain the direct-generic missing-method control, and run ten fallback assertions in an R oracle. The initial test failed with RY050; R ran the fixture successfully.

Workspace tests, Clippy with warnings denied, formatting, and the full R oracle matrix pass. The full Posit and tidyverse corpus checks pass unchanged. A final comparison across 500 packages removes exactly one diagnostic: the false RY050 on `sum(freq)` in Hmisc `R/describe.s:550`, where `freq` retains its table class. No diagnostics were added or changed elsewhere.

Includes the same two walker boolean simplifications as #284 to pass Clippy on Rust 1.96.1. No behavior change is intended in those conditions.

R documents these members and group dispatch in its [group generic reference](https://stat.ethz.ch/R-manual/R-devel/library/base/html/groupGeneric.html); the executable oracle confirms their fallback behavior.
