### PR TITLE
fix(checker): avoid borrowing element types for fold accumulators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -513,6 +513,8 @@ All notable changes to ry are documented in this file.
 - Refine only affected functions after edits, using observed callable reads and
   forwarding or S3 metadata dependencies. Keep diagnostic invalidation conservative.
 
+- Keep fold accumulators and results conservative in `Reduce()` and
+  `purrr::reduce()`, while retaining element checks for known directions.
 - Reduce scope copying for assertions and short-circuit expressions.
 
 - **One pass-1 walk per file, syntax-only attachment harvest**: the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -443,6 +443,9 @@ All notable changes to ry are documented in this file.
   `ry-core` AST adds `Expr::Missing(Span)`; consumers with exhaustive expression
   matches must handle it separately from unsupported `Expr::Unknown` forms.
 
+- Keep fold accumulators and results conservative in `Reduce()` and
+  `purrr::reduce()`, while retaining element checks for known directions.
+
 - Custom or masked `factor` and `new` calls no longer acquire builtin constructor facts. S4 constructor inference requires methods provenance, and detaching a package invalidates the default search-path assumption.
 
 - Resolve visible custom arithmetic, comparison, and vector logical operators
@@ -513,8 +516,6 @@ All notable changes to ry are documented in this file.
 - Refine only affected functions after edits, using observed callable reads and
   forwarding or S3 metadata dependencies. Keep diagnostic invalidation conservative.
 
-- Keep fold accumulators and results conservative in `Reduce()` and
-  `purrr::reduce()`, while retaining element checks for known directions.
 - Reduce scope copying for assertions and short-circuit expressions.
 
 - **One pass-1 walk per file, syntax-only attachment harvest**: the

