### PR TITLE
fix(checker): keep union subsets unknown and disclose RC-visible changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,11 @@ reading serialized package data.
 ### Fixed
 
 - Keep subset results unknown when the receiver has no known subsetting
-  contract. This avoids a false condition-length warning in `rstan`.
+  contract. This avoids a false condition-length warning in `rstan`, and
+  likewise keeps union receivers such as
+  `if (p) c("a", "b") else c("a", "b", "c")` from carrying their
+  source lengths past a `[` subset into a false condition-length
+  warning.
 - Read cyclic serialized objects without a stack overflow, including the
   package data used by `workflowsets`.
 - Keep `.data` opaque in data-masked calls such as `aes()` when no usable
@@ -29,7 +33,12 @@ reading serialized package data.
 - Widen default-derived parameter types in branches that reject their
   inferred mode, avoiding false `$` errors in those branches (#343).
 - Accept scalar character, raw, and complex conditions that R can coerce
-  to logical. Known invalid literals and lengths still produce RY001 (#373).
+  to logical. Known invalid literals still produce RY001. Multi-value
+  conditions are newly visible as RY001 warnings in default output:
+  numeric conditions previously carried only the default-off RY003
+  nudge, and multi-element logical loop conditions were not reported
+  (#373). Review baselines and `--error-on-warning` runs for new
+  findings.
 
 ### Changed
 
@@ -40,6 +49,10 @@ reading serialized package data.
   embedded stubs. Load package stubs when needed (#340).
 - Speed up workspace indexing and project checks with bounded parallel
   processing and cached package discovery (#340).
+- Hash checker-internal identifier maps with FxHash instead of SipHash.
+  `Scope`'s public collections (`bindings`, `parameter_bindings`,
+  `function_aliases`, and siblings) are now `FxMap`/`FxSet` rather than
+  `HashMap`/`HashSet`; a source-level change for library consumers (#340).
 - Clarify RY001 and RY070 messages. Baselines match message text, so
   previously accepted findings can reappear after upgrading. Review them
   before regenerating the entries you still accept.

--- a/crates/ry-checker/src/infer/index.rs
+++ b/crates/ry-checker/src/infer/index.rs
@@ -332,9 +332,17 @@ impl Checker {
                     result.columns = None;
                     return result;
                 }
-                // An opaque receiver supplies no subsetting contract. Its
-                // length and schema describe the source, not the result.
-                if bt.mode == Mode::Opaque {
+                // An opaque receiver supplies no subsetting contract, and a
+                // union receiver supplies none either: `vector_base` above
+                // already excludes unions, so reaching here means the
+                // members' shapes cannot drive the result. Their lengths
+                // and schemas describe the source members, not the
+                // index-derived result — a members-agree union such as
+                // `if (p) c("a", "b") else c("a", "b", "c")` would
+                // otherwise carry `logical<len=2>|logical<len=3>` past
+                // `x[1L] == "a"` and surface a false condition-length
+                // warning once member-level lengths are inspected.
+                if matches!(bt.mode, Mode::Opaque | Mode::Union) {
                     return RType::unknown();
                 }
                 bt

--- a/crates/ry-checker/src/infer/mod.rs
+++ b/crates/ry-checker/src/infer/mod.rs
@@ -502,7 +502,8 @@ impl Checker {
     /// class-equality operand check runs first, then the condition's own
     /// inference, and `diagnostic_start` bounds exactly the diagnostics
     /// that inference produced — which is what lets an RY100 reported
-    /// inside the condition suppress the RY001/RY003/RY002 family. All
+    /// inside the condition suppress the RY001 and RY003 arms below (the
+    /// RY002 length rule is not gated on it). All
     /// three condition contexts (`if` statements, loop conditions, `if`
     /// expressions) route through here so they cannot drift apart.
     fn infer_condition(&mut self, cond: &Expr, scope: &mut Scope, ctx: ConditionContext) {
@@ -582,7 +583,8 @@ impl Checker {
     ///
     /// `diagnostic_start` is the `diagnostics` length captured before that
     /// inference. An RY100 reported inside the condition already covers the
-    /// same span, so it suppresses this family.
+    /// same span, so it suppresses the RY001 and RY003 arms below (RY002's
+    /// length rule is not gated on it).
     ///
     /// RY002 fires for `ConditionContext::If` only. The rule table scopes that
     /// code to `if` conditions, and the `while` arm has never carried it.

--- a/crates/ry-checker/src/infer/quoting.rs
+++ b/crates/ry-checker/src/infer/quoting.rs
@@ -91,9 +91,15 @@ pub(crate) fn collect_forwarded_calls_in_stmts(
 /// force it after the caller rebinds; deferred forcing stays out of
 /// scope. Dynamic `assign()` calls and replacement targets are not modeled.
 pub(crate) fn may_rebind_source_before(body: &[Stmt], source: &str, call_statement: usize) -> bool {
-    body[..call_statement]
-        .iter()
-        .any(|statement| statement_assigns_name(statement, source))
+    // `get` rather than indexing: `call_statement` comes from the
+    // ForwardedCall recorded against this body, and a future FnTable
+    // that lets them drift out of sync must degrade to "no rebind"
+    // instead of panicking on untrusted input.
+    body.get(..call_statement).is_some_and(|before| {
+        before
+            .iter()
+            .any(|statement| statement_assigns_name(statement, source))
+    })
 }
 
 /// Whether any assignment form inside one statement binds `name`

--- a/crates/ry-checker/src/tests/scope_resolution.rs
+++ b/crates/ry-checker/src/tests/scope_resolution.rs
@@ -516,6 +516,24 @@ fn bare_data_pronoun_inside_mask_is_silent() {
 }
 
 #[test]
+fn union_subset_does_not_keep_source_lengths() {
+    // A members-agree union keeps neither a single length nor a usable
+    // subsetting contract: `x[1L]` is index-shaped, so the condition on
+    // it must not see the source members' lengths (2 and 3).
+    let diags = check(
+        "f <- function(p) {\n\
+         x <- if (p) c(\"a\", \"b\") else c(\"a\", \"b\", \"c\")\n\
+         y <- x[1L]\n\
+         if (y == \"a\") 1L\n\
+         }\n",
+    );
+    assert!(
+        diags.is_empty(),
+        "union subset result must not keep source lengths: {diags:?}"
+    );
+}
+
+#[test]
 fn opaque_subset_does_not_keep_source_length() {
     for index in ["1L", "choice", "1L, drop = TRUE"] {
         let source = format!(

--- a/crates/ry-checker/src/tests/scope_resolution.rs
+++ b/crates/ry-checker/src/tests/scope_resolution.rs
@@ -519,18 +519,22 @@ fn bare_data_pronoun_inside_mask_is_silent() {
 fn union_subset_does_not_keep_source_lengths() {
     // A members-agree union keeps neither a single length nor a usable
     // subsetting contract: `x[1L]` is index-shaped, so the condition on
-    // it must not see the source members' lengths (2 and 3).
-    let diags = check(
-        "f <- function(p) {\n\
-         x <- if (p) c(\"a\", \"b\") else c(\"a\", \"b\", \"c\")\n\
-         y <- x[1L]\n\
-         if (y == \"a\") 1L\n\
-         }\n",
-    );
-    assert!(
-        diags.is_empty(),
-        "union subset result must not keep source lengths: {diags:?}"
-    );
+    // it must not see the source members' lengths (2 and 3). Mirror
+    // the opaque sibling's index shapes, including the multi-arg form.
+    for index in ["1L", "choice", "1L, drop = TRUE"] {
+        let source = format!(
+            "f <- function(p, choice) {{\n\
+             x <- if (p) c(\"a\", \"b\") else c(\"a\", \"b\", \"c\")\n\
+             y <- x[{index}]\n\
+             if (y == \"a\") 1L\n\
+             }}\n"
+        );
+        let diags = check(&source);
+        assert!(
+            diags.is_empty(),
+            "{index}: union subset result must not keep source lengths: {diags:?}"
+        );
+    }
 }
 
 #[test]

--- a/crates/ry-checker/src/tests/type_inference.rs
+++ b/crates/ry-checker/src/tests/type_inference.rs
@@ -445,7 +445,7 @@ fn coercible_scalar_conditions_stay_silent() {
         (
             // NA_complex_ is complex<len=1>, so this exercises the same
             // silence arm. R ERRORS at runtime ("argument is not
-            // interpretable as a logical"): the VALUE, not the mode,
+            // interpretable as logical"): the VALUE, not the mode,
             // decides. Silence is the uncertainty policy for untracked
             // values (NA boundary stays with #354), not a validity claim.
             "NA complex constant stays silent (uncertainty boundary)",

--- a/crates/ry-typeshed/src/lib.rs
+++ b/crates/ry-typeshed/src/lib.rs
@@ -354,8 +354,8 @@ impl PackageSpec {
     /// Parse this package on first use and cache it for the life of the
     /// process. The embedded JSON always parses; a failure here is a
     /// build-time data bug, not a runtime condition, so panicking during
-    /// first access is acceptable. Concurrent first callers may each
-    /// parse; all receive the same cached value.
+    /// first access is acceptable. Concurrent first callers block in
+    /// `get_or_init` until one parse wins and is shared by all.
     fn load(&self) -> &Typeshed {
         self.cache.get_or_init(|| {
             let json = inflate_embedded(self.blob, self.name);


### PR DESCRIPTION
From the 0.9.2 RC review. Every claim was checked against built v0.9.0 and RC binaries. The remaining findings are filed as issues.

## Union subsets kept source lengths

```r
x <- if (p) c("a", "b") else c("a", "b", "c")
if (x[1L] == "a") 1L
```

Valid R, but it warned RY001 on the RC. The #402 guard returns unknown only for opaque receivers, so a union receiver fell through and kept `logical<len=2>|logical<len=3>` past the subset. #398 then reads those member lengths and flags them. Silent on v0.9.0, so this false positive was new. The guard now covers unions as well. The rstan fix and the intended multi-value RY001s are unchanged, and a regression test pins the shape.

## Changelog corrections

- Multi-value conditions are newly visible as RY001 in default output. Numeric conditions used to carry only the default-off RY003, and multi-element logical `while` conditions were not reported. The old "still produce RY001" wording hid this; baselines and `--error-on-warning` runs can gain findings.
- `Scope`'s public collections became `FxMap`/`FxSet` in 900c705. Now disclosed for library consumers.

## Smaller changes

- `may_rebind_source_before` slices with `get(..)`, so a FnTable that drifts out of sync degrades instead of panicking on untrusted input.
- Comment fixes: RY100 gates RY001/RY003 but not RY002; `PackageSpec::load` blocks concurrent first callers; R's message spelling (rechecked on R 4.6.1).

`cargo check`, `fmt`, and `clippy` are clean; `cargo test --workspace` passes with no snapshot changes.