### PR TITLE
Prove incompatible Ops methods from unequal literal bodies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -412,7 +412,8 @@ All notable changes to ry are documented in this file.
 - Class assignments no longer infer literal classes from custom class builders or preserve payload types under an unproven replacement function.
 
 - Report RY051 when literal `chooseOpsMethod` results are `FALSE` on both
-  sides and reject provably distinct operator methods. Infer primitive
+  sides and reject provably distinct operator methods, including methods
+  with unequal literal bodies of the same storage mode. Infer primitive
   fallback and its class behavior only for proven scalar operands.
 
 - Extend explicit `FALSE`/`FALSE` Ops chooser fallback to plain vectors built

--- a/crates/ry-checker/src/infer/ops_chooser.rs
+++ b/crates/ry-checker/src/infer/ops_chooser.rs
@@ -8,11 +8,36 @@ pub(crate) enum Dispatch {
     },
 }
 
+/// Literal body values can prove inequality without assuming that separately
+/// allocated closures differ. R ignores numeric spelling and source locations.
+#[derive(Debug, PartialEq)]
+enum LiteralBody {
+    Logical(bool),
+    Integer(i64),
+    Double(f64),
+    Character(Option<String>),
+}
+
+impl LiteralBody {
+    fn definitely_differs(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::Double(left), Self::Double(right)) => {
+                left != right && !(left.is_nan() && right.is_nan())
+            }
+            (Self::Character(left), Self::Character(right)) => {
+                matches!((left, right), (Some(left), Some(right)) if left != right)
+            }
+            _ => self != other,
+        }
+    }
+}
+
 /// Evidence about a function value installed by an ordinary assignment.
 /// Aliases share this allocation; equal return types alone are not identity.
 #[derive(Debug)]
 pub(crate) struct LiteralFunction {
     mode: Mode,
+    body: LiteralBody,
     choice: Option<bool>,
     accepts_two: bool,
     accepts_six: bool,
@@ -36,11 +61,17 @@ pub(crate) fn literal_function(
     let [Stmt::Expr(value)] = body.as_slice() else {
         return None;
     };
-    let (mode, choice) = match value {
-        Expr::Logical(value, _) => (Mode::Logical, Some(*value)),
-        Expr::Integer(..) => (Mode::Integer, None),
-        Expr::Double(..) => (Mode::Double, None),
-        Expr::String(..) => (Mode::Character, None),
+    let (mode, body, choice) = match value {
+        Expr::Logical(value, _) => (Mode::Logical, LiteralBody::Logical(*value), Some(*value)),
+        Expr::Integer(value, _) => (Mode::Integer, LiteralBody::Integer(*value), None),
+        Expr::Double(value, _) => (Mode::Double, LiteralBody::Double(*value), None),
+        Expr::String(value, _) => (
+            Mode::Character,
+            // Undecodable byte escapes remain raw text in the AST. Do not
+            // mistake alternate escape spellings for unequal R strings.
+            LiteralBody::Character((!value.contains('\\')).then(|| value.clone())),
+            None,
+        ),
         _ => return None,
     };
     if syntax_rebound(checker, scope) {
@@ -60,6 +91,7 @@ pub(crate) fn literal_function(
     };
     Some(Arc::new(LiteralFunction {
         mode,
+        body,
         choice,
         accepts_two: accepts(&["e1", "e2"]),
         accepts_six: accepts(&["x", "y", "mx", "my", "cl", "reverse"]),
@@ -131,12 +163,12 @@ pub(crate) fn dispatch(
         (Some(true), _) => Dispatch::Value(RType::scalar(left.mode)),
         (Some(false), Some(true)) => Dispatch::Value(RType::scalar(right.mode)),
         (Some(false), Some(false))
-            if left.mode != right.mode
+            if left.body.definitely_differs(&right.body)
                 && ((scalar_primitive(lhs) && scalar_primitive(rhs))
                     || (plain_vectors && known_atomic(lhs) && known_atomic(rhs))) =>
         {
-            // Different literal storage modes prove that the method bodies
-            // are not identical. Equal modes alone prove nothing about identity.
+            // Unequal literal values prove distinct bodies even when their
+            // storage modes match. Equal bodies alone do not prove identity.
             Dispatch::IncompatiblePrimitive {
                 left_method: left_name,
                 right_method: right_name,

--- a/crates/ry-checker/src/tests/ops_fallback.rs
+++ b/crates/ry-checker/src/tests/ops_fallback.rs
@@ -47,6 +47,56 @@ fn false_ops_choosers_use_scalar_primitive_modes_and_classes() {
 }
 
 #[test]
+fn false_ops_choosers_recognize_distinct_literals_of_the_same_mode() {
+    for (left, right) in [
+        ("1L", "2L"),
+        ("1", "2"),
+        ("TRUE", "FALSE"),
+        ("'left'", "'right'"),
+    ] {
+        for (operator, mode) in [("+", Mode::Integer), ("==", Mode::Logical)] {
+            let source = source(operator, "left", "right")
+                .replace("function(e1,e2) 1L", &format!("function(e1,e2) {left}"))
+                .replace(
+                    "function(e1,e2) 'right'",
+                    &format!("function(e1,e2) {right}"),
+                );
+            let (diagnostics, scope) = check_with_scope(&source);
+            assert_eq!(
+                diagnostics.iter().filter(|d| d.code == "RY051").count(),
+                1,
+                "{source}: {diagnostics:?}"
+            );
+            assert_eq!(scope.get("out").unwrap().mode, mode, "{source}");
+            assert_eq!(scope.get("out").unwrap().length, Length::One, "{source}");
+        }
+    }
+}
+
+#[test]
+fn equal_literal_spellings_do_not_prove_distinct_methods() {
+    for (left, right) in [
+        ("1L", "1L"),
+        ("1", "1.0"),
+        ("TRUE", "TRUE"),
+        ("'same'", "\"same\""),
+        (r#""\xff""#, r#""\377""#),
+    ] {
+        let source = source("+", "left", "right")
+            .replace("function(e1,e2) 1L", &format!("function(e1,e2) {left}"))
+            .replace(
+                "function(e1,e2) 'right'",
+                &format!("function(e1,e2) {right}"),
+            );
+        let (diagnostics, _) = check_with_scope(&source);
+        assert!(
+            diagnostics.iter().all(|d| d.code != "RY051"),
+            "{source}: {diagnostics:?}"
+        );
+    }
+}
+
+#[test]
 fn false_ops_choosers_bypass_factor_and_data_frame_methods() {
     for class in ["factor", "data.frame"] {
         let source = source("+", class, "right");
@@ -68,7 +118,7 @@ fn false_ops_choosers_bypass_factor_and_data_frame_methods() {
 }
 
 #[test]
-fn false_ops_fallback_needs_both_choices_and_different_method_modes() {
+fn false_ops_fallback_needs_both_choices_and_distinct_method_bodies() {
     let original = source("+", "left", "right");
     for source in [
         original.replace(
@@ -81,7 +131,7 @@ fn false_ops_fallback_needs_both_choices_and_different_method_modes() {
         ),
         original.replace("chooseOpsMethod.right <- function(...) FALSE", ""),
         original.replace("chooseOpsMethod.left <- function(...) FALSE", ""),
-        original.replace("function(e1,e2) 'right'", "function(e1,e2) 2L"),
+        original.replace("function(e1,e2) 'right'", "function(e1,e2) 1L"),
         original.replace(
             "`+.right` <- function(e1,e2) 'right'",
             "`+.right` <- `+.left`",

--- a/crates/ry-checker/testdata/oracle/ops_equal_byte_literal_bodies.R
+++ b/crates/ry-checker/testdata/oracle/ops_equal_byte_literal_bodies.R
@@ -1,0 +1,9 @@
+# oracle: must-pass
+x <- structure(1L, class = "left")
+y <- structure(2L, class = "right")
+`+.left` <- function(e1, e2) "\xff"
+`+.right` <- function(e1, e2) "\377"
+chooseOpsMethod.left <- function(...) FALSE
+chooseOpsMethod.right <- function(...) FALSE
+out <- x + y
+stopifnot(identical(out, "\xff"), length(warnings()) == 0L)

--- a/crates/ry-checker/testdata/oracle/ops_equal_literal_bodies.R
+++ b/crates/ry-checker/testdata/oracle/ops_equal_literal_bodies.R
@@ -1,0 +1,9 @@
+# oracle: must-pass
+x <- structure(1L, class = "left")
+y <- structure(2L, class = "right")
+`+.left` <- function(e1, e2) 1
+`+.right` <- function(e1, e2) 1.0
+chooseOpsMethod.left <- function(...) FALSE
+chooseOpsMethod.right <- function(...) FALSE
+out <- x + y
+stopifnot(identical(out, 1), length(warnings()) == 0L)

--- a/crates/ry-checker/testdata/oracle/ops_same_mode_literal_fallback.R
+++ b/crates/ry-checker/testdata/oracle/ops_same_mode_literal_fallback.R
@@ -1,0 +1,10 @@
+# oracle: must-warn RY051
+x <- structure(1L, class = "left")
+y <- structure(2L, class = "right")
+`+.left` <- function(e1, e2) 1L
+`+.right` <- function(e1, e2) 2L
+chooseOpsMethod.left <- function(...) FALSE
+chooseOpsMethod.right <- function(...) FALSE
+out <- x + y
+stopifnot(identical(unclass(out), 3L), identical(class(out), "left"))
+stopifnot(any(grepl("Incompatible methods", names(warnings()), fixed = TRUE)))


### PR DESCRIPTION
With explicit `FALSE` decisions from both `chooseOpsMethod` methods, R warns and uses the primitive when operator methods have different literal bodies—even when both return integers, doubles, logicals, or strings. ry only proved the conflict when the return storage modes differed.

Track literal body values to recognize these additional conflicts. Equal values, numeric spelling differences, aliases, and undecodable byte-string escapes do not establish distinct methods. Existing chooser, operand, and environment requirements remain in place.

This is partial progress on #193. It does not infer absent class-specific chooser or operator methods from an incomplete S3 registry, and it does not widen the existing operand/attribute proof.

Validation: workspace tests, strict Clippy, formatting, and the full R oracle (17/17) pass in this worktree’s own target directory. R witnesses verify incompatible same-mode methods, equal numeric bodies, and equal byte-string spellings. All 500 audited packages have identical diagnostic JSON to the integrated baseline at `441cd87`; the new minimized witness changes from no diagnostic to exactly RY051.
