### PR TITLE
Skip hashing empty scope metadata tables during assignments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -509,6 +509,8 @@ All notable changes to ry are documented in this file.
 - Refine only affected functions after edits, using observed callable reads and
   forwarding or S3 metadata dependencies. Keep diagnostic invalidation conservative.
 
+- Skip name hashing when assignments invalidate empty scope metadata tables.
+
 - Reduce scope copying for assertions and short-circuit expressions.
 
 - **One pass-1 walk per file, syntax-only attachment harvest**: the

--- a/crates/ry-checker/src/lib.rs
+++ b/crates/ry-checker/src/lib.rs
@@ -381,14 +381,32 @@ impl Scope {
         if let Some(provenance) = self.reference_provenance.as_mut() {
             provenance.invalidate(&name);
         }
-        self.literal_functions.remove(semantic_argument_name(&name));
-        self.plain_ops_vectors.remove(semantic_argument_name(&name));
-        self.function_aliases.remove(&name);
-        self.lexical_functions.remove(&name);
-        self.list_origin_bindings.remove(&name);
-        self.parameter_bindings.remove(&name);
-        self.default_parameter_bindings.remove(&name);
-        self.narrowed_bindings.remove(&name);
+        // Empty tables can retain capacity; skipping their removal avoids
+        // hashing names that cannot be present.
+        if !self.literal_functions.is_empty() {
+            self.literal_functions.remove(semantic_argument_name(&name));
+        }
+        if !self.plain_ops_vectors.is_empty() {
+            self.plain_ops_vectors.remove(semantic_argument_name(&name));
+        }
+        if !self.function_aliases.is_empty() {
+            self.function_aliases.remove(&name);
+        }
+        if !self.lexical_functions.is_empty() {
+            self.lexical_functions.remove(&name);
+        }
+        if !self.list_origin_bindings.is_empty() {
+            self.list_origin_bindings.remove(&name);
+        }
+        if !self.parameter_bindings.is_empty() {
+            self.parameter_bindings.remove(&name);
+        }
+        if !self.default_parameter_bindings.is_empty() {
+            self.default_parameter_bindings.remove(&name);
+        }
+        if !self.narrowed_bindings.is_empty() {
+            self.narrowed_bindings.remove(&name);
+        }
         self.bindings.insert(name, t);
     }
 

--- a/crates/ry-checker/src/reference_facts.rs
+++ b/crates/ry-checker/src/reference_facts.rs
@@ -79,7 +79,9 @@ impl ScopeProvenance {
     }
 
     pub(crate) fn invalidate(&mut self, name: &str) {
-        self.bindings.remove(name);
+        if !self.bindings.is_empty() {
+            self.bindings.remove(name);
+        }
     }
 }
 


### PR DESCRIPTION
Assignments invalidate several scope metadata tables. Removing a name from an empty table can still hash that name when the table retains capacity, so repeated assignments spend work on removals that cannot succeed.

Skip those removals in `Scope::insert` and reference-binding invalidation. Nonempty tables keep the same removal behavior, including the canonical-name handling for literal functions and plain Ops vectors. This changes neither scope storage nor merge semantics.

Controlled Callgrind comparison against main `259369c`, using the same inputs and isolated checker builds:

| Input | Baseline instructions | Candidate instructions | Change |
|---|---:|---:|---:|
| 1,024 bindings, 24 sparse branches | 237,738,849 | 230,123,702 | -3.20% |
| Dense same-type writes | 1,847,117,905 | 1,726,473,712 | -6.53% |
| Dense alternating-type writes | 2,069,868,637 | 1,843,932,734 | -10.92% |
| Current 253-file fixture sample | 274,121,109 | 268,416,051 | -2.08% |

Diagnostics match byte for byte in all four workloads under both Callgrind and DHAT. DHAT shows no meaningful change in allocated bytes or peak heap. These are instruction counts, not wall-time claims; the harness uses one thread and disables installed-library discovery.

Workspace tests, strict Clippy, formatting, and the full R oracle (17/17) pass in this worktree's own target directory. All 500 audited packages produce byte-identical JSON diagnostics against the pinned main baseline (0 removed, 0 added).

Related to #130; O(1) snapshots remain unimplemented and that issue stays open.
