### PR TITLE
fix(editors): use ry-checker on VS Code Marketplace

### DIFF
--- a/.github/workflows/release-vscode.yml
+++ b/.github/workflows/release-vscode.yml
@@ -134,14 +134,27 @@ jobs:
           # version must not fail with "Version not changed".
           npm version "$RELEASE_VERSION" --no-git-tag-version --allow-same-version
 
-      - name: Package VSIX
+      - name: Package Marketplace VSIX
         working-directory: editors/code
         run: bunx @vscode/vsce package --target ${{ matrix.code-target }} --no-dependencies ${{ inputs.pre-release && '--pre-release' || '' }}
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: ry-vscode-${{ matrix.code-target }}
+          name: ry-vscode-marketplace-${{ matrix.code-target }}
           path: editors/code/*.vsix
+
+      - name: Package Open VSX VSIX
+        working-directory: editors/code
+        run: |
+          # Preserve the already-published Open VSX identity.
+          npm pkg set name=ry
+          mkdir -p openvsx
+          bunx @vscode/vsce package --target ${{ matrix.code-target }} --no-dependencies ${{ inputs.pre-release && '--pre-release' || '' }} --out openvsx/ry-${{ matrix.code-target }}.vsix
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ry-vscode-openvsx-${{ matrix.code-target }}
+          path: editors/code/openvsx/*.vsix
 
   # ---------------------------------------------------------------------------
   # Publish: two jobs consuming all platform VSIXs.
@@ -157,7 +170,7 @@ jobs:
 
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          pattern: ry-vscode-*
+          pattern: ry-vscode-marketplace-*
           merge-multiple: true
           path: vsix
 
@@ -184,7 +197,7 @@ jobs:
 
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          pattern: ry-vscode-*
+          pattern: ry-vscode-openvsx-*
           merge-multiple: true
           path: vsix
 

--- a/.github/workflows/release-vscode.yml
+++ b/.github/workflows/release-vscode.yml
@@ -17,6 +17,14 @@ on:
         description: "Core binary release tag (e.g. v0.9.0)"
         required: true
         type: string
+      registry:
+        description: "Registry to publish to"
+        type: choice
+        default: both
+        options:
+          - both
+          - marketplace
+          - openvsx
       pre-release:
         description: "Publish as a pre-release"
         type: boolean
@@ -160,6 +168,7 @@ jobs:
   # Publish: two jobs consuming all platform VSIXs.
   # ---------------------------------------------------------------------------
   publish-marketplace:
+    if: inputs.registry != 'openvsx'
     name: Publish to VS Code Marketplace
     runs-on: ubuntu-latest
     needs: build
@@ -186,6 +195,7 @@ jobs:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}
 
   publish-openvsx:
+    if: inputs.registry != 'marketplace'
     name: Publish to Open VSX
     runs-on: ubuntu-latest
     needs: build

--- a/.github/workflows/release-vscode.yml
+++ b/.github/workflows/release-vscode.yml
@@ -147,7 +147,7 @@ jobs:
         working-directory: editors/code
         run: |
           # Preserve the already-published Open VSX identity.
-          npm pkg set name=ry
+          npm pkg set name=ry displayName=ry
           mkdir -p openvsx
           bunx @vscode/vsce package --target ${{ matrix.code-target }} --no-dependencies ${{ inputs.pre-release && '--pre-release' || '' }} --out openvsx/ry-${{ matrix.code-target }}.vsix
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ missing signatures can produce false positives or missed bugs. See
 ## Editors
 
 Install **ry** from the
-[VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=scholzmx.ry)
+[VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=scholzmx.ry-checker)
 or Positron's Open VSX gallery. The extension bundles the checker and provides
 diagnostics, inferred type hints, and suppression actions.
 

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -117,6 +117,9 @@ v{version}  (e.g. v0.9.0)
 
 ## VS Code extension release
 
+The `registry` dispatch input defaults to `both`; select `marketplace` or
+`openvsx` when an extension update is specific to one registry.
+
 ### Prerequisites
 
 - Marketplace identity verified: `scholzmx.ry-checker` across `package.json`,

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -119,9 +119,10 @@ v{version}  (e.g. v0.9.0)
 
 ### Prerequisites
 
-- Publisher identity verified: `scholzmx.ry` across `package.json`,
+- Marketplace identity verified: `scholzmx.ry-checker` across `package.json`,
   `constants.ts`, `README.md`, and both test-suite `getExtension` lookups
-  (enforced by the `publisher-consistency` job).
+  (enforced by the `publisher-consistency` job). The release workflow packages
+  Open VSX separately as `scholzmx.ry`, preserving its existing listing.
 - Core binary release tag exists with verified artifacts.
 - The Marketplace publisher `scholzmx` exists and the `VSCE_PAT` repository
   secret can publish under it. The Open VSX namespace `scholzmx` exists,

--- a/editors/code/CHANGELOG.md
+++ b/editors/code/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## [0.9.1] - 2026-09-07
+
+- Publish on VS Code Marketplace as `scholzmx.ry-checker`, displayed as
+  `ry - R Type Checker`. Open VSX retains `scholzmx.ry`.
+
 ## [0.9.0] - 2026-09-07
 
 ### Added

--- a/editors/code/README.md
+++ b/editors/code/README.md
@@ -9,7 +9,7 @@ functions. Unknown types and assignments the checker does not visit are omitted.
 ## Installation
 
 Install from the
-[VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=scholzmx.ry)
+[VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=scholzmx.ry-checker)
 or Positron's Open VSX gallery, then open an R file.
 
 The extension bundles ry. By default it uses an executable on `PATH` when

--- a/editors/code/bun.lock
+++ b/editors/code/bun.lock
@@ -3,7 +3,7 @@
   "configVersion": 1,
   "workspaces": {
     "": {
-      "name": "ry",
+      "name": "ry-checker",
       "dependencies": {
         "effect": "^3",
         "vscode-languageclient": "^9.0.1",

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ry-checker",
-  "displayName": "ry",
+  "displayName": "ry — R Type Checker",
   "description": "Static type checker for R.",
   "version": "0.9.0",
   "publisher": "scholzmx",

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -1,8 +1,8 @@
 {
   "name": "ry-checker",
-  "displayName": "ry — R Type Checker",
+  "displayName": "ry - R Type Checker",
   "description": "Static type checker for R.",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "publisher": "scholzmx",
   "license": "MIT",
   "homepage": "https://github.com/sims1253/ry",

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ry",
+  "name": "ry-checker",
   "displayName": "ry",
   "description": "Static type checker for R.",
   "version": "0.9.0",

--- a/editors/code/src/common/constants.ts
+++ b/editors/code/src/common/constants.ts
@@ -11,7 +11,7 @@ export const EXTENSION_ROOT_DIR =
 /**
  * Extension ID on the marketplaces (`<publisher>.<name>`).
  */
