### PR TITLE
fix(typeshed): preserve arbitrary Find result shapes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -167,6 +167,8 @@ All notable changes to ry are documented in this file.
 
 ### Fixed
 
+- Keep `Find` results unknown when no-match values or matching list elements
+  can have arbitrary types and lengths. Preserve predicate diagnostics.
 - Keep `Filter` subset results and `Position` no-match values unknown instead
   of borrowing input types or assuming scalar indices.
 

--- a/crates/ry-checker/src/tests/packages_typeshed.rs
+++ b/crates/ry-checker/src/tests/packages_typeshed.rs
@@ -927,3 +927,26 @@ fn filter_and_position_results_do_not_borrow_input_or_index_shapes() {
     );
     assert!(check("1L$value").iter().any(|d| d.code == "RY061"));
 }
+
+#[test]
+fn find_results_preserve_no_match_and_list_element_uncertainty() {
+    for source in [
+        "f <- function() { result <- Find(function(x) FALSE, 1:3); if (length(result) == 0L) TRUE }",
+        "result <- Find(function(x) FALSE, 'a', nomatch = c(1L, 2L)); result + 1L",
+        "result <- Find(function(x) FALSE, 'a', TRUE, c(1L, 2L)); result + 1L",
+        "result <- Find(function(x) TRUE, list(c(1L, 2L))); if (length(result) == 0L) TRUE",
+    ] {
+        let diagnostics = check(source);
+        assert!(diagnostics.is_empty(), "{source}: {diagnostics:?}");
+    }
+    assert!(
+        check("Find(function(x) x + 1L, c('a', 'b'))")
+            .iter()
+            .any(|d| d.code == "RY040")
+    );
+    assert!(
+        check("if (length(sum(1:3)) == 0L) TRUE")
+            .iter()
+            .any(|d| d.code == "RY105")
+    );
+}

--- a/crates/ry-typeshed/src/lib.rs
+++ b/crates/ry-typeshed/src/lib.rs
@@ -1909,7 +1909,7 @@ mod tests {
     #[test]
     fn typeshed_preserves_embedded_schema_version() {
         let t = load_base().expect("loads");
-        assert_eq!(t.version, "0.0.16");
+        assert_eq!(t.version, "0.0.17");
         assert_eq!(t.schema_version.as_deref(), Some("2"));
     }
 

--- a/crates/ry-typeshed/vendor/SOURCE
+++ b/crates/ry-typeshed/vendor/SOURCE
@@ -1,4 +1,4 @@
 repository: https://github.com/sims1253/r-typeshed
-commit: fd6f65c4613a1bd454c1d8ebf865cff5cc167a59
+commit: c1ee1cc6af8f6ad5b68f56c82dd6a942ea1a7493
 tree-state: clean
 stubs-sha256: 305c378ce7ae7f4ce9398e996846c0b8d2e08f2648003b390aaf52bbaaa4f5a2

--- a/crates/ry-typeshed/vendor/SOURCE
+++ b/crates/ry-typeshed/vendor/SOURCE
@@ -1,4 +1,4 @@
 repository: https://github.com/sims1253/r-typeshed
-commit: 2c1ae94011ee8f986337bb7c77d3b9f6990c37d5
+commit: fd6f65c4613a1bd454c1d8ebf865cff5cc167a59
 tree-state: clean
-stubs-sha256: ce93eca68d5d3371a40c2270b762fbe2baeef7cdf8384d17d7b3d22f2d05556b
+stubs-sha256: 305c378ce7ae7f4ce9398e996846c0b8d2e08f2648003b390aaf52bbaaa4f5a2

--- a/crates/ry-typeshed/vendor/base/base.json
+++ b/crates/ry-typeshed/vendor/base/base.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "2",
   "package": "base",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "globals": {
     "ambient": [
       "..deparseOpts",
@@ -2466,13 +2466,14 @@
           "element_of_arg1"
         ],
         "result": {
-          "kind": "callback_return",
-          "source_arg": 1
+          "kind": "vector_of",
+          "mode": "opaque"
         }
       },
       "return": {
         "mode": "opaque",
-        "length": "1"
+        "length": "unknown",
+        "na": true
       }
     },
     "IQR": {

--- a/docs/corpus/README.md
+++ b/docs/corpus/README.md
@@ -18,7 +18,7 @@ the other, `upstream-ggplot2`, names the upstream package.
 | Ledger | `ry` | Packages | Diagnostics | TP / FP / Unc | Reconciliation |
 | :-- | :-- | :-- | ---: | :-- | :-- |
 | [`tidyverse-0.7.1.json`](tidyverse-0.7.1.json) | 0.9 dev | 24 | 107 | 10 / 45 / 0 (+52 unowned) | hermetic (strict CI gate) |
-| [`posit-0.9.0.json`](posit-0.9.0.json) | 0.9 dev | 62 | 619 | 43 / 576 / 0 | hermetic (strict CI gate) |
+| [`posit-0.9.0.json`](posit-0.9.0.json) | 0.9 dev | 62 | 532 | 43 / 489 / 0 | hermetic (strict CI gate) |
 
 The default ledger keeps its historical `tidyverse-0.7.1.json` filename; its
 version and source revision describe the current regenerated diagnostics.


### PR DESCRIPTION
`Find` can return NULL, a supplied no-match value, or a matching list element of arbitrary shape. Borrowing a scalar input element caused a false zero-length warning and rejected valid arithmetic on a numeric no-match value supplied with character input.

Sync exact merged r-typeshed `c1ee1cc6af8f6ad5b68f56c82dd6a942ea1a7493` ([r-typeshed#39](https://github.com/sims1253/r-typeshed/pull/39)). Regression tests cover both false positives, named and positional no-match values, matching list elements, invalid predicate arithmetic, and the existing scalar-length warning. Callback invocation metadata remains intact.

Validation: targeted regression fails before the sync and passes afterward; fresh R controls pass. After integrating PR #315, workspace tests, strict all-target Clippy, formatting, and all 17 R oracle tests pass. The fresh matched 500-package comparison against integrated PR #315 produces 1,952 diagnostics on each side, with zero added or removed full records. The reproduced false positives are separate examples outside that corpus. The earlier pre-integration comparison likewise had zero changes (1,962 on each side).

Both complete ecosystem checks pass with current committed reports. Posit remains 532 findings, 43 true positives, and 530 readable identities.

Production validation and the frozen comparison use `837bcec`; final head `a519841` adds only the two inherited comment corrections from PR #315, whose corpus tests and formatting check also pass.
