### PR TITLE
Resolve backtick-bound top-level values from ordinary reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,6 +128,11 @@ All notable changes to ry are documented in this file.
   attachment and no import), a bare unattached `expr(undefined)` still
   reports the name like any other unknown call.
 
+- **Backtick-bound top-level values resolve from functions**: a bare
+  read of `n1` after `` `n1` <- 42 `` no longer reports RY010. This also
+  covers functions used as values. Escaped identifier spellings remain
+  conservative, and string assignment targets retain their literal names.
+
 - **Names inside quoted blocks cannot borrow unrelated function
   types**: inside an unevaluated block (a data-mask argument, or code
   quoted for later use), a bare name that matches nothing locally used

--- a/crates/ry-checker/src/collect.rs
+++ b/crates/ry-checker/src/collect.rs
@@ -60,6 +60,16 @@ impl Checker {
             table.has_escaped_operator_names |=
                 custom_operator::escaped_name_may_mask_operator(name);
             table.known_vars.insert(name.to_string());
+            // Keep raw names for type/provenance lookup, but recognize an
+            // ordinary read of a backtick-bound symbol as an existing value.
+            // String assignment targets name their literal contents instead;
+            // escaped identifiers require an R decoder before aliasing.
+            if matches!(target, Expr::Ident { .. })
+                && !name.contains('\\')
+                && let Some(unquoted) = name.strip_prefix('`').and_then(|s| s.strip_suffix('`'))
+            {
+                table.known_vars.insert(unquoted.to_string());
+            }
             if is_callable_object_constructor(value) {
                 table.callable_vars.insert(name.to_string());
             } else {

--- a/crates/ry-checker/src/tests/scope_resolution.rs
+++ b/crates/ry-checker/src/tests/scope_resolution.rs
@@ -644,6 +644,16 @@ fn cross_file_top_level_variables_resolve_between_files() {
     for (label, definition, use_src) in [
         ("literal constant", "my_const <- 42\n", "x <- my_const\n"),
         (
+            "backtick-bound constant",
+            "`my_const` <- 42\n",
+            "read_constant <- function() my_const + 1\n",
+        ),
+        (
+            "backtick-bound function as value",
+            "`helper` <- function(x) x + 1\n",
+            "read_helper <- function() { f <- helper; f(1) }\n",
+        ),
+        (
             "opaque call result",
             "GeomRect <- ggproto(\"GeomRect\", Geom, draw = function() NULL)\n",
             "x <- GeomRect\n",

--- a/crates/ry-checker/src/tests/type_inference.rs
+++ b/crates/ry-checker/src/tests/type_inference.rs
@@ -1355,3 +1355,32 @@ fn loop_carried_values_do_not_keep_the_initial_empty_length() {
     let source = "quote <- raw()\nfor (x in as.raw(c(1, 2))) {\nif (length(quote)) { if (x == quote) print(x) }\nquote <- x\n}";
     assert!(check(source).is_empty(), "{:?}", check(source));
 }
+
+#[test]
+fn quoted_top_level_symbols_resolve_as_values_in_functions() {
+    for source in [
+        "`n1` <- 42; f <- function() n1 + 1",
+        "`g` <- function(x) x + 1; f <- function() { z <- g; z(1) }",
+        "`g` <- function() 1; `g` <- 42; f <- function() g + 1",
+        "`n1` <- 1; n1 <- 2; f <- function() n1",
+        "n1 <- 1; `n1` <- 2; f <- function() n1",
+    ] {
+        let diagnostics = check(source);
+        assert!(diagnostics.is_empty(), "{source}: {diagnostics:?}");
+    }
+}
+
+#[test]
+fn quoted_symbol_existence_does_not_invent_distinct_bindings() {
+    for source in [
+        "`n1` <- 42; f <- function() n2",
+        r#""`n1`" <- 42; f <- function() n1"#,
+        r#"`n\x31` <- 42; f <- function() n2"#,
+    ] {
+        let diagnostics = check(source);
+        assert!(
+            diagnostics.iter().any(|d| d.code == "RY010"),
+            "{source}: {diagnostics:?}"
+        );
+    }
+}

--- a/crates/ry-checker/testdata/oracle/quoted_symbol_values.R
+++ b/crates/ry-checker/testdata/oracle/quoted_symbol_values.R
@@ -1,0 +1,11 @@
+# oracle: must-pass
+`n1` <- 42
+f <- function() n1 + 1
+stopifnot(f() == 43)
+`g` <- function(x) x + 1
+h <- function() { z <- g; z(1) }
+stopifnot(h() == 2)
+`value` <- 1
+value <- 2
+read_value <- function() value
+stopifnot(read_value() == 2)


### PR DESCRIPTION
A function reading `n1` after `` `n1` <- 42 `` incorrectly reports RY010. The same problem affects backtick-defined functions passed as values, including across package files.

Record the unescaped ordinary spelling in the collected set of known bindings. This establishes that a value exists while preserving the raw type and reference keys. String assignment targets keep their literal contents; escaped identifiers remain conservative.

Validation: workspace tests, strict Clippy, formatting, and all 17 R oracle tests pass in this worktree’s own target directory. Tests cover same-file and cross-file reads, function values, function redefinition, mixed spelling, distinct string targets, and genuinely missing names. A committed R oracle exercises valid reads.

Across all 500 audited packages, 57 RY010 warnings disappear and no diagnostics are added relative to `71d3a76`: RCurl 3, brew 3, lava 7, permute 1, quantmod 11, vegan 27, and xts 5. Every removed identity has a matching backtick definition in its package source. Cumulative ledgers retain previously known mgcv and rlang warnings; the mgcv loop warning is addressed separately by #298.
