### PR TITLE
fix(typeshed): rebuild embedded stubs after successful sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -268,7 +268,8 @@ All notable changes to ry are documented in this file.
 - Validate typeshed updates before replacing the vendored snapshot. Failed
   validation leaves the existing stubs and provenance intact. Restore the old
   snapshot if installation fails or receives a handled interrupt, and retain a
-  recovery copy if restoration fails.
+  recovery copy if restoration fails. Refresh the embedded provenance timestamp
+  after validation so the next Cargo build includes the installed snapshot.
 
 - Infer vector-constructor lengths from size values, including empty defaults
   and fractional sizes. Correct factor arithmetic with NULL and unary minus.

--- a/scripts/sync_typeshed.sh
+++ b/scripts/sync_typeshed.sh
@@ -61,6 +61,11 @@ EOF
 cargo run --manifest-path "$repo_root/Cargo.toml" -p ry-cli -- \
   typeshed validate "$staged"
 
+# Validation may compile ry-typeshed against the old vendor after staging.
+# Cargo checks include_str! inputs by mtime; refresh the shared embedded
+# provenance file so the next build cannot reuse that older snapshot.
+touch "$staged/SOURCE"
+
 # Both directories stay on the same filesystem. Keep the old snapshot until
 # the staged directory is installed; EXIT restores it on a failed move or a
 # handled signal. SIGKILL and power loss can still require manual recovery.

--- a/scripts/test_sync_typeshed.py
+++ b/scripts/test_sync_typeshed.py
@@ -35,6 +35,9 @@ test -f "$candidate/base/base.json"
 test -f "$candidate/SOURCE"
 # The old snapshot must remain available throughout validation.
 test "$(cat "$EXPECTED_VENDOR/old.json")" = "old snapshot"
+if [[ -n "${FRESHNESS_MANIFEST:-}" ]]; then
+  "$REAL_CARGO" build --offline --quiet --manifest-path "$FRESHNESS_MANIFEST"
+fi
 exit "$VALIDATION_STATUS"
 """)
         cargo.chmod(0o755)
@@ -94,6 +97,50 @@ exec "$REAL_MV" "$@"
         self.assertEqual((self.vendor / "base/base.json").read_bytes(),
                          (self.checkout / "stubs/base/base.json").read_bytes())
         self.assertIn("stubs-sha256:", (self.vendor / "SOURCE").read_text())
+        self.assert_no_staging_directory()
+
+    @unittest.skipUnless(shutil.which("cargo"), "requires Cargo")
+    def test_next_cargo_build_embeds_the_installed_snapshot(self):
+        # The validator builds after staging, while the original vendor files
+        # are still installed. Cargo must not consider the replacement fresh
+        # merely because its copied mtimes predate that build.
+        manifest = self.repo / "Cargo.toml"
+        manifest.write_text(
+            '[package]\nname="embedded-snapshot"\nversion="0.1.0"\n'
+            'edition="2021"\n[workspace]\n'
+        )
+        source = self.repo / "src"
+        source.mkdir()
+        (source / "main.rs").write_text(
+            'fn main() { print!("{}{}", '
+            'include_str!("../crates/ry-typeshed/vendor/SOURCE"), '
+            'include_str!("../crates/ry-typeshed/vendor/base/base.json")); }\n'
+        )
+        old_base = self.vendor / "base"
+        old_base.mkdir()
+        (old_base / "base.json").write_text('{"package":"old"}\n')
+        real_cargo = shutil.which("cargo")
+        self.env.update(REAL_CARGO=real_cargo, FRESHNESS_MANIFEST=str(manifest),
+                        CARGO_TARGET_DIR=str(self.repo / "isolated target"))
+        result = self.run_sync(0)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        rebuilt = subprocess.run(
+            [real_cargo, "run", "--offline", "--quiet", "--manifest-path", str(manifest)],
+            env=self.env, capture_output=True, text=True,
+        )
+        self.assertEqual(rebuilt.returncode, 0, rebuilt.stderr)
+        expected = ((self.vendor / "SOURCE").read_text()
+                    + (self.vendor / "base/base.json").read_text())
+        self.assertEqual(rebuilt.stdout, expected)
+        self.assert_no_staging_directory()
+
+    def test_failed_freshness_refresh_preserves_snapshot(self):
+        touch = self.binaries / "touch"
+        touch.write_text("#!/usr/bin/env bash\nexit 8\n")
+        touch.chmod(0o755)
+        result = self.run_sync(0)
+        self.assertEqual(result.returncode, 8, result.stderr)
+        self.assert_old_snapshot()
         self.assert_no_staging_directory()
 
     def test_failed_install_restores_snapshot_and_provenance(self):


### PR DESCRIPTION
The sync script stages new stubs before building its validator. That build can embed the old vendor snapshot with a newer Cargo fingerprint than the staged files, so the next build incorrectly reuses old metadata after a successful sync.

Refresh the staged `SOURCE` timestamp after validation, before installing the snapshot. `ry-typeshed` always embeds this provenance file, so Cargo rebuilds the crate to include the installed JSON. If the refresh fails, the existing snapshot stays intact.

Validation: a new regression uses a real, isolated Cargo build during validation and checks the next build’s embedded provenance and JSON, without sleeps. It fails before the fix and passes afterward. A refresh-failure control verifies transactional cleanup. All 13 script tests and shell syntax checks pass. Workspace tests, strict Clippy, formatting, and all 17 full R oracle tests pass.
