### PR TITLE
fix(checker): keep the data-mask pronoun opaque without a data argument

### DIFF
--- a/crates/ry-checker/src/infer/call.rs
+++ b/crates/ry-checker/src/infer/call.rs
@@ -1204,6 +1204,14 @@ impl Checker {
                         // A declared source is conditional: without a
                         // supplied `data` argument, formula extras evaluate
                         // normally in the caller environment.
+                        let leading_argument_is_masked =
+                            declared_binding
+                                .as_ref()
+                                .is_some_and(|(signature, bindings)| {
+                                    eval_mode_for_arg(signature, bindings, 0).is_some_and(|mode| {
+                                        matches!(mode, EvalMode::DataMask | EvalMode::TidySelect)
+                                    })
+                                });
                         let Some(data) = supplied_data_mask_source
                             .as_ref()
                             .map(|(_, data)| data.clone())
@@ -1212,7 +1220,21 @@ impl Checker {
                                     .as_ref()
                                     .is_some_and(|signature| signature.data_mask_source.is_none())
                                     .then(|| {
-                                        arg_types.first().cloned().unwrap_or_else(RType::unknown)
+                                        if leading_argument_is_masked {
+                                            // A signature that data-masks its own
+                                            // leading formals (ggplot2 `aes()`,
+                                            // `vars()`, tidyr `nesting()`) has no
+                                            // data argument at the call site: the
+                                            // mask is unknown and `.data` stays
+                                            // opaque instead of adopting a sibling
+                                            // argument's atomic type.
+                                            RType::unknown()
+                                        } else {
+                                            arg_types
+                                                .first()
+                                                .cloned()
+                                                .unwrap_or_else(RType::unknown)
+                                        }
                                     })
                             })
                         else {

--- a/crates/ry-checker/src/infer/call.rs
+++ b/crates/ry-checker/src/infer/call.rs
@@ -1204,11 +1204,36 @@ impl Checker {
                         // A declared source is conditional: without a
                         // supplied `data` argument, formula extras evaluate
                         // normally in the caller environment.
+                        // Classify by the first argument's OWN binding, not
+                        // `eval_mode_for_arg`: its `...` fallback would also
+                        // mark a leading data argument masked. Signatures such
+                        // as dplyr `transmute(.data, ...)` declare no eval
+                        // entry on the data formal, only on `...`, and their
+                        // first argument is the data frame at every real call
+                        // site -- the schema mask must survive. A named formal
+                        // counts as masked only through its own entry; an
+                        // argument absorbed by `...` counts through the dots
+                        // entry (ggplot2 `aes()`, tidyr `nesting()`).
                         let leading_argument_is_masked =
                             declared_binding
                                 .as_ref()
                                 .is_some_and(|(signature, bindings)| {
-                                    eval_mode_for_arg(signature, bindings, 0).is_some_and(|mode| {
+                                    let own_formal = bindings
+                                        .param_for_arg
+                                        .first()
+                                        .and_then(|parameter| {
+                                            parameter.and_then(|index| signature.params.get(index))
+                                        })
+                                        .map(|param| param.name.as_str());
+                                    let own_mode = own_formal
+                                        .and_then(|name| signature.eval.get(name))
+                                        .or_else(|| {
+                                            own_formal
+                                                .is_none()
+                                                .then(|| signature.eval.get("..."))
+                                                .flatten()
+                                        });
+                                    own_mode.is_some_and(|mode| {
                                         matches!(mode, EvalMode::DataMask | EvalMode::TidySelect)
                                     })
                                 });

--- a/crates/ry-checker/src/tests/packages_typeshed.rs
+++ b/crates/ry-checker/src/tests/packages_typeshed.rs
@@ -1021,3 +1021,23 @@ fn find_results_preserve_no_match_and_list_element_uncertainty() {
             .any(|d| d.code == "RY105")
     );
 }
+
+#[test]
+fn attached_ggplot2_aes_data_pronoun_stays_opaque() {
+    // Unit-level attachment coverage, not end-to-end NAMESPACE import
+    // coverage: `set_bare_loaded` reproduces only the checker state the
+    // CLI derives from `import(ggplot2)` (ggplot2 on this file's search
+    // path). It pins that the pronoun stays opaque under that state --
+    // a sibling aesthetic's atomic type cannot become the data mask and
+    // flag `.data$col` (#383). End-to-end package evidence is the
+    // pinned-CRAN-package CLI comparison recorded in the issue
+    // investigation (see 0.14.2: 10 RY061 pre-fix, 0 post-fix).
+    let source = include_str!("../../testdata/ok_ggplot2_aes_data_pronoun.R");
+    let diagnostics = check_with(source, |checker| {
+        checker.set_bare_loaded(HashSet::from(["ggplot2".to_string()]));
+    });
+    assert!(
+        diagnostics.is_empty(),
+        "attached ggplot2 must keep `.data` opaque: {diagnostics:?}"
+    );
+}

--- a/crates/ry-checker/testdata/ok_ggplot2_aes_data_pronoun.R
+++ b/crates/ry-checker/testdata/ok_ggplot2_aes_data_pronoun.R
@@ -1,0 +1,42 @@
+# no-diag
+# `.data` inside aes()/vars()/qplot() has no usable data argument at the
+# call site: the first supplied argument is itself data-masked, so it
+# cannot serve as the fallback mask source. The pronoun must stay
+# opaque and cannot adopt a sibling argument's atomic type (#383). A
+# preceding double, character, or call-typed sibling must not become the
+# mask. A named `data` argument the signature does not declare as a
+# mask source stays conservative: unsupported, never an error.
+ribbon1 <- ggplot2::geom_ribbon(
+  ggplot2::aes(ymin = -Inf, ymax = .data$se.lo),
+  alpha = 0.1
+)
+ribbon2 <- geom_ribbon(aes(ymin = 0, ymax = .data$curve_y))
+edge <- ggraph::geom_edge_arc(
+  aes(
+    alpha = as.numeric(.data$Component == "Correlation"),
+    label = .data$Label_Correlation,
+    color = .data$Coefficient
+  ),
+  strength = 0.1
+)
+# A character sibling must not leak its mode either.
+chr_sibling <- ggplot2::aes(colour = "red", x = .data$mpg)
+# `.data` in the leading argument is evaluated before any sibling type
+# exists and stays quiet in both directions.
+leading <- ggplot2::aes(x = .data$mpg, colour = "red")
+only <- ggplot2::aes(ymin = .data$se)
+plain <- ggplot(df, aes(x = .data$x, y = .data$y))
+keep <- ggplot(df, aes(x = .data$x)) + geom_point(aes(colour = .data$grp))
+# Leading `...` data-masked formals have no data argument either.
+vars_q <- ggplot2::vars(.data$mpg)
+# qplot's first supplied argument is itself masked and the named `data`
+# argument is not a declared mask source, so the mask stays unknown and
+# `$` access is never an error.
+q <- qplot(x = .data$mpg, y = .data$wt, data = mtcars)
+# Checker-behavior retention controls (not R-oracle claims): APIs whose
+# leading formal is the data argument keep their mask -- positional,
+# named, and data_mask_source-declaring signatures.
+w1 <- with(mtcars, .data$mpg)
+w2 <- with(data = mtcars, .data$mpg)
+t1 <- transform(mtcars, k = .data$mpg * 2)
+m1 <- lm(mpg ~ wt, data = mtcars)

--- a/crates/ry-checker/testdata/ry060_data_mask_pronoun_schema_miss.R
+++ b/crates/ry-checker/testdata/ry060_data_mask_pronoun_schema_miss.R
@@ -1,0 +1,11 @@
+# expect: RY060, RY060, RY060
+# Two genuine data-mask true positives: dplyr supplies `.data` at
+# runtime, so a column outside mtcars' known schema is a real miss in
+# filter() and mutate(). These must fire identically before and after
+# the source-less mask fix (#383). The final `with()` line pins checker
+# schema behavior only -- base R's `with()` provides no `.data` pronoun,
+# so it is retention coverage, not an R-truth claim.
+library(dplyr)
+a <- filter(mtcars, .data$nonexistent > 1)
+b <- mutate(mtcars, z = .data$nonexistent)
+c <- with(mtcars, .data$nonexistent)

--- a/crates/ry-checker/testdata/ry060_dots_fallback_data_pronoun.R
+++ b/crates/ry-checker/testdata/ry060_dots_fallback_data_pronoun.R
@@ -1,0 +1,12 @@
+# expect: RY060, RY060
+# Retention pins for data-leading signatures whose data formal has no
+# eval entry of its own (only `...` is data-masked): the first argument
+# IS the data frame, so schema-driven pronoun diagnostics must survive
+# the own-binding guard from #383 (these 31 signatures -- dplyr
+# transmute/count, tidyr expand/complete, survival tmerge, rlist
+# list.* -- previously lost their RY060 true positives through the
+# `...` eval fallback).
+library(dplyr)
+library(tidyr)
+a <- dplyr::transmute(mtcars, z = .data$nonexistent)
+b <- tidyr::expand(mtcars, .data$nonexistent)

--- a/crates/ry-checker/tests/snapshots/corpus__checker_fixture_diagnostics.snap
+++ b/crates/ry-checker/tests/snapshots/corpus__checker_fixture_diagnostics.snap
@@ -1217,6 +1217,24 @@ expression: snapshots
       message: "column `nonexistent` not found in data frame schema; available columns: am, carb, cyl, disp, drat, ..."
       severity: error
       span:
+        column: 34
+        end: 537
+        line: 10
+        start: 520
+    - code: RY060
+      message: "column `nonexistent` not found in data frame schema; available columns: am, carb, cyl, disp, drat, ..."
+      severity: error
+      span:
+        column: 27
+        end: 583
+        line: 11
+        start: 566
+  fixture: ry060_dots_fallback_data_pronoun.R
+- diagnostics:
+    - code: RY060
+      message: "column `nonexistent` not found in data frame schema; available columns: am, carb, cyl, disp, drat, ..."
+      severity: error
+      span:
         column: 7
         end: 189
         line: 4

--- a/crates/ry-checker/tests/snapshots/corpus__checker_fixture_diagnostics.snap
+++ b/crates/ry-checker/tests/snapshots/corpus__checker_fixture_diagnostics.snap
@@ -729,6 +729,8 @@ expression: snapshots
 - diagnostics: []
   fixture: ok_function_def.R
 - diagnostics: []
+  fixture: ok_ggplot2_aes_data_pronoun.R
+- diagnostics: []
   fixture: ok_global_variables_declaration.R
 - diagnostics: []
   fixture: ok_ho_filter_find.R
@@ -1184,6 +1186,32 @@ expression: snapshots
         line: 6
         start: 321
   fixture: ry050_missing_method.R
+- diagnostics:
+    - code: RY060
+      message: "column `nonexistent` not found in data frame schema; available columns: am, carb, cyl, disp, drat, ..."
+      severity: error
+      span:
+        column: 20
+        end: 486
+        line: 8
+        start: 469
+    - code: RY060
+      message: "column `nonexistent` not found in data frame schema; available columns: am, carb, cyl, disp, drat, ..."
+      severity: error
+      span:
+        column: 24
+        end: 533
+        line: 9
+        start: 516
+    - code: RY060
+      message: "column `nonexistent` not found in data frame schema; available columns: am, carb, cyl, disp, drat, ..."
+      severity: error
+      span:
+        column: 18
+        end: 570
+        line: 10
+        start: 553
+  fixture: ry060_data_mask_pronoun_schema_miss.R
 - diagnostics:
     - code: RY060
       message: "column `nonexistent` not found in data frame schema; available columns: am, carb, cyl, disp, drat, ..."


### PR DESCRIPTION
## Summary

`.data` inside `aes()`-style calls was flagged RY061 ("$ operator is invalid for atomic vectors of mode `double`") in package code such as `see` (10 findings on CRAN see 0.14.2; all sites `aes(ymin = -Inf, ymax = .data$se.lo)`-shaped).

Root cause: for signatures without a `data_mask_source`, the `EvalMode::DataMask` fallback used the call's first argument type as the data mask, and `dplyr_data_mask_scope` binds `.data` to that mask. Signatures that data-mask their own leading formals (ggplot2 `aes()`/`qplot()`/`vars()`, tidyr `nesting()`/`crossing()`) have no usable data argument — the first supplied argument is itself masked — so a sibling aesthetic's atomic type (double, character, or a call result) leaked into `.data` and later `.data$col` arguments were flagged.

Fix: when the first supplied argument is itself declared data-mask/tidy-select, the fallback mask is `unknown`, keeping `.data` opaque in those contexts. Schema-driven `.data` typing from a real leading data argument (`with()`, `transform()`, dplyr verbs) and `data_mask_source`-declaring signatures (lm/glm/t.test family) are unchanged.

Fixes #383 — limited to the investigated pronoun-inference cause.

## The stub-drift claim is disproved only for the tested artifact/evidence

The issue also alleged the shipped 0.9.0 binary carries stubs that drifted from the vendored stubs. Within the evidence gathered, no drift exists: all 36 vendored stub files are embedded byte-for-byte in the published v0.9.0 x86_64 Linux artifact (sha256-matched against the release checksum); the v0.9.0 tag and main `dde15b6` are identical under `crates/`; the published binary and a tracked-source `dde15b6` build emit byte-identical diagnostics on the reproduction corpus. This PR does not add a build-time drift guard (no drift was observed to guard against); that remains an optional hardening decision separate from this fix.

## Tests

- New fixture `testdata/ok_ggplot2_aes_data_pronoun.R` (`# no-diag`): sibling double/character literals, `.data`-first/only, nested calls, unknown-package callees, `qplot` with a named `data` argument (not a declared mask source: stays conservative), plus retention controls for `with()` positional/named, `transform()`, and `lm(data=)`.
- New fixture `testdata/ry060_data_mask_pronoun_schema_miss.R` (`# expect: RY060, RY060, RY060`): genuine data-mask true positives `filter(mtcars, .data$nonexistent > 1)` and `mutate(mtcars, z = .data$nonexistent)` (dplyr supplies `.data` at runtime) plus a `with(mtcars, ...)` checker-behavior retention line, explicitly not an R-truth claim.
- Unit test `attached_ggplot2_aes_data_pronoun_stays_opaque`: ggplot2 attachment (the checker state `import(ggplot2)` produces) — labeled unit-level coverage, not end-to-end NAMESPACE coverage.
- End-to-end evidence (recorded during investigation, CRAN-pinned): see 0.14.2 goes from 10 RY061 (published 0.9.0 and tracked `dde15b6` build, byte-identical) to 0 with this change, all other diagnostics unchanged; real-error RY061 controls on provably atomic receivers still fire.

## Checks

Scoped local checks run on the exact head: `cargo test -p ry-checker` (all targets, zero failures), `cargo clippy -p ry-checker --all-targets -- -D warnings`, `cargo fmt --all -- --check`. Full workspace gates (workspace tests, complete oracle matrix, fuzz smoke, ecosystem checks) are not claimed run locally and are delegated to PR CI.
