### PR TITLE
Fix constant-length warnings for S3-dispatched values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -171,6 +171,10 @@ All notable changes to ry are documented in this file.
 
 ### Fixed
 
+- Suppress RY093 for proven base `grep()` position comparisons used directly
+  as boolean guards, while retaining warnings for value results and uncertain
+  or nested comparisons.
+
 - Distinguish `@` slot extraction from `$`. Valid atomic `.Data` reads no
   longer trigger dollar-access errors. Keep slot results and replaced roots
   unknown, including mixed nested replacements; respect explicit accessors.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -171,6 +171,9 @@ All notable changes to ry are documented in this file.
 
 ### Fixed
 
+- Respect S3 `length()` dispatch and uncertain class metadata before reporting
+  zero-length guards as constant; classless scalar bindings retain RY105.
+
 - Distinguish `@` slot extraction from `$`. Valid atomic `.Data` reads no
   longer trigger dollar-access errors. Keep slot results and replaced roots
   unknown, including mixed nested replacements; respect explicit accessors.

--- a/crates/ry-checker/src/higher_order.rs
+++ b/crates/ry-checker/src/higher_order.rs
@@ -784,7 +784,9 @@ pub(crate) fn s3_group_generic(generic: &str) -> Option<&'static str> {
 /// classification combines the base stub's `s3_generics`, the registered
 /// Math/Summary group members, and the standalone `mean` generic. Callers may
 /// add rule-specific fallbacks at their callsite, such as RY105's `length`
-/// exception.
+/// exception. `mean.<class>` dispatches, while `Summary.<class>` does not;
+/// once r-typeshed registers `mean` in `s3_generics` (issue #41), this
+/// fallback can be removed.
 pub(crate) fn is_dispatch_capable_generic(
     globals: &ry_typeshed::Globals,
     function_name: &str,

--- a/crates/ry-checker/src/higher_order.rs
+++ b/crates/ry-checker/src/higher_order.rs
@@ -780,6 +780,23 @@ pub(crate) fn s3_group_generic(generic: &str) -> Option<&'static str> {
     }
 }
 
