### PR TITLE
fix(inference): discard source length after opaque subsetting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to ry are documented in this file.
 
 ### Fixed
 
+- Keep subset results unknown when the receiver has no known subsetting
+  contract. This avoids a false condition-length warning in `rstan`.
 - Read serialized package data containing cyclic objects without crashing.
   This fixes a stack overflow while checking `workflowsets` and preserves
   unbound-name diagnostics after data inventory.

--- a/crates/ry-checker/src/infer/index.rs
+++ b/crates/ry-checker/src/infer/index.rs
@@ -332,6 +332,11 @@ impl Checker {
                     result.columns = None;
                     return result;
                 }
+                // An opaque receiver supplies no subsetting contract. Its
+                // length and schema describe the source, not the result.
+                if bt.mode == Mode::Opaque {
+                    return RType::unknown();
+                }
                 bt
             }
         }

--- a/crates/ry-checker/src/tests/scope_resolution.rs
+++ b/crates/ry-checker/src/tests/scope_resolution.rs
@@ -516,6 +516,25 @@ fn bare_data_pronoun_inside_mask_is_silent() {
 }
 
 #[test]
+fn opaque_subset_does_not_keep_source_length() {
+    for index in ["1L", "choice", "1L, drop = TRUE"] {
+        let source = format!(
+            "f <- function(flag, choice) {{\n\
+             choices <- c(if (flag) \"a\", \"b\", \"c\")\n\
+             if (choices[{index}] == \"a\") 1L\n\
+             }}\n"
+        );
+        let diagnostics = check(&source);
+        assert!(diagnostics.is_empty(), "{index}: {diagnostics:?}");
+    }
+    let diagnostics =
+        check("f <- function(flag) { x <- c(if (flag) 1L, 2L, 3L); x[undefined_index] }\n");
+    assert!(diagnostics.iter().any(|diagnostic| {
+        diagnostic.code == "RY010" && diagnostic.message.contains("undefined_index")
+    }));
+}
+
+#[test]
 fn scalar_string_subset_of_atomic_vector_has_length_one() {
     let (diags, scope) = check_with_scope("x <- c(first = 1L, second = 2L)\ny <- x[\"first\"]\n");
     assert!(diags.is_empty(), "{diags:?}");

--- a/crates/ry-checker/testdata/oracle/conditional_vector_scalar_subset.R
+++ b/crates/ry-checker/testdata/oracle/conditional_vector_scalar_subset.R
@@ -1,0 +1,8 @@
+# oracle: must-pass
+# The optional first element changes the source length. A scalar subscript
+# still selects one element, as in rstan's example-model menu.
+choose <- function(flag) {
+  choices <- c(if (flag) "a", "b", "c")
+  if (choices[1L] == "a") 1L else 2L
+}
+stopifnot(choose(TRUE) == 1L, choose(FALSE) == 2L)

--- a/crates/ry-cli/tests/config_e2e.rs
+++ b/crates/ry-cli/tests/config_e2e.rs
@@ -1030,6 +1030,11 @@ fn full_output_reports_argument_type_mismatch_with_types() {
 fn cyclic_serialized_data_keeps_bindings_and_unbound_diagnostics() {
     // Generated from two distinct self-referential R environments wrapped
     // in pairlists. The decoder must not compare their cyclic graphs in dedup.
+    // Regenerate in tests/fixtures/ with R:
+    // a <- new.env(parent = emptyenv()); a$self <- a
+    // b <- new.env(parent = emptyenv()); b$self <- b
+    // x <- pairlist(a); y <- pairlist(b)
+    // save(x, y, file = "cyclic-pairlists.rda", version = 2, compress = FALSE)
     let tmp = tempfile::tempdir().unwrap();
     let pkg = tmp.path();
     fs::write(


### PR DESCRIPTION
A scalar selection in rstan's example-model menu produces a false RY001 warning: ry carries the source vector's length into the subset, then reports a length-two condition. This appeared during the 0.9.1 corpus comparison.

```r
choices <- c(if (flag) "a", "b", "c")
if (choices[1L] == "a") 1L
```

When the receiver is opaque and no earlier schema rule resolves the access, keep the subset result unknown. Subscripts still receive normal diagnostic checks. Known vector lengths retain their existing rules.

Validation: the regression fails before this change and passes after it; 74 scope tests and the full 17-test R oracle matrix pass. The R fixture exercises both values of `flag`. Full workspace and corpus checks are running.

Also add the R generation recipe for the cyclic-data fixture requested in #401's review.

Part of #392. Stacked on #401 until that PR merges.
