### PR TITLE
chore(editors): publish as scholzmx.ry

### DIFF
--- a/.github/workflows/build-vscode.yml
+++ b/.github/workflows/build-vscode.yml
@@ -134,9 +134,15 @@ jobs:
           # Extract from README marketplace link
           readme_id=$(grep -oP 'itemName=\K[^")\s]+' README.md | head -1)
 
+          # Extract the getExtension() lookup from both test suites
+          e2e_id=$(grep -oP 'getExtension\("\K[^"]+' editors/code/src/test/e2e.test.ts)
+          perf_id=$(grep -oP 'getExtension\("\K[^"]+' editors/code/test/performance.cjs)
+
           echo "package.json: ${ext_id}"
           echo "constants.ts: ${ts_id}"
           echo "README.md:    ${readme_id}"
+          echo "e2e.test.ts:  ${e2e_id}"
+          echo "performance:  ${perf_id}"
 
           if [[ "${ext_id}" != "${ts_id}" ]]; then
             echo "ERROR: package.json (${ext_id}) != constants.ts (${ts_id})"
@@ -144,6 +150,14 @@ jobs:
           fi
           if [[ "${ext_id}" != "${readme_id}" ]]; then
             echo "ERROR: package.json (${ext_id}) != README.md (${readme_id})"
+            exit 1
+          fi
+          if [[ "${ext_id}" != "${e2e_id}" ]]; then
+            echo "ERROR: package.json (${ext_id}) != e2e.test.ts (${e2e_id})"
+            exit 1
+          fi
+          if [[ "${ext_id}" != "${perf_id}" ]]; then
+            echo "ERROR: package.json (${ext_id}) != performance.cjs (${perf_id})"
             exit 1
           fi
           echo "All publisher identities agree: ${ext_id}"

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ missing signatures can produce false positives or missed bugs. See
 ## Editors
 
 Install **ry** from the
-[VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=sims1253.ry)
+[VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=scholzmx.ry)
 or Positron's Open VSX gallery. The extension bundles the checker and provides
 diagnostics, inferred type hints, and suppression actions.
 

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -94,7 +94,8 @@ v{version}  (e.g. v0.9.0)
 ### Prerequisites
 
 - Publisher identity verified: `scholzmx.ry` across `package.json`,
-  `constants.ts`, and `README.md`.
+  `constants.ts`, `README.md`, and both test-suite `getExtension` lookups
+  (enforced by the `publisher-consistency` job).
 - Core binary release tag exists with verified artifacts.
 
 ### Steps

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -93,7 +93,7 @@ v{version}  (e.g. v0.9.0)
 
 ### Prerequisites
 
-- Publisher identity verified: `sims1253.ry` across `package.json`,
+- Publisher identity verified: `scholzmx.ry` across `package.json`,
   `constants.ts`, and `README.md`.
 - Core binary release tag exists with verified artifacts.
 
@@ -121,8 +121,8 @@ v{version}  (e.g. v0.9.0)
 
 ### Rollback
 
-- VS Code Marketplace: `vsce unpublish sims1253.ry@{version}`
-- Open VSX: `ovsx unpublish sims1253.ry@{version}`
+- VS Code Marketplace: `vsce unpublish scholzmx.ry@{version}`
+- Open VSX: `ovsx unpublish scholzmx.ry@{version}`
 
 ## Zed extension release
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -145,7 +145,7 @@ and suppression actions in VS Code, Positron, or Zed.
 
 ### VS Code / Positron
 
-Install the **ry** extension from the [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=sims1253.ry)
+Install the **ry** extension from the [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=scholzmx.ry)
 or Open VSX (for Positron). The extension bundles the `ry` binary.
 
 See the [extension guide](../editors/code/README.md) for settings, commands,

--- a/editors/code/README.md
+++ b/editors/code/README.md
@@ -9,7 +9,7 @@ functions. Unknown types and assignments the checker does not visit are omitted.
 ## Installation
 
 Install from the
