### PR TITLE
fix(checker): preserve valid grep-length boolean idioms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -171,6 +171,10 @@ All notable changes to ry are documented in this file.
 
 ### Fixed
 
+- Suppress RY093 for proven base `grep()` position comparisons used directly
+  as boolean guards, while retaining warnings for value results and uncertain
+  or nested comparisons.
+
 - Distinguish `@` slot extraction from `$`. Valid atomic `.Data` reads no
   longer trigger dollar-access errors. Keep slot results and replaced roots
   unknown, including mixed nested replacements; respect explicit accessors.

--- a/crates/ry-checker/src/infer/binop.rs
+++ b/crates/ry-checker/src/infer/binop.rs
@@ -412,7 +412,7 @@ impl Checker {
         // than recursing from the enclosing `if`) reports each site exactly
         // once no matter how the operators nest.
         self.check_class_equality_operand(lhs, scope);
-        let lt = self.infer(lhs, scope);
+        let lt = self.infer_boolean_operand(lhs, scope);
         let narrowing = self.extract_type_narrowing(lhs, scope);
         let rhs_parameter_vector = self.short_circuit_parameter_vector(op, lhs, rhs, scope);
         let rt = match op {
@@ -425,13 +425,13 @@ impl Checker {
                 let mut rhs_scope = scope.clone();
                 apply_narrowing_branch(&mut rhs_scope, &narrowing, branch);
                 self.check_class_equality_operand(rhs, &rhs_scope);
-                let rt = self.infer(rhs, &mut rhs_scope);
+                let rt = self.infer_boolean_operand(rhs, &mut rhs_scope);
                 merge_condition_assignments(scope, &rhs_scope, rhs);
                 rt
             }
             _ => {
                 self.check_class_equality_operand(rhs, scope);
-                self.infer(rhs, scope)
+                self.infer_boolean_operand(rhs, scope)
             }
         };
         // A parameter guard relies on lazy short-circuit evaluation, so it
@@ -460,6 +460,16 @@ impl Checker {
             );
             self.emit(Severity::Warning, span, "RY032", message);
         }
+        result
+    }
+
+    /// Infer one direct `&&`/`||` operand while retaining its exact syntax
+    /// span. This lets call-site checks distinguish a scalar boolean operand
+    /// from a value nested inside that operand.
+    fn infer_boolean_operand(&mut self, expr: &Expr, scope: &mut Scope) -> RType {
+        let previous_boolean_context = self.boolean_context_span.replace(span_of(expr));
+        let result = self.infer(expr, scope);
+        self.boolean_context_span = previous_boolean_context;
         result
     }
 

--- a/crates/ry-checker/src/infer/call.rs
+++ b/crates/ry-checker/src/infer/call.rs
@@ -101,7 +101,20 @@ impl Checker {
             return t;
         }
 
-        self.check_comparison_inside_aggregate(&lookup_name, args);
+        let base_aggregate = lookup_name == "length"
+            && self.boolean_context_span == Some(span)
+            && matches!(
+                self.special_call_provenance(
+                    &name,
+                    func,
+                    &semantic_name,
+                    &lookup_name,
+                    "base",
+                    scope,
+                ),
+                crate::resolve::SpecialCallProvenance::Proven
+            );
+        self.check_comparison_inside_aggregate(&lookup_name, args, scope, span, base_aggregate);
         self.check_comparison_inside_math_fn(&lookup_name, args);
         self.check_identical_list_subset(&lookup_name, args, scope);
 