-export const RY_EXTENSION_ID = "scholzmx.ry";
+export const RY_EXTENSION_ID = "scholzmx.ry-checker";
 
 /**
  * The VS Code settings namespace (`ry.*`).

--- a/editors/code/src/test/e2e.test.ts
+++ b/editors/code/src/test/e2e.test.ts
@@ -23,7 +23,7 @@ describe("Installed ry extension", () => {
     this.timeout(60000);
     const trusted = process.env.RY_TEST_TRUSTED === "true";
     expect(vscode.workspace.isTrusted).to.equal(trusted);
-    const extension = vscode.extensions.getExtension("scholzmx.ry")!;
+    const extension = vscode.extensions.getExtension("scholzmx.ry-checker")!;
     expect(extension.extensionPath).to.include(
       `${path.sep}extensions${path.sep}`,
     );

--- a/editors/code/test/performance.cjs
+++ b/editors/code/test/performance.cjs
@@ -7,7 +7,7 @@ const { performance } = require("node:perf_hooks");
 // Invoked inside a fresh extension host by @vscode/test-electron.
 exports.run = async () => {
   const vscode = require("vscode");
-  const extension = vscode.extensions.getExtension("scholzmx.ry");
+  const extension = vscode.extensions.getExtension("scholzmx.ry-checker");
   assert.ok(extension, "ry extension is available");
   assert.equal(extension.isActive, false, "ry must not activate before timing");
   assert.equal(vscode.workspace.isTrusted, true);


### PR DESCRIPTION
The Marketplace rejects the package name `ry` because it is already registered. Publish the Marketplace extension as `scholzmx.ry-checker`, with display name `ry - R Type Checker`, and continue publishing Open VSX as `scholzmx.ry` with display name `ry`.

The release workflow builds separate VSIX artifacts for each registry. Marketplace links and installed-extension lookups use the new ID.

Validation: TypeScript and lint passed; Linux VSIX manifests verified for both identities; renamed installed-extension test passed; workflow validation passed with shellcheck disabled (existing matrix-comparison warnings).

Marketplace 0.9.1 replaces the display-name em dash with a plain hyphen. The registry dispatch input permits this update without republishing Open VSX.
