### PR TITLE
refactor(cli): simplify project setup and correct release guidance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,10 +75,8 @@ jobs:
       - name: Check release.yml matches generated output
         run: dist generate --check
 
-  # Separate job: the oracle suite shells out to `Rscript`, so it needs
-  # R installed. Kept separate from `build-test` to keep the main job
-  # R-free and fast. The oracle test is `#[ignore]`'d by default, so
-  # `--ignored` is required to run it at all.
+  # Run the full oracle matrix with R and its fixture dependencies.
+  # build-test checks claim completeness without requiring R.
   oracle:
     name: Oracle (R)
     runs-on: ubuntu-latest

--- a/crates/ry-cli/Cargo.toml
+++ b/crates/ry-cli/Cargo.toml
@@ -29,12 +29,9 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
-# Only the runtime pieces needed to drive the async LSP server from a
-# synchronous `fn main()`. We do NOT pull in the full `tokio` feature
-# set here (the ry-lsp crate does that itself).
+# Runtime features for driving the LSP server from synchronous main.
 tokio = { workspace = true, features = ["rt-multi-thread", "io-std"] }
-# Parallel file parsing. tree-sitter parsers are not
-# `Send`, so the parse loop uses a rayon thread-local parser pool.
+# Parallel file parsing with a parser reused on each rayon thread.
 rayon = { workspace = true }
 sha2 = { workspace = true }
 

--- a/crates/ry-cli/src/check.rs
+++ b/crates/ry-cli/src/check.rs
@@ -29,33 +29,30 @@ pub struct CheckInput {
     /// User typeshed stubs.
     pub user_stubs: Arc<BTreeMap<String, ry_typeshed::Typeshed>>,
     /// Workspace context (package metadata, bindings).
-    pub workspace: Option<ry_workspace::WorkspaceContext>,
+    pub workspace: ry_workspace::WorkspaceContext,
 }
 