@@ -590,20 +603,140 @@ impl Checker {
     /// an element guard but counts coercion results. `sum(x > 0)` is the
     /// idiomatic R way to count matches, so `sum` is deliberately excluded
     /// from this mis-parenthesization family.
-    fn check_comparison_inside_aggregate(&mut self, lookup_name: &str, args: &[Arg]) {
-        if matches!(lookup_name, "length" | "nchar")
-            && let Some(Expr::BinOp {
-                op,
-                span: comparison_span,
-                ..
-            }) = args.first().map(|arg| &arg.value)
-            && is_comparison(*op)
-        {
+    fn check_comparison_inside_aggregate(
+        &mut self,
+        lookup_name: &str,
+        args: &[Arg],
+        scope: &Scope,
+        call_span: Span,
+        base_aggregate: bool,
+    ) {
+        if !matches!(lookup_name, "length" | "nchar") {
+            return;
+        }
+        let Some(Expr::BinOp {
+            op,
+            lhs,
+            rhs,
+            span: comparison_span,
+        }) = args.first().map(|arg| &arg.value)
+        else {
+            return;
+        };
+        if !is_comparison(*op) {
+            return;
+        }
+        let proven_boolean_grep = lookup_name == "length"
+            && self.boolean_context_span == Some(call_span)
+            && base_aggregate
+            && self.resolves_to_base(op_symbol(*op), scope)
+            && !ops_chooser::operator_rebound(self, op_symbol(*op), scope)
+            && self.proven_grep_position_call(*op, lhs, rhs, scope);
+        if !proven_boolean_grep {
             let message = format!(
                 "comparison is inside `{lookup_name}()`; compare `{lookup_name}(x)` instead"
             );
             self.emit(Severity::Warning, *comparison_span, "RY093", message);
         }
+    }
+
+    /// The result of ordinary `grep()` is a positive integer position for
+    /// each match. Therefore `length(grep(...) > 0)` has the same boolean
+    /// truth behavior as `length(grep(...)) > 0`, but only when `grep()` is
+    /// proven to return positions. `value = TRUE` changes that contract to
+    /// character results and remains under RY093.
+    fn proven_grep_position_call(
+        &self,
+        op: BinOpKind,
+        lhs: &Expr,
+        rhs: &Expr,
+        scope: &Scope,
+    ) -> bool {
+        let is_zero = |expr: &Expr| match expr {
+            Expr::Integer(0, _) => true,
+            Expr::Double(value, _) => *value == 0.0,
+            _ => false,
+        };
+        let grep_expr = match op {
+            BinOpKind::Gt | BinOpKind::Ge if is_zero(rhs) => lhs,
+            BinOpKind::Lt | BinOpKind::Le if is_zero(lhs) => rhs,
+            BinOpKind::Ne if is_zero(rhs) => lhs,
+            BinOpKind::Ne if is_zero(lhs) => rhs,
+            _ => return false,
+        };
+        let Expr::Call {
+            func: grep_func,
+            args: grep_args,
+            ..
+        } = grep_expr
+        else {
+            return false;
+        };
+        let Some(grep_name) = ident_name(grep_func) else {
+            return false;
+        };
+        if crate::semantic_lists::bare_name(grep_name) != "grep"
+            || !matches!(
+                self.special_call_provenance(
+                    grep_name, grep_func, grep_name, "grep", "base", scope,
+                ),
+                crate::resolve::SpecialCallProvenance::Proven
+            )
+        {
+            return false;
+        }
+
+        // `grep`'s fifth formal is `value`; match it exactly as R does so
+        // reordered and partial named arguments cannot bypass the control.
+        let bindings = match_arguments(
+            &[
+                "pattern",
+                "x",
+                "ignore.case",
+                "perl",
+                "value",
+                "fixed",
+                "useBytes",
+                "invert",
+            ],
+            grep_args,
+        );
+        // A failed match, duplicate formal, or missing required input means
+        // R does not produce a positional result at all. Keep the exemption
+        // out of those calls instead of proving a shape for an invalid call.
+        if !bindings.unmatched_named.is_empty()
+            || bindings.param_for_arg.iter().any(Option::is_none)
+            || bindings
+                .param_for_arg
+                .iter()
+                .enumerate()
+                .any(|(index, param)| {
+                    param
+                        .is_some_and(|param| bindings.param_for_arg[..index].contains(&Some(param)))
+                })
+            || (0..=1).any(|formal| {
+                bindings
+                    .arg_for_param(formal)
+                    .is_none_or(|index| matches!(grep_args[index].value, Expr::Missing(_)))
+            })
+        {
+            return false;
+        }
+        // The position contract is independent of pattern/text values, but
+        // unknown controls can still change whether the call succeeds. A
+        // literal logical control keeps this proof deliberately bounded.
+        if grep_args.iter().enumerate().any(|(index, argument)| {
+            bindings.param_for_arg[index]
+                .is_some_and(|formal| formal >= 2 && !matches!(argument.value, Expr::Logical(_, _)))
+        }) {
+            return false;
+        }
+        let Some(value_index) = bindings.arg_for_param(4) else {
+            // The default is `value = FALSE`, so an omitted control still
+            // produces integer positions.
+            return true;
+        };
+        matches!(grep_args[value_index].value, Expr::Logical(false, _))
     }
 
     /// RY100: numeric math functions coerce logical comparisons to 0/1,

--- a/crates/ry-checker/src/infer/mod.rs
+++ b/crates/ry-checker/src/infer/mod.rs
@@ -441,7 +441,9 @@ impl Checker {
     fn infer_condition(&mut self, cond: &Expr, scope: &mut Scope, ctx: ConditionContext) {
         self.check_class_equality_operand(cond, scope);
         let diagnostic_start = self.diagnostics.len();
+        let previous_boolean_context = self.boolean_context_span.replace(span_of(cond));
         let ct = self.infer(cond, scope);
+        self.boolean_context_span = previous_boolean_context;
         self.emit_condition_diagnostics(cond, ct, scope, diagnostic_start, ctx);
     }
 

--- a/crates/ry-checker/src/lib.rs
+++ b/crates/ry-checker/src/lib.rs
@@ -882,6 +882,11 @@ pub struct Checker {
     // cache is populated only for the duration of that rewritten call, so it
     // never crosses a scope-changing inference boundary.
     pipe_argument_types: HashMap<Span, RType>,
+    /// Span of the expression currently being coerced to a scalar logical
+    /// value by `if`, `&&`, or `||`. Call-site idiom checks use this exact
+    /// span so a proven boolean operand is distinguished from a value nested
+    /// inside another expression.
+    boolean_context_span: Option<Span>,
     // When true, the pass-3 walk snapshots every completed lexical scope
     // into `scope_records`. Off by default so ordinary checks (and the
     // LSP) pay nothing; `dump-types` opts in. Recording is additionally
@@ -1029,6 +1034,7 @@ impl Checker {
             #[cfg(test)]
             journal_branches: true,
             pipe_argument_types: HashMap::new(),
+            boolean_context_span: None,
             capture_scopes: false,
             capture_references: false,
             reference_capture: None,

--- a/crates/ry-checker/src/tests/packages_typeshed.rs
+++ b/crates/ry-checker/src/tests/packages_typeshed.rs
@@ -828,6 +828,75 @@ fn grep_value_results_do_not_claim_numeric_comparisons() {
 }
 
 #[test]
+fn grep_position_length_predicate_is_silent_only_as_a_boolean_guard() {
+    for source in [
+        "f <- function(pattern, i) is.character(i) && length(grep(pattern, i) > 0)\n",
+        "if (length(grep('a', c('a', 'b'), value = FALSE) > 0)) TRUE\n",
+        "if (length(grep('a', c('a', 'b'), FALSE, FALSE, FALSE) > 0)) TRUE\n",
+        "if (length(grep('a', c('a', 'b'), val = FALSE) > 0)) TRUE\n",
+        "if (length(base::grep('a', c('a', 'b')) > 0)) TRUE\n",
+        "if (length(grep(x = c('a', 'b'), pattern = 'a') > 0)) TRUE\n",
+        "if (length(grep('a', c('a', 'b')) > 0) && identical(1L, 1L)) TRUE\n",
+    ] {
+        let diagnostics = check(source);
+        assert!(
+            !diagnostics.iter().any(|d| d.code == "RY093"),
+            "proven grep position guard should be silent: {source}: {diagnostics:?}"
+        );
+    }
+
+    for source in [
+        "length(grep('a', c('a', 'b')) > 0)\n",
+        "if (length(grep('a', c('a', 'b')) > 0) == 1L) TRUE\n",
+        "if (identical(length(grep('a', c('a', 'b')) > 0), 1L)) TRUE\n",
+        "if (isTRUE(identity(length(grep('a', c('a', 'b')) > 0)))) TRUE\n",
+        "grep <- function(pattern, x, ...) 1L\nif (length(grep('a', c('a', 'b')) > 0)) TRUE\n",
+        "`>` <- function(e1, e2) logical(0)\nif (length(grep('a', c('a', 'b')) > 0)) TRUE\n",
+        "library(unknown_package)\nif (length(grep('a', c('a', 'b')) > 0)) TRUE\n",
+        "value <- TRUE\nif (length(grep('a', c('a', 'b'), value = value) > 0)) TRUE\n",
+        "control <- TRUE\nif (length(grep('a', c('a', 'b'), ignore.case = control) > 0)) TRUE\n",
+        "if (length(grep('a', c('a', 'b'), value = TRUE) > 0)) TRUE\n",
+        "if (length(grep('a', c('a', 'b'), FALSE, FALSE, TRUE) > 0)) TRUE\n",
+        "if (length(grep('a', c('a', 'b'), val = TRUE) > 0)) TRUE\n",
+    ] {
+        let diagnostics = check(source);
+        assert!(
+            diagnostics.iter().any(|d| d.code == "RY093"),
+            "non-proven grep comparison should retain RY093: {source}: {diagnostics:?}"
+        );
+    }
+
+    // A user `base` stub replaces the embedded base database. Its declarations
+    // may give grep a different result contract, so the built-in position proof
+    // must not override that model for either bare or qualified calls.
+    let custom_base = r#"{
+        "schema_version": "1",
+        "package": "base",
+        "version": "test",
+        "functions": {
+            "grep": {
+                "params": ["pattern", "x", "ignore.case", "perl", "value", "fixed", "useBytes", "invert"],
+                "return": {"mode": "character", "length": "many"}
+            },
+            "length": {
+                "params": ["x"],
+                "return": {"mode": "integer", "length": "1"}
+            }
+        }
+    }"#;
+    for source in [
+        "if (length(grep('a', c('a', 'b')) > 0)) TRUE\n",
+        "if (length(base::grep('a', c('a', 'b')) > 0)) TRUE\n",
+    ] {
+        let (diagnostics, _) = check_with_stubs(source, &[("base.json", custom_base)]);
+        assert!(
+            diagnostics.iter().any(|d| d.code == "RY093"),
+            "custom base stub must retain RY093: {source}: {diagnostics:?}"
+        );
+    }
+}
+
+#[test]
 fn confint_dispatch_does_not_claim_an_atomic_result() {
     let diagnostics = check("f <- function(model) { ci <- stats::confint(model); ci$interval }");
     assert!(diagnostics.is_empty(), "{diagnostics:?}");

--- a/crates/ry-checker/testdata/oracle/grep_length_boolean_guard.R
+++ b/crates/ry-checker/testdata/oracle/grep_length_boolean_guard.R
@@ -1,0 +1,10 @@
+# oracle: must-pass
+# R evaluates the comparison element-wise before length(); grep() returns
+# positive integer positions by default, so the guard is scalar and exact.
+has_match <- function(pattern, x) is.character(x) && length(grep(pattern, x) > 0)
+stopifnot(identical(has_match("a", c("a", "a")), TRUE))
+stopifnot(identical(has_match("z", c("a", "a")), FALSE))
+qualified_match <- function(pattern, x) is.character(x) &&
+  length(base::grep(x = x, pattern = pattern) > 0)
+stopifnot(identical(qualified_match("a", c("a", "b")), TRUE))
+stopifnot(identical(qualified_match("z", c("a", "b")), FALSE))

--- a/crates/ry-checker/testdata/oracle/grep_length_value_control.R
+++ b/crates/ry-checker/testdata/oracle/grep_length_value_control.R
@@ -1,0 +1,7 @@
+# oracle: must-warn RY093
+# value = TRUE changes grep() from integer positions to character matches;
+# the comparison is therefore outside the proven positional contract.
+check <- function(value) {
+  length(grep("a", c("a", "b"), value = value) > 0)
+}
+stopifnot(identical(check(TRUE), 1L), identical(check(FALSE), 1L))


### PR DESCRIPTION
The valid boolean idiom `length(grep(pattern, x) > 0)` triggered high-confidence RY093. Exempt comparisons with proven positional grep results when the length call is used directly as a scalar boolean guard.

The exemption requires base function and operator provenance, matched arguments, and known positional controls. RY093 remains for nested/value uses, nchar, value=TRUE, unknown controls, custom base stubs, and rebound operators. Added positive and negative regressions, matching/nonmatching R witnesses, and a changelog entry.

Validation passed: workspace tests, Clippy with warnings denied, formatting, and the full R oracle (six existing documented known gaps unchanged). Parent review separately checked both sides of &&, integer-value comparisons, nested calls, nchar, masked operators, and genuine misplaced comparisons. The 500-package corpus was not used for this validation.

Closes #322.
