### PR TITLE
fix(infer): discard prior types after exhaustive branch assignment

### DIFF
--- a/crates/ry-checker/src/infer/mod.rs
+++ b/crates/ry-checker/src/infer/mod.rs
@@ -313,7 +313,13 @@ impl Checker {
                 // assignments inside an `if` branch leak to the enclosing
                 // scope, so a name bound conditionally must still be visible
                 // after the `if` (otherwise uses fire RY010 false positives).
-                self.merge_branch_bindings(scope, &then_scope, &else_scope, has_else, &narrowed);
+                self.merge_branch_bindings(
+                    scope,
+                    &then_scope,
+                    &else_scope,
+                    (then, else_.as_deref()),
+                    &narrowed,
+                );
                 // Refinements normally remain branch-local (see
                 // `apply_narrowing`). A diverging arm is the exception: the
                 // continuation is reachable only through its sibling, so its
@@ -678,13 +684,10 @@ impl Checker {
     /// Merge bindings introduced inside the two `if` branches back into the
     /// parent `scope`.
     ///
-    /// A name that is newly bound in BOTH branches gets the join of the two
-    /// branch types. A name bound in only one branch (or when there is no
-    /// `else`) is inserted into the parent as [`RType::unknown`]: there is no
-    /// sound type for "possibly missing" in the current model, and the goal
-    /// here is solely to stop RY010 false positives on the conditional
-    /// assignment idiom. Modeling "definitely unbound" as a diagnostic is a
-    /// separate future rule and intentionally out of scope.
+    /// A name assigned in both branches gets the join of their types.
+    /// If a path can retain an existing parent binding, its type contributes
+    /// too. A name introduced on only one path becomes [`RType::unknown`]:
+    /// the current model has no sound type for "possibly missing".
     ///
     /// "Newly bound" means present in the branch scope but absent from the
     /// parent (or bound to a different type): names that already existed in
@@ -703,9 +706,10 @@ impl Checker {
         scope: &mut Scope,
         then_scope: &Scope,
         else_scope: &Scope,
-        has_else: bool,
+        branches: (&[Stmt], Option<&[Stmt]>),
         narrowed: &HashSet<String>,
     ) {
+        let has_else = branches.1.is_some();
         // Types can compare equal after replacing a literal function. Do not
         // carry its identity or constant result across a branch merge.
         scope.literal_functions.clear();
@@ -771,38 +775,40 @@ impl Checker {
                 }
             }
         }
+        // Scope differences alone do not prove assignment: loop inference
+        // can expose a body write even when the loop executes zero times.
+        let definitely_rebound = if branch_types
+            .values()
+            .any(|(a, b)| a.is_some() && b.is_some())
+        {
+            let mut names = definitely_assigned_names(branches.0);
+            let other = definitely_assigned_names(branches.1.unwrap_or_default());
+            names.retain(|name| other.contains(name));
+            names
+        } else {
+            HashSet::new()
+        };
         for (name, (then_t, else_t)) in branch_types {
             let merged = match (then_t, else_t) {
-                (Some(a), Some(b)) => a.clone().join(b.clone()),
+                (Some(a), Some(b)) => {
+                    let joined = a.clone().join(b.clone());
+                    match scope.get(name) {
+                        Some(parent) if !definitely_rebound.contains(name) => {
+                            parent.clone().join(joined)
+                        }
+                        _ => joined,
+                    }
+                }
                 (Some(a), None) | (None, Some(a)) => {
-                    // The name is assigned in only one branch (no
-                    // `else`). When the name is already bound in the
-                    // parent it is definitely defined on every path --
-                    // only its type changes -- so carry the branch's
-                    // type and let the parent fold below union in the
-                    // prior type (so `s <- 1L; if (c) { s <- "x" }`
-                    // stays `union[integer, character]` rather than
-                    // collapsing to opaque). When the parent has NO
-                    // binding the name is possibly missing, which has no
-                    // sound type, so it degrades to opaque. Joining with
-                    // `RType::unknown()` here would be absorbing and make
-                    // the parent fold below dead code.
-                    if scope.get(name).is_some() {
-                        a.clone()
-                    } else {
-                        a.clone().join(RType::unknown())
+                    // One path keeps the parent binding, including an
+                    // unchanged assignment or an implicit no-else path.
+                    // If no parent binding exists, the name may be missing.
+                    match scope.get(name) {
+                        Some(parent) => parent.clone().join(a.clone()),
+                        None => RType::unknown(),
                     }
                 }
                 (None, None) => continue,
-            };
-            // If the name already existed in the parent with a *different*
-            // type, fold that prior type into the merge so a branch
-            // reassignment doesn't silently degrade a precise parent type
-            // to unknown (e.g. `s <- 1L; if (c) { s <- "x" }` keeps `s` as
-            // union[integer, character] rather than collapsing to unknown).
-            let merged = match scope.get(name) {
-                Some(p) => p.clone().join(merged),
-                None => merged,
             };
             // A branch scope that does not bind the name (an implicit
             // no-`else`, or an arm that never assigns it) cannot supply a
@@ -2133,4 +2139,37 @@ pub(crate) fn embraced_symbol(body: &[Stmt]) -> Option<(&str, Span)> {
         return None;
     };
     Some((name, *span))
+}
+
+/// Names assigned on every path that reaches the end of this block.
+/// Loops, calls, and nested function bodies cannot establish this fact.
+fn definitely_assigned_names(body: &[Stmt]) -> HashSet<&str> {
+    let mut names = HashSet::new();
+    for statement in body {
+        match statement {
+            Stmt::Assign {
+                target: Expr::Ident { name, .. },
+                ..
+            } => {
+                names.insert(name.as_str());
+            }
+            Stmt::If {
+                then,
+                else_: Some(other),
+                ..
+            } => {
+                let then_names = definitely_assigned_names(then);
+                let else_names = definitely_assigned_names(other);
+                names.extend(
+                    then_names
+                        .into_iter()
+                        .filter(|name| else_names.contains(name)),
+                );
+            }
+            Stmt::Expr(Expr::Block { body, .. }) => names.extend(definitely_assigned_names(body)),
+            Stmt::Return { .. } => break,
+            _ => {}
+        }
+    }
+    names
 }

--- a/crates/ry-checker/src/tests/narrowing.rs
+++ b/crates/ry-checker/src/tests/narrowing.rs
@@ -1011,11 +1011,9 @@ fn if_branch_reassignment_over_existing_type_stays_visible() {
 }
 
 #[test]
-fn if_branch_both_branches_over_existing_type_folds_parent() {
+fn if_branch_both_branches_over_existing_type_replace_parent() {
     // `s <- 1L` (parent Integer) then reassigned in BOTH branches to
-    // character. The merged branch type is character; folding the
-    // parent's integer in yields union[integer, character] rather than
-    // losing the parent's prior type.
+    // character. Neither path can retain the parent's integer type.
     let (diags, top) =
         check_with_scope("s <- 1L\nif (TRUE) { s <- \"a\" } else { s <- \"b\" }\ns\n");
     assert!(
@@ -1025,8 +1023,8 @@ fn if_branch_both_branches_over_existing_type_folds_parent() {
     );
     let t = top.get("s").expect("s should be bound at top level");
     assert!(
-        matches!(t.mode, Mode::Union),
-        "both-branch reassignment over a different parent type should fold the parent in (union), got {:?}",
+        matches!(t.mode, Mode::Character),
+        "both-branch reassignment replaces the prior parent type, got {:?}",
         t
     );
 }
@@ -1042,6 +1040,84 @@ fn diverging_length_guards_narrow_null_defaults_in_the_continuation() {
                 .iter()
                 .all(|diagnostic| diagnostic.code != "RY040"),
             "a diverging {guard} guard must narrow x away from NULL: {diagnostics:?}"
+        );
+    }
+}
+
+#[test]
+fn both_branches_replace_the_prior_binding_type() {
+    for branches in [
+        "if (flag) g <- function(x) x else g <- function(x) x + 1L",
+        "if (flag) { if (other) g <- function(x) x else g <- function(x) x + 1L } else g <- function(x) x",
+    ] {
+        let source = format!("f <- function(flag, other) {{ g <- NULL; {branches}; g(1L) }}");
+        let diagnostics = check(&source);
+        assert!(
+            diagnostics
+                .iter()
+                .all(|diagnostic| diagnostic.code != "RY070"),
+            "both arms replace NULL with a function: {diagnostics:?}"
+        );
+    }
+}
+
+#[test]
+fn branches_that_retain_or_install_nonfunctions_still_report_calls() {
+    for branches in [
+        "if (flag) g <- function(x) x",
+        "if (flag) g <- function(x) x else g <- NULL",
+        "if (flag) g <- function(x) x else g <- 1L",
+        "if (flag) { if (other) g <- function(x) x } else g <- function(x) x",
+    ] {
+        let source = format!("f <- function(flag, other) {{ g <- NULL; {branches}; g(1L) }}");
+        let diagnostics = check(&source);
+        assert!(
+            diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.code == "RY070"),
+            "a reachable non-function arm must remain visible: {diagnostics:?}"
+        );
+    }
+}
+
+#[test]
+fn branch_narrowing_without_reassignment_keeps_parent_members() {
+    let (_, scope) = check_with_scope(
+        "x <- if (TRUE) 1L else 'text'\nif (is.character(x)) { nchar(x) } else { x + 1L }\n",
+    );
+    let members = scope.get("x").unwrap().members.as_ref().unwrap();
+    assert!(members.iter().any(|ty| ty.mode == Mode::Integer));
+    assert!(members.iter().any(|ty| ty.mode == Mode::Character));
+}
+
+#[test]
+fn zero_iteration_loop_retains_the_prebranch_nonfunction_path() {
+    // Loop inference may make the binding opaque. It must never claim
+    // every path installs a function when the loop can run zero times.
+    let (_, scope) = check_with_scope(
+        "g <- NULL\nif (TRUE) { for (i in integer(0)) g <- function(x) x } else g <- function(x) x\n",
+    );
+    let ty = scope.get("g").unwrap();
+    assert!(
+        ty.mode == Mode::Opaque
+            || ty
+                .members
+                .as_ref()
+                .is_some_and(|members| members.iter().any(|ty| ty.mode == Mode::Null))
+    );
+}
+
+#[test]
+fn diverging_branch_does_not_reintroduce_prior_nonfunction_type() {
+    for branches in [
+        "if (flag) return(0L) else g <- function(x) x",
+        "if (flag) g <- function(x) x else return(0L)",
+    ] {
+        let source = format!("f <- function(flag) {{ g <- NULL; {branches}; g(1L) }}");
+        assert!(
+            check(&source)
+                .iter()
+                .all(|diagnostic| diagnostic.code != "RY070")
         );
     }
 }

--- a/crates/ry-checker/testdata/oracle/exhaustive_branch_rebinding.R
+++ b/crates/ry-checker/testdata/oracle/exhaustive_branch_rebinding.R
@@ -1,0 +1,21 @@
+# oracle: must-pass
+# Every reachable branch replaces the initial binding before it is used.
+choose_callback <- function(flag, nested) {
+  callback <- NULL
+  if (flag) {
+    if (nested) callback <- function(x) x else callback <- function(x) x + 1L
+  } else callback <- function(x) x + 2L
+  callback(1L)
+}
+stopifnot(identical(choose_callback(TRUE, TRUE), 1L))
+stopifnot(identical(choose_callback(TRUE, FALSE), 2L))
+stopifnot(identical(choose_callback(FALSE, TRUE), 3L))
+stopifnot(identical(choose_callback(FALSE, FALSE), 3L))
+
+replace_integer <- function(flag) {
+  value <- 1L
+  if (flag) value <- "first" else value <- "second"
+  value
+}
+stopifnot(identical(replace_integer(TRUE), "first"))
+stopifnot(identical(replace_integer(FALSE), "second"))

--- a/crates/ry-core/src/walk.rs
+++ b/crates/ry-core/src/walk.rs
@@ -195,7 +195,7 @@ fn expr_step<B>(
         }
         Expr::BinOp { op, lhs, rhs, .. } => {
             let assignment = matches!(op, BinOpKind::Assign | BinOpKind::SuperAssign);
-            if !(assignment && !policy.assign_operands) {
+            if !assignment || policy.assign_operands {
                 expr_step(lhs, policy, fn_depth, visit)?;
             }
             expr_step(rhs, policy, fn_depth, visit)?;
@@ -205,7 +205,7 @@ fn expr_step<B>(
             base, kind, args, ..
         } => {
             expr_step(base, policy, fn_depth, visit)?;
-            if !(*kind == IndexKind::Dollar && !policy.dollar_args) {
+            if *kind != IndexKind::Dollar || policy.dollar_args {
                 for argument in args {
                     expr_step(&argument.value, policy, fn_depth, visit)?;
                 }


### PR DESCRIPTION
`g <- NULL; if (flag) g <- function(x) x else g <- function(x) x + 1L; g(1L)` reported RY070 even though both branches replace NULL. Branch merging joined the old parent type back into every result, including exhaustive reassignment.

Drop that old type only when both explicit arms contribute changed types and their statement trees establish assignment on every path. Direct assignments, blocks, and exhaustive nested conditionals supply this proof; loop-only writes and nested function bodies do not. Preserve the parent for unchanged assignments, missing else arms, and unassigned narrowing. The callable-union rule still rejects reachable non-function members.

The release comparison removes exactly six false JacFunc RY070 reports from deSolve (18 diagnostics → 12), with no new findings. Hmisc (60) and cachem (6) are unchanged. A minimized witness passes R and is now checker-clean. Added controls cover NULL/non-function arms, nested incomplete assignments, zero-iteration loops, narrowing, and returning paths. Corrected an existing test that required the stale parent type, and added an R oracle fixture that executes every branch.

Validation: workspace tests, Clippy with denied warnings, formatting, full R oracle matrix (17 tests), release witness and package comparison. A separate prerequisite commit fixes two pre-existing Clippy boolean warnings.
