### PR TITLE
Fix apply-family simplification and empty-input results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -171,6 +171,11 @@ All notable changes to ry are documented in this file.
 
 ### Fixed
 
+- Avoid claiming atomic `sapply()` and `mapply()` results when simplification
+  is disabled or uncertain, or when their inputs may be empty. Scalar
+  simplification requires a matched, enabled control and a provably nonempty
+  input.
+
 - Distinguish `@` slot extraction from `$`. Valid atomic `.Data` reads no
   longer trigger dollar-access errors. Keep slot results and replaced roots
   unknown, including mixed nested replacements; respect explicit accessors.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -171,10 +171,10 @@ All notable changes to ry are documented in this file.
 
 ### Fixed
 
-- Avoid claiming atomic `sapply()` and `mapply()` results when simplification
-  is disabled or uncertain, or when their inputs may be empty. Scalar
-  simplification requires a matched, enabled control and a provably nonempty
-  input.
+- Avoid claiming atomic `sapply()`, `mapply()`, and `tapply()` results when
+  simplification is disabled or uncertain, controls are forwarded through
+  `...`, or inputs may be empty. Scalar simplification requires a matched,
+  enabled control and a provably nonempty input.
 
 - Distinguish `@` slot extraction from `$`. Valid atomic `.Data` reads no
   longer trigger dollar-access errors. Keep slot results and replaced roots

--- a/crates/ry-checker/src/higher_order.rs
+++ b/crates/ry-checker/src/higher_order.rs
@@ -21,6 +21,53 @@ fn argument_bound_to_formal<'a>(
         .and_then(|index| args.get(index))
 }
 
+fn simplify_control(
+    base_identity: bool,
+    params: &[ParamSpec],
+    args: &[Arg],
+    argument_match: &ArgumentMatch,
+) -> Option<bool> {
+    if !base_identity {
+        return Some(true);
+    }
+    let control = params
+        .iter()
+        .position(|param| matches!(param.name.as_str(), "simplify" | "SIMPLIFY"));
+    let Some(control) = control else {
+        return Some(true);
+    };
+    let Some(argument) = argument_bound_to_formal(args, argument_match, control) else {
+        return Some(true);
+    };
+    match &argument.value {
+        Expr::Logical(value, _) => Some(*value),
+        _ => None,
+    }
+}
+
+fn definitely_nonempty(length: Length) -> bool {
+    matches!(length, Length::One) || matches!(length, Length::Known(n) if n > 0)
+}
+
+fn result_may_be_empty(
+    spec: &HigherOrderSpec,
+    arg_types: &[RType],
+    argument_match: &ArgumentMatch,
+    inputs: &[RType],
+) -> bool {
+    if spec.callback_args == [CallbackArg::ElementsAfterCallback] {
+        return inputs.is_empty()
+            || inputs
+                .iter()
+                .any(|input| !definitely_nonempty(input.length));
+    }
+    let Some(length_arg) = spec.result.length_arg else {
+        return false;
+    };
+    !matched_argument_type(arg_types, argument_match, length_arg)
+        .is_some_and(|input| definitely_nonempty(input.length))
+}
+
 /// With a `...` formal, every unmatched actual is part of dots (one
 /// ordinary R argument match drives callback, source, length, and
 /// template lookup throughout the higher-order path).
@@ -54,6 +101,12 @@ impl Checker {
         span: Span,
     ) -> Option<RType> {
         let spec = signature.higher_order.as_ref()?;
+        // The simplification controls have this meaning only for the base
+        // sapply/mapply contracts. Resolve the callee before callback
+        // traversal, which can extend the lexical scope with callback data.
+        let base_simplification = !self.user_stubs.contains_key("base")
+            && matches!(crate::semantic_lists::bare_name(name), "sapply" | "mapply")
+            && self.resolves_to_base(name, scope);
         self.walk_callback_for_diagnostics(signature, args, arg_types, scope);
         // A fold's initializer describes only the first invocation. Later
         // accumulators are callback results, and zero iterations return the
@@ -66,6 +119,12 @@ impl Checker {
             return Some(RType::unknown());
         }
         let argument_match = match_params(&signature.params, args);
+        let simplify = simplify_control(
+            base_simplification,
+            &signature.params,
+            args,
+            &argument_match,
+        );
         let declared_length = match &signature.return_ {
             ReturnSpec::Concrete(ty) => json_length_to_length(JsonLength::parse(&ty.length)),
             ReturnSpec::Slot(_) => Length::Unknown,
@@ -79,6 +138,7 @@ impl Checker {
             &argument_match,
             scope,
             span,
+            simplify,
         ))
     }
 
