### PR TITLE
fix(checker): respect scalar parameter guard result lengths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,6 +151,9 @@ All notable changes to ry are documented in this file.
 
 ### Fixed
 
+- Avoid RY032 warnings when a parameter is only the lookup table for `%in%`,
+  or a base `length(x) == 1` guard protects a scalar predicate.
+
 - Report an explicit nesting-limit error before deeply nested syntax can
   overflow the parser stack. The limit is 128 tree-sitter syntax levels.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,9 +151,6 @@ All notable changes to ry are documented in this file.
 
 ### Fixed
 
-- Avoid RY032 warnings when a parameter is only the lookup table for `%in%`,
-  or a base `length(x) == 1` guard protects a scalar predicate.
-
 - `ry check` now emits an empty JSON/GitLab array or JUnit report when no R
   files are discovered, including when configuration excludes every source.
 
@@ -254,6 +251,9 @@ All notable changes to ry are documented in this file.
 
 - Detect recursive and prematurely forced defaults passed to `base::identity` or
   `base::force`, while preserving laziness in quoted, masked, and conditional calls.
+
+- Avoid RY032 warnings when a parameter is only the lookup table for `%in%`,
+  or a base `length(x) == 1` guard protects a scalar predicate.
 
 - Correct RY002 and RY032 explanations: R rejects conditions and scalar
   logical operands with more than one element.

--- a/crates/ry-checker/src/infer/binop.rs
+++ b/crates/ry-checker/src/infer/binop.rs
@@ -509,19 +509,48 @@ impl Checker {
             direct_parameter(&args.first()?.value, scope)
         }
 
-        fn length_guard_parameter<'a>(expr: &'a Expr, scope: &Scope) -> Option<&'a str> {
+        fn length_guard_parameter<'a>(
+            checker: &Checker,
+            expr: &'a Expr,
+            scope: &Scope,
+        ) -> Option<&'a str> {
             if let Some(parameter) = call_on_parameter(expr, &["length"], scope) {
                 return Some(parameter);
             }
