### PR TITLE
fix(typeshed): correct expand.grid result contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -267,6 +267,10 @@ All notable changes to ry are documented in this file.
   `substitute`, `expression`, and `rlang::expr` calls in defaults. Keep
   checking evaluated control arguments and tidy-injection payloads.
 
+- Keep `expand.grid` results conservative, so dropped numeric columns and
+  data-frame arithmetic do not inherit the plain-list storage type. Include
+  its exact `KEEP.OUT.ATTRS` and `stringsAsFactors` control names.
+
 - Resolve S3 operators before inferring data-frame results, so subclass methods
   can return other types and conflicting methods do not retain column schemas.
 

--- a/crates/ry-checker/src/tests/functions_classes.rs
+++ b/crates/ry-checker/src/tests/functions_classes.rs
@@ -859,9 +859,8 @@ fn typed_multi_input_maps_preserve_atomic_modes_without_claiming_a_length() {
 
 #[test]
 fn expand_grid_dropped_columns_do_not_inherit_list_storage() {
-    let (diagnostics, _) = check_with_scope(
-        "p23 <- expand.grid(0:2, 0:2)\nvalue <- 2^p23[, 1] * 3^p23[, 2]\n",
-    );
+    let (diagnostics, _) =
+        check_with_scope("p23 <- expand.grid(0:2, 0:2)\nvalue <- 2^p23[, 1] * 3^p23[, 2]\n");
     assert!(diagnostics.is_empty(), "{diagnostics:?}");
     let (diagnostics, _) = check_with_scope("x <- list(1L)\nx + 1L\n");
     assert!(diagnostics.iter().any(|d| d.code == "RY040"));

--- a/crates/ry-checker/src/tests/functions_classes.rs
+++ b/crates/ry-checker/src/tests/functions_classes.rs
@@ -856,3 +856,13 @@ fn typed_multi_input_maps_preserve_atomic_modes_without_claiming_a_length() {
     let (_, scope) = check_with_scope("position <- Position(is.na, c(1, 2, 3))\n");
     assert_eq!(scope.get("position").unwrap().length, Length::One);
 }
+
+#[test]
+fn expand_grid_dropped_columns_do_not_inherit_list_storage() {
+    let (diagnostics, _) = check_with_scope(
+        "p23 <- expand.grid(0:2, 0:2)\nvalue <- 2^p23[, 1] * 3^p23[, 2]\n",
+    );
+    assert!(diagnostics.is_empty(), "{diagnostics:?}");
+    let (diagnostics, _) = check_with_scope("x <- list(1L)\nx + 1L\n");
+    assert!(diagnostics.iter().any(|d| d.code == "RY040"));
+}

--- a/crates/ry-checker/testdata/oracle/expand_grid_columns.R
+++ b/crates/ry-checker/testdata/oracle/expand_grid_columns.R
@@ -1,0 +1,4 @@
+# oracle: must-pass
+p23 <- expand.grid(0:2, 0:2)
+value <- 2^p23[, 1] * 3^p23[, 2]
+stopifnot(identical(value, c(1, 2, 4, 3, 6, 12, 9, 18, 36)))

--- a/crates/ry-typeshed/src/lib.rs
+++ b/crates/ry-typeshed/src/lib.rs
@@ -1907,7 +1907,7 @@ mod tests {
     #[test]
     fn typeshed_preserves_embedded_schema_version() {
         let t = load_base().expect("loads");
-        assert_eq!(t.version, "0.0.13");
+        assert_eq!(t.version, "0.0.14");
         assert_eq!(t.schema_version.as_deref(), Some("2"));
     }
 

--- a/crates/ry-typeshed/vendor/SOURCE
+++ b/crates/ry-typeshed/vendor/SOURCE
@@ -1,4 +1,4 @@
 repository: https://github.com/sims1253/r-typeshed
-commit: e692a516fcb9b30e538635aeefe65d7a5b24f61f
+commit: 3bed017adfad91606d031c5b3f78c6eab7922e70
 tree-state: clean
-stubs-sha256: 9300a0f8ada141586fd7fc3d9edb20367edbaa86c3ed529db95b10cef175f6e0
+stubs-sha256: 887a37a3c36a790e60706b9e143913d0f817872586e526341b85b4523a55f2cc

--- a/crates/ry-typeshed/vendor/base/base.json
+++ b/crates/ry-typeshed/vendor/base/base.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "2",
   "package": "base",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "globals": {
     "ambient": [
       "..deparseOpts",
@@ -3903,12 +3903,14 @@
     },
     "expand.grid": {
       "params": [
-        "..."
+        "...",
+        "KEEP.OUT.ATTRS",
+        "stringsAsFactors"
       ],
       "return": {
-        "mode": "list",
+        "mode": "opaque",
         "length": "unknown",
-        "na": false
+        "na": true
       }
     },
     "expm1": {


### PR DESCRIPTION
`expand.grid` was described as list storage, causing false arithmetic errors on dropped numeric columns. Sync the verified contract from r-typeshed merge `3bed017adfad91606d031c5b3f78c6eab7922e70`: arbitrary results stay unknown, and the complete formals include both named controls after `...`.

A checker regression and executable R oracle cover dropped numeric columns. Arithmetic on an ordinary list still emits RY040.

Validation at `1f27ee6`, including merged base-contract PR309:

- Workspace tests, strict Clippy, formatting, and all 17 R oracle tests pass.
- Fresh frozen 500-package comparison against main `f64f015`: 2,127 → 2,119 diagnostics. Exactly eight verified false positives removed across fields, hexbin, lava, and vcd; no additions; 496 packages unchanged. These match the earlier isolated source comparison.
- Both full ecosystem checks pass unchanged, retaining all 43 Posit true positives and 617 readable identities.
- Independent source review, live R controls, and Pullfrog review confirm the contract and regression tests. Vendor provenance identifies the exact merged source and stub hash.