@@ -98,6 +158,7 @@ impl Checker {
         argument_match: &ArgumentMatch,
         scope: &Scope,
         span: Span,
+        simplify: Option<bool>,
     ) -> RType {
         let inputs = self.higher_order_input_types(spec, arg_types, argument_match);
         let callback_runs = !inputs.is_empty()
@@ -199,6 +260,16 @@ impl Checker {
             HigherOrderResultKind::Simplify => {
                 if spec.callback_args == [CallbackArg::Unknown] {
                     return Self::ho_rapply(args, arg_types, argument_match);
+                }
+                if simplify != Some(true) {
+                    return if simplify == Some(false) {
+                        RType::new(Mode::List, Length::Unknown)
+                    } else {
+                        RType::unknown()
+                    };
+                }
+                if result_may_be_empty(spec, arg_types, argument_match, &inputs) {
+                    return RType::unknown();
                 }
                 match callback_return {
                     Some(ty)

--- a/crates/ry-checker/src/higher_order.rs
+++ b/crates/ry-checker/src/higher_order.rs
@@ -22,13 +22,17 @@ fn argument_bound_to_formal<'a>(
 }
 
 fn simplify_control(
-    base_identity: bool,
+    base_identity: Option<bool>,
     params: &[ParamSpec],
     args: &[Arg],
     argument_match: &ArgumentMatch,
 ) -> Option<bool> {
-    if !base_identity {
-        return Some(true);
+    match base_identity {
+        Some(true) => {}
+        Some(false) => return Some(true),
+        // An unresolved bare name may be supplied by an attached package;
+        // its control must not be treated as the base contract by default.
+        None => return None,
     }
     let control = params
         .iter()
@@ -104,9 +108,16 @@ impl Checker {
         // The simplification controls have this meaning only for the base
         // sapply/mapply contracts. Resolve the callee before callback
         // traversal, which can extend the lexical scope with callback data.
-        let base_simplification = !self.user_stubs.contains_key("base")
-            && matches!(crate::semantic_lists::bare_name(name), "sapply" | "mapply")
-            && self.resolves_to_base(name, scope);
+        let base_simplification =
+            if !matches!(crate::semantic_lists::bare_name(name), "sapply" | "mapply") {
+                Some(false)
+            } else if !self.user_stubs.contains_key("base") && self.resolves_to_base(name, scope) {
+                Some(true)
+            } else if name.contains("::") || self.user_stubs.contains_key("base") {
+                Some(false)
+            } else {
+                None
+            };
         self.walk_callback_for_diagnostics(signature, args, arg_types, scope);
         // A fold's initializer describes only the first invocation. Later
         // accumulators are callback results, and zero iterations return the

--- a/crates/ry-checker/src/higher_order.rs
+++ b/crates/ry-checker/src/higher_order.rs
@@ -29,10 +29,7 @@ fn simplify_control(
     argument_match: &ArgumentMatch,
 ) -> Option<bool> {
     match base_identity {
-        Some(true) if !forwarded_dots => {}
-        // Forwarded dots can supply an omitted simplify control, so the
-        // default cannot establish the base function's enabled contract.
-        Some(true) => return None,
+        Some(true) => {}
         Some(false) => return Some(true),
         // An unresolved bare name may be supplied by an attached package;
         // its control must not be treated as the base contract by default.
@@ -45,6 +42,11 @@ fn simplify_control(
         return Some(true);
     };
     let Some(argument) = argument_bound_to_formal(args, argument_match, control) else {
+        // Forwarded dots can supply an omitted simplify control, so the
+        // default cannot establish the base function's enabled contract.
+        if forwarded_dots {
+            return None;
+        }
         return Some(true);
     };
     match &argument.value {

--- a/crates/ry-checker/src/higher_order.rs
+++ b/crates/ry-checker/src/higher_order.rs
@@ -23,12 +23,16 @@ fn argument_bound_to_formal<'a>(
 
 fn simplify_control(
     base_identity: Option<bool>,
+    forwarded_dots: bool,
     params: &[ParamSpec],
     args: &[Arg],
     argument_match: &ArgumentMatch,
 ) -> Option<bool> {
     match base_identity {
-        Some(true) => {}
+        Some(true) if !forwarded_dots => {}
+        // Forwarded dots can supply an omitted simplify control, so the
+        // default cannot establish the base function's enabled contract.
+        Some(true) => return None,
         Some(false) => return Some(true),
         // An unresolved bare name may be supplied by an attached package;
         // its control must not be treated as the base contract by default.
@@ -106,18 +110,21 @@ impl Checker {
     ) -> Option<RType> {
         let spec = signature.higher_order.as_ref()?;
         // The simplification controls have this meaning only for the base
-        // sapply/mapply contracts. Resolve the callee before callback
+        // apply contracts. Resolve the callee before callback
         // traversal, which can extend the lexical scope with callback data.
-        let base_simplification =
-            if !matches!(crate::semantic_lists::bare_name(name), "sapply" | "mapply") {
-                Some(false)
-            } else if !self.user_stubs.contains_key("base") && self.resolves_to_base(name, scope) {
-                Some(true)
-            } else if name.contains("::") || self.user_stubs.contains_key("base") {
-                Some(false)
-            } else {
-                None
-            };
+        let base_simplification = if !matches!(
+            crate::semantic_lists::bare_name(name),
+            "sapply" | "mapply" | "tapply"
+        ) {
+            Some(false)
+        } else if !self.user_stubs.contains_key("base") && self.resolves_to_base(name, scope) {
+            Some(true)
+        } else if name.contains("::") || self.user_stubs.contains_key("base") {
+            Some(false)
+        } else {
+            None
+        };
+        let forwarded_dots = args.iter().any(|argument| self.is_forwarded_dots(argument));
         self.walk_callback_for_diagnostics(signature, args, arg_types, scope);
         // A fold's initializer describes only the first invocation. Later
         // accumulators are callback results, and zero iterations return the
@@ -132,6 +139,7 @@ impl Checker {
         let argument_match = match_params(&signature.params, args);
         let simplify = simplify_control(
             base_simplification,
+            forwarded_dots,
             &signature.params,
             args,
             &argument_match,

--- a/crates/ry-checker/src/infer/args.rs
+++ b/crates/ry-checker/src/infer/args.rs
@@ -180,7 +180,7 @@ pub(crate) fn match_args_to_params(
 }
 
 impl Checker {
-    fn is_forwarded_dots(&self, argument: &Arg) -> bool {
+    pub(crate) fn is_forwarded_dots(&self, argument: &Arg) -> bool {
         let Expr::Ident { name, span } = &argument.value else {
             return false;
         };

--- a/crates/ry-checker/src/tests/typed_maps.rs
+++ b/crates/ry-checker/src/tests/typed_maps.rs
@@ -7,6 +7,7 @@ fn simplify_false_keeps_sapply_and_mapply_results_as_lists() {
         "a <- sapply(simplify = FALSE, FUN = function(v) 1L, X = 1L); a$field",
         "b <- mapply(SIMPLIFY = FALSE, FUN = function(x) 1L, x = 1L); b$field",
         "b <- mapply(FUN = function(x) 1L, x = 1L, SIMPLIFY = FALSE); b$field",
+        "c <- tapply(1L, 1L, function(v) 1L, simplify = FALSE); c$field",
     ] {
         let diagnostics = check(source);
         assert!(
@@ -22,6 +23,7 @@ fn unknown_simplify_controls_do_not_prove_atomic_results() {
         "control <- identity(FALSE); a <- sapply(1L, function(v) 1L, simplify = control); a$field",
         "control <- identity(FALSE); b <- mapply(FUN = function(x) 1L, x = 1L, SIMPLIFY = control); b$field",
         "library(dplyr); c <- sapply(1L, function(v) 1L, simplify = FALSE); c$field",
+        "wrapper <- function(...) sapply(1L, function(v) 1L, ...); wrapper(simplify = FALSE)$field",
     ] {
         let diagnostics = check(source);
         assert!(
@@ -94,6 +96,7 @@ fn known_nonempty_scalar_simplification_still_reports_atomic_dollar() {
     for source in [
         "a <- sapply(1L, function(v) 1L, simplify = TRUE); a$field",
         "b <- mapply(FUN = function(x) 1L, x = 1L, SIMPLIFY = TRUE); b$field",
+        "c <- tapply(1L, 1L, function(v) 1L, simplify = TRUE); c$field",
     ] {
         let diagnostics = check(source);
         assert!(

--- a/crates/ry-checker/src/tests/typed_maps.rs
+++ b/crates/ry-checker/src/tests/typed_maps.rs
@@ -21,6 +21,7 @@ fn unknown_simplify_controls_do_not_prove_atomic_results() {
     for source in [
         "control <- identity(FALSE); a <- sapply(1L, function(v) 1L, simplify = control); a$field",
         "control <- identity(FALSE); b <- mapply(FUN = function(x) 1L, x = 1L, SIMPLIFY = control); b$field",
+        "library(dplyr); c <- sapply(1L, function(v) 1L, simplify = FALSE); c$field",
     ] {
         let diagnostics = check(source);
         assert!(

--- a/crates/ry-checker/src/tests/typed_maps.rs
+++ b/crates/ry-checker/src/tests/typed_maps.rs
@@ -8,6 +8,7 @@ fn simplify_false_keeps_sapply_and_mapply_results_as_lists() {
         "b <- mapply(SIMPLIFY = FALSE, FUN = function(x) 1L, x = 1L); b$field",
         "b <- mapply(FUN = function(x) 1L, x = 1L, SIMPLIFY = FALSE); b$field",
         "c <- tapply(1L, 1L, function(v) 1L, simplify = FALSE); c$field",
+        "wrapper <- function(...) sapply(1L, function(v) 1L, simplify = FALSE, ...); wrapper(USE.NAMES = FALSE)$field",
     ] {
         let diagnostics = check(source);
         assert!(
@@ -97,6 +98,7 @@ fn known_nonempty_scalar_simplification_still_reports_atomic_dollar() {
         "a <- sapply(1L, function(v) 1L, simplify = TRUE); a$field",
         "b <- mapply(FUN = function(x) 1L, x = 1L, SIMPLIFY = TRUE); b$field",
         "c <- tapply(1L, 1L, function(v) 1L, simplify = TRUE); c$field",
+        "wrapper <- function(...) sapply(1L, function(v) 1L, simplify = TRUE, ...); wrapper(USE.NAMES = FALSE)$field",
     ] {
         let diagnostics = check(source);
         assert!(

--- a/crates/ry-checker/src/tests/typed_maps.rs
+++ b/crates/ry-checker/src/tests/typed_maps.rs
@@ -1,6 +1,122 @@
 use super::*;
 
 #[test]
+fn simplify_false_keeps_sapply_and_mapply_results_as_lists() {
+    for source in [
+        "a <- sapply(1L, function(v) 1L, simplify = FALSE); a$field",
+        "a <- sapply(simplify = FALSE, FUN = function(v) 1L, X = 1L); a$field",
+        "b <- mapply(SIMPLIFY = FALSE, FUN = function(x) 1L, x = 1L); b$field",
+        "b <- mapply(FUN = function(x) 1L, x = 1L, SIMPLIFY = FALSE); b$field",
+    ] {
+        let diagnostics = check(source);
+        assert!(
+            diagnostics.iter().all(|d| d.code != "RY061"),
+            "{source}: {diagnostics:?}"
+        );
+    }
+}
+
+#[test]
+fn unknown_simplify_controls_do_not_prove_atomic_results() {
+    for source in [
+        "control <- identity(FALSE); a <- sapply(1L, function(v) 1L, simplify = control); a$field",
+        "control <- identity(FALSE); b <- mapply(FUN = function(x) 1L, x = 1L, SIMPLIFY = control); b$field",
+    ] {
+        let diagnostics = check(source);
+        assert!(
+            diagnostics.iter().all(|d| d.code != "RY061"),
+            "{source}: {diagnostics:?}"
+        );
+    }
+}
+
+#[test]
+fn non_base_simplify_signatures_keep_their_existing_contract() {
+    let stub = r#"{
+        "schema_version": "2",
+        "package": "custom",
+        "version": "test",
+        "functions": {
+            "sapply": {
+                "params": [
+                    {"name": "X", "required": true},
+                    {"name": "FUN", "required": true},
+                    {"name": "simplify", "default": true}
+                ],
+                "higher_order": {
+                    "callback_param": "FUN",
+                    "callback_position": 1,
+                    "callback_args": ["element_of_arg0"],
+                    "result": {"kind": "simplify", "length_arg": 0}
+                },
+                "return": {"mode": "opaque", "length": "unknown"}
+            }
+        }
+    }"#;
+    let base_stub = stub.replace("\"package\": \"custom\"", "\"package\": \"base\"");
+    for (source, file, contents) in [
+        (
+            "a <- custom::sapply(1L, function(v) 1L, simplify = FALSE); a$field",
+            "custom.json",
+            stub,
+        ),
+        (
+            "a <- sapply(1L, function(v) 1L, simplify = FALSE); a$field",
+            "base.json",
+            base_stub.as_str(),
+        ),
+    ] {
+        let diagnostics = check_with_stubs(source, &[(file, contents)]).0;
+        assert!(
+            diagnostics.iter().any(|d| d.code == "RY061"),
+            "{source}: {diagnostics:?}"
+        );
+    }
+}
+
+#[test]
+fn unknown_higher_order_input_length_does_not_prove_simplification() {
+    for source in [
+        "x <- integer(1L - 1L); a <- sapply(x, function(v) 1L, USE.NAMES = FALSE); a$field",
+        "x <- integer(1L - 1L); b <- mapply(function(v) 1L, x, USE.NAMES = FALSE); b$field",
+    ] {
+        let diagnostics = check(source);
+        assert!(
+            diagnostics.iter().all(|d| d.code != "RY061"),
+            "{source}: {diagnostics:?}"
+        );
+    }
+}
+
+#[test]
+fn known_nonempty_scalar_simplification_still_reports_atomic_dollar() {
+    for source in [
+        "a <- sapply(1L, function(v) 1L, simplify = TRUE); a$field",
+        "b <- mapply(FUN = function(x) 1L, x = 1L, SIMPLIFY = TRUE); b$field",
+    ] {
+        let diagnostics = check(source);
+        assert!(
+            diagnostics.iter().any(|d| d.code == "RY061"),
+            "{source}: {diagnostics:?}"
+        );
+    }
+}
+
+#[test]
+fn simplify_false_does_not_skip_callback_diagnostics() {
+    for source in [
+        "sapply(1L, function(v) v + 'bad', simplify = FALSE)",
+        "mapply(function(x) x + 'bad', x = 1L, SIMPLIFY = FALSE)",
+    ] {
+        let diagnostics = check(source);
+        assert!(
+            diagnostics.iter().any(|d| d.code == "RY040"),
+            "{source}: {diagnostics:?}"
+        );
+    }
+}
+
+#[test]
 fn regmatches_callbacks_do_not_assume_scalar_elements() {
     for source in [
         "x <- c('ab','z'); matches <- regmatches(x,regexec('(a)(b)',x)); Filter(function(z) length(z)>0L,matches)",

--- a/crates/ry-checker/testdata/oracle/sapply_mapply_empty_input.R
+++ b/crates/ry-checker/testdata/oracle/sapply_mapply_empty_input.R
@@ -1,0 +1,10 @@
+# oracle: must-pass
+# An input with unknown static length can be empty, so both higher-order calls
+# return an empty list in this witness rather than a definite atomic vector.
+x <- integer(1L - 1L)
+a <- sapply(x, function(v) 1L, USE.NAMES = FALSE)
+b <- mapply(function(v) 1L, x, USE.NAMES = FALSE)
+stopifnot(
+  is.list(a), is.list(b), length(a) == 0L, length(b) == 0L,
+  identical(a$field, NULL), identical(b$field, NULL)
+)

--- a/crates/ry-checker/testdata/oracle/sapply_mapply_simplify_controls.R
+++ b/crates/ry-checker/testdata/oracle/sapply_mapply_simplify_controls.R
@@ -1,0 +1,16 @@
+# oracle: must-pass
+# Explicit simplification controls retain list results in R, including when
+# the actuals are named and reordered. A nonliteral control is also not a
+# static proof that the result is atomic.
+a <- sapply(1L, function(v) 1L, simplify = FALSE)
+b <- sapply(simplify = FALSE, FUN = function(v) 1L, X = 1L)
+c <- mapply(SIMPLIFY = FALSE, FUN = function(x) 1L, x = 1L)
+d <- mapply(FUN = function(x) 1L, x = 1L, SIMPLIFY = FALSE)
+control <- identity(FALSE)
+e <- sapply(1L, function(v) 1L, simplify = control)
+stopifnot(
+  is.list(a), is.list(b), is.list(c), is.list(d), is.list(e),
+  identical(a$field, NULL), identical(b$field, NULL),
+  identical(c$field, NULL), identical(d$field, NULL),
+  identical(e$field, NULL)
+)

--- a/crates/ry-checker/testdata/oracle/sapply_mapply_simplify_controls.R
+++ b/crates/ry-checker/testdata/oracle/sapply_mapply_simplify_controls.R
@@ -11,11 +11,15 @@ e <- sapply(1L, function(v) 1L, simplify = control)
 f <- tapply(1L, 1L, function(v) 1L, simplify = FALSE)
 wrapper <- function(...) sapply(1L, function(v) 1L, ...)
 g <- wrapper(simplify = FALSE)
+wrapper_true <- function(...) sapply(1L, function(v) 1L, simplify = TRUE, ...)
+h <- wrapper_true(USE.NAMES = FALSE)
+wrapper_false <- function(...) sapply(1L, function(v) 1L, simplify = FALSE, ...)
+i <- wrapper_false(USE.NAMES = FALSE)
 stopifnot(
   is.list(a), is.list(b), is.list(c), is.list(d), is.list(e), is.list(f),
-  is.list(g),
+  is.list(g), is.atomic(h), is.list(i),
   identical(a$field, NULL), identical(b$field, NULL),
   identical(c$field, NULL), identical(d$field, NULL),
   identical(e$field, NULL), identical(f$field, NULL),
-  identical(g$field, NULL)
+  identical(g$field, NULL), identical(i$field, NULL)
 )

--- a/crates/ry-checker/testdata/oracle/sapply_mapply_simplify_controls.R
+++ b/crates/ry-checker/testdata/oracle/sapply_mapply_simplify_controls.R
@@ -1,16 +1,21 @@
 # oracle: must-pass
 # Explicit simplification controls retain list results in R, including when
-# the actuals are named and reordered. A nonliteral control is also not a
-# static proof that the result is atomic.
+# the actuals are named and reordered. A nonliteral or forwarded control is
+# also not a static proof that the result is atomic.
 a <- sapply(1L, function(v) 1L, simplify = FALSE)
 b <- sapply(simplify = FALSE, FUN = function(v) 1L, X = 1L)
 c <- mapply(SIMPLIFY = FALSE, FUN = function(x) 1L, x = 1L)
 d <- mapply(FUN = function(x) 1L, x = 1L, SIMPLIFY = FALSE)
 control <- identity(FALSE)
 e <- sapply(1L, function(v) 1L, simplify = control)
+f <- tapply(1L, 1L, function(v) 1L, simplify = FALSE)
+wrapper <- function(...) sapply(1L, function(v) 1L, ...)
+g <- wrapper(simplify = FALSE)
 stopifnot(
-  is.list(a), is.list(b), is.list(c), is.list(d), is.list(e),
+  is.list(a), is.list(b), is.list(c), is.list(d), is.list(e), is.list(f),
+  is.list(g),
   identical(a$field, NULL), identical(b$field, NULL),
   identical(c$field, NULL), identical(d$field, NULL),
-  identical(e$field, NULL)
+  identical(e$field, NULL), identical(f$field, NULL),
+  identical(g$field, NULL)
 )


### PR DESCRIPTION
Valid list results from `sapply`, `mapply`, and `tapply` could be inferred as atomic, causing false RY061 errors on `$` access. Respect matched simplification controls for proven base calls, including uncertainty from forwarded `...` and attached packages, and stop claiming atomic output when inputs may be empty. Custom stub contracts and callback diagnostics are preserved.

Regression tests and two R oracle fixtures cover named/reordered arguments, unknown and forwarded controls, empty inputs, custom stubs, and retained atomic results. Focused CLI checks also preserve ordinary data-frame callback errors and known-nonempty scalar results.

Workspace tests, clippy with warnings denied, formatting, and the full R oracle pass. No 500-package run was used; unknown-length inputs intentionally lose an unsupported atomic guarantee.

Closes #321.