-            let Expr::BinOp { lhs, rhs, .. } = expr else {
+            let Expr::BinOp { op, lhs, rhs, .. } = expr else {
                 return None;
             };
+            // The RHS of `length(x) == 1 && ...` is reached only for a
+            // scalar x. This guard is not evidence of an unchecked vector.
+            let is_one = |value: &Expr| {
+                matches!(value, Expr::Integer(1, _))
+                    || matches!(value, Expr::Double(n, _) if *n == 1.0)
+            };
+            let base_length = |value: &Expr| {
+                let Expr::Call { func, .. } = value else {
+                    return false;
+                };
+                ident_name(func).is_some_and(|name| checker.resolves_to_base(name, scope))
+                    && call_on_parameter(value, &["length"], scope).is_some()
+            };
+            if *op == BinOpKind::Eq
+                && ((is_one(rhs) && base_length(lhs)) || (is_one(lhs) && base_length(rhs)))
+            {
+                return None;
+            }
             call_on_parameter(lhs, &["length"], scope)
                 .or_else(|| call_on_parameter(rhs, &["length"], scope))
         }
 
         fn vector_predicate_parameter<'a>(expr: &'a Expr, scope: &Scope) -> Option<&'a str> {
             match expr {
+                // Membership returns one logical per LHS element; the
+                // lookup table on the RHS does not determine result length.
+                Expr::BinOp {
+                    op: BinOpKind::In,
+                    lhs,
+                    ..
+                } => direct_parameter(lhs, scope),
                 Expr::BinOp {
                     op:
                         BinOpKind::Lt
@@ -529,8 +558,7 @@ impl Checker {
                         | BinOpKind::Gt
                         | BinOpKind::Ge
                         | BinOpKind::Eq
-                        | BinOpKind::Ne
-                        | BinOpKind::In,
+                        | BinOpKind::Ne,
                     lhs,
                     rhs,
                     ..
@@ -547,7 +575,7 @@ impl Checker {
 
         let guarded = match op {
             BinOpKind::OrOr => call_on_parameter(lhs, &["is.null"], scope),
-            BinOpKind::AndAnd => length_guard_parameter(lhs, scope),
+            BinOpKind::AndAnd => length_guard_parameter(self, lhs, scope),
             _ => None,
         };
         // Both `guarded` and `vector_predicate_parameter` resolve through

--- a/crates/ry-checker/src/tests/type_inference.rs
+++ b/crates/ry-checker/src/tests/type_inference.rs
@@ -1251,6 +1251,41 @@ fn guarded_unknown_parameter_vector_emits_ry032_without_other_vector_intent() {
 }
 
 #[test]
+fn parameter_guards_respect_scalar_membership_and_exact_length() {
+    for source in [
+        "f <- function(x) is.null(x) || 'value' %in% x",
+        "f <- function(x) is.null(x) || !('value' %in% x)",
+        "f <- function(x) length(x) == 1L && is.na(x)",
+        "f <- function(x) 1 == length(x) && x == ''",
+        "f <- function(x) base::length(x) == 1 && x == ''",
+    ] {
+        let diagnostics = check(source);
+        assert!(
+            diagnostics.iter().all(|d| d.code != "RY032"),
+            "{source}: {diagnostics:?}"
+        );
+    }
+}
+
+#[test]
+fn guarded_vector_membership_and_nonempty_lengths_still_warn() {
+    for source in [
+        "f <- function(x) is.null(x) || x %in% 'value'",
+        "f <- function(x) length(x) > 0 && x == ''",
+        "f <- function(x) length(x) == 2L && is.na(x)",
+        "length <- function(x) 1L; f <- function(x) length(x) == 1L && is.na(x)",
+        "f <- function(x, length) length(x) == 1L && is.na(x)",
+        "f <- function(x) other::length(x) == 1L && is.na(x)",
+    ] {
+        let diagnostics = check(source);
+        assert!(
+            diagnostics.iter().any(|d| d.code == "RY032"),
+            "{source}: {diagnostics:?}"
+        );
+    }
+}
+
+#[test]
 fn loop_carried_values_do_not_keep_the_initial_empty_length() {
     let source = "quote <- raw()\nfor (x in as.raw(c(1, 2))) {\nif (length(quote)) { if (x == quote) print(x) }\nquote <- x\n}";
     assert!(check(source).is_empty(), "{:?}", check(source));

--- a/crates/ry-checker/testdata/oracle/scalar_parameter_guards.R
+++ b/crates/ry-checker/testdata/oracle/scalar_parameter_guards.R
@@ -1,0 +1,8 @@
+# oracle: must-pass
+# Membership length follows its left operand, and exact guards protect the RHS.
+accept <- function(x = NULL) is.null(x) || "value" %in% x
+check_na <- function(x) length(x) == 1L && is.na(x)
+check_empty <- function(x) 1 == length(x) && x == ""
+stopifnot(accept(NULL), accept(c("other", "value")), !accept(character()))
+stopifnot(check_na(NA), !check_na(c(NA, NA)), !check_na(logical()))
+stopifnot(check_empty(""), !check_empty(c("", "")), !check_empty(character()))

--- a/crates/ry-core/src/walk.rs
+++ b/crates/ry-core/src/walk.rs
@@ -195,7 +195,7 @@ fn expr_step<B>(
         }
         Expr::BinOp { op, lhs, rhs, .. } => {
             let assignment = matches!(op, BinOpKind::Assign | BinOpKind::SuperAssign);
-            if !(assignment && !policy.assign_operands) {
+            if !assignment || policy.assign_operands {
                 expr_step(lhs, policy, fn_depth, visit)?;
             }
             expr_step(rhs, policy, fn_depth, visit)?;
@@ -205,7 +205,7 @@ fn expr_step<B>(
             base, kind, args, ..
         } => {
             expr_step(base, policy, fn_depth, visit)?;
-            if !(*kind == IndexKind::Dollar && !policy.dollar_args) {
+            if *kind != IndexKind::Dollar || policy.dollar_args {
                 for argument in args {
                     expr_step(&argument.value, policy, fn_depth, visit)?;
                 }


### PR DESCRIPTION
`is.null(x) || "value" %in% x` received RY032 because the checker treated the lookup table as determining membership-result length. Membership now tracks its left operand. Exact `length(x) == 1 && ...` guards also stop triggering the parameter-vector heuristic when the call resolves to base R; shadowed, parameter-bound, unrelated-namespace and uncertain search-path calls keep their previous behavior.

The frozen 500-package comparison removes 10 RY032 diagnostics across seven packages and adds none. Each removed expression uses the parameter as the membership lookup table. The broader candidate removed 78, but its exact-length exemption admitted a shadowed `length()` counterexample; strict base resolution retains the other 68. Plain-script and explicitly qualified exact-length guards are covered by regression tests and executable R witnesses.

Validation: new positive regression failed before the fix; full workspace tests, Clippy with warnings denied, formatting, and all 17 R oracle tests passed in this worktree's own target directory. Independent Astra review found the shadowing gap and verified its correction. Full Posit regeneration and both strict ecosystem checks pass with no committed report or message changes. Workspace tests and Clippy also pass after merging current main; the full R oracle is being repeated on that merged tree. CI and Pullfrog review remain required before merge.
