### PR TITLE
Sync model.extract component capture contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -167,6 +167,9 @@ All notable changes to ry are documented in this file.
 
 ### Fixed
 
+- Capture bare component names in `stats::model.extract` without reporting
+  them as unbound variables; keep ordinary frame arguments checked.
+
 - Keep `grep`, `confint`, and fold results conservative across their supported
   return shapes. Complete `grep` and `confint` formals; character grep results
   and list-valued confidence intervals no longer cause false type errors.

--- a/crates/ry-checker/src/tests/packages_typeshed.rs
+++ b/crates/ry-checker/src/tests/packages_typeshed.rs
@@ -845,3 +845,21 @@ fn fold_results_do_not_claim_scalar_length_guards() {
             .any(|d| d.code == "RY105")
     );
 }
+
+#[test]
+fn model_extract_quotes_component_names_and_checks_frame_arguments() {
+    for expression in [
+        "f <- function(mf) stats::model.extract(mf, response)",
+        "f <- function(mf) stats::model.extract(component = response, frame = mf)",
+        "f <- function(mf) stats::model.extract(mf, comp = response)",
+    ] {
+        let diagnostics = check(expression);
+        assert!(diagnostics.is_empty(), "{expression}: {diagnostics:?}");
+    }
+    assert!(
+        check("stats::model.extract(unbound_frame, response)")
+            .iter()
+            .any(|d| d.code == "RY010")
+    );
+    assert!(check("f <- function(mf) { x <- 1L; stats::model.extract({ x <- 'a'; mf }, response); x + 1L }").iter().any(|d| d.code == "RY040"));
+}

--- a/crates/ry-checker/testdata/oracle/model_extract_components.R
+++ b/crates/ry-checker/testdata/oracle/model_extract_components.R
@@ -1,0 +1,8 @@
+# oracle: must-pass
+mf <- stats::model.frame(y ~ x, data.frame(y = 1:3, x = 4:6))
+expected <- stats::model.response(mf)
+stopifnot(identical(stats::model.extract(mf, response), expected))
+stopifnot(identical(stats::model.extract(component = response, frame = mf), expected))
+stopifnot(identical(stats::model.extract(mf, comp = response), expected))
+forced <- FALSE
+stopifnot(identical(stats::model.extract({ forced <- TRUE; mf }, response), expected), forced)

--- a/crates/ry-typeshed/src/lib.rs
+++ b/crates/ry-typeshed/src/lib.rs
@@ -1907,7 +1907,7 @@ mod tests {
     #[test]
     fn typeshed_preserves_embedded_schema_version() {
         let t = load_base().expect("loads");
-        assert_eq!(t.version, "0.0.14");
+        assert_eq!(t.version, "0.0.15");
         assert_eq!(t.schema_version.as_deref(), Some("2"));
     }
 

--- a/crates/ry-typeshed/vendor/SOURCE
+++ b/crates/ry-typeshed/vendor/SOURCE
@@ -1,4 +1,4 @@
 repository: https://github.com/sims1253/r-typeshed
-commit: 3bed017adfad91606d031c5b3f78c6eab7922e70
+commit: 06b8b97a054e37efad5a89df9f034c220fe8573f
 tree-state: clean
-stubs-sha256: 887a37a3c36a790e60706b9e143913d0f817872586e526341b85b4523a55f2cc
+stubs-sha256: 65d2d2bff5f9c10501194633c0893ccc17b32a7e819724d9ffc94ffd4f5027cb

--- a/crates/ry-typeshed/vendor/base/base.json
+++ b/crates/ry-typeshed/vendor/base/base.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "2",
   "package": "base",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "globals": {
     "ambient": [
       "..deparseOpts",
@@ -1565,7 +1565,6 @@
       "mirror2html",
       "missingArg",
       "mode<-",
-      "model.extract",
       "model.frame",
       "model.frame.default",
       "model.matrix.default",
@@ -5241,6 +5240,20 @@
         "mode": "logical",
         "length": "1",
         "na": false
+      }
+    },
+    "model.extract": {
+      "params": [
+        "frame",
+        "component"
+      ],
+      "return": {
+        "mode": "opaque",
+        "length": "unknown",
+        "na": true
+      },
+      "eval": {
+        "component": "quoted_symbol"
       }
     },
     "mode": {


### PR DESCRIPTION
`stats::model.extract(mf, response)` treats `response` as a component name rather than looking it up in the caller. Sync the verified source contract so this valid call no longer emits RY010, while ordinary frame arguments and their assignment effects remain checked.

Pins clean r-typeshed master `06b8b97a054e37efad5a89df9f034c220fe8573f` (source #36, base 0.0.15). Originally measured on #310 at `1f27ee68fe5c83c437fd077824a39c9241e0fe5f`; now integrated with main `12518ac8190d498f2446fde7eb371e029827786f` at `540f2a7`. no checker inference implementation changes and no source37/38 additions.

The source uses the existing `quoted_symbol` mode, not an unconditional quoted-expression contract. R tests in the source repository verify that classed language coercion can force the original promise. This consumer change does not claim to model dynamically constructed classed calls or preserve diagnostics inside every non-symbol component expression.

Validation:

- Ordered workspace tests, strict Clippy, formatting, and the full 17-test R oracle matrix pass again after main integration at `540f2a7`.
- Checker regressions cover bare, reordered, and partially matched components; genuine unbound frame arguments and frame assignment effects remain checked. R oracle controls verify the valid calls and forcing behavior.
- The source-only embedded candidate at `c71c0e7f253eeaa8ef155c8aee0608f34ab14e33`, before main integration, checks all 500 fixed-manifest packages with 2,118 diagnostics and statuses 0/1. Matched final #310 release baseline: 2,119→2,118 diagnostics, with only Hmisc `R/na.detail.response.s:6:33` RY010 removed, no additions, and 499 packages unchanged. Every diagnostic field was compared.
- At the source-only candidate, the full Tidyverse ecosystem check is unchanged. Full Posit also passes unchanged: 619 findings, all 43 required true positives retained, and 617 readable identities match.

Frozen source-only candidate `/tmp/ry-model-extract-sync-candidate` (debug); evidence `/tmp/ry-release-sprint-20260907/model-extract-sync-after`. This is a semantic comparison, with no performance claim.
