### PR TITLE
refactor(vscode): use Effect for commands and server lifecycle

### DIFF
--- a/.github/workflows/build-vscode.yml
+++ b/.github/workflows/build-vscode.yml
@@ -96,7 +96,7 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Unit tests
-        run: bun test src/test/binary.test.ts
+        run: bun test src/test/binary.test.ts src/test/errors.test.ts
 
       - name: Package the built binary
         run: |

--- a/editors/code/bun.lock
+++ b/editors/code/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "ry",
       "dependencies": {
+        "effect": "^3",
         "vscode-languageclient": "^9.0.1",
       },
       "devDependencies": {
@@ -179,6 +180,8 @@
     "@secretlint/types": ["@secretlint/types@10.2.2", "", {}, "sha512-Nqc90v4lWCXyakD6xNyNACBJNJ0tNCwj2WNk/7ivyacYHxiITVgmLUFXTBOeCdy79iz6HtN9Y31uw/jbLrdOAg=="],
 
     "@sindresorhus/merge-streams": ["@sindresorhus/merge-streams@2.3.0", "", {}, "sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg=="],
+
+    "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
     "@textlint/ast-node-types": ["@textlint/ast-node-types@15.8.0", "", {}, "sha512-5CiH9COYmovWmExQgs7763DzX6Gy9zjkjJ7JxCC95wyTcjwQn/8poNF6fv3qzRlmx8CRRde8DHr9FcgAAiPzgw=="],
 
@@ -358,6 +361,8 @@
 
     "editions": ["editions@6.22.0", "", { "dependencies": { "version-range": "^4.15.0" } }, "sha512-UgGlf8IW75je7HZjNDpJdCv4cGJWIi6yumFdZ0R7A8/CIhQiWUjyGLCxdHpd8bmyD1gnkfUNK0oeOXqUS2cpfQ=="],
 
+    "effect": ["effect@3.22.1", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "fast-check": "^3.23.1" } }, "sha512-TNoXushmPOBAjJlthF5d2QwnX2xBPEtcNJr5XKNKbRLbDvBcOYkXlYDfvGfSA0zriwLFuCll5MDtNMAdZL17PQ=="],
+
     "emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
 
     "encoding-sniffer": ["encoding-sniffer@0.2.1", "", { "dependencies": { "iconv-lite": "^0.6.3", "whatwg-encoding": "^3.1.1" } }, "sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw=="],
@@ -383,6 +388,8 @@
     "escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
 
     "expand-template": ["expand-template@2.0.3", "", {}, "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg=="],
+
+    "fast-check": ["fast-check@3.23.2", "", { "dependencies": { "pure-rand": "^6.1.0" } }, "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A=="],
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
@@ -649,6 +656,8 @@
     "pump": ["pump@3.0.4", "", { "dependencies": { "end-of-stream": "^1.1.0", "once": "^1.3.1" } }, "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA=="],
 
     "punycode.js": ["punycode.js@2.3.1", "", {}, "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA=="],