+/// Whether an ordinary function call can dispatch through an S3 generic. The
+/// classification combines the base stub's `s3_generics`, the registered
+/// Math/Summary group members, and the standalone `mean` generic. Callers may
+/// add rule-specific fallbacks at their callsite, such as RY105's `length`
+/// exception.
+pub(crate) fn is_dispatch_capable_generic(
+    globals: &ry_typeshed::Globals,
+    function_name: &str,
+) -> bool {
+    globals
+        .s3_generics
+        .iter()
+        .any(|generic| generic == function_name)
+        || s3_group_generic(function_name).is_some()
+        || function_name == "mean"
+}
+
 fn higher_order_mode(mode: Option<&str>) -> Mode {
     match mode.and_then(JsonMode::parse) {
         Some(JsonMode::Logical) => Mode::Logical,

--- a/crates/ry-checker/src/infer/args.rs
+++ b/crates/ry-checker/src/infer/args.rs
@@ -417,29 +417,14 @@ fn edit_distance(left: &str, right: &str) -> usize {
     previous[right_chars.len()]
 }
 
-/// Whether `function_name` is an S3 generic whose stub parameter types
-/// method dispatch can defeat: a classed or NULL argument may route to a
-/// method that accepts it, so RY092 stays quiet. The names come from the
-/// same two sources the dispatch path in `infer_call` consults: the base
-/// stub's `globals.s3_generics` and the registered group-generic member
-/// lists ([`crate::semantic_lists::S3_MATH_GENERICS`] and
-/// [`crate::semantic_lists::S3_SUMMARY_GENERICS`], which cover
-/// `round`, `log`, `sqrt`, and `exp`). `mean` stays a documented special
-/// case: it is a plain S3 generic (a `mean.<class>` method catches it,
-/// but a `Summary.<class>` method does not), so it belongs in neither
-/// group list, and the base stub's `globals.s3_generics` omits it.
-/// r-typeshed registering it there lets this fallback shrink (issue #41).
+/// Whether RY092 should defer its argument mode check: a classed or NULL
+/// actual may dispatch to a method that accepts it.
 fn generic_argument_may_dispatch(
     globals: &ry_typeshed::Globals,
     function_name: &str,
     actual: &RType,
 ) -> bool {
-    let generic = globals
-        .s3_generics
-        .iter()
-        .any(|generic| generic == function_name)
-        || crate::higher_order::s3_group_generic(function_name).is_some()
-        || function_name == "mean";
+    let generic = crate::higher_order::is_dispatch_capable_generic(globals, function_name);
     generic && (actual.class.has_known_class() || actual.mode == Mode::Null)
 }
 

--- a/crates/ry-checker/src/infer/binop.rs
+++ b/crates/ry-checker/src/infer/binop.rs
@@ -412,7 +412,7 @@ impl Checker {
         // than recursing from the enclosing `if`) reports each site exactly
         // once no matter how the operators nest.
         self.check_class_equality_operand(lhs, scope);
-        let lt = self.infer(lhs, scope);
+        let lt = self.infer_boolean_operand(lhs, scope);
         let narrowing = self.extract_type_narrowing(lhs, scope);
         let rhs_parameter_vector = self.short_circuit_parameter_vector(op, lhs, rhs, scope);
         let rt = match op {
@@ -425,13 +425,13 @@ impl Checker {
                 let mut rhs_scope = scope.clone();
                 apply_narrowing_branch(&mut rhs_scope, &narrowing, branch);
                 self.check_class_equality_operand(rhs, &rhs_scope);
-                let rt = self.infer(rhs, &mut rhs_scope);
+                let rt = self.infer_boolean_operand(rhs, &mut rhs_scope);
                 merge_condition_assignments(scope, &rhs_scope, rhs);
                 rt
             }
             _ => {
                 self.check_class_equality_operand(rhs, scope);
-                self.infer(rhs, scope)
+                self.infer_boolean_operand(rhs, scope)
             }
         };
         // A parameter guard relies on lazy short-circuit evaluation, so it
@@ -460,6 +460,16 @@ impl Checker {
             );
             self.emit(Severity::Warning, span, "RY032", message);
         }
+        result
+    }
+
+    /// Infer one direct `&&`/`||` operand while retaining its exact syntax
+    /// span. This lets call-site checks distinguish a scalar boolean operand
+    /// from a value nested inside that operand.
+    fn infer_boolean_operand(&mut self, expr: &Expr, scope: &mut Scope) -> RType {
+        let previous_boolean_context = self.boolean_context_span.replace(span_of(expr));
+        let result = self.infer(expr, scope);
+        self.boolean_context_span = previous_boolean_context;
         result
     }
 

--- a/crates/ry-checker/src/infer/call.rs
+++ b/crates/ry-checker/src/infer/call.rs
@@ -101,7 +101,20 @@ impl Checker {
             return t;
         }
 
-        self.check_comparison_inside_aggregate(&lookup_name, args);
+        let base_aggregate = lookup_name == "length"
+            && self.boolean_context_span == Some(span)
+            && matches!(
+                self.special_call_provenance(
+                    &name,
+                    func,
+                    &semantic_name,
+                    &lookup_name,
+                    "base",
+                    scope,
+                ),
+                crate::resolve::SpecialCallProvenance::Proven
+            );
+        self.check_comparison_inside_aggregate(&lookup_name, args, scope, span, base_aggregate);
         self.check_comparison_inside_math_fn(&lookup_name, args);
         self.check_identical_list_subset(&lookup_name, args, scope);
 
@@ -590,20 +603,140 @@ impl Checker {
     /// an element guard but counts coercion results. `sum(x > 0)` is the
     /// idiomatic R way to count matches, so `sum` is deliberately excluded
     /// from this mis-parenthesization family.
-    fn check_comparison_inside_aggregate(&mut self, lookup_name: &str, args: &[Arg]) {
-        if matches!(lookup_name, "length" | "nchar")
-            && let Some(Expr::BinOp {
-                op,
-                span: comparison_span,
-                ..
-            }) = args.first().map(|arg| &arg.value)
-            && is_comparison(*op)
-        {
+    fn check_comparison_inside_aggregate(
+        &mut self,
+        lookup_name: &str,
+        args: &[Arg],
+        scope: &Scope,
+        call_span: Span,
+        base_aggregate: bool,
+    ) {
+        if !matches!(lookup_name, "length" | "nchar") {
+            return;
+        }
+        let Some(Expr::BinOp {
+            op,
+            lhs,
+            rhs,
+            span: comparison_span,
+        }) = args.first().map(|arg| &arg.value)
+        else {
+            return;
+        };
+        if !is_comparison(*op) {
+            return;
+        }
+        let proven_boolean_grep = lookup_name == "length"
+            && self.boolean_context_span == Some(call_span)
+            && base_aggregate
+            && self.resolves_to_base(op_symbol(*op), scope)
+            && !ops_chooser::operator_rebound(self, op_symbol(*op), scope)
+            && self.proven_grep_position_call(*op, lhs, rhs, scope);
+        if !proven_boolean_grep {
             let message = format!(
                 "comparison is inside `{lookup_name}()`; compare `{lookup_name}(x)` instead"
             );
             self.emit(Severity::Warning, *comparison_span, "RY093", message);
         }
+    }
+
+    /// The result of ordinary `grep()` is a positive integer position for
+    /// each match. Therefore `length(grep(...) > 0)` has the same boolean
+    /// truth behavior as `length(grep(...)) > 0`, but only when `grep()` is
+    /// proven to return positions. `value = TRUE` changes that contract to
+    /// character results and remains under RY093.
+    fn proven_grep_position_call(
+        &self,
+        op: BinOpKind,
+        lhs: &Expr,
+        rhs: &Expr,
+        scope: &Scope,
+    ) -> bool {
+        let is_zero = |expr: &Expr| match expr {
+            Expr::Integer(0, _) => true,
+            Expr::Double(value, _) => *value == 0.0,
+            _ => false,
+        };
+        let grep_expr = match op {
+            BinOpKind::Gt | BinOpKind::Ge if is_zero(rhs) => lhs,
+            BinOpKind::Lt | BinOpKind::Le if is_zero(lhs) => rhs,
+            BinOpKind::Ne if is_zero(rhs) => lhs,
+            BinOpKind::Ne if is_zero(lhs) => rhs,
+            _ => return false,
+        };
+        let Expr::Call {
+            func: grep_func,
+            args: grep_args,
+            ..
+        } = grep_expr
+        else {
+            return false;
+        };
+        let Some(grep_name) = ident_name(grep_func) else {
+            return false;
+        };
+        if crate::semantic_lists::bare_name(grep_name) != "grep"
+            || !matches!(
+                self.special_call_provenance(
+                    grep_name, grep_func, grep_name, "grep", "base", scope,
+                ),
+                crate::resolve::SpecialCallProvenance::Proven
+            )
+        {
+            return false;
+        }
+
+        // `grep`'s fifth formal is `value`; match it exactly as R does so
+        // reordered and partial named arguments cannot bypass the control.
+        let bindings = match_arguments(
+            &[
+                "pattern",
+                "x",
+                "ignore.case",
+                "perl",
+                "value",
+                "fixed",
+                "useBytes",
+                "invert",
+            ],
+            grep_args,
+        );
+        // A failed match, duplicate formal, or missing required input means
+        // R does not produce a positional result at all. Keep the exemption
+        // out of those calls instead of proving a shape for an invalid call.
+        if !bindings.unmatched_named.is_empty()
+            || bindings.param_for_arg.iter().any(Option::is_none)
+            || bindings
+                .param_for_arg
+                .iter()
+                .enumerate()
+                .any(|(index, param)| {
+                    param
+                        .is_some_and(|param| bindings.param_for_arg[..index].contains(&Some(param)))
+                })
+            || (0..=1).any(|formal| {
+                bindings
+                    .arg_for_param(formal)
+                    .is_none_or(|index| matches!(grep_args[index].value, Expr::Missing(_)))
+            })
+        {
+            return false;
+        }
+        // The position contract is independent of pattern/text values, but
+        // unknown controls can still change whether the call succeeds. A
+        // literal logical control keeps this proof deliberately bounded.
+        if grep_args.iter().enumerate().any(|(index, argument)| {
+            bindings.param_for_arg[index]
+                .is_some_and(|formal| formal >= 2 && !matches!(argument.value, Expr::Logical(_, _)))
+        }) {
+            return false;
+        }
+        let Some(value_index) = bindings.arg_for_param(4) else {
+            // The default is `value = FALSE`, so an omitted control still
+            // produces integer positions.
+            return true;
+        };
+        matches!(grep_args[value_index].value, Expr::Logical(false, _))
     }
 
     /// RY100: numeric math functions coerce logical comparisons to 0/1,

--- a/crates/ry-checker/src/infer/mod.rs
+++ b/crates/ry-checker/src/infer/mod.rs
@@ -441,7 +441,9 @@ impl Checker {
     fn infer_condition(&mut self, cond: &Expr, scope: &mut Scope, ctx: ConditionContext) {
         self.check_class_equality_operand(cond, scope);
         let diagnostic_start = self.diagnostics.len();
+        let previous_boolean_context = self.boolean_context_span.replace(span_of(cond));
         let ct = self.infer(cond, scope);
+        self.boolean_context_span = previous_boolean_context;
         self.emit_condition_diagnostics(cond, ct, scope, diagnostic_start, ctx);
     }
 

--- a/crates/ry-checker/src/infer/recall.rs
+++ b/crates/ry-checker/src/infer/recall.rs
@@ -376,14 +376,7 @@ impl Checker {
     fn scalar_call_is_classless(&self, callee: &str, args: &[Arg], scope: &Scope) -> bool {
         let bare = crate::semantic_lists::bare_name(callee);
         let may_dispatch = bare == "length"
-            || bare == "mean"
-            || self
-                .typeshed
-                .globals
-                .s3_generics
-                .iter()
-                .any(|generic| generic == bare)
-            || crate::higher_order::s3_group_generic(bare).is_some();
+            || crate::higher_order::is_dispatch_capable_generic(&self.typeshed.globals, bare);
         !may_dispatch
             || args
                 .iter()

--- a/crates/ry-checker/src/infer/recall.rs
+++ b/crates/ry-checker/src/infer/recall.rs
@@ -252,11 +252,14 @@ impl Checker {
     /// mode these rules guard against):
     ///
     /// 1. a direct call to a function whose typeshed stub declares a return
-    ///    length of exactly 1 (Checker::is_typeshed_scalar_reduction); or
+    ///    length of exactly 1 and whose arguments cannot trigger S3 dispatch;
+    ///    or
     /// 2. a local binding whose inferred type is a length-1 *atomic* and which
     ///    is neither a parameter, a parameter default, nor a flow-narrowed
     ///    refinement — a parameter's type comes from one default or one call
-    ///    site and is not proof of the runtime length.
+    ///    site and is not proof of the runtime length. The binding must also
+    ///    have a known empty class vector: storage length does not determine
+    ///    `length(x)` for a classed object.
     pub(crate) fn check_constant_length_comparison(
         &mut self,
         op: BinOpKind,
@@ -357,10 +360,86 @@ impl Checker {
         if !self.resolves_to_base_lenient(callee, scope) {
             return None;
         }
-        if !args.is_empty() && self.is_typeshed_scalar_reduction(callee) {
+        if !args.is_empty()
+            && self.is_typeshed_scalar_reduction(callee)
+            && self.scalar_call_is_classless(callee, args, scope)
+        {
             return Some(format!("`{bare}()` always returns a single value"));
         }
         None
+    }
+
+    /// Whether every argument to a dispatch-capable scalar call is proven to
+    /// be classless. Keep this proof at the literal/local seam: inferring a
+    /// class through arbitrary calls or operators would duplicate inference
+    /// and could miss dispatch or rebinding.
+    fn scalar_call_is_classless(&self, callee: &str, args: &[Arg], scope: &Scope) -> bool {
+        let bare = crate::semantic_lists::bare_name(callee);
+        let may_dispatch = bare == "length"
+            || bare == "mean"
+            || self
+                .typeshed
+                .globals
+                .s3_generics
+                .iter()
+                .any(|generic| generic == bare)
+            || crate::higher_order::s3_group_generic(bare).is_some();
+        !may_dispatch
+            || args
+                .iter()
+                .all(|argument| self.scalar_call_argument_is_classless(&argument.value, scope))
+    }
+
+    /// Prove the narrow set of argument expressions whose classlessness is
+    /// established without running an arbitrary call. Operators are admitted
+    /// only while their base identity is known; otherwise a rebound operator
+    /// can manufacture a classed value from scalar literals.
+    fn scalar_call_argument_is_classless(&self, expr: &Expr, scope: &Scope) -> bool {
+        match expr {
+            Expr::Ident { name, .. } => {
+                !(scope.parameter_bindings.contains(name)
+                    || scope.default_parameter_bindings.contains(name)
+                    || scope.narrowed_bindings.contains(name))
+                    && scope
+                        .get(name)
+                        .is_some_and(|ty| ty.class.known && ty.class.len == 0)
+            }
+            Expr::Logical(..)
+            | Expr::Integer(..)
+            | Expr::Double(..)
+            | Expr::String(..)
+            | Expr::Null(..)
+            | Expr::Na(..) => true,
+            Expr::BinOp { op, lhs, rhs, .. }
+                if op.is_arithmetic() || matches!(op, BinOpKind::Colon) =>
+            {
+                self.scalar_call_operator_is_base(op_symbol(*op), scope)
+                    && self.scalar_call_argument_is_classless(lhs, scope)
+                    && self.scalar_call_argument_is_classless(rhs, scope)
+            }
+            Expr::UnaryOp { op, expr, .. } => {
+                self.scalar_call_unary_operator_is_base(*op, scope)
+                    && self.scalar_call_argument_is_classless(expr, scope)
+            }
+            _ => false,
+        }
+    }
+
+    fn scalar_call_operator_is_base(&self, symbol: &str, scope: &Scope) -> bool {
+        !scope.ops_environment_unknown
+            && !scope.data_mask_unknown
+            && !scope.search_path_unknown
+            && self.bare_loaded.is_empty()
+            && !ops_chooser::syntax_rebound(self, scope)
+            && !ops_chooser::operator_rebound(self, symbol, scope)
+    }
+
+    fn scalar_call_unary_operator_is_base(&self, op: UnaryOpKind, scope: &Scope) -> bool {
+        let symbol = match op {
+            UnaryOpKind::Neg => "-",
+            UnaryOpKind::Not => "!",
+        };
+        self.scalar_call_operator_is_base(symbol, scope)
     }
 
     fn scalar_by_construction_local(&self, expr: &Expr, scope: &Scope) -> Option<String> {
@@ -383,6 +462,9 @@ impl Checker {
         ) {
             return None;
         }
+        if !bound.class.known || bound.class.len != 0 {
+            return None;
+        }
         Some(format!("`{name}` is a length-1 {}", bound.mode))
     }
 
@@ -394,7 +476,7 @@ impl Checker {
         };
         matches!(
             &sig.return_,
-            ReturnSpec::Concrete(rt) if rt.length == "1"
+            ReturnSpec::Concrete(rt) if rt.length == "1" && rt.class.is_empty()
         )
     }
 }
@@ -412,7 +494,11 @@ mod scalar_reduction_tests {
             checker.take_diagnostics().iter().any(|d| d.code == code)
         }
         for callee in ["sum", "any", "all", "length", "isTRUE", "identical"] {
-            let src = format!("f <- function(x) if (length({callee}(x)) > 0) 1\n");
+            let args = match callee {
+                "identical" => "1L, 1L",
+                _ => "1L",
+            };
+            let src = format!("if (length({callee}({args})) > 0) 1\n");
             assert!(
                 fires(&src, "RY105"),
                 "`{callee}` has return length 1 in the typeshed but RY105 did not fire"

--- a/crates/ry-checker/src/lib.rs
+++ b/crates/ry-checker/src/lib.rs
@@ -882,6 +882,11 @@ pub struct Checker {
     // cache is populated only for the duration of that rewritten call, so it
     // never crosses a scope-changing inference boundary.
     pipe_argument_types: HashMap<Span, RType>,
+    /// Span of the expression currently being coerced to a scalar logical
+    /// value by `if`, `&&`, or `||`. Call-site idiom checks use this exact
+    /// span so a proven boolean operand is distinguished from a value nested
+    /// inside another expression.
+    boolean_context_span: Option<Span>,
     // When true, the pass-3 walk snapshots every completed lexical scope
     // into `scope_records`. Off by default so ordinary checks (and the
     // LSP) pay nothing; `dump-types` opts in. Recording is additionally
@@ -1029,6 +1034,7 @@ impl Checker {
             #[cfg(test)]
             journal_branches: true,
             pipe_argument_types: HashMap::new(),
+            boolean_context_span: None,
             capture_scopes: false,
             capture_references: false,
             reference_capture: None,

--- a/crates/ry-checker/src/tests/packages_typeshed.rs
+++ b/crates/ry-checker/src/tests/packages_typeshed.rs
@@ -828,6 +828,75 @@ fn grep_value_results_do_not_claim_numeric_comparisons() {
 }
 
 #[test]
+fn grep_position_length_predicate_is_silent_only_as_a_boolean_guard() {
+    for source in [
+        "f <- function(pattern, i) is.character(i) && length(grep(pattern, i) > 0)\n",
+        "if (length(grep('a', c('a', 'b'), value = FALSE) > 0)) TRUE\n",
+        "if (length(grep('a', c('a', 'b'), FALSE, FALSE, FALSE) > 0)) TRUE\n",
+        "if (length(grep('a', c('a', 'b'), val = FALSE) > 0)) TRUE\n",
+        "if (length(base::grep('a', c('a', 'b')) > 0)) TRUE\n",
+        "if (length(grep(x = c('a', 'b'), pattern = 'a') > 0)) TRUE\n",
+        "if (length(grep('a', c('a', 'b')) > 0) && identical(1L, 1L)) TRUE\n",
+    ] {
+        let diagnostics = check(source);
+        assert!(
+            !diagnostics.iter().any(|d| d.code == "RY093"),
+            "proven grep position guard should be silent: {source}: {diagnostics:?}"
+        );
+    }
+
+    for source in [
+        "length(grep('a', c('a', 'b')) > 0)\n",
+        "if (length(grep('a', c('a', 'b')) > 0) == 1L) TRUE\n",
+        "if (identical(length(grep('a', c('a', 'b')) > 0), 1L)) TRUE\n",
+        "if (isTRUE(identity(length(grep('a', c('a', 'b')) > 0)))) TRUE\n",
+        "grep <- function(pattern, x, ...) 1L\nif (length(grep('a', c('a', 'b')) > 0)) TRUE\n",
+        "`>` <- function(e1, e2) logical(0)\nif (length(grep('a', c('a', 'b')) > 0)) TRUE\n",
+        "library(unknown_package)\nif (length(grep('a', c('a', 'b')) > 0)) TRUE\n",
+        "value <- TRUE\nif (length(grep('a', c('a', 'b'), value = value) > 0)) TRUE\n",
+        "control <- TRUE\nif (length(grep('a', c('a', 'b'), ignore.case = control) > 0)) TRUE\n",
+        "if (length(grep('a', c('a', 'b'), value = TRUE) > 0)) TRUE\n",
+        "if (length(grep('a', c('a', 'b'), FALSE, FALSE, TRUE) > 0)) TRUE\n",
+        "if (length(grep('a', c('a', 'b'), val = TRUE) > 0)) TRUE\n",
+    ] {
+        let diagnostics = check(source);
+        assert!(
+            diagnostics.iter().any(|d| d.code == "RY093"),
+            "non-proven grep comparison should retain RY093: {source}: {diagnostics:?}"
+        );
+    }
+
+    // A user `base` stub replaces the embedded base database. Its declarations
+    // may give grep a different result contract, so the built-in position proof
+    // must not override that model for either bare or qualified calls.
+    let custom_base = r#"{
+        "schema_version": "1",
+        "package": "base",
+        "version": "test",
+        "functions": {
+            "grep": {
+                "params": ["pattern", "x", "ignore.case", "perl", "value", "fixed", "useBytes", "invert"],
+                "return": {"mode": "character", "length": "many"}
+            },
+            "length": {
+                "params": ["x"],
+                "return": {"mode": "integer", "length": "1"}
+            }
+        }
+    }"#;
+    for source in [
+        "if (length(grep('a', c('a', 'b')) > 0)) TRUE\n",
+        "if (length(base::grep('a', c('a', 'b')) > 0)) TRUE\n",
+    ] {
+        let (diagnostics, _) = check_with_stubs(source, &[("base.json", custom_base)]);
+        assert!(
+            diagnostics.iter().any(|d| d.code == "RY093"),
+            "custom base stub must retain RY093: {source}: {diagnostics:?}"
+        );
+    }
+}
+
+#[test]
 fn confint_dispatch_does_not_claim_an_atomic_result() {
     let diagnostics = check("f <- function(model) { ci <- stats::confint(model); ci$interval }");
     assert!(diagnostics.is_empty(), "{diagnostics:?}");

--- a/crates/ry-checker/testdata/oracle/classed_length_dispatch.R
+++ b/crates/ry-checker/testdata/oracle/classed_length_dispatch.R
@@ -1,0 +1,38 @@
+# oracle: must-pass
+# oracle-claim: RY105
+# S3 methods can change the result length even when storage is scalar.
+local({
+  length.ry_cleanup <- function(x) 0L
+  x <- structure(1L, class = "ry_cleanup")
+  stopifnot(identical(length(x), 0L))
+  if (length(x) > 0L) stop("unreachable")
+
+  class_name <- "ry_cleanup"
+  uncertain <- structure(1L, class = class_name)
+  stopifnot(identical(length(uncertain), 0L))
+
+  sum.ry_cleanup <- function(x, ...) integer(0)
+  stopifnot(identical(length(sum(x)), 0L))
+  if (length(sum(x)) > 0L) stop("unreachable")
+  if (length(sum(structure(1L, class = "ry_cleanup"))) > 0L) {
+    stop("unreachable")
+  }
+
+  guarded <- function(x = 1L) {
+    if (length(sum(x)) > 0L) stop("unreachable")
+  }
+  guarded(structure(1L, class = "ry_cleanup"))
+
+  `+` <- function(x, y) structure(1L, class = "ry_cleanup")
+  stopifnot(identical(length(sum(1L + 1L)), 0L))
+  if (length(sum(1L + 1L)) > 0L) stop("unreachable")
+
+  masked <- function(x) {
+    length <- function(x) 1L
+    length(x)
+  }
+  stopifnot(identical(masked(1L), 1L))
+
+  plain <- 1L
+  stopifnot(isTRUE(length(plain) > 0L))
+})

--- a/crates/ry-checker/testdata/oracle/grep_length_boolean_guard.R
+++ b/crates/ry-checker/testdata/oracle/grep_length_boolean_guard.R
@@ -1,0 +1,10 @@
+# oracle: must-pass
+# R evaluates the comparison element-wise before length(); grep() returns
+# positive integer positions by default, so the guard is scalar and exact.
+has_match <- function(pattern, x) is.character(x) && length(grep(pattern, x) > 0)
+stopifnot(identical(has_match("a", c("a", "a")), TRUE))
+stopifnot(identical(has_match("z", c("a", "a")), FALSE))
+qualified_match <- function(pattern, x) is.character(x) &&
+  length(base::grep(x = x, pattern = pattern) > 0)
+stopifnot(identical(qualified_match("a", c("a", "b")), TRUE))
+stopifnot(identical(qualified_match("z", c("a", "b")), FALSE))

--- a/crates/ry-checker/testdata/oracle/grep_length_value_control.R
+++ b/crates/ry-checker/testdata/oracle/grep_length_value_control.R
@@ -1,0 +1,7 @@
+# oracle: must-warn RY093
+# value = TRUE changes grep() from integer positions to character matches;
+# the comparison is therefore outside the proven positional contract.
+check <- function(value) {
+  length(grep("a", c("a", "b"), value = value) > 0)
+}
+stopifnot(identical(check(TRUE), 1L), identical(check(FALSE), 1L))

--- a/crates/ry-checker/tests/probes.rs
+++ b/crates/ry-checker/tests/probes.rs
@@ -262,7 +262,7 @@ static PROBES: &[Probe] = &[
     Probe {
         code: "RY105",
         note: "`length()` of a length-1-by-construction value against 0",
-        positive: "f <- function(v) if (length(sum(v)) > 0) 1 else 2\n",
+        positive: "if (length(sum(1L)) > 0) 1 else 2\n",
         negative: "f <- function(v) if (length(v) > 0) 1 else 2\n",
     },
 ];

--- a/crates/ry-checker/tests/recall_rules.rs
+++ b/crates/ry-checker/tests/recall_rules.rs
@@ -245,10 +245,7 @@ fn ry103_stays_silent_for_elementwise_operators() {
 fn ry105_fires_on_length_of_a_scalar_reduction() {
     // pak R/confirmation.R:42. `length(sum(...))` is 1 by construction, so
     // the guard is always TRUE.
-    assert!(fires(
-        "f <- function(v) if (length(sum(v)) > 0) 1\n",
-        "RY105"
-    ));
+    assert!(fires("if (length(sum(1L)) > 0) 1\n", "RY105"));
 }
 
 #[test]
@@ -260,8 +257,76 @@ fn ry105_fires_through_a_local_binding() {
 }
 
 #[test]
+fn ry105_stays_silent_for_a_classed_scalar_local() {
+    // Storage length does not determine `length(x)` for an S3 object:
+    // `length.<class>` may return any length.
+    assert!(!fires(
+        "length.ry_cleanup <- function(x) 0L\nx <- structure(1L, class = \"ry_cleanup\")\nif (length(x) > 0L) stop(\"unreachable\")\n",
+        "RY105"
+    ));
+}
+
+#[test]
+fn ry105_stays_silent_for_a_classed_scalar_call() {
+    // A scalar-returning typeshed generic may dispatch to a method that
+    // returns a non-scalar vector.
+    assert!(!fires(
+        "sum.ry_cleanup <- function(x, ...) integer(0)\nx <- structure(1L, class = \"ry_cleanup\")\nif (length(sum(x)) > 0L) stop(\"unreachable\")\n",
+        "RY105"
+    ));
+    // A class constructor hidden inside the direct call carries the same
+    // dispatch uncertainty as a classed local binding.
+    assert!(!fires(
+        "sum.ry_cleanup <- function(x, ...) integer(0)\nif (length(sum(structure(1L, class = \"ry_cleanup\"))) > 0L) stop(\"unreachable\")\n",
+        "RY105"
+    ));
+}
+
+#[test]
+fn ry105_stays_silent_for_a_parameter_with_a_scalar_default() {
+    assert!(!fires(
+        "sum.ry_cleanup <- function(x, ...) integer(0)\nf <- function(x = 1L) if (length(sum(x)) > 0L) stop(\"unreachable\")\nf(structure(1L, class = \"ry_cleanup\"))\n",
+        "RY105"
+    ));
+}
+
+#[test]
+fn ry105_stays_silent_for_a_masked_operator_argument() {
+    assert!(!fires(
+        "`+` <- function(x, y) structure(1L, class = \"ry_cleanup\")\nsum.ry_cleanup <- function(x, ...) integer(0)\nif (length(sum(1L + 1L)) > 0L) stop(\"unreachable\")\n",
+        "RY105"
+    ));
+}
+
+#[test]
+fn ry105_stays_silent_when_a_scalar_class_is_unknown() {
+    // A dynamic class may add an S3 length method, so storage length is not
+    // enough evidence for the zero-length comparison.
+    assert!(!fires(
+        "class_name <- \"ry_cleanup\"\nx <- structure(1L, class = class_name)\nif (length(x) > 0L) stop(\"unreachable\")\n",
+        "RY105"
+    ));
+}
+
+#[test]
+fn ry105_stays_silent_when_length_is_masked() {
+    assert!(!fires(
+        "length <- function(x) 1L\nx <- 1L\nif (length(x) > 0L) stop(\"unreachable\")\n",
+        "RY105"
+    ));
+}
+
+#[test]
 fn ry105_stays_silent_on_a_plain_vector() {
     assert!(!fires("f <- function(v) if (length(v) > 0) 1\n", "RY105"));
+}
+
+#[test]
+fn ry105_retains_the_classless_scalar_warning() {
+    assert!(fires(
+        "x <- 1L\nif (length(x) > 0L) stop(\"unreachable\")\n",
+        "RY105"
+    ));
 }
 
 #[test]
@@ -301,7 +366,7 @@ fn ry105_normalizes_operand_order_for_constant_outcome() {
     let file = parser
         .parse(
             "recall.R",
-            "f <- function(v) if (0 > length(sum(v))) 1
+            "if (0 > length(sum(1L))) 1
 ",
         )
         .expect("parse");
@@ -319,7 +384,7 @@ fn ry105_normalizes_operand_order_for_constant_outcome() {
     let file = parser
         .parse(
             "recall.R",
-            "f <- function(v) if (0 < length(sum(v))) 1
+            "if (0 < length(sum(1L))) 1
 ",
         )
         .expect("parse");

--- a/crates/ry-checker/tests/semantic_lists.rs
+++ b/crates/ry-checker/tests/semantic_lists.rs
@@ -575,7 +575,7 @@ fn non_base_qualified_does_not_resolve() {
 /// diagnostic. A shadowed sum does not.
 #[test]
 fn scalar_reduction_respects_base_resolution() {
-    let diags = check_source("f <- function(x) if (length(base::sum(x)) > 0) 1\n");
+    let diags = check_source("if (length(base::sum(1L)) > 0) 1\n");
     assert!(
         diags.iter().any(|c| c == "RY105"),
         "base::sum length comparison should fire RY105, got {diags:?}"


### PR DESCRIPTION
Fix false RY105 warnings when S3 methods change `length()` or the result of a scalar reduction. Classed values and arguments whose classes are unknown no longer justify a constant-length claim; classless literals, locals, and proven base arithmetic retain their warnings.

Added regression tests and an R oracle fixture covering classed locals, nested constructors, default parameters, and rebound operators. Workspace tests, clippy, formatting, and the full R oracle pass. Independent CLI checks also preserve the `sum(1:3)` positive control. No 500-package run was used.

Share generic classification with RY092 while preserving each rule's existing behavior, including RY105's explicit `length` fallback.

Closes #333
Closes #326


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved zero-length diagnostics to account for S3 dispatch, uncertain class information, masked functions, and overridden operators.
  - Continued reporting diagnostics for provably classless scalar values.
  - Prevented false positives for proven `grep()` position comparisons used directly as boolean guards, while preserving warnings for value results and uncertain cases.

- **Tests**
  - Added coverage for class-aware reductions, dynamic classes, operator overrides, and `grep()` boolean guards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
