### PR TITLE
fix(typeshed): preserve unknown Filter and Position results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -167,6 +167,9 @@ All notable changes to ry are documented in this file.
 
 ### Fixed
 
+- Keep `Filter` subset results and `Position` no-match values unknown instead
+  of borrowing input types or assuming scalar indices.
+
 - Capture bare component names in `stats::model.extract` without reporting
   them as unbound variables; keep ordinary frame arguments checked.
 

--- a/crates/ry-checker/src/infer/mod.rs
+++ b/crates/ry-checker/src/infer/mod.rs
@@ -462,12 +462,10 @@ impl Checker {
     /// pure noise there; a genuinely wrong condition (e.g. `if (1L)`)
     /// still emits it.
     ///
-    /// The explicit `na: false` matters: `Position` also returns a
-    /// scalar integer, but its no-match value is `nomatch`
-    /// (`NA_integer_`), so `if (Position(...))` is TRUE-or-error — R
-    /// raises "argument is not interpretable as logical" on the NA —
-    /// and can never be the non-empty idiom. A stub that omits `na` has
-    /// not claimed the value is NA-free, so it does not qualify either.
+    /// The explicit `na: false` matters: `match` can return NA, so
+    /// `if (match(1L, 2L))` errors in R. Its stub declares `na: true`
+    /// and does not qualify. A stub that omits `na` has not claimed
+    /// the value is NA-free, so it does not qualify either.
     ///
     /// `sum` declares a `double_or_int` return, so its count idiom
     /// (`if (sum(x > 0))`) is recognized by argument shape instead: a

--- a/crates/ry-checker/src/tests/functions_classes.rs
+++ b/crates/ry-checker/src/tests/functions_classes.rs
@@ -834,19 +834,14 @@ fn reduce_result_does_not_borrow_input_or_first_callback_type() {
 }
 
 #[test]
-fn filter_preserves_data_type() {
-    // `Filter(f, x)` returns x's type. For integer x, result is
-    // integer. Using it with character fires RY040.
-    let diags = check(
-        "even <- function(x) x %% 2 == 0\n\
-             v <- Filter(even, c(1L, 2L, 3L, 4L))\n\
-             bad <- v + \"x\"\n",
+fn filter_result_does_not_assume_input_mode() {
+    let diagnostics = check(
+        "`[.filter_result` <- function(x, i, ...) 1:3\n\
+         x <- structure('a', class = 'filter_result')\n\
+         result <- Filter(function(x) TRUE, x)\n\
+         result + 1L\n",
     );
-    assert!(
-        diags.iter().any(|d| d.code == "RY040"),
-        "expected RY040 from Filter result + character, got {:?}",
-        diags
-    );
+    assert!(diagnostics.is_empty(), "{diagnostics:?}");
 }
 
 #[test]
@@ -893,7 +888,8 @@ fn typed_multi_input_maps_preserve_atomic_modes_without_claiming_a_length() {
         }
     }
     let (_, scope) = check_with_scope("position <- Position(is.na, c(1, 2, 3))\n");
-    assert_eq!(scope.get("position").unwrap().length, Length::One);
+    assert_eq!(scope.get("position").unwrap().mode, Mode::Opaque);
+    assert_eq!(scope.get("position").unwrap().length, Length::Unknown);
 }
 
 #[test]

--- a/crates/ry-checker/src/tests/packages_typeshed.rs
+++ b/crates/ry-checker/src/tests/packages_typeshed.rs
@@ -896,3 +896,34 @@ fn exported_html_tags_are_values_under_package_lookup() {
         "{diagnostics:?}"
     );
 }
