### PR TITLE
chore(zed): prepare ry-lsp gallery identity

### DIFF
--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -214,13 +214,13 @@ run after correcting the cause. It reuses the packaged artifacts, and
 
 Follow the [Zed publishing guide](https://zed.dev/docs/extensions/publishing/publishing-guide).
 In a fork of `zed-industries/extensions`, add `https://github.com/sims1253/ry`
-as the `extensions/ry` submodule and check out the reviewed release commit.
+as the `extensions/ry-lsp` submodule and check out the reviewed release commit.
 The commit must also be reachable from a branch in the public ry repository.
 Add this entry to the gallery's `extensions.toml`:
 
 ```toml
-[ry]
-submodule = "extensions/ry"
+[ry-lsp]
+submodule = "extensions/ry-lsp"
 path = "editors/zed"
 version = "0.9.0"
 ```

--- a/editors/zed/extension.toml
+++ b/editors/zed/extension.toml
@@ -1,4 +1,4 @@
-id = "ry"
+id = "ry-lsp"
 name = "ry"
 description = "Static type checker for R"
 version = "0.9.0"


### PR DESCRIPTION
Use `ry-lsp` as the Zed gallery ID to meet the current naming requirement for language-server-only extensions. The language server name and settings key remain `ry`. Update the gallery submission example to match.

Validation: all 11 Zed extension tests passed; wasm32-wasip2 build passed.