-/// Result of a unified diagnostics check.
-pub struct CheckOutput {
-    /// Per-file diagnostics: (path, Vec<Diagnostic>).
-    pub diagnostics: Vec<(String, Vec<ry_checker::Diagnostic>)>,
+impl CheckInput {
+    fn into_project(self) -> ry_checker::Project {
+        let mut project = ry_checker::Project::new();
+        let workspace = self.workspace;
+        project.set_loaded(workspace.attached_packages);
+        project.set_bare_loaded(workspace.bare_bindings);
+        project.set_user_stubs(self.user_stubs);
+        project.set_external_bindings(workspace.external_bindings);
+        project.set_imported_from(workspace.imported_bindings);
+        project.set_external_s3_methods(workspace.s3_methods);
+        project.set_load_bindings(workspace.load_bindings);
+        for (path, file) in self.files {
+            project.add_file_arc(path, file);
+        }
+        project
+    }
 }
 
 /// Run a one-shot project check with workspace metadata.
-///
-/// This is the single entry point for diagnostics computation.
-/// ry-cli calls this instead of coordinating Project setters.
-pub fn check_project(input: CheckInput) -> CheckOutput {
-    let mut project = apply_workspace(
-        ry_checker::Project::new(),
-        input.workspace.as_ref(),
-        &input.user_stubs,
-    );
-
-    for (path, file) in &input.files {
-        project.add_file_arc(path.clone(), Arc::clone(file));
-    }
-
-    let diagnostics = project.check();
-
-    CheckOutput { diagnostics }
+pub fn check_project(input: CheckInput) -> Vec<(String, Vec<ry_checker::Diagnostic>)> {
+    input.into_project().check()
 }
 
 /// Run the same one-shot check, additionally snapshotting every file's
@@ -83,14 +80,7 @@ pub(crate) fn check_project_with_facts_capture(
     input: CheckInput,
     references: bool,
 ) -> CapturedFacts {
-    let mut project = apply_workspace(
-        ry_checker::Project::new(),
-        input.workspace.as_ref(),
-        &input.user_stubs,
-    );
-    for (path, file) in &input.files {
-        project.add_file_arc(path.clone(), Arc::clone(file));
-    }
+    let mut project = input.into_project();
     project.enable_scope_capture();
     if references {
         project.enable_reference_capture();
@@ -100,26 +90,6 @@ pub(crate) fn check_project_with_facts_capture(
         scopes: project.take_scope_records(),
         references: project.take_reference_facts(),
     }
-}
-
-/// Install the workspace metadata onto a fresh project. Shared by
-/// [`check_project`] and [`check_project_with_scope_capture`] so the two
-/// entry points can never drift in what environment they model.
-fn apply_workspace(
-    mut project: ry_checker::Project,
-    workspace: Option<&ry_workspace::WorkspaceContext>,
-    user_stubs: &Arc<BTreeMap<String, ry_typeshed::Typeshed>>,
-) -> ry_checker::Project {
-    let empty_workspace = ry_workspace::WorkspaceContext::default();
-    let workspace = workspace.unwrap_or(&empty_workspace);
-    project.set_loaded(workspace.attached_packages.clone());
-    project.set_bare_loaded(workspace.bare_bindings.clone());
-    project.set_user_stubs(Arc::clone(user_stubs));
-    project.set_external_bindings(workspace.external_bindings.clone());
-    project.set_imported_from(workspace.imported_bindings.clone());
-    project.set_external_s3_methods(workspace.s3_methods.clone());
-    project.set_load_bindings(workspace.load_bindings.clone());
-    project
 }
 
 /// Drive `ry check`: merge the CLI flags with `ry.toml`, discover the
@@ -191,11 +161,7 @@ pub(crate) fn run_check(
         None => None,
     };
 
-    // Re-init tracing with the merged verbosity so a `verbose = 2` in
-    // ry.toml takes effect even when the user runs a bare `ry check`.
-    // `try_init` is idempotent (the first subscriber wins), so if main
-    // already installed one this is a no-op; that's fine because main
-    // used the CLI counts which are a superset here.
+    // Initialize after config discovery so ry.toml verbosity takes effect.
     init_tracing(cfg.verbose, cfg.quiet);
 
     let format = ry_checker::format::OutputFormat::parse(&cfg.output_format).ok_or_else(|| {
@@ -505,8 +471,7 @@ fn run_check_once(paths: &[PathBuf], ctx: &CheckContext) -> Result<CheckResult> 
 
     let mut per_file_diagnostics = Vec::new();
     for group in groups {
-        let check_output = check_project(group.check_input);
-        per_file_diagnostics.extend(check_output.diagnostics);
+        per_file_diagnostics.extend(check_project(group.check_input));
         for (path, reason) in group.degraded_scopes {
             degraded.insert(format!("{} ({})", path.display(), reason));
         }
@@ -1082,11 +1047,11 @@ mod tests {
         let input = CheckInput {
             files: vec![("test.R".to_string(), Arc::new(file))],
             user_stubs: Arc::new(BTreeMap::new()),
-            workspace: None,
+            workspace: Default::default(),
         };
         let output = check_project(input);
         // A clean file should produce no diagnostics.
-        let total: usize = output.diagnostics.iter().map(|(_, d)| d.len()).sum();
+        let total: usize = output.iter().map(|(_, d)| d.len()).sum();
         assert_eq!(total, 0, "clean file should have no diagnostics");
     }
 
@@ -1097,10 +1062,10 @@ mod tests {
         let input = CheckInput {
             files: vec![("test.R".to_string(), Arc::new(file))],
             user_stubs: Arc::new(BTreeMap::new()),
-            workspace: None,
+            workspace: Default::default(),
         };
         let output = check_project(input);
-        let total: usize = output.diagnostics.iter().map(|(_, d)| d.len()).sum();
+        let total: usize = output.iter().map(|(_, d)| d.len()).sum();
         assert!(total > 0, "undefined variable should produce diagnostics");
     }
 
@@ -1113,7 +1078,7 @@ mod tests {
         // check_project actually feeds attached_packages into the checker
         // instead of ignoring it.
         let src = "x <- NULL\nif (is_null(x)) stop(\"missing\")\nx()\n";
-        let run = |workspace: Option<ry_workspace::WorkspaceContext>| -> usize {
+        let run = |workspace: ry_workspace::WorkspaceContext| -> usize {
             let mut parser = ry_core::RParser::new().unwrap();
             let file = parser.parse("test.R", src).unwrap();
             let output = check_project(CheckInput {
@@ -1122,14 +1087,13 @@ mod tests {
                 workspace,
             });
             output
-                .diagnostics
                 .iter()
                 .flat_map(|(_, diags)| diags.iter())
                 .filter(|d| d.code == "RY070")
                 .count()
         };
 
-        let without = run(None);
+        let without = run(Default::default());
         assert!(
             without > 0,
             "without rlang the predicate cannot narrow x; RY070 must fire for x()"
@@ -1138,7 +1102,7 @@ mod tests {
         let mut with = ry_workspace::WorkspaceContext::default();
         with.attached_packages.insert("rlang".to_string());
         assert_eq!(
-            run(Some(with)),
+            run(with),
             0,
             "with rlang attached the predicate narrows x; no RY070 may survive"
         );
@@ -1155,12 +1119,11 @@ mod tests {
                 ("b.R".to_string(), Arc::new(file_b)),
             ],
             user_stubs: Arc::new(BTreeMap::new()),
-            workspace: None,
+            workspace: Default::default(),
         };
         let output = check_project(input);
         // shared_fn is defined in a.R and called in b.R — should resolve.
         let b_diags: usize = output
-            .diagnostics
             .iter()
             .find(|(p, _)| p == "b.R")
             .map(|(_, d)| d.len())
@@ -1177,7 +1140,7 @@ mod tests {
         let records = check_project_with_scope_capture(CheckInput {
             files: vec![("a.R".to_string(), Arc::new(file))],
             user_stubs: Arc::new(BTreeMap::new()),
-            workspace: None,
+            workspace: Default::default(),
         });
         assert_eq!(records.len(), 1);
         let (path, file_records) = &records[0];

--- a/crates/ry-cli/src/facts.rs
+++ b/crates/ry-cli/src/facts.rs
@@ -358,10 +358,7 @@ pub(crate) fn run_dump_facts(
     let mut exported = Vec::new();
     for group in groups {
         let input = group.check_input;
-        let workspace = input
-            .workspace
-            .as_ref()
-            .expect("resolved groups have workspace context");
+        let workspace = &input.workspace;
         let mut context_sources: Vec<_> = input
             .files
             .iter()

--- a/crates/ry-cli/src/pipeline.rs
+++ b/crates/ry-cli/src/pipeline.rs
@@ -69,11 +69,8 @@ pub(crate) enum FailureAction {
 
 /// Parse every path in parallel on rayon's pool, in input order.
 ///
-/// tree-sitter parsers are NOT `Send`, so each rayon thread keeps its
-/// own `RParser` in a `thread_local!` (the grammar is loaded once per
-/// thread; the thread pool is reused across runs). The single-parser
-/// optimization (reusing one parser across documents) is preserved
-/// within each thread.
+/// Each rayon thread reuses an `RParser` across files and runs to avoid
+/// loading the grammar for every file.
 ///
 /// Every failure is passed to `on_failure` as it happens; the callback
 /// reports it and picks the action. `Skip`ped files are dropped from
@@ -227,13 +224,12 @@ pub(crate) fn resolve_groups(
             })
             .collect();
         let degraded_scopes = std::mem::take(&mut package_scope.degraded_scopes);
-        let workspace = package_scope;
         resolved.push(ResolvedGroup {
             resolution_root,
             check_input: crate::check::CheckInput {
                 files: analysis_files,
                 user_stubs: Arc::clone(user_stubs),
-                workspace: Some(workspace),
+                workspace: package_scope,
             },
             degraded_scopes,
         });

--- a/crates/ry-core/src/parser.rs
+++ b/crates/ry-core/src/parser.rs
@@ -43,8 +43,7 @@ impl RParser {
     /// Parse with an old tree-sitter `Tree` for incremental re-parsing.
     /// The old tree must have been edited via `InputEdit`
     /// before calling this method. The AST is rebuilt from the new tree,
-    /// but tree-sitter reuses unchanged subtrees internally, making
-    /// reparse cost proportional to the edited region, not the file size.
+    /// but tree-sitter reuses unchanged subtrees internally.
     ///
     /// If `old_tree` is `None`, falls back to a full parse.
     pub fn parse_with_tree(

--- a/crates/ry-lsp/src/backend.rs
+++ b/crates/ry-lsp/src/backend.rs
@@ -64,9 +64,8 @@ pub(super) struct State {
     /// record the version here so cache freshness can be validated.
     versions: HashMap<String, i32>,
     /// path -> (version, parsed SourceFile). Populated lazily by the
-    /// request handlers, invalidated by `update_doc`. `SourceFile` is
-    /// `Send` but `RParser` is not, so the parser is constructed per
-    /// request and only the result is cached.
+    /// request handlers, invalidated by `update_doc`. Each cache miss
+    /// constructs a parser; only the result is cached.
     parsed: HashMap<String, (i32, Arc<SourceFile>)>,
     /// Hints belong to one document version and loaded stub snapshot.
     hints: HashMap<String, CachedHints>,
@@ -661,16 +660,13 @@ impl Backend {
     /// UTF-16 conversions that must match the AST's span offsets, so a
     /// concurrent `didChange` racing the parse can never yield a stale
     /// text applied to a fresher AST (or vice versa). The parse cache is
-    /// read and repopulated under the state lock; parsing itself (the
-    /// non-`Send` `RParser`) happens outside it. Returns `None` when the
-    /// path is not an open document or parsing fails.
+    /// read and repopulated under the state lock; parsing happens outside
+    /// it. Returns `None` when the path is not open or parsing fails.
     async fn parsed_file(&self, path: &str) -> Option<(Arc<SourceFile>, String)> {
         loop {
             // One guard reads the parse cache, the document text/version,
-            // and the old tree as one snapshot; only the parse itself
-            // (the non-`Send` `RParser`) happens outside the lock. The
-            // old tree is only cloned on the miss path — a cache hit must
-            // not pay for a tree copy it never hands to the parser.
+            // and the old tree as one snapshot; parsing happens outside
+            // the lock. Clone the old tree only on a cache miss.
             let (text, version, old_tree) = {
                 let state = self.state.lock().await;
                 if let (Some(text), Some(version)) =

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -9,9 +9,10 @@ Before starting any release:
 
 1. **All gates green:**
    - `cargo test --workspace`
-   - `cargo test -p ry-core`
+   - `cargo test -p ry-checker --test oracle --test semantic_lists -- --include-ignored`
+   - `cargo clippy --workspace --all-targets -- -D warnings`
+   - `cargo fmt --all -- --check`
    - `cargo +nightly fuzz run parse -- -max_total_time=300 -max_len=4096`
-   - `cargo test -p ry-lsp --test protocol_contract`
    - `cargo test -p ry-lsp --test session_state_machine -- --ignored`
    - `ecosystem/run.sh --check --manifest ecosystem/posit-packages.txt --ledger docs/corpus/posit-0.9.0.json --tier fast`
    - `ecosystem/test-drift-detection.sh`


### PR DESCRIPTION
The CLI check and dump paths duplicated project construction, cloned metadata they already owned, and represented resolved workspace context as optional. Consume each input through one constructor, return diagnostics directly, and require workspace context. This removes the `CheckOutput` wrapper, the empty-workspace fallback, and a matching `dump-facts` assertion while preserving output and analysis behavior.

Correct comments that claimed the parser was not `Send` and that incremental parsing cost depended only on the edited region. Update the release runbook to include the full R oracle, Clippy, and formatting checks, and remove two test commands already covered by the workspace suite. Net change: 53 fewer lines.

Validation:

- `cargo test --workspace`: 1,370 passed, 10 ignored.
- `cargo test -p ry-checker --test oracle --test semantic_lists -- --include-ignored`: 43 passed.
- `cargo clippy --workspace --all-targets -- -D warnings`: passed.
- `cargo fmt --all -- --check` and `git diff --check`: passed.

The 500-package corpus and editor packaging were not rerun. Review also identified the classed-length false positive tracked in #326; that remains a pre-release follow-up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Workspace checks now use consistent workspace context handling and provide diagnostics in a simpler, more direct format.
  - Resolved workspace inputs no longer trigger an avoidable failure when gathering facts.

- **Documentation**
  - Updated parsing, caching, and workflow descriptions for greater clarity.
  - Refreshed the release checklist with current testing, linting, formatting, and validation commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->