+
+    "pure-rand": ["pure-rand@6.1.0", "", {}, "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA=="],
 
     "qs": ["qs@6.15.3", "", { "dependencies": { "es-define-property": "^1.0.1", "side-channel": "^1.1.1" } }, "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A=="],
 

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -223,6 +223,7 @@
     ]
   },
   "dependencies": {
+    "effect": "^3",
     "vscode-languageclient": "^9.0.1"
   },
   "devDependencies": {

--- a/editors/code/src/common/binary.ts
+++ b/editors/code/src/common/binary.ts
@@ -13,8 +13,8 @@
  */
 
 import * as path from "path";
-import { execFile } from "child_process";
-import { promisify } from "util";
+import { Effect, Schema } from "effect";
+import { runBinary } from "./process";
 import * as fs from "fs";
 import { BUNDLED_RY_EXECUTABLE, RY_BINARY_NAME } from "./constants";
 import {
@@ -99,39 +99,17 @@ function findOnPath(binary: string): string | undefined {
   return undefined;
 }
 
-const execFileAsync = promisify(execFile);
+const decodeVersion = Schema.decodeUnknown(
+  Schema.parseJson(Schema.Struct({ version: Schema.String })),
+);
 
-/**
- * Probe the ry binary version by executing `ry version --output-format json`.
- * Returns undefined if the binary cannot be executed or the output
- * cannot be parsed.
- */
-export async function getRyVersion(
-  binaryPath: string,
-): Promise<VersionInfo | undefined> {
-  try {
-    const { stdout } = await execFileAsync(
-      binaryPath,
-      ["version", "--output-format", "json"],
-      {
-        encoding: "utf-8",
-        timeout: 5000,
-      },
-    );
-    const parsed: unknown = JSON.parse(stdout);
-    if (
-      typeof parsed !== "object" ||
-      parsed === null ||
-      !("version" in parsed) ||
-      typeof parsed.version !== "string"
-    ) {
-      return undefined;
-    }
-    return versionFromString(parsed.version);
-  } catch {
-    return undefined;
-  }
-}
+/** An unavailable binary or invalid response produces an unknown version. */
+export const getRyVersion = (binaryPath: string) =>
+  runBinary(binaryPath, ["version", "--output-format", "json"]).pipe(
+    Effect.flatMap(({ stdout }) => decodeVersion(stdout)),
+    Effect.map(({ version }) => versionFromString(version)),
+    Effect.catchAll(() => Effect.succeed(undefined)),
+  );
 
 /**
  * Check if the resolved binary meets the minimum version for a capability.

--- a/editors/code/src/common/commands.ts
+++ b/editors/code/src/common/commands.ts
@@ -3,86 +3,104 @@
  */
 
 import * as vscode from "vscode";
-import { execFile } from "child_process";
-import { promisify } from "util";
-
-const execFileAsync = promisify(execFile);
+import { Effect, Schema } from "effect";
+import { runBinary } from "./process";
 import { ResolvedBinary } from "./binary";
 import { type ISettings } from "./settings";
 
-export async function debugInformationCommand(
+export const debugInformationCommand = (
   binary: ResolvedBinary | undefined,
   settings: ISettings | undefined,
-): Promise<void> {
-  const lines: string[] = [];
-  lines.push("## ry debug information");
-  lines.push("");
-  lines.push(`**Binary path**: ${binary?.path ?? "not resolved"}`);
-  lines.push(
-    `**Version**: ${
-      binary?.version
-        ? `${binary.version.major}.${binary.version.minor}.${binary.version.patch}`
-        : "unknown"
-    }`,
-  );
-  lines.push("");
-  lines.push("**Settings:**");
-  lines.push("```json");
-  lines.push(JSON.stringify(settings ?? {}, null, 2));
-  lines.push("```");
-  lines.push("");
-  lines.push("**Workspace folders:**");
-  for (const folder of vscode.workspace.workspaceFolders ?? []) {
-    lines.push(`- ${folder.name}: ${folder.uri.fsPath}`);
-  }
-
-  const output = lines.join("\n");
-  const doc = await vscode.workspace.openTextDocument({
-    content: output,
-    language: "markdown",
-  });
-  await vscode.window.showTextDocument(doc);
-}
-
-export async function explainRuleCommand(binaryPath: string): Promise<void> {
-  try {
-    const { stdout } = await execFileAsync(
-      binaryPath,
-      ["explain", "rule", "--output-format", "json"],
-      {
-        encoding: "utf-8",
-        timeout: 5000,
-      },
+) =>
+  Effect.gen(function* () {
+    const lines: string[] = [];
+    lines.push("## ry debug information");
+    lines.push("");
+    lines.push(`**Binary path**: ${binary?.path ?? "not resolved"}`);
+    lines.push(
+      `**Version**: ${
+        binary?.version
+          ? `${binary.version.major}.${binary.version.minor}.${binary.version.patch}`
+          : "unknown"
+      }`,
     );
-    const rules: unknown = JSON.parse(stdout);
-    if (!Array.isArray(rules)) throw new Error("Expected a rule list");
-    const items = rules.map((rule: unknown) => {
-      if (
-        typeof rule !== "object" ||
-        rule === null ||
-        !("code" in rule) ||
-        typeof rule.code !== "string" ||
-        !("name" in rule) ||
-        typeof rule.name !== "string" ||
-        !("summary" in rule) ||
-        typeof rule.summary !== "string"
-      ) {
-        throw new Error("Invalid rule description");
-      }
-      return { label: rule.code, description: rule.name, detail: rule.summary };
-    });
-    const picked = await vscode.window.showQuickPick(items, {
-      placeHolder: "Select a rule to explain",
-    });
-    if (!picked) return;
+    lines.push("");
+    lines.push("**Settings:**");
+    lines.push("```json");
+    lines.push(JSON.stringify(settings ?? {}, null, 2));
+    lines.push("```");
+    lines.push("");
+    lines.push("**Workspace folders:**");
+    for (const folder of vscode.workspace.workspaceFolders ?? []) {
+      lines.push(`- ${folder.name}: ${folder.uri.fsPath}`);
+    }
 
-    const md = `# ${picked.label}: ${picked.description}\n\n${picked.detail}`;
-    const doc = await vscode.workspace.openTextDocument({
-      content: md,
-      language: "markdown",
-    });
-    await vscode.window.showTextDocument(doc, { preview: true });
-  } catch (e) {
-    vscode.window.showErrorMessage(`Failed to explain rule: ${e}`);
-  }
-}
+    const output = lines.join("\n");
+    const doc = yield* Effect.tryPromise(() =>
+      Promise.resolve(
+        vscode.workspace.openTextDocument({
+          content: output,
+          language: "markdown",
+        }),
+      ),
+    );
+    yield* Effect.tryPromise(() =>
+      Promise.resolve(vscode.window.showTextDocument(doc)),
+    );
+  });
+
+const decodeRules = Schema.decodeUnknown(
+  Schema.parseJson(
+    Schema.Array(
+      Schema.Struct({
+        code: Schema.String,
+        name: Schema.String,
+        summary: Schema.String,
+      }),
+    ),
+  ),
+);
+
+export const explainRuleCommand = (binaryPath: string) =>
+  Effect.gen(function* () {
+    const { stdout } = yield* runBinary(binaryPath, [
+      "explain",
+      "rule",
+      "--output-format",
+      "json",
+    ]);
+    const rules = yield* decodeRules(stdout);
+    const items = rules.map((rule) => ({
+      label: rule.code,
+      description: rule.name,
+      detail: rule.summary,
+    }));
+    const picked = yield* Effect.tryPromise(() =>
+      Promise.resolve(
+        vscode.window.showQuickPick(items, {
+          placeHolder: "Select a rule to explain",
+        }),
+      ),
+    );
+    if (!picked) return;
+    const doc = yield* Effect.tryPromise(() =>
+      Promise.resolve(
+        vscode.workspace.openTextDocument({
+          content: `# ${picked.label}: ${picked.description}\n\n${picked.detail}`,
+          language: "markdown",
+        }),
+      ),
+    );
+    yield* Effect.tryPromise(() =>
+      Promise.resolve(vscode.window.showTextDocument(doc, { preview: true })),
+    );
+  }).pipe(
+    Effect.catchAll((error) =>
+      Effect.tryPromise(() =>
+        Promise.resolve(
+          vscode.window.showErrorMessage(`Failed to explain rule: ${error}`),
+        ),
+      ),
+    ),
+    Effect.asVoid,
+  );

--- a/editors/code/src/common/commands.ts
+++ b/editors/code/src/common/commands.ts
@@ -4,6 +4,7 @@
 
 import * as vscode from "vscode";
 import { Effect, Schema } from "effect";
+import { errorMessage } from "./errors";
 import { runBinary } from "./process";
 import { ResolvedBinary } from "./binary";
 import { type ISettings } from "./settings";
@@ -98,7 +99,9 @@ export const explainRuleCommand = (binaryPath: string) =>
     Effect.catchAll((error) =>
       Effect.tryPromise(() =>
         Promise.resolve(
-          vscode.window.showErrorMessage(`Failed to explain rule: ${error}`),
+          vscode.window.showErrorMessage(
+            `Failed to explain rule: ${errorMessage(error)}`,
+          ),
         ),
       ),
     ),

--- a/editors/code/src/common/errors.ts
+++ b/editors/code/src/common/errors.ts
@@ -1,0 +1,16 @@
+import { Cause } from "effect";
+
+/** Unwrap Effect's default Promise error while preserving domain error messages. */
+export function errorMessage(error: unknown): string {
+  if (Cause.isUnknownException(error) && "cause" in error)
+    return errorMessage(error.cause);
+  return error instanceof Error ? error.message : String(error);
+}
+
+/** Show failure reasons in notifications without Effect's internal stack frames. */
+export function causeMessage(cause: Cause.Cause<unknown>): string {
+  const errors = [...Cause.failures(cause), ...Cause.defects(cause)];
+  return errors.length > 0
+    ? errors.map(errorMessage).join("; ")
+    : "Operation interrupted";
+}

--- a/editors/code/src/common/process.ts
+++ b/editors/code/src/common/process.ts
@@ -1,0 +1,22 @@
+import { execFile } from "child_process";
+import { promisify } from "util";
+import { Data, Effect } from "effect";
+
+const execFileAsync = promisify(execFile);
+
+export class ProcessError extends Data.TaggedError("ProcessError")<{
+  readonly binaryPath: string;
+  readonly cause: unknown;
+}> {}
+
+/** Cancellation interrupts the child process; the timeout bounds CLI probes. */
+export const runBinary = (binaryPath: string, args: string[]) =>
+  Effect.tryPromise({
+    try: (signal) =>
+      execFileAsync(binaryPath, args, {
+        encoding: "utf-8",
+        timeout: 5000,
+        signal,
+      }),
+    catch: (cause) => new ProcessError({ binaryPath, cause }),
+  });

--- a/editors/code/src/common/process.ts
+++ b/editors/code/src/common/process.ts
@@ -2,11 +2,14 @@ import { execFile } from "child_process";
 import { promisify } from "util";
 import { Data, Effect } from "effect";
 
+import { errorMessage } from "./errors";
+
 const execFileAsync = promisify(execFile);
 
 export class ProcessError extends Data.TaggedError("ProcessError")<{
   readonly binaryPath: string;
   readonly cause: unknown;
+  readonly message: string;
 }> {}
 
 /** Cancellation interrupts the child process; the timeout bounds CLI probes. */
@@ -18,5 +21,6 @@ export const runBinary = (binaryPath: string, args: string[]) =>
         timeout: 5000,
         signal,
       }),
-    catch: (cause) => new ProcessError({ binaryPath, cause }),
+    catch: (cause) =>
+      new ProcessError({ binaryPath, cause, message: errorMessage(cause) }),
   });