+
+#[test]
+fn filter_and_position_results_do_not_borrow_input_or_index_shapes() {
+    for expression in [
+        "if (length(Filter(function(x) FALSE, 1L)) == 0) TRUE",
+        "found <- Position(function(x) FALSE, 1:3, nomatch = list(value = NA_real_)); found$value",
+        "found <- Position(function(x) FALSE, 1:3, FALSE, list(value = NA_real_)); found$value",
+        "found <- Position(function(x) FALSE, 1:3, nom = list(value = NA_real_)); found$value",
+        "Position(function(x) x + 1L > 0L, list('a', 1L), right = TRUE)",
+    ] {
+        let diagnostics = check(expression);
+        assert!(diagnostics.is_empty(), "{expression}: {diagnostics:?}");
+    }
+    for expression in [
+        "Filter(function(x) x + 'a', 1:2)",
+        "Position(function(x) x + 'a', 1:2, right = FALSE)",
+        "Position(function(x) x + 'a', 1:2, right = TRUE)",
+    ] {
+        let diagnostics = check(expression);
+        assert!(
+            diagnostics.iter().any(|d| d.code == "RY040"),
+            "{expression}: {diagnostics:?}"
+        );
+    }
+    assert!(
+        check("if (length(sum(1:3)) == 0) TRUE")
+            .iter()
+            .any(|d| d.code == "RY105")
+    );
+    assert!(check("1L$value").iter().any(|d| d.code == "RY061"));
+}

--- a/crates/ry-checker/src/tests/type_inference.rs
+++ b/crates/ry-checker/src/tests/type_inference.rs
@@ -184,20 +184,15 @@ fn shadowed_sum_keeps_the_coercion_nudge() {
     );
 }
 
