### PR TITLE
fix(cli): render empty reports when no R files are discovered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,6 +151,9 @@ All notable changes to ry are documented in this file.
 
 ### Fixed
 
+- `ry check` now emits an empty JSON/GitLab array or JUnit report when no R
+  files are discovered, including when configuration excludes every source.
+
 - Report an explicit nesting-limit error before deeply nested syntax can
   overflow the parser stack. The limit is 128 tree-sitter syntax levels.
 

--- a/crates/ry-cli/src/check.rs
+++ b/crates/ry-cli/src/check.rs
@@ -219,6 +219,11 @@ pub(crate) fn run_check(
     let mut all_paths = rescan(&search_roots, config_root.as_deref(), &cfg, true);
 
     if all_paths.is_empty() {
+        // An empty discovery result still needs a complete machine-readable report.
+        print!(
+            "{}",
+            render_diagnostics(&[], format, &HashMap::new(), color)
+        );
         let roots = search_roots
             .iter()
             .map(|root| root.display().to_string())

--- a/crates/ry-cli/tests/config_e2e.rs
+++ b/crates/ry-cli/tests/config_e2e.rs
@@ -1196,3 +1196,57 @@ fn registered_native_symbols_resolve_in_value_position() {
         "without .registration the symbol is not proven bound: {undeclared_stdout}"
     );
 }
+
+#[test]
+fn empty_discovery_preserves_output_format_contracts() {
+    let tmp = tempfile::tempdir().unwrap();
+    fs::write(
+        tmp.path().join("DESCRIPTION"),
+        "Package: dataonly\nVersion: 1.0\n",
+    )
+    .unwrap();
+    for format in ["json", "gitlab", "junit", "github", "full", "concise"] {
+        let output = Command::new(env!("CARGO_BIN_EXE_ry"))
+            .current_dir(tmp.path())
+            .args(["check", ".", "--output-format", format])
+            .output()
+            .unwrap();
+        assert!(output.status.success(), "{format}: {output:?}");
+        assert!(String::from_utf8_lossy(&output.stderr).contains("no .R / .r files found"));
+        match format {
+            "json" | "gitlab" => {
+                let value: serde_json::Value = serde_json::from_slice(&output.stdout)
+                    .unwrap_or_else(|error| panic!("{format}: {error}: {output:?}"));
+                assert_eq!(value, serde_json::json!([]));
+            }
+            "junit" => {
+                let stdout = String::from_utf8(output.stdout).unwrap();
+                assert!(stdout.contains("<?xml"), "{stdout}");
+                assert!(stdout.contains("tests=\"0\""), "{stdout}");
+                assert!(stdout.contains("failures=\"0\""), "{stdout}");
+                assert!(stdout.contains("</testsuites>"), "{stdout}");
+            }
+            _ => assert!(output.stdout.is_empty(), "{format}: {output:?}"),
+        }
+    }
+}
+
+#[test]
+fn excluded_sources_still_emit_json_document() {
+    let tmp = tempfile::tempdir().unwrap();
+    fs::write(
+        tmp.path().join("ry.toml"),
+        "exclude = [\"*.R\"]\noutput-format = \"json\"\n",
+    )
+    .unwrap();
+    fs::write(tmp.path().join("excluded.R"), "1 + 'bad'\n").unwrap();
+    let output = Command::new(env!("CARGO_BIN_EXE_ry"))
+        .current_dir(tmp.path())
+        .args(["check", "."])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("no .R / .r files found"));
+    let value: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(value, serde_json::json!([]));
+}

--- a/crates/ry-core/src/walk.rs
+++ b/crates/ry-core/src/walk.rs
@@ -195,7 +195,7 @@ fn expr_step<B>(
         }
         Expr::BinOp { op, lhs, rhs, .. } => {
             let assignment = matches!(op, BinOpKind::Assign | BinOpKind::SuperAssign);
-            if !(assignment && !policy.assign_operands) {
+            if !assignment || policy.assign_operands {
                 expr_step(lhs, policy, fn_depth, visit)?;
             }
             expr_step(rhs, policy, fn_depth, visit)?;
@@ -205,7 +205,7 @@ fn expr_step<B>(
             base, kind, args, ..
         } => {
             expr_step(base, policy, fn_depth, visit)?;
-            if !(*kind == IndexKind::Dollar && !policy.dollar_args) {
+            if *kind != IndexKind::Dollar || policy.dollar_args {
                 for argument in args {
                     expr_step(&argument.value, policy, fn_depth, visit)?;
                 }


### PR DESCRIPTION
Checking a directory with no discovered R files exits successfully but leaves stdout empty even with `--output-format json`. This breaks JSON consumers auditing data-only packages such as BH and carData.

Render the empty diagnostic list before the early return. JSON and GitLab now produce `[]`; JUnit produces an empty report. Human and GitHub stdout remain empty, and the existing stderr message and successful exit are preserved.

Real-process CLI tests cover all six formats and config-driven JSON when every source file is excluded. BH and carData both reproduce empty stdout on d5414ff and produce `[]` with this change.

Validation passed in CONTRIBUTING order: `cargo test --workspace`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo fmt --all -- --check`. The complete R oracle matrix also passes: `cargo test -p ry-checker --test oracle -- --include-ignored` (17 passed).

Includes the shared walker-condition Clippy cleanup prerequisite so the required gate remains clean.
