### PR TITLE
fix(checker): supply S3 context inside subset methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -171,6 +171,9 @@ All notable changes to ry are documented in this file.
   bindings, formals, and aliases. Retain existing inference under ambient
   lookup uncertainty, while requiring methods provenance for RY096.
 
+- Recognize `.Generic`, `.Method`, and `.Class` inside subset and subset
+  replacement methods, avoiding false undefined-variable warnings.
+
 - Compute data-frame column types after scalar arithmetic instead of copying
   their input types. Keep classed column results unknown when methods may run.
 

--- a/crates/ry-checker/src/infer/index.rs
+++ b/crates/ry-checker/src/infer/index.rs
@@ -628,10 +628,22 @@ pub(crate) fn insert_s3_dispatch_context(method_name: &str, scope: &mut Scope, g
     let method_name = semantic_argument_name(method_name);
     let group_method = split_s3_method_name(method_name, globals)
         .is_some_and(|(generic, _)| crate::semantic_lists::is_group_generic(&generic));
-    if group_method {
+    // Subset primitives supply the S3 dispatch bindings too, but do not
+    // belong to a group. Require a nonempty class suffix, as for group methods.
+    let subset_method = ["[", "[[", "$", "[<-", "[[<-", "$<-"]
+        .iter()
+        .any(|generic| {
+            method_name
+                .strip_prefix(generic)
+                .and_then(|suffix| suffix.strip_prefix('.'))
+                .is_some_and(|class| !class.is_empty())
+        });
+    if group_method || subset_method {
         scope.insert(".Generic", RType::scalar(Mode::Character));
         scope.insert(".Method", RType::new(Mode::Character, Length::Unknown));
         scope.insert(".Class", RType::new(Mode::Character, Length::Unknown));
+    }
+    if group_method {
         scope.insert(".Group", RType::scalar(Mode::Character));
     }
 }

--- a/crates/ry-checker/src/tests/data_frames_s3.rs
+++ b/crates/ry-checker/src/tests/data_frames_s3.rs
@@ -882,3 +882,33 @@ fn for_over_homogeneous_list_does_not_fire_ry040() {
         diags
     );
 }
+
+#[test]
+fn subset_methods_receive_s3_dispatch_context() {
+    for generic in ["[", "[[", "$", "[<-", "[[<-", "$<-"] {
+        let source =
+            format!("`{generic}.widget` <- function(x, ...) list(.Generic, .Method, .Class)\n");
+        let diagnostics = check(&source);
+        assert!(
+            diagnostics.iter().all(|d| d.code != "RY010"),
+            "{source}: {diagnostics:?}"
+        );
+    }
+}
+
+#[test]
+fn subset_context_does_not_define_group_or_ordinary_variables() {
+    for source in [
+        "`[<-.widget` <- function(x, ...) .Group",
+        "helper.widget <- function(x) .Generic",
+        "`[<-` <- function(x) .Generic",
+        "`[<-.` <- function(x) .Generic",
+        ".Generic",
+    ] {
+        let diagnostics = check(source);
+        assert!(
+            diagnostics.iter().any(|d| d.code == "RY010"),
+            "{source}: {diagnostics:?}"
+        );
+    }
+}

--- a/crates/ry-checker/testdata/oracle/subset_method_context.R
+++ b/crates/ry-checker/testdata/oracle/subset_method_context.R
@@ -1,0 +1,38 @@
+# oracle: must-pass
+# R supplies these bindings to subset and subset replacement methods.
+`[.widget` <- function(x, ...) {
+  stopifnot(.Generic == "[", .Method == "[.widget", identical(.Class, "widget"))
+  unclass(x)
+}
+`[[.widget` <- function(x, ...) {
+  stopifnot(.Generic == "[[", .Method == "[[.widget", identical(.Class, "widget"))
+  unclass(x)
+}
+`$.widget` <- function(x, ...) {
+  stopifnot(.Generic == "$", .Method == "$.widget", identical(.Class, "widget"))
+  unclass(x)
+}
+`[<-.widget` <- function(x, ...) {
+  stopifnot(.Generic == "[<-", .Method == "[<-.widget", identical(.Class, "widget"))
+  unclass(x)
+}
+`[[<-.widget` <- function(x, ...) {
+  stopifnot(.Generic == "[[<-", .Method == "[[<-.widget", identical(.Class, "widget"))
+  unclass(x)
+}
+`$<-.widget` <- function(x, ...) {
+  stopifnot(.Generic == "$<-", .Method == "$<-.widget", identical(.Class, "widget"))
+  unclass(x)
+}
+x <- structure(list(a = 1L), class = "widget")
+x[1]
+x <- structure(list(a = 1L), class = "widget")
+x[[1]]
+x <- structure(list(a = 1L), class = "widget")
+x$a
+x <- structure(list(a = 1L), class = "widget")
+x[1] <- list(2L)
+x <- structure(list(a = 1L), class = "widget")
+x[[1]] <- 2L
+x <- structure(list(a = 1L), class = "widget")
+x$a <- 2L


### PR DESCRIPTION
R supplies `.Generic`, `.Method`, and `.Class` when it dispatches `[`, `[[`, `$`, and their replacement operations. ry only supplied them inside group methods, so valid `[<-.dates`, `[<-.times`, and `[.xts` bodies received undefined-variable warnings.

Recognize those six method-name prefixes with a nonempty class suffix and supply the three dispatch bindings. `.Group` remains exclusive to group methods. Ordinary functions, bare operators, empty class suffixes, and top-level `.Generic` keep their undefined-variable warnings.

Validation: the new positive test fails before the fix. Fresh R witnesses execute all six operations and assert the actual dispatch bindings. Full workspace tests, Clippy with warnings denied, formatting, and all 17 R oracle tests pass in an isolated target directory. The final 500-package comparison against integrated baseline `441cd87` removes exactly three RY010 findings (chron ×2, xts ×1) and adds none. Full Posit regeneration has no report or message changes. Both strict ecosystem checks and the merged-tree workspace, Clippy, formatting, and full R oracle checks pass.
