### PR TITLE
Complete S3 Math group inventory and method recognition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -153,7 +153,9 @@ All notable changes to ry are documented in this file.
 
 - Math and Summary member calls no longer emit RY050 just because an unrelated
   class has a local group method. Built-ins such as `sum()` and `abs()` can
-  use their default behavior without a class-specific method.
+  use their default behavior without a class-specific method. The Math
+  inventory includes cumulative functions, `signif`, the `*pi` functions,
+  `digamma`, and `trigamma`, with recognition of their specific methods.
 
 - `ry check` now emits an empty JSON/GitLab array or JUnit report when no R
   files are discovered, including when configuration excludes every source.

--- a/crates/ry-checker/src/lib.rs
+++ b/crates/ry-checker/src/lib.rs
@@ -189,8 +189,8 @@ fn type_with_assigned_column(mut base: RType, name: &str, value: RType) -> RType
 
 /// Returns `Some((generic, class))` if `name` matches the S3 method
 /// naming convention `<generic>.<class>` and `<generic>` is in the
-/// curated stub-data generic table. Longest match wins (handles rare
-/// multi-segment cases).
+/// curated stub-data or group-member generic tables. Longest match wins
+/// (handles rare multi-segment cases).
 fn split_s3_method_name(name: &str, globals: &Globals) -> Option<(String, String)> {
     if globals
         .s3_split_denylist
@@ -200,7 +200,13 @@ fn split_s3_method_name(name: &str, globals: &Globals) -> Option<(String, String
         return None;
     }
     let mut best: Option<(String, String)> = None;
-    for generic in &globals.s3_generics {
+    for generic in globals
+        .s3_generics
+        .iter()
+        .map(String::as_str)
+        .chain(semantic_lists::S3_MATH_GENERICS.iter().copied())
+        .chain(semantic_lists::S3_SUMMARY_GENERICS.iter().copied())
+    {
         if let Some(class) = name
             .strip_prefix(generic)
             .and_then(|rest| rest.strip_prefix('.'))
@@ -211,7 +217,7 @@ fn split_s3_method_name(name: &str, globals: &Globals) -> Option<(String, String
             // Prefer the longest matching prefix (more specific).
             let is_better = best.as_ref().is_none_or(|(g, _)| g.len() < generic.len());
             if is_better {
-                best = Some((generic.clone(), class.to_string()));
+                best = Some((generic.to_string(), class.to_string()));
             }
         }
     }

--- a/crates/ry-checker/src/semantic_lists.rs
+++ b/crates/ry-checker/src/semantic_lists.rs
@@ -124,16 +124,13 @@ pub const METADATA_ARGS: &[&str] = &[
 /// generic, so `abs(x)` can hit a `Math.foo` method (the `Ops` group is
 /// operator syntax, handled in `infer/binop.rs`).
 ///
-/// Checked by typeshed agreement: every member exists in the embedded base
-/// typeshed -- most in the `functions` map, with `acosh`, `asinh`, and
-/// `atanh` declared as ambient functions. The set is the subset of R's
-/// `Math` group that ry models; R additionally routes `signif`, the
-/// `cum*` family, and the `*pi`/`digamma`/`trigamma` members through the
-/// group, which ry does not model.
+/// Checked against R's Math and Math2 inventories and the embedded base
+/// typeshed. S3 uses Math for both S4 subgroups, including round and signif.
 pub const S3_MATH_GENERICS: &[&str] = &[
-    "abs", "acos", "acosh", "asin", "asinh", "atan", "atanh", "ceiling", "cos", "cosh", "exp",
-    "expm1", "floor", "gamma", "lgamma", "log", "log10", "log1p", "log2", "round", "sign", "sin",
-    "sinh", "sqrt", "tan", "tanh", "trunc",
+    "abs", "acos", "acosh", "asin", "asinh", "atan", "atanh", "ceiling", "cos", "cosh", "cospi",
+    "cummax", "cummin", "cumprod", "cumsum", "digamma", "exp", "expm1", "floor", "gamma", "lgamma",
+    "log", "log10", "log1p", "log2", "round", "sign", "signif", "sin", "sinh", "sinpi", "sqrt",
+    "tan", "tanh", "tanpi", "trigamma", "trunc",
 ];
 
 /// Functions whose ordinary calls dispatch through the S3 `Summary` group

--- a/crates/ry-checker/src/tests/data_frames_s3.rs
+++ b/crates/ry-checker/src/tests/data_frames_s3.rs
@@ -180,6 +180,53 @@ fn math_summary_members_do_not_require_a_class_method() {
 }
 
 #[test]
+fn complete_math_inventory_keeps_specific_and_group_dispatch() {
+    for generic in [
+        "cummax", "cummin", "cumprod", "cumsum", "cospi", "sinpi", "tanpi", "digamma", "trigamma",
+        "signif",
+    ] {
+        let (diags, scope) = check_with_scope(&format!(
+            "{generic}.other <- function(x, ...) 99\n\
+             x <- structure(c(1, 2), class = \"widget\")\n\
+             result <- {generic}(x)\n"
+        ));
+        assert!(
+            diags.iter().all(|d| d.code != "RY050"),
+            "{generic}: {diags:?}"
+        );
+        assert_eq!(
+            scope.get("result").map(|ty| ty.mode),
+            Some(Mode::Opaque),
+            "{generic}"
+        );
+        let (diags, scope) = check_with_scope(&format!(
+            "Math.widget <- function(x, ...) list(value = 1L)\n\
+             x <- structure(list(), class = \"widget\")\n\
+             result <- {generic}(x)\n"
+        ));
+        assert!(
+            diags.iter().all(|d| !matches!(d.code, "RY050" | "RY040")),
+            "{generic}: {diags:?}"
+        );
+        assert_eq!(
+            scope.get("result").map(|ty| ty.mode),
+            Some(Mode::Opaque),
+            "{generic}"
+        );
+        let diags = check(&format!(
+            "{generic}.widget <- function(x, ...) \"text\"\n\
+             Math.widget <- function(x, ...) 1L\n\
+             x <- structure(1, class = \"widget\")\n\
+             {generic}(x) + 1\n"
+        ));
+        assert!(
+            diags.iter().any(|d| d.code == "RY040"),
+            "specific method must win for {generic}: {diags:?}"
+        );
+    }
+}
+
+#[test]
 fn s3_dispatch_walks_every_class_before_reporting_a_miss() {
     let diags = check(
         "print.b <- function(x, ...) invisible(x)\n\

--- a/crates/ry-checker/testdata/oracle/math_summary_primitive_fallback.R
+++ b/crates/ry-checker/testdata/oracle/math_summary_primitive_fallback.R
@@ -9,3 +9,22 @@ stopifnot(identical(as.numeric(abs(x)), c(1, 2)))
 stopifnot(identical(as.numeric(sqrt(x)), sqrt(c(1, 2))))
 tab <- structure(c(2L, 1L), dim = 2L, class = "table")
 stopifnot(sum(tab) == 3L)
+
+# These members also belong to S3 Math, including S4's Math2 subgroup.
+cummax.other <- cummin.other <- cumprod.other <- cumsum.other <- function(x, ...) 99
+cospi.other <- sinpi.other <- tanpi.other <- function(x, ...) 99
+digamma.other <- trigamma.other <- signif.other <- function(x, ...) 99
+stopifnot(identical(as.numeric(cummax(x)), c(1, 2)))
+stopifnot(identical(as.numeric(cummin(x)), c(1, 1)))
+stopifnot(identical(as.numeric(cumprod(x)), c(1, 2)))
+stopifnot(identical(as.numeric(cumsum(x)), c(1, 3)))
+stopifnot(identical(as.numeric(cospi(x)), c(-1, 1)))
+stopifnot(identical(as.numeric(sinpi(x)), c(0, 0)))
+stopifnot(identical(as.numeric(tanpi(x)), c(0, 0)))
+stopifnot(identical(as.numeric(digamma(x)), digamma(c(1, 2))))
+stopifnot(identical(as.numeric(trigamma(x)), trigamma(c(1, 2))))
+stopifnot(identical(as.numeric(signif(x)), c(1, 2)))
+
+Math.widget <- function(x, ...) .Generic
+members <- c(getGroupMembers("Math"), getGroupMembers("Math2"))
+stopifnot(all(vapply(members, function(name) identical(do.call(name, list(x)), name), logical(1))))

--- a/crates/ry-checker/tests/semantic_lists.rs
+++ b/crates/ry-checker/tests/semantic_lists.rs
@@ -215,6 +215,30 @@ fn operators_match_r_oracle() {
     );
 }
 
+/// S3 Math includes S4 Math2 (round/signif); Summary has the same inventory.
+#[test]
+fn math_summary_groups_match_r_oracle() {
+    if !rscript_available() {
+        eprintln!("Rscript not on PATH; skipping oracle check");
+        return;
+    }
+    for (groups, members) in [
+        (
+            "c(getGroupMembers('Math'), getGroupMembers('Math2'))",
+            semantic_lists::S3_MATH_GENERICS,
+        ),
+        (
+            "getGroupMembers('Summary')",
+            semantic_lists::S3_SUMMARY_GENERICS,
+        ),
+    ] {
+        let output = r_eval(&format!("cat({groups}, sep='\\n')"));
+        let actual: BTreeSet<&str> = output.trim().lines().collect();
+        let expected: BTreeSet<&str> = members.iter().copied().collect();
+        assert_eq!(expected, actual, "group inventory differs from R: {groups}");
+    }
+}
+
 /// METADATA_ARGS matches the non-`...` parameter names of `formals(data.frame)`.
 #[test]
 fn metadata_args_match_r_oracle() {


### PR DESCRIPTION
Calls such as `cumsum(x)` can use R’s primitive fallback when `x` has a class and only `cumsum.other` is defined. Ten Math members were missing from the dispatch inventory, causing false RY050 warnings or bypassing group methods.

Complete the Math inventory and use it when recognizing specific method names. Summary already matches R. Existing method precedence and conservative fallback behavior remain in place.

Validation: R 4.6.1 verifies the full Math/Math2 and Summary inventories, all 37 S3 Math group dispatches, and primitive results for the ten added members. Checker controls cover unrelated methods, group methods, and specific-method precedence for each added member. Workspace tests, strict Clippy, formatting, and the full R oracle pass using this worktree’s own target directory.

All 500 audited packages have identical diagnostic JSON to the integrated baseline at `441cd87`. The improvement is established by the new minimized cases; this sample contains no affected diagnostics.