--- a/crates/ry-checker/src/higher_order.rs
+++ b/crates/ry-checker/src/higher_order.rs
@@ -55,6 +55,16 @@ impl Checker {
     ) -> Option<RType> {
         let spec = signature.higher_order.as_ref()?;
         self.walk_callback_for_diagnostics(signature, args, arg_types, scope);
+        // A fold's initializer describes only the first invocation. Later
+        // accumulators are callback results, and zero iterations return the
+        // initializer/input directly. Neither one invocation nor an input
+        // element establishes the final result (including accumulated output).
+        if spec
+            .callback_args
+            .contains(&CallbackArg::AccumulatorAndElement)
+        {
+            return Some(RType::unknown());
+        }
         let argument_match = match_params(&signature.params, args);
         let declared_length = match &signature.return_ {
             ReturnSpec::Concrete(ty) => json_length_to_length(JsonLength::parse(&ty.length)),
@@ -271,11 +281,7 @@ impl Checker {
                 }
                 CallbackArg::Unknown => types.push(RType::unknown()),
                 CallbackArg::AccumulatorAndElement => {
-                    let data_index = if spec.callback_position == 0 { 1 } else { 0 };
-                    let element = matched_argument_type(arg_types, argument_match, data_index)
-                        .cloned()
-                        .unwrap_or_else(RType::unknown);
-                    types.extend([element.clone(), element]);
+                    types.extend([RType::unknown(), RType::unknown()]);
                 }
                 CallbackArg::ElementsAfterCallback => {
                     types.extend(arguments_bound_to_dots(arg_types, argument_match).cloned())
@@ -473,6 +479,63 @@ impl Checker {
         })
     }
 
+    fn fold_callback_inputs(
+        signature: &FunctionSig,
+        args: &[Arg],
+        arg_types: &[RType],
+        argument_match: &ArgumentMatch,
+    ) -> Vec<RType> {
+        let unknown = || vec![RType::unknown(), RType::unknown()];
+        // Dots can supply controls or shift positional matching.
+        if args
+            .iter()
+            .any(|arg| matches!(&arg.value, Expr::Ident { name, .. } if name == "..."))
+        {
+            return unknown();
+        }
+        let formal = |name| signature.params.iter().position(|param| param.name == name);
+        let actual =
+            |name| formal(name).and_then(|i| argument_bound_to_formal(args, argument_match, i));
+        let (data, init, right) = if formal("right").is_some() {
+            let right = match actual("right").map(|arg| &arg.value) {
+                None | Some(Expr::Missing(_)) => Some(false),
+                Some(Expr::Logical(value, _)) => Some(*value),
+                _ => None,
+            };
+            (formal("x"), actual("init"), right)
+        } else if formal(".dir").is_some() {
+            let right = match actual(".dir").map(|arg| &arg.value) {
+                None | Some(Expr::Missing(_)) => Some(false),
+                Some(Expr::String(value, _)) if value == "forward" => Some(false),
+                Some(Expr::String(value, _)) if value == "backward" => Some(true),
+                _ => None,
+            };
+            (formal(".x"), actual(".init"), right)
+        } else {
+            return unknown();
+        };
+        let Some(input) = data.and_then(|i| matched_argument_type(arg_types, argument_match, i))
+        else {
+            return unknown();
+        };
+        if input.class.is_unknown() || input.class.has_known_class() {
+            return unknown();
+        }
+        let init_missing = init.is_none_or(|arg| matches!(arg.value, Expr::Missing(_)));
+        if matches!(input.length, Length::Zero | Length::Known(0))
+            || (init_missing && matches!(input.length, Length::One | Length::Known(1)))
+        {
+            return Vec::new();
+        }
+        // Keep the element operand precise, but never reuse the initializer
+        // or input element as the loop-carried accumulator's type.
+        match right {
+            Some(false) => vec![RType::unknown(), input.clone()],
+            Some(true) => vec![input.clone(), RType::unknown()],
+            None => unknown(),
+        }
+    }
+
     /// Walk the callback body of a higher-order function call for
     /// diagnostics (RY010 unbound variables, RY040 type errors, etc.).
     /// Called from pass 3 (`infer_call`) before the type-computation
@@ -501,7 +564,11 @@ impl Checker {
             return;
         }
         let argument_match = match_params(&signature.params, args);
-        let inputs = self.higher_order_input_types(spec, arg_types, &argument_match);
+        let inputs = if spec.callback_args == [CallbackArg::AccumulatorAndElement] {
+            Self::fold_callback_inputs(signature, args, arg_types, &argument_match)
+        } else {
+            self.higher_order_input_types(spec, arg_types, &argument_match)
+        };
         if inputs.is_empty()
             || inputs.iter().any(|ty| {
                 matches!(ty.length, Length::Zero | Length::Known(0)) || ty.mode == Mode::Function

--- a/crates/ry-checker/src/tests/functions_classes.rs
+++ b/crates/ry-checker/src/tests/functions_classes.rs
@@ -718,19 +718,80 @@ fn purrr_not_loaded_does_not_treat_map_as_higher_order() {
 }
 
 #[test]
-fn reduce_returns_element_type() {
-    // `Reduce(f, x)` returns the element type of x. For a double
-    // vector, the result is double. Using it with character fires
-    // RY040.
-    let diags = check(
-        "v <- Reduce(function(a, b) a + b, c(1.0, 2.0, 3.0))\n\
-             bad <- v + \"x\"\n",
-    );
-    assert!(
-        diags.iter().any(|d| d.code == "RY040"),
-        "expected RY040 from Reduce result + character, got {:?}",
-        diags
-    );
+fn reduce_accumulator_is_not_an_input_element() {
+    for code in [
+        "Reduce(function(keep, cmp) keep | startsWith('cc main.c', cmp), c('cc', 'c++'), FALSE)",
+        "Reduce(x = c('cc', 'c++'), init = FALSE, f = function(keep, cmp) keep | startsWith('cc main.c', cmp))",
+        "Reduce(function(cmp, keep) keep | startsWith('cc main.c', cmp), c('cc', 'c++'), FALSE, right = TRUE)",
+        "Reduce(function(a, b) { if (is.character(a)) 1L else a + 1L }, c('a', 'b', 'c'))",
+    ] {
+        let diagnostics = check(code);
+        assert!(
+            !diagnostics
+                .iter()
+                .any(|d| matches!(d.code, "RY031" | "RY040")),
+            "{code}: {diagnostics:?}"
+        );
+    }
+}
+
+#[test]
+fn reduce_preserves_element_errors_when_direction_is_known() {
+    for code in [
+        "Reduce(function(a, b) b | TRUE, c('a', 'b'))",
+        "Reduce(function(a, b) a | TRUE, c('a', 'b'), right = TRUE)",
+        "Reduce(function(a, b) b | TRUE, c('a', 'b'), right = FALSE)",
+        "Reduce(x = c('a', 'b'), f = function(a, b) a | TRUE, ri = TRUE)",
+        "purrr::reduce(c('a', 'b'), function(a, b) b | TRUE)",
+        "purrr::reduce(.f = function(a, b) a | TRUE, .x = c('a', 'b'), .dir = 'backward')",
+    ] {
+        let diagnostics = check(code);
+        assert!(
+            diagnostics.iter().any(|d| d.code == "RY031"),
+            "{code}: {diagnostics:?}"
+        );
+    }
+}
+
+#[test]
+fn reduce_dynamic_controls_and_skipped_callbacks_stay_conservative() {
+    for code in [
+        "f <- function(flag) Reduce(function(a, b) a | b, c('a', 'b'), FALSE, right = flag)",
+        "f <- function(...) Reduce(function(a, b) a | b, c('a', 'b'), ...)",
+        "f <- function(direction) purrr::reduce(c('a', 'b'), function(a, b) a | b, .init = FALSE, .dir = direction)",
+        "Reduce(function(a, b) b | TRUE, 'a')",
+        "Reduce(function(a, b) b | TRUE, character(), FALSE)",
+        "Reduce(function(a, b) b | TRUE, 'a', init = )",
+        "purrr::reduce('a', function(a, b) b | TRUE)",
+        "purrr::reduce(c('a', 'b'), function(a, b) a | TRUE, .init = FALSE)",
+        "purrr::reduce(c('a', 'b'), function(a, b) b | TRUE, .init = FALSE, .dir = 'backward')",
+    ] {
+        let diagnostics = check(code);
+        assert!(
+            !diagnostics.iter().any(|d| d.code == "RY031"),
+            "{code}: {diagnostics:?}"
+        );
+    }
+}
+
+#[test]
+fn reduce_result_does_not_borrow_input_or_first_callback_type() {
+    for code in [
+        "v <- Reduce(function(a, b) TRUE, c('a', 'b')); v | FALSE",
+        "v <- Reduce(function(a, b) 'changed', 1:3, FALSE); nchar(v)",
+        "v <- Reduce(function(a, b) TRUE, character(), list(1L)); v[[1L]]",
+        "v <- Reduce(function(a, b) TRUE, c('a', 'b'), accumulate = TRUE)",
+        "v <- purrr::reduce('a', function(a, b) TRUE)",
+    ] {
+        let (diagnostics, scope) = check_with_scope(code);
+        assert_eq!(scope.get("v").unwrap().mode, Mode::Opaque, "{code}");
+        assert!(
+            !diagnostics
+                .iter()
+                .any(|d| matches!(d.code, "RY031" | "RY040")),
+            "{code}: {diagnostics:?}"
+        );
+    }
 }
 
 #[test]

--- a/crates/ry-checker/testdata/oracle/reduce_accumulator.R
+++ b/crates/ry-checker/testdata/oracle/reduce_accumulator.R
@@ -24,12 +24,8 @@ for (right in c(FALSE, TRUE)) {
               else function(accumulator, element) accumulator | startsWith('cc main.c', element)
   stopifnot(identical(Reduce(callback, c('cc', 'c++'), FALSE, right = right), TRUE))
 }
-stopifnot(inherits(try(eval(quote(Reduce(function(a, b) b | TRUE, c('a', 'b')))), silent = TRUE), 'try-error'))
-stopifnot(inherits(try(eval(quote(Reduce(function(a, b) a | TRUE, c('a', 'b'), right = TRUE))), silent = TRUE), 'try-error'))
 if (requireNamespace('purrr', quietly = TRUE)) {
   stopifnot(identical(purrr::reduce(c('a', 'b'), function(a, b) a | TRUE, .init = FALSE), TRUE))
   stopifnot(identical(purrr::reduce(c('a', 'b'), function(a, b) b | TRUE, .init = FALSE, .dir = 'backward'), TRUE))
   stopifnot(identical(purrr::reduce('a', function(a, b) TRUE), 'a'))
-  stopifnot(inherits(try(eval(quote(purrr::reduce(c('a', 'b'), function(a, b) b | TRUE))), silent = TRUE), 'try-error'))
-  stopifnot(inherits(try(eval(quote(purrr::reduce(c('a', 'b'), function(a, b) a | TRUE, .dir = 'backward'))), silent = TRUE), 'try-error'))
 }

--- a/crates/ry-checker/testdata/oracle/reduce_accumulator.R
+++ b/crates/ry-checker/testdata/oracle/reduce_accumulator.R
@@ -24,12 +24,12 @@ for (right in c(FALSE, TRUE)) {
               else function(accumulator, element) accumulator | startsWith('cc main.c', element)
   stopifnot(identical(Reduce(callback, c('cc', 'c++'), FALSE, right = right), TRUE))
 }
-stopifnot(inherits(try(Reduce(function(a, b) b | TRUE, c('a', 'b')), silent = TRUE), 'try-error'))
-stopifnot(inherits(try(Reduce(function(a, b) a | TRUE, c('a', 'b'), right = TRUE), silent = TRUE), 'try-error'))
+stopifnot(inherits(try(eval(quote(Reduce(function(a, b) b | TRUE, c('a', 'b')))), silent = TRUE), 'try-error'))
+stopifnot(inherits(try(eval(quote(Reduce(function(a, b) a | TRUE, c('a', 'b'), right = TRUE))), silent = TRUE), 'try-error'))
 if (requireNamespace('purrr', quietly = TRUE)) {
   stopifnot(identical(purrr::reduce(c('a', 'b'), function(a, b) a | TRUE, .init = FALSE), TRUE))
   stopifnot(identical(purrr::reduce(c('a', 'b'), function(a, b) b | TRUE, .init = FALSE, .dir = 'backward'), TRUE))
   stopifnot(identical(purrr::reduce('a', function(a, b) TRUE), 'a'))
-  stopifnot(inherits(try(purrr::reduce(c('a', 'b'), function(a, b) b | TRUE), silent = TRUE), 'try-error'))
-  stopifnot(inherits(try(purrr::reduce(c('a', 'b'), function(a, b) a | TRUE, .dir = 'backward'), silent = TRUE), 'try-error'))
+  stopifnot(inherits(try(eval(quote(purrr::reduce(c('a', 'b'), function(a, b) b | TRUE))), silent = TRUE), 'try-error'))
+  stopifnot(inherits(try(eval(quote(purrr::reduce(c('a', 'b'), function(a, b) a | TRUE, .dir = 'backward'))), silent = TRUE), 'try-error'))
 }

--- a/crates/ry-checker/testdata/oracle/reduce_accumulator.R
+++ b/crates/ry-checker/testdata/oracle/reduce_accumulator.R
@@ -1,0 +1,35 @@
+# oracle: must-pass
+# Fold initializers describe the first invocation, not later accumulators.
+stopifnot(identical(
+  Reduce(function(keep, cmp) keep | startsWith('cc main.c', cmp), c('cc', 'c++'), FALSE),
+  TRUE
+))
+stopifnot(identical(
+  Reduce(x = c('cc', 'c++'), init = FALSE,
+         f = function(cmp, keep) keep | startsWith('cc main.c', cmp), right = TRUE),
+  TRUE
+))
+stopifnot(identical(
+  Reduce(function(a, b) if (is.character(a)) 1L else a + 1L, c('a', 'b', 'c')),
+  2L
+))
+stopifnot(identical(Reduce(function(a, b) 'changed', 1:3, FALSE), 'changed'))
+stopifnot(identical(Reduce(function(a, b) TRUE, character(), list(1L)), list(1L)))
+stopifnot(identical(Reduce(function(a, b) b | TRUE, 'a'), 'a'))
+stopifnot(identical(Reduce(function(a, b) b | TRUE, 'a', init = ), 'a'))
+stopifnot(identical(Reduce(function(a, b) b | TRUE, character(), FALSE), FALSE))
+stopifnot(identical(Reduce(function(a, b) TRUE, c('a', 'b'), accumulate = TRUE), c('a', 'TRUE')))
+for (right in c(FALSE, TRUE)) {
+  callback <- if (right) function(element, accumulator) accumulator | startsWith('cc main.c', element)
+              else function(accumulator, element) accumulator | startsWith('cc main.c', element)
+  stopifnot(identical(Reduce(callback, c('cc', 'c++'), FALSE, right = right), TRUE))
+}
+stopifnot(inherits(try(Reduce(function(a, b) b | TRUE, c('a', 'b')), silent = TRUE), 'try-error'))
+stopifnot(inherits(try(Reduce(function(a, b) a | TRUE, c('a', 'b'), right = TRUE), silent = TRUE), 'try-error'))
+if (requireNamespace('purrr', quietly = TRUE)) {
+  stopifnot(identical(purrr::reduce(c('a', 'b'), function(a, b) a | TRUE, .init = FALSE), TRUE))
+  stopifnot(identical(purrr::reduce(c('a', 'b'), function(a, b) b | TRUE, .init = FALSE, .dir = 'backward'), TRUE))
+  stopifnot(identical(purrr::reduce('a', function(a, b) TRUE), 'a'))
+  stopifnot(inherits(try(purrr::reduce(c('a', 'b'), function(a, b) b | TRUE), silent = TRUE), 'try-error'))
+  stopifnot(inherits(try(purrr::reduce(c('a', 'b'), function(a, b) a | TRUE, .dir = 'backward'), silent = TRUE), 'try-error'))
+}

--- a/crates/ry-checker/testdata/oracle/reduce_backward_element_error.R
+++ b/crates/ry-checker/testdata/oracle/reduce_backward_element_error.R
@@ -1,0 +1,3 @@
+# oracle: must-flag
+# A right fold passes the input element as its first operand.
+Reduce(function(a, b) a | TRUE, c('a', 'b'), right = TRUE)

--- a/crates/ry-checker/testdata/oracle/reduce_forward_element_error.R
+++ b/crates/ry-checker/testdata/oracle/reduce_forward_element_error.R
@@ -1,0 +1,3 @@
+# oracle: must-flag
+# The second operand is an input element, even with no initializer.
+Reduce(function(a, b) b | TRUE, c('a', 'b'))


### PR DESCRIPTION
A logical fold initializer was ignored when checking its callback: `Reduce(function(keep, cmp) keep | startsWith(out, cmp), compilers(), FALSE)` inferred both callback operands from the character input and emitted false RY031. This occurs in pkgload's compilation database builder.

The accumulator now remains unknown across iterations. An initializer describes only the first callback invocation; later invocations receive the previous callback result, which can have a different type. The element operand stays precise when ordinary R argument matching establishes the literal or omitted fold direction. Base `right = TRUE` and purrr `.dir = "backward"` reverse the operand order. Dynamic controls, forwarded dots, and classed inputs stay conservative. Known-empty inputs and single-element inputs without an initializer do not walk the callback.

The fold result also stays unknown: the old base model borrowed the input element type, while purrr could borrow one callback invocation's result. Neither covers changing accumulators, zero iterations, or accumulated output. Other higher-order callback families retain their current model.

Regression controls cover named/positional/partial formal matching, omitted initializers, reverse and dynamic directions, preserved element errors, skipped callbacks, and changing accumulator/result modes. A fresh R oracle verifies base behavior and purrr behavior when purrr is installed.

Validation: all workspace tests, strict Clippy, formatting, and all 17 R oracle tests pass. The forward and backward element-error controls are explicit must-flag R fixtures; the positive fixture succeeds in R. Both default and full Posit ecosystem checks pass with unchanged committed reports (646 Posit message identities). The runtime evidence used R 4.6.1 and purrr 1.2.2.

This deliberately gives up fold accumulator/result precision until iteration semantics can justify it. It does not change RY031 itself or the callback model for unrelated higher-order functions. Matching upstream typeshed return-contract corrections are being handled separately.

Frozen comparison of all 500 pinned audit packages: exactly one false positive removed, pkgload RY031 at `R/compilation-db.R:203:25`; no diagnostics added. The other 499 complete diagnostic multisets are identical. Evaluating that exact source expression in fresh R with representative compiler output produces the expected logical mask. The final release binary is byte-identical to the measured candidate.
