### PR TITLE
chore(typeshed): sync mirai status contract

### DIFF
--- a/crates/ry-checker/testdata/err_dollar_atomic_controls.R
+++ b/crates/ry-checker/testdata/err_dollar_atomic_controls.R
@@ -1,0 +1,11 @@
+# expect: RY061, RY061, RY061
+# True-positive controls around the mirai::status fix: `$` on provably
+# atomic receivers must keep firing (double literal, integer-returning
+# nchar(), and mirai::unresolved()'s logical(1) result).
+x <- 1.5
+a <- x$foo
+n <- nchar("abc")
+b <- n$len
+m <- mirai::mirai(1 + 1)
+i <- mirai::unresolved(m)
+c <- i$extra

--- a/crates/ry-checker/testdata/ok_mirai_status_dollar.R
+++ b/crates/ry-checker/testdata/ok_mirai_status_dollar.R
@@ -1,0 +1,13 @@
+# no-diag
+# mirai::status() returns a named list ($connections, $daemons, plus
+# $mirai/$memory under a dispatcher), so `$` access must stay valid
+# (ry #382; r-typeshed mirai 0.0.2, merged a682775d). Covers positional
+# and named `.compute` supply, miraiCluster and character profile
+# arguments, and member extraction through the qualified call.
+s <- mirai::status()
+s$connections
+s$daemons
+s$mirai
+s$memory
+u <- mirai::status("profile")$mirai
+v <- mirai::status(.compute = "profile")$connections

--- a/crates/ry-checker/tests/snapshots/corpus__checker_fixture_diagnostics.snap
+++ b/crates/ry-checker/tests/snapshots/corpus__checker_fixture_diagnostics.snap
@@ -98,6 +98,32 @@ expression: snapshots
   fixture: err_dollar_assign_atomic.R
 - diagnostics:
     - code: RY061
+      message: "$ operator is invalid for atomic vectors of mode `double`"
+      severity: error
+      span:
+        column: 5
+        end: 248
+        line: 5
+        start: 243
+    - code: RY061
+      message: "$ operator is invalid for atomic vectors of mode `integer`"
+      severity: error
+      span:
+        column: 5
+        end: 277
+        line: 7
+        start: 272
+    - code: RY061
+      message: "$ operator is invalid for atomic vectors of mode `logical`"
+      severity: error
+      span:
+        column: 5
+        end: 341
+        line: 10
+        start: 334
+  fixture: err_dollar_atomic_controls.R
+- diagnostics:
+    - code: RY061
       message: "$ operator is invalid for atomic vectors of mode `integer`"
       severity: error
       span:
@@ -794,6 +820,8 @@ expression: snapshots
   fixture: ok_loops.R
 - diagnostics: []
   fixture: ok_mirai_minimal.R
+- diagnostics: []
+  fixture: ok_mirai_status_dollar.R
 - diagnostics: []
   fixture: ok_multi_assign.R
 - diagnostics: []

--- a/crates/ry-typeshed/vendor/SOURCE
+++ b/crates/ry-typeshed/vendor/SOURCE
@@ -1,4 +1,4 @@
 repository: https://github.com/sims1253/r-typeshed
-commit: c1ee1cc6af8f6ad5b68f56c82dd6a942ea1a7493
+commit: a682775dd353ffcd4410bd7da69dec4a23e1457f
 tree-state: clean
-stubs-sha256: 305c378ce7ae7f4ce9398e996846c0b8d2e08f2648003b390aaf52bbaaa4f5a2
+stubs-sha256: 924b739591ae86499f132bedabb79143c5f9bdc226e174d01d1e0d85a9129cd5

--- a/crates/ry-typeshed/vendor/mirai/mirai.json
+++ b/crates/ry-typeshed/vendor/mirai/mirai.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "2",
   "package": "mirai",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "functions": {
     "call_mirai": {
       "params": [
@@ -89,12 +89,13 @@
     },
     "status": {
       "params": [
-        ".x"
+        ".compute"
       ],
       "return": {
-        "mode": "integer",
-        "length": "1",
-        "na": false
+        "mode": "list",
+        "length": "unknown",
+        "na": false,
+        "note": "Named list: connections (integer), daemons (character URL or 0L); mirai (named integer) and memory (named numeric) present only under a dispatcher. Source: mirai 2.7.2 R/daemons.R status(); runtime checked on mirai 2.7.1 / R 4.6.1."
       }
     },
     "stop_mirai": {


### PR DESCRIPTION
## Summary

`mirai::status()` was stubbed with params `[".x"]` and an `integer(1)` return, so every `$` access on its result — `status()$mirai`, `status()$connections` — was flagged RY061 ("$ operator is invalid for atomic vectors of mode integer"). The upstream contract is different: the formal is `.compute` (character | miraiCluster | NULL) and the return is a named list (`$connections` integer, `$daemons` character URL or `0L`, plus `$mirai`/`$memory` only under a dispatcher).

This vendors the corrected contract: r-typeshed PR #40, merged as `a682775dd353ffcd4410bd7da69dec4a23e1457f` on master (mirai stub revision 0.0.2), synced through `scripts/sync_typeshed.sh` from a clean checkout at that exact merge commit. No direct vendored edits: the vendor diff is exactly `mirai.json` + `SOURCE` (commit `a682775d`, tree-state clean, stubs-sha256 `924b7395…`).

Fixes #382.

## Tests

- `testdata/ok_mirai_status_dollar.R` (`# no-diag`): bare, positional-string, and named `.compute =` supply (the mlr3 real-world shape), all four documented member accesses, and a chained qualified call.
- `testdata/err_dollar_atomic_controls.R` (`# expect: RY061, RY061, RY061`): true-positive controls on provably atomic receivers (double literal, `nchar()` integer, `mirai::unresolved()` logical) — these keep firing.
- Corpus snapshot update is additions-only.

## Evidence

- Upstream contract verified against mirai 2.7.2 source (`R/daemons.R`) and runtime R 4.6.1 / mirai 2.7.1 (return is a named list; formal `.compute`).
- Native corpus delta on the synced binary (mlr3 1.8.0, not part of the pinned ecosystem manifest): exactly the three `mirai::status(...)` RY061s removed, zero added, all other diagnostics byte-identical. This is a targeted delta, not a full corpus audit.
- Scoped local gates on the exact head: `cargo test -p ry-checker` (all targets, zero failures), `cargo clippy -p ry-checker --all-targets -- -D warnings`, `cargo fmt --all -- --check`; `vendor_snapshot` green.
- Ecosystem: the harness exercises the built checker/typeshed behavior, so no independence is claimed. Native pinned-corpus gate run on this exact head: `RY_BINARY=<candidate release build> ecosystem/run.sh --check` — result `ecosystem: committed reports are current` (exit 0): every pinned tidyverse manifest package reproduces its committed reports byte-identically under the synced stub. PR CI (including the remote ecosystem job) remains the authoritative remote gate.