-// The numeric-truthiness idiom requires the stub's explicit never-NA
-// claim. `Position` also declares an integer length-1 return, but its
-// no-match value is `nomatch` (`NA_integer_`), so `if (Position(...))`
-// is TRUE-or-error in R — verified: `if (Position(is.na, c(1,2,3)))`
-// raises "argument is not interpretable as logical". Its stub omits
-// `na: false`, which is not a non-NA guarantee, so the coercion nudge
-// fires while every stub that does declare `na: false` keeps the
-// suppression.
+// A missing match is NA_integer_, so its scalar integer must not receive the
+// never-NA numeric-truthiness suppression. Position is no longer a suitable
+// control because its arbitrary nomatch value requires an opaque result.
 #[test]
 fn na_capable_integer_count_keeps_the_coercion_nudge() {
-    let position = check("x <- c(1, 2, 3)\nif (Position(is.na, x)) 1\n");
+    let missing_match = check("if (match(1L, 2L)) 1\n");
     assert!(
-        position.iter().any(|d| d.code == "RY003"),
-        "Position's NA-capable return must not feed the non-empty idiom: {position:?}"
+        missing_match.iter().any(|d| d.code == "RY003"),
+        "A missing match must not feed the non-empty idiom: {missing_match:?}"
     );
     for suppressed in [
         "x <- c(1, 2, 3)\nif (length(x)) 1\n",

--- a/crates/ry-checker/testdata/ok_ho_filter_find.R
+++ b/crates/ry-checker/testdata/ok_ho_filter_find.R
@@ -1,7 +1,6 @@
 # no-diag
-# `Filter` and `Find` preserve the data type. `Filter(f, x)` returns
-# the same type as `x`; `Find(f, x)` returns the element type. Both
-# are well-typed when used arithmetically.
+# Arithmetic is valid for these concrete integer inputs and predicate.
+# Filter returns c(2L, 4L), and Find returns 2L.
 even <- function(x) x %% 2 == 0
 filtered <- Filter(even, c(1L, 2L, 3L, 4L))
 found <- Find(even, c(1L, 2L, 3L))

--- a/crates/ry-checker/testdata/ok_if_length_idiom.R
+++ b/crates/ry-checker/testdata/ok_if_length_idiom.R
@@ -6,9 +6,9 @@
 # direct call whose resolved stub declares an integer length-1 return
 # that is never NA — the original three plus everything the stubs record
 # the same way (`NROW`, `NCOL`, `nobs`, vctrs' `vec_size`, ...).
-# `Position` is NOT here: its no-match value is NA, so
-# `if (Position(...))` errors rather than testing non-empty (see
-# warn_position_condition.R).
+# `match` is NOT here: its no-match value is NA, so
+# `if (match(1L, 2L))` errors rather than testing non-empty (see
+# warn_missing_match_condition.R).
 x <- c(1, 2, 3)
 if (length(x)) print(1)
 d <- data.frame(a = 1)

--- a/crates/ry-checker/testdata/oracle/filter_callback_error.R
+++ b/crates/ry-checker/testdata/oracle/filter_callback_error.R
@@ -1,0 +1,2 @@
+# oracle: must-flag
+Filter(function(x) x + 'a', 1:2)

--- a/crates/ry-checker/testdata/oracle/filter_position_results.R
+++ b/crates/ry-checker/testdata/oracle/filter_position_results.R
@@ -1,0 +1,12 @@
+# oracle: must-pass
+stopifnot(identical(Filter(function(x) FALSE, 1L), integer()))
+if (length(Filter(function(x) FALSE, 1L)) == 0) TRUE
+stopifnot(identical(Filter(function(x) c(TRUE, FALSE, TRUE), 1:2), c(1L, NA_integer_, NA_integer_, NA_integer_)))
+found <- Position(function(x) FALSE, 1:3, nomatch = list(value = NA_real_))
+stopifnot(is.na(found$value))
+stopifnot(identical(Position(function(x) FALSE, 1:3), NA_integer_))
+stopifnot(identical(Position(function(x) x + 1L > 0L, list('a', 1L), right = TRUE), 2L))
+`[.filter_result` <- function(x, i, ...) 1:3
+x <- structure('a', class = 'filter_result')
+result <- Filter(function(x) TRUE, x)
+stopifnot(identical(result + 1L, 2:4))

--- a/crates/ry-checker/testdata/oracle/position_backward_callback_error.R
+++ b/crates/ry-checker/testdata/oracle/position_backward_callback_error.R
@@ -1,0 +1,2 @@
+# oracle: must-flag
+Position(function(x) x + 'a', 1:2, right = TRUE)

--- a/crates/ry-checker/testdata/oracle/position_forward_callback_error.R
+++ b/crates/ry-checker/testdata/oracle/position_forward_callback_error.R
@@ -1,0 +1,2 @@
+# oracle: must-flag
+Position(function(x) x + 'a', 1:2, right = FALSE)

--- a/crates/ry-checker/testdata/warn_missing_match_condition.R
+++ b/crates/ry-checker/testdata/warn_missing_match_condition.R
@@ -1,0 +1,4 @@
+# expect: RY003
+# A missing match returns NA_integer_, so this scalar integer condition
+# errors in R. It must not inherit the never-NA non-empty count idiom.
+if (match(1L, 2L)) print(1)

--- a/crates/ry-checker/testdata/warn_position_condition.R
+++ b/crates/ry-checker/testdata/warn_position_condition.R
@@ -1,9 +1,0 @@
-# expect: RY003
-# `Position()` returns `nomatch` — `NA_integer_` by default — when
-# nothing matches, so `if (Position(...))` is TRUE-or-error in R:
-# `if (Position(is.na, c(1, 2, 3)))` raises "argument is not
-# interpretable as logical". It can never be the `if (length(x))`
-# non-empty idiom, whose suppression requires a stub-declared never-NA
-# integer-1 return (ok_if_length_idiom.R). Position's stub deliberately
-# omits `na: false`, so the coercion nudge fires like `if (1L)` does.
-if (Position(is.na, c(1, 2, 3))) print(1)

--- a/crates/ry-checker/tests/snapshots/corpus__checker_fixture_diagnostics.snap
+++ b/crates/ry-checker/tests/snapshots/corpus__checker_fixture_diagnostics.snap
@@ -1219,6 +1219,16 @@ expression: snapshots
         start: 57
   fixture: warn_forwarded_null_default_condition.R
 - diagnostics:
+    - code: RY003
+      message: "`if` condition is `integer`; R coerces nonzero to TRUE"
+      severity: info
+      span:
+        column: 4
+        end: 176
+        line: 3
+        start: 163
+  fixture: warn_missing_match_condition.R
+- diagnostics:
     - code: RY001
       message: "`if` condition is `NULL<len=0>`, expected length-1 logical"
       severity: error
@@ -1238,16 +1248,6 @@ expression: snapshots
         line: 1
         start: 20
   fixture: warn_numeric_min_condition.R
-- diagnostics:
-    - code: RY003
-      message: "`if` condition is `integer`; R coerces nonzero to TRUE"
-      severity: info
-      span:
-        column: 4
-        end: 524
-        line: 8
-        start: 497
-  fixture: warn_position_condition.R
 - diagnostics:
     - code: RY051
       message: "incompatible S3 methods `+.left` and `+.right` for `+`; R uses the primitive operator"

--- a/crates/ry-typeshed/src/lib.rs
+++ b/crates/ry-typeshed/src/lib.rs
@@ -1909,7 +1909,7 @@ mod tests {
     #[test]
     fn typeshed_preserves_embedded_schema_version() {
         let t = load_base().expect("loads");
-        assert_eq!(t.version, "0.0.15");
+        assert_eq!(t.version, "0.0.16");
         assert_eq!(t.schema_version.as_deref(), Some("2"));
     }
 

--- a/crates/ry-typeshed/vendor/SOURCE
+++ b/crates/ry-typeshed/vendor/SOURCE
@@ -1,4 +1,4 @@
 repository: https://github.com/sims1253/r-typeshed
-commit: 65de2df1e4d8120984c344c7fde8756cc6c3b285
+commit: 2c1ae94011ee8f986337bb7c77d3b9f6990c37d5
 tree-state: clean
-stubs-sha256: 3837766528a5ae888651def7bec912445df98c4d8a6ac43f9bb7306251fe72f6
+stubs-sha256: ce93eca68d5d3371a40c2270b762fbe2baeef7cdf8384d17d7b3d22f2d05556b

--- a/crates/ry-typeshed/vendor/base/base.json
+++ b/crates/ry-typeshed/vendor/base/base.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "2",
   "package": "base",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "globals": {
     "ambient": [
       "..deparseOpts",
@@ -2430,11 +2430,15 @@
           "element_of_arg1"
         ],
         "result": {
-          "kind": "same_as_arg0",
-          "source_arg": 1
+          "kind": "vector_of",
+          "mode": "opaque"
         }
       },
-      "return": "arg0"
+      "return": {
+        "mode": "opaque",
+        "length": "unknown",
+        "na": true
+      }
     },
     "Find": {
       "params": [
@@ -2562,12 +2566,13 @@
         ],
         "result": {
           "kind": "vector_of",
-          "mode": "integer"
+          "mode": "opaque"
         }
       },
       "return": {
-        "mode": "integer",
-        "length": "1"
+        "mode": "opaque",
+        "length": "unknown",
+        "na": true
       }
     },
     "R.version": {


### PR DESCRIPTION
`Filter()` can change output length and class through subsetting, and `Position()` can return an arbitrary `nomatch` value. Sync their verified result contracts so calls no longer inherit an unjustified input type or scalar integer result.

Pins merged r-typeshed source PR38 at `2c1ae94011ee8f986337bb7c77d3b9f6990c37d5` (base 0.0.16). Stacked on PR314 and integrated with its current main updates. Production changes are vendored metadata; checker inference implementation is unchanged.

Regressions cover empty Filter results, custom subset return types, named/positional/partial Position `nomatch`, and backward early exit. Separate callback error controls remain diagnosed for Filter and both Position directions. Tests that asserted incorrect contracts now use valid runtime examples; missing-index truthiness remains independently covered through `match()`.

Validation:

- Ordered workspace tests, strict Clippy, formatting, and all 17 R oracle tests pass at integrated production head `a64363f9678d02be68321a5047696d683fdc4bcc`.
- The inherited qualified-tags test passes; final comment corrections at `4d74694` pass the corpus suite and formatting.
- Integrated actual embedded comparison against PR314: all 500 packages retain exactly 1,952 diagnostics, with zero full-record additions or removals and all statuses 0/1.
- Both integrated full ecosystem checks pass unchanged, including Posit 532 findings, all 43 true positives, and 530 readable identities. The original pre-integration 500 comparison was also unchanged at 1,962 diagnostics.

Existing callback element inference does not model every classed `as.list`/`[[` dispatch. This change corrects result metadata; it does not claim to close that separate callback precision gap. The sibling Find correction is independently verified in source PR39 and consumer PR317.

Frozen integrated candidate `/tmp/ry-filter-position-main-candidate` is a debug build (SHA256 `1bf3b927ff263c2df731a0e9a8634ddef6fc2016d348723c4c17e686b604a025`). Exact baseline, invocation, and results: `/tmp/ry-release-sprint-20260907/filter-position-main-after/{provenance,changes}.json`. This is a semantic comparison, with no performance claim.