-[VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=sims1253.ry)
+[VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=scholzmx.ry)
 or Positron's Open VSX gallery, then open an R file.
 
 The extension bundles ry. By default it uses an executable on `PATH` when

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -3,7 +3,7 @@
   "displayName": "ry",
   "description": "Static type checker for R.",
   "version": "0.9.0",
-  "publisher": "sims1253",
+  "publisher": "scholzmx",
   "license": "MIT",
   "homepage": "https://github.com/sims1253/ry",
   "repository": {

--- a/editors/code/src/common/constants.ts
+++ b/editors/code/src/common/constants.ts
@@ -11,7 +11,7 @@ export const EXTENSION_ROOT_DIR =
 /**
  * Extension ID on the marketplaces (`<publisher>.<name>`).
  */
-export const RY_EXTENSION_ID = "sims1253.ry";
+export const RY_EXTENSION_ID = "scholzmx.ry";
 
 /**
  * The VS Code settings namespace (`ry.*`).

--- a/editors/code/src/test/e2e.test.ts
+++ b/editors/code/src/test/e2e.test.ts
@@ -23,7 +23,7 @@ describe("Installed ry extension", () => {
     this.timeout(60000);
     const trusted = process.env.RY_TEST_TRUSTED === "true";
     expect(vscode.workspace.isTrusted).to.equal(trusted);
-    const extension = vscode.extensions.getExtension("sims1253.ry")!;
+    const extension = vscode.extensions.getExtension("scholzmx.ry")!;
     expect(extension.extensionPath).to.include(
       `${path.sep}extensions${path.sep}`,
     );

--- a/editors/code/test/performance.cjs
+++ b/editors/code/test/performance.cjs
@@ -7,7 +7,7 @@ const { performance } = require("node:perf_hooks");
 // Invoked inside a fresh extension host by @vscode/test-electron.
 exports.run = async () => {
   const vscode = require("vscode");
-  const extension = vscode.extensions.getExtension("sims1253.ry");
+  const extension = vscode.extensions.getExtension("scholzmx.ry");
   assert.ok(extension, "ry extension is available");
   assert.equal(extension.isActive, false, "ry must not activate before timing");
   assert.equal(vscode.workspace.isTrusted, true);


### PR DESCRIPTION
## Summary

Switch the VS Code extension's marketplace identity from `sims1253` to
`scholzmx`, ahead of the first publish.

- `editors/code/package.json` — `publisher: "scholzmx"`
- `editors/code/src/common/constants.ts` — `RY_EXTENSION_ID`
- `editors/code/src/test/e2e.test.ts` — `getExtension` lookup
- `editors/code/test/performance.cjs` — `getExtension` lookup (missed in
  the first sweep, caught in review)
- `README.md`, `editors/code/README.md`, `docs/usage.md` — marketplace links
- `docs/release-runbook.md` — identity note and rollback commands
- `.github/workflows/build-vscode.yml` — `publisher-consistency` job now
  also checks the `getExtension` lookups in both test suites (it previously
  covered only `package.json`, `constants.ts`, and `README.md`, which is
  how the performance.cjs miss escaped)

Not changed: `github.com/sims1253/ry` repo URLs (repo stays under that
account), and the historical CHANGELOG entry recording the old identity.

## Why

The `scholzmx` publisher was created on the VS Code Marketplace and the
`VSCE_PAT`/`OVSX_PAT` secrets are set. The publisher ID must be finalized
**before** the first publish — it is part of the extension ID, so changing
it after publishing would mean a new listing with no user migration.

## Verification

- Publisher-consistency check (same logic as the `publisher-consistency`
  CI job): `package.json`, `constants.ts`, `README.md`, `e2e.test.ts`, and
  `test/performance.cjs` all agree on `scholzmx.ry`.
- Repo-wide sweep for `sims1253.ry` with no file-type filters: no live
  references remain.
- `tsc --noEmit` passes.

## Release note

Merge before dispatching `release-vscode.yml`; the workflow packages the
VSIX from the dispatched ref. The Open VSX namespace is created separately:
`npx ovsx create-namespace scholzmx -p <token>`.