--- a/editors/code/src/common/server.ts
+++ b/editors/code/src/common/server.ts
@@ -1,3 +1,4 @@
+import { Effect } from "effect";
 import * as vscode from "vscode";
 import { type Disposable, type OutputChannel } from "vscode";
 import {
@@ -51,131 +52,131 @@ const disposables = new WeakMap<LanguageClient, Disposable[]>();
  * `findRyBinaryPath()` (which honors workspace trust) so the launched
  * binary is the same one that was version-gated and displayed.
  */
-export async function startServer(
+export const startServer = (
   namespace: string,
   binaryPath: string,
   outputChannel: OutputChannel,
   traceOutputChannel: OutputChannel,
-): Promise<LanguageClient | null> {
-  const initializationOptions = getInitializationOptions(namespace);
-  logger.info(
-    `Initialization options: ${JSON.stringify(initializationOptions, null, 4)}`,
-  );
+) =>
+  Effect.gen(function* () {
+    const initializationOptions = getInitializationOptions(namespace);
+    logger.info(
+      `Initialization options: ${JSON.stringify(initializationOptions, null, 4)}`,
+    );
 
-  const logLevel = vscode.workspace
-    .getConfiguration(namespace)
-    .get<string>("logLevel");
-  const serverArgs: string[] = logLevel
-    ? [RY_SERVER_SUBCOMMAND, "--log-level", logLevel]
-    : [RY_SERVER_SUBCOMMAND];
-  logger.info(
-    `ry language server command: '${[binaryPath, ...serverArgs].join(" ")}'`,
-  );
+    const logLevel = vscode.workspace
+      .getConfiguration(namespace)
+      .get<string>("logLevel");
+    const serverArgs: string[] = logLevel
+      ? [RY_SERVER_SUBCOMMAND, "--log-level", logLevel]
+      : [RY_SERVER_SUBCOMMAND];
+    logger.info(
+      `ry language server command: '${[binaryPath, ...serverArgs].join(" ")}'`,
+    );
 
-  const serverOptions = {
-    command: binaryPath,
-    args: serverArgs,
-    options: { env: process.env },
-  };
+    const serverOptions = {
+      command: binaryPath,
+      args: serverArgs,
+      options: { env: process.env },
+    };
 
-  const clientOptions: LanguageClientOptions = {
-    // Register the server for R documents (and ry.toml).
-    documentSelector: [
-      { scheme: "file", language: "r" },
-      { scheme: "untitled", language: "r" },
-      { scheme: "vscode-notebook", language: "r" },
-      { scheme: "vscode-notebook-cell", language: "r" },
-      { scheme: "file", pattern: "**/{ry.toml}" },
-    ],
-    outputChannel,
-    traceOutputChannel,
-    revealOutputChannelOn: RevealOutputChannelOn.Never,
-    initializationOptions,
-    synchronize: { configurationSection: namespace },
-    middleware: {
-      workspace: {
-        configuration: async (params, token, next) => {
-          const values = await next(params, token);
-          if (!Array.isArray(values)) return values;
-          return params.items.map((item, index) => {
-            if (item.section !== namespace) return values[index];
-            const folder = item.scopeUri
-              ? vscode.workspace.getWorkspaceFolder(
-                  vscode.Uri.parse(item.scopeUri),
-                )
-              : undefined;
-            return folder
-              ? getWorkspaceSettings(namespace, folder)
-              : getGlobalSettings(namespace);
-          });
+    const clientOptions: LanguageClientOptions = {
+      // Register the server for R documents (and ry.toml).
+      documentSelector: [
+        { scheme: "file", language: "r" },
+        { scheme: "untitled", language: "r" },
+        { scheme: "vscode-notebook", language: "r" },
+        { scheme: "vscode-notebook-cell", language: "r" },
+        { scheme: "file", pattern: "**/{ry.toml}" },
+      ],
+      outputChannel,
+      traceOutputChannel,
+      revealOutputChannelOn: RevealOutputChannelOn.Never,
+      initializationOptions,
+      synchronize: { configurationSection: namespace },
+      middleware: {
+        workspace: {
+          configuration: async (params, token, next) => {
+            const values = await next(params, token);
+            if (!Array.isArray(values)) return values;
+            return params.items.map((item, index) => {
+              if (item.section !== namespace) return values[index];
+              const folder = item.scopeUri
+                ? vscode.workspace.getWorkspaceFolder(
+                    vscode.Uri.parse(item.scopeUri),
+                  )
+                : undefined;
+              return folder
+                ? getWorkspaceSettings(namespace, folder)
+                : getGlobalSettings(namespace);
+            });
+          },
         },
       },
-    },
-  };
+    };
 
-  const newLSClient = new LanguageClient(
-    namespace,
-    `${LOG_CHANNEL_NAME} Language Server`,
-    serverOptions,
-    clientOptions,
-  );
-
-  disposables.set(newLSClient, [
-    newLSClient.onDidChangeState((e) => {
-      switch (e.newState) {
-        case State.Stopped:
-          logger.debug("Server State: Stopped");
-          break;
-        case State.Starting:
-          logger.debug("Server State: Starting");
-          break;
-        case State.Running:
-          logger.debug("Server State: Running");
-          break;
-      }
-    }),
-    // Intercept `window/showMessage` from the server and attach a
-    // "Show Logs" button, turning an opaque server error into something
-    // actionable.
-    newLSClient.onNotification(ShowMessageNotification.type, (params) => {
-      const showMessageMethod =
-        params.type === MessageType.Error
-          ? vscode.window.showErrorMessage
-          : params.type === MessageType.Warning
-            ? vscode.window.showWarningMessage
-            : vscode.window.showInformationMessage;
-      showMessageMethod(params.message, "Show Logs").then((selection) => {
-        if (selection) {
-          outputChannel.show();
-        }
-      });
-    }),
-  ]);
-
-  logger.info("Server: Start requested.");
-  try {
-    await newLSClient.start();
-  } catch (ex) {
-    logger.error(`Server: Start failed: ${ex}`);
-    await dispose(newLSClient).catch((error) =>
-      logger.error(`Server cleanup failed: ${error}`),
+    const newLSClient = new LanguageClient(
+      namespace,
+      `${LOG_CHANNEL_NAME} Language Server`,
+      serverOptions,
+      clientOptions,
     );
-    return null;
-  }
 
-  return newLSClient;
-}
+    disposables.set(newLSClient, [
+      newLSClient.onDidChangeState((e) => {
+        switch (e.newState) {
+          case State.Stopped:
+            logger.debug("Server State: Stopped");
+            break;
+          case State.Starting:
+            logger.debug("Server State: Starting");
+            break;
+          case State.Running:
+            logger.debug("Server State: Running");
+            break;
+        }
+      }),
+      // Intercept `window/showMessage` from the server and attach a
+      // "Show Logs" button, turning an opaque server error into something
+      // actionable.
+      newLSClient.onNotification(ShowMessageNotification.type, (params) => {
+        const showMessageMethod =
+          params.type === MessageType.Error
+            ? vscode.window.showErrorMessage
+            : params.type === MessageType.Warning
+              ? vscode.window.showWarningMessage
+              : vscode.window.showInformationMessage;
+        showMessageMethod(params.message, "Show Logs").then((selection) => {
+          if (selection) {
+            outputChannel.show();
+          }
+        });
+      }),
+    ]);
 
-/**
- * Stop the language server client.
- */
-export async function stopServer(lsClient: LanguageClient): Promise<void> {
-  logger.info("Server: Stop requested");
-  await dispose(lsClient);
-}
+    logger.info("Server: Start requested.");
+    yield* Effect.tryPromise(() => newLSClient.start()).pipe(
+      Effect.onError(() =>
+        dispose(newLSClient).pipe(
+          Effect.catchAll((error) =>
+            Effect.sync(() => logger.error(`Server cleanup failed: ${error}`)),
+          ),
+        ),
+      ),
+    );
+    return newLSClient;
+  });
 
-async function dispose(client: LanguageClient): Promise<void> {
-  for (const disposable of disposables.get(client) ?? []) disposable.dispose();
-  disposables.delete(client);
-  await client.dispose();
-}
+export const stopServer = (lsClient: LanguageClient) =>
+  Effect.gen(function* () {
+    logger.info("Server: Stop requested");
+    yield* dispose(lsClient);
+  });
+
+const dispose = (client: LanguageClient) =>
+  Effect.gen(function* () {
+    for (const disposable of disposables.get(client) ?? [])
+      disposable.dispose();
+    disposables.delete(client);
+    yield* Effect.tryPromise(() => client.dispose());
+  });

--- a/editors/code/src/common/server.ts
+++ b/editors/code/src/common/server.ts
@@ -1,4 +1,5 @@
-import { Effect } from "effect";
+import { Data, Effect } from "effect";
+import { errorMessage } from "./errors";
 import * as vscode from "vscode";
 import { type Disposable, type OutputChannel } from "vscode";
 import {
@@ -42,6 +43,11 @@ export function getInitializationOptions(
     globalSettings,
   };
 }
+
+class ServerError extends Data.TaggedError("ServerError")<{
+  readonly cause: unknown;
+  readonly message: string;
+}> {}
 
 const disposables = new WeakMap<LanguageClient, Disposable[]>();
 
@@ -155,11 +161,23 @@ export const startServer = (
     ]);
 
     logger.info("Server: Start requested.");
-    yield* Effect.tryPromise(() => newLSClient.start()).pipe(
+    yield* Effect.tryPromise({
+      try: () => newLSClient.start(),
+      catch: (cause) =>
+        new ServerError({
+          cause,
+          message: `Server failed to start at ${binaryPath}: ${errorMessage(cause)}`,
+        }),
+    }).pipe(
+      Effect.tapError((error) =>
+        Effect.sync(() => logger.error(error.message)),
+      ),
       Effect.onError(() =>
         dispose(newLSClient).pipe(
           Effect.catchAll((error) =>
-            Effect.sync(() => logger.error(`Server cleanup failed: ${error}`)),
+            Effect.sync(() =>
+              logger.error(`Server cleanup failed: ${errorMessage(error)}`),
+            ),
           ),
         ),
       ),
@@ -178,5 +196,9 @@ const dispose = (client: LanguageClient) =>
     for (const disposable of disposables.get(client) ?? [])
       disposable.dispose();
     disposables.delete(client);
-    yield* Effect.tryPromise(() => client.dispose());
+    yield* Effect.tryPromise({
+      try: () => client.dispose(),
+      catch: (cause) =>
+        new ServerError({ cause, message: errorMessage(cause) }),
+    });
   });

--- a/editors/code/src/extension.ts
+++ b/editors/code/src/extension.ts
@@ -1,3 +1,4 @@
+import { Effect } from "effect";
 import * as vscode from "vscode";
 import { LOG_CHANNEL_NAME, RY_SETTINGS_NAMESPACE } from "./common/constants";
 import { LazyOutputChannel, logger } from "./common/logger";
@@ -71,56 +72,66 @@ export async function activate(
     logger.error(message);
     if (serverState && resolvedBinary) statusItem?.setReady(resolvedBinary);
     else statusItem?.setError(message);
-    void vscode.window
-      .showErrorMessage(message, "Show Logs", "Configure")
-      .then((action) => {
+    void Effect.runPromise(
+      Effect.gen(function* () {
+        const action = yield* Effect.tryPromise(() =>
+          Promise.resolve(
+            vscode.window.showErrorMessage(message, "Show Logs", "Configure"),
+          ),
+        );
         if (action === "Show Logs") outputChannel.show();
-        else if (action === "Configure")
-          void vscode.commands.executeCommand(
-            "workbench.action.openSettings",
-            "ry.path",
+        else if (action === "Configure") {
+          yield* Effect.tryPromise(() =>
+            Promise.resolve(
+              vscode.commands.executeCommand(
+                "workbench.action.openSettings",
+                "ry.path",
+              ),
+            ),
           );
-      });
+        }
+      }).pipe(
+        Effect.catchAll((error) => Effect.sync(() => logger.error(error))),
+      ),
+    );
   };
-  const runServer = async () => {
-    const nextSettings = readSettings();
-    const path = findRyBinaryPath(nextSettings, !vscode.workspace.isTrusted);
-    const nextBinary = { path, version: await getRyVersion(path) };
-    const error = checkVersionCapability(
-      nextBinary,
-      MINIMUM_SETTINGS_CHANNEL_VERSION,
-      "settings channel",
-    );
-    if (error) {
-      reportFailure(error);
-      return;
-    }
-
-    statusItem?.setBusy();
-    const nextClient = await startServer(
-      serverId,
-      path,
-      outputChannel,
-      traceOutputChannel,
-    );
-    if (!nextClient) {
-      reportFailure(`Server failed to start at ${path}`);
-      return;
-    }
-
-    const previous = serverState;
-    serverState = nextClient;
-    resolvedBinary = nextBinary;
-    settings = nextSettings;
-    statusItem?.setReady(nextBinary);
-    if (previous) {
-      try {
-        await stopServer(previous);
-      } catch (error) {
-        reportFailure(`Failed to stop the previous server: ${error}`);
+  const runServer = () =>
+    Effect.gen(function* () {
+      const nextSettings = readSettings();
+      const path = findRyBinaryPath(nextSettings, !vscode.workspace.isTrusted);
+      const nextBinary = { path, version: yield* getRyVersion(path) };
+      const error = checkVersionCapability(
+        nextBinary,
+        MINIMUM_SETTINGS_CHANNEL_VERSION,
+        "settings channel",
+      );
+      if (error) {
+        reportFailure(error);
+        return;
       }
-    }
-  };
+
+      statusItem?.setBusy();
+      const nextClient = yield* startServer(
+        serverId,
+        path,
+        outputChannel,
+        traceOutputChannel,
+      );
+      const previous = serverState;
+      serverState = nextClient;
+      resolvedBinary = nextBinary;
+      settings = nextSettings;
+      statusItem?.setReady(nextBinary);
+      if (previous) {
+        yield* stopServer(previous).pipe(
+          Effect.catchAll((error) =>
+            Effect.sync(() =>
+              reportFailure(`Failed to stop the previous server: ${error}`),
+            ),
+          ),
+        );
+      }
+    });
 
   // Restart orchestration: at most one restart runs, at most one pends.
   const requestRestart = async () => {
@@ -136,22 +147,30 @@ export async function activate(
     }
 
     restartQueued = false;
-    restartPromise = (async () => {
-      try {
+    restartPromise = Effect.runPromise(
+      Effect.gen(function* () {
+        // Publish the in-flight promise before even a synchronous failure completes.
+        yield* Effect.yieldNow();
         do {
           restartQueued = false;
-          try {
-            await runServer();
-          } catch (error) {
-            reportFailure(
-              `Failed to start the ${LOG_CHANNEL_NAME} server: ${error}`,
-            );
-          }
+          yield* runServer().pipe(
+            Effect.catchAllCause((cause) =>
+              Effect.sync(() =>
+                reportFailure(
+                  `Failed to start the ${LOG_CHANNEL_NAME} server: ${cause}`,
+                ),
+              ),
+            ),
+          );
         } while (restartQueued);
-      } finally {
-        restartPromise = null;
-      }
-    })();
+      }).pipe(
+        Effect.ensuring(
+          Effect.sync(() => {
+            restartPromise = null;
+          }),
+        ),
+      ),
+    );
     await restartPromise;
   };
 
@@ -193,12 +212,14 @@ export async function activate(
     vscode.commands.registerCommand(
       `${serverId}.debugInformation`,
       async () => {
-        await debugInformationCommand(resolvedBinary ?? undefined, settings);
+        await Effect.runPromise(
+          debugInformationCommand(resolvedBinary ?? undefined, settings),
+        );
       },
     ),
     vscode.commands.registerCommand(`${serverId}.explainRule`, async () => {
       if (resolvedBinary) {
-        await explainRuleCommand(resolvedBinary.path);
+        await Effect.runPromise(explainRuleCommand(resolvedBinary.path));
       }
     }),
   );
@@ -211,16 +232,19 @@ export async function activate(
   });
 }
 
-export async function deactivate(): Promise<void> {
-  if (restartPromise != null) {
-    try {
-      await restartPromise;
-    } catch {
-      // A failed start leaves nothing to stop.
-    }
-  }
-  if (serverState != null) {
-    await stopServer(serverState);
-    serverState = null;
-  }
+export function deactivate(): Promise<void> {
+  return Effect.runPromise(
+    Effect.gen(function* () {
+      const pendingRestart = restartPromise;
+      if (pendingRestart != null) {
+        yield* Effect.tryPromise(() => pendingRestart).pipe(
+          Effect.catchAll(() => Effect.void),
+        );
+      }
+      if (serverState != null) {
+        yield* stopServer(serverState);
+        serverState = null;
+      }
+    }),
+  );
 }

--- a/editors/code/src/extension.ts
+++ b/editors/code/src/extension.ts
@@ -1,4 +1,5 @@
 import { Effect } from "effect";
+import { causeMessage, errorMessage } from "./common/errors";
 import * as vscode from "vscode";
 import { LOG_CHANNEL_NAME, RY_SETTINGS_NAMESPACE } from "./common/constants";
 import { LazyOutputChannel, logger } from "./common/logger";
@@ -126,7 +127,9 @@ export async function activate(
         yield* stopServer(previous).pipe(
           Effect.catchAll((error) =>
             Effect.sync(() =>
-              reportFailure(`Failed to stop the previous server: ${error}`),
+              reportFailure(
+                `Failed to stop the previous server: ${errorMessage(error)}`,
+              ),
             ),
           ),
         );
@@ -157,7 +160,7 @@ export async function activate(
             Effect.catchAllCause((cause) =>
               Effect.sync(() =>
                 reportFailure(
-                  `Failed to start the ${LOG_CHANNEL_NAME} server: ${cause}`,
+                  `Failed to start the ${LOG_CHANNEL_NAME} server: ${causeMessage(cause)}`,
                 ),
               ),
             ),

--- a/editors/code/src/test/binary.test.ts
+++ b/editors/code/src/test/binary.test.ts
@@ -1,3 +1,5 @@
+import { Effect, Either } from "effect";
+import { runBinary } from "../common/process";
 /**
  * Unit tests for binary resolution trust behavior.
  *
@@ -102,7 +104,7 @@ it.skipIf(process.platform === "win32")(
         { mode: 0o755 },
       );
       let resolved = false;
-      const probe = getRyVersion(binary).then((version) => {
+      const probe = Effect.runPromise(getRyVersion(binary)).then((version) => {
         resolved = true;
         return version;
       });
@@ -132,8 +134,49 @@ it.skipIf(process.platform === "win32")(
         fs.writeFileSync(binary, `#!/bin/sh\nprintf '%s\\n' '${output}'\n`, {
           mode: 0o755,
         });
-        expect(await getRyVersion(binary)).toBeUndefined();
+        expect(await Effect.runPromise(getRyVersion(binary))).toBeUndefined();
       }
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  },
+);
+
+it("returns an unknown version when the executable is missing", async () => {
+  expect(
+    await Effect.runPromise(getRyVersion("/nonexistent/ry")),
+  ).toBeUndefined();
+});
+
+it("keeps process failures in the typed error channel", async () => {
+  const result = await Effect.runPromise(
+    runBinary("/nonexistent/ry", []).pipe(Effect.either),
+  );
+  expect(Either.isLeft(result)).toBe(true);
+  if (Either.isLeft(result)) {
+    expect(result.left._tag).toBe("ProcessError");
+    expect(result.left.binaryPath).toBe("/nonexistent/ry");
+  }
+});
+
+it.skipIf(process.platform === "win32")(
+  "CLI effects are lazy and reusable",
+  async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "ry-effect-"));
+    try {
+      const binary = path.join(dir, "ry");
+      const marker = path.join(dir, "invocations");
+      fs.writeFileSync(
+        binary,
+        `#!/bin/sh\necho run >> "$0.marker"\necho '{"version":"0.9.0"}'\n`,
+        { mode: 0o755 },
+      );
+      const probe = getRyVersion(binary);
+      expect(fs.existsSync(binary + ".marker")).toBe(false);
+      await Effect.runPromise(probe);
+      await Effect.runPromise(probe);
+      fs.renameSync(binary + ".marker", marker);
+      expect(fs.readFileSync(marker, "utf8")).toBe("run\nrun\n");
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });
     }

--- a/editors/code/src/test/binary.test.ts
+++ b/editors/code/src/test/binary.test.ts
@@ -156,6 +156,8 @@ it("keeps process failures in the typed error channel", async () => {
   if (Either.isLeft(result)) {
     expect(result.left._tag).toBe("ProcessError");
     expect(result.left.binaryPath).toBe("/nonexistent/ry");
+    expect(String(result.left)).toContain("ENOENT");
+    expect(String(result.left)).toContain("/nonexistent/ry");
   }
 });
 

--- a/editors/code/src/test/errors.test.ts
+++ b/editors/code/src/test/errors.test.ts
@@ -1,0 +1,110 @@
+// Partial VS Code doubles expose only the methods these failure paths use.
+/* oxlint-disable typescript/consistent-type-assertions */
+import { describe, expect, it, mock } from "bun:test";
+import { Effect, Exit } from "effect";
+
+const logs: string[] = [];
+let startFailure: unknown;
+let stopFailure: unknown;
+let disposed = 0;
+
+mock.module("vscode", () => ({
+  workspace: { getConfiguration: () => ({ get: () => undefined }) },
+}));
+mock.module("../common/logger", () => ({
+  logger: {
+    info() {},
+    debug() {},
+    error: (message: string) => logs.push(message),
+  },
+}));
+mock.module("../common/settings", () => ({
+  getExtensionSettings: () => [],
+  getGlobalSettings: () => ({ lint: {} }),
+  getWorkspaceSettings: () => ({ lint: {} }),
+}));
+mock.module("vscode-languageclient", () => ({
+  MessageType: {},
+  ShowMessageNotification: { type: {} },
+  State: {},
+}));
+mock.module("vscode-languageclient/node", () => ({
+  RevealOutputChannelOn: { Never: 0 },
+  LanguageClient: class {
+    onDidChangeState() {
+      return { dispose() {} };
+    }
+    onNotification() {
+      return { dispose() {} };
+    }
+    start() {
+      return Promise.reject(startFailure);
+    }
+    dispose() {
+      disposed++;
+      return stopFailure ? Promise.reject(stopFailure) : Promise.resolve();
+    }
+  },
+}));
+
+const { causeMessage, errorMessage } = await import("../common/errors");
+
+const { startServer, stopServer } = await import("../common/server");
+
+describe("server failure details", () => {
+  it("preserves the start reason and binary path in the error and log", async () => {
+    logs.length = 0;
+    disposed = 0;
+    startFailure = new Error("spawn ENOENT");
+    stopFailure = undefined;
+    const result = await Effect.runPromiseExit(
+      startServer("ry", "/missing/ry", {} as never, {} as never),
+    );
+    expect(Exit.isFailure(result)).toBe(true);
+    if (Exit.isFailure(result)) {
+      expect(causeMessage(result.cause)).toContain("spawn ENOENT");
+      expect(causeMessage(result.cause)).not.toContain("core-effect");
+      expect(causeMessage(result.cause)).toContain("/missing/ry");
+    }
+    expect(logs.join("\n")).toContain("spawn ENOENT");
+    expect(disposed).toBe(1);
+  });
+
+  it("preserves a stop rejection", async () => {
+    const client = {
+      dispose: () => Promise.reject(new Error("shutdown failed")),
+    };
+    const result = await Effect.runPromiseExit(stopServer(client as never));
+    expect(Exit.isFailure(result)).toBe(true);
+    if (Exit.isFailure(result))
+      expect(causeMessage(result.cause)).toBe("shutdown failed");
+  });
+});
+
+it("unwraps Promise errors and preserves string rejections", async () => {
+  for (const reason of [
+    new Error("document unavailable"),
+    "document unavailable",
+  ]) {
+    const message = await Effect.runPromise(
+      Effect.tryPromise(() => Promise.reject(reason)).pipe(
+        Effect.catchAll((error) => Effect.succeed(errorMessage(error))),
+      ),
+    );
+    expect(message).toBe("document unavailable");
+  }
+});
+
+it("logs cleanup failure without hiding the original startup failure", async () => {
+  logs.length = 0;
+  startFailure = new Error("initialization failed");
+  stopFailure = new Error("cleanup failed");
+  const result = await Effect.runPromiseExit(
+    startServer("ry", "/broken/ry", {} as never, {} as never),
+  );
+  expect(Exit.isFailure(result)).toBe(true);
+  if (Exit.isFailure(result))
+    expect(causeMessage(result.cause)).toContain("initialization failed");
+  expect(logs.join("\n")).toContain("initialization failed");
+  expect(logs.join("\n")).toContain("cleanup failed");
+});

--- a/editors/code/tsconfig.test.json
+++ b/editors/code/tsconfig.test.json
@@ -4,9 +4,9 @@
     "types": ["node", "vscode", "mocha", "chai"]
   },
   "include": ["src/test/**/*"],
-  // binary.test.ts is a Bun unit test (`bun test src/test/binary.test.ts`).
-  // It imports `bun:test`, which resolves neither here nor in the VS Code
-  // Extension Host, so it must not be compiled into the Mocha suite that
+  // Binary and error unit tests run with Bun.
+  // They import `bun:test`, which resolves neither here nor in the VS Code
+  // Extension Host, so they must not be compiled into the Mocha suite that
   // test/installed.cjs runs from out/test/e2e.test.js.
-  "exclude": ["src/test/binary.test.ts"]
+  "exclude": ["src/test/binary.test.ts", "src/test/errors.test.ts"]
 }


### PR DESCRIPTION
The VS Code extension used separate Promise and try/catch flows for CLI probes, commands, and server startup. Move these flows to Effect, with schema validation for version and rule responses, typed process failures, and cancellation support for CLI calls.

Preserve binary resolution and workspace trust behavior, queued restarts, and cleanup after failed startup. Convert effects to Promises at the VS Code entry points. All TypeScript is in the VS Code extension; the Zed extension uses Rust.

Validation:

- Formatting, lint, TypeScript checks, and test compilation passed.
- All nine binary and process unit tests passed.
- VSIX packaging passed with Effect bundled.
- Installed-extension tests passed in trusted and untrusted workspaces using a locally built server and VS Code 1.136.1.
