### PR TITLE
rc 0.9.2 review: panic-path hardening and extension upgrade note

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,9 @@ reading serialized package data.
   nudge, and multi-element logical loop conditions were not reported
   (#373). Review baselines and `--error-on-warning` runs for new
   findings.
+- Report files whose parser cannot be initialized instead of panicking the
+  whole check, and fall back to serial indexing in the language server when
+  its parse pool cannot be built.
 
 ### Changed
 

--- a/crates/ry-cli/src/pipeline.rs
+++ b/crates/ry-cli/src/pipeline.rs
@@ -146,13 +146,24 @@ fn parse_one(path: &Path) -> Result<Arc<ry_core::SourceFile>, ParseFailure> {
     let path_str = path.to_string_lossy().to_string();
     let file = PARSER.with(|cell| {
         let mut slot = cell.borrow_mut();
-        let parser = slot
-            .get_or_insert_with(|| ry_core::RParser::new().expect("parser init (thread-local)"));
-        parser.parse(&path_str, &src)
+        let parser = match slot.as_mut() {
+            Some(parser) => parser,
+            None => match ry_core::RParser::new() {
+                Ok(parser) => slot.insert(parser),
+                // A worker whose parser cannot initialize must not panic the
+                // whole check: report the file as unparseable and leave the
+                // slot empty so the next file retries, matching the LSP's
+                // index tolerance.
+                Err(error) => return Err(error.to_string()),
+            },
+        };
+        parser
+            .parse(&path_str, &src)
+            .map_err(|message| message.to_string())
     });
     file.map(Arc::new).map_err(|message| ParseFailure {
         path: path.to_path_buf(),
-        error: ParseError::Parse(message.to_string()),
+        error: ParseError::Parse(message),
     })
 }
 

--- a/crates/ry-lsp/src/index.rs
+++ b/crates/ry-lsp/src/index.rs
@@ -46,7 +46,9 @@ const MAX_INDEX_THREADS: usize = 8;
 /// Bounded rayon pool dedicated to workspace indexing, created lazily on
 /// the first index and reused for every re-index (watched-files and
 /// configuration changes trigger rescans) so worker threads and their
-/// cached parsers survive between scans.
+/// cached parsers survive between scans. Returns `None` when no pool can
+/// be built at all (thread exhaustion), in which case callers index
+/// serially: indexing must never take the server down.
 ///
 /// The CLI parses on rayon's global pool — its whole process exists to
 /// check one workspace and then exit, so using every core is right. The
@@ -58,8 +60,8 @@ const MAX_INDEX_THREADS: usize = 8;
 /// workspaces while leaving headroom on big machines. Idle pool threads
 /// park (no CPU cost) and each holds one parser, so the pool's steady
 /// footprint is at most 8 cached tree-sitter parsers.
-fn index_pool() -> &'static rayon::ThreadPool {
-    static POOL: OnceLock<rayon::ThreadPool> = OnceLock::new();
+fn index_pool() -> Option<&'static rayon::ThreadPool> {
+    static POOL: OnceLock<Option<rayon::ThreadPool>> = OnceLock::new();
     POOL.get_or_init(|| {
         let threads = std::thread::available_parallelism()
             .map(|n| n.get())
@@ -69,7 +71,7 @@ fn index_pool() -> &'static rayon::ThreadPool {
             .num_threads(threads)
             .thread_name(|i| format!("ry-index-{i}"))
             .build()
-            .unwrap_or_else(|error| {
+            .or_else(|error| {
                 tracing::warn!(%error, threads, "failed to build index pool; indexing single-threaded");
                 // Indexing must never take the server down: degrade to
                 // one worker rather than propagate the panic.
@@ -77,9 +79,14 @@ fn index_pool() -> &'static rayon::ThreadPool {
                     .num_threads(1)
                     .thread_name(|i| format!("ry-index-{i}"))
                     .build()
-                    .expect("single-threaded rayon pool")
             })
+            .map_err(|error| {
+                tracing::warn!(%error, "single-threaded index pool also failed; indexing serially");
+                error
+            })
+            .ok()
     })
+    .as_ref()
 }
 
 fn parse_paths(paths: &[PathBuf]) -> HashMap<String, Arc<SourceFile>> {
@@ -89,17 +96,17 @@ fn parse_paths(paths: &[PathBuf]) -> HashMap<String, Arc<SourceFile>> {
     // cheap to construct, so one per worker is the right granularity).
     // Error tolerance matches the previous serial loop: an unreadable
     // file or a parse failure is skipped, never fatal to the index.
-    index_pool().install(|| {
-        paths
-            .par_iter()
-            .filter_map(|path| {
-                let source = ry_workspace::read_r_source(path).ok()?;
-                let path_str = path.to_string_lossy().into_owned();
-                let file = parse_with_worker_parser(&path_str, &source)?;
-                Some((path_str, Arc::new(file)))
-            })
-            .collect()
-    })
+    // When no pool could be built, the same per-file logic runs inline.
+    let parse_one = |path: &PathBuf| {
+        let source = ry_workspace::read_r_source(path).ok()?;
+        let path_str = path.to_string_lossy().into_owned();
+        let file = parse_with_worker_parser(&path_str, &source)?;
+        Some((path_str, Arc::new(file)))
+    };
+    match index_pool() {
+        Some(pool) => pool.install(|| paths.par_iter().filter_map(parse_one).collect()),
+        None => paths.iter().filter_map(parse_one).collect(),
+    }
 }
 
 /// Parse one file with this worker thread's cached parser, constructing

--- a/crates/ry-lsp/src/index.rs
+++ b/crates/ry-lsp/src/index.rs
@@ -89,21 +89,34 @@ fn index_pool() -> Option<&'static rayon::ThreadPool> {
     .as_ref()
 }
 
+/// Parse every discovered path on the lazily built [`index_pool`], in
+/// parallel when the pool is available and serially when it is not.
+///
+/// Error tolerance is unchanged from the previous serial loop: a file
+/// that cannot be read or parsed is skipped, never fatal to the index.
 fn parse_paths(paths: &[PathBuf]) -> HashMap<String, Arc<SourceFile>> {
-    // Parse in parallel on the bounded index pool, mirroring the CLI's
-    // `ry-cli::pipeline::parse_files`: each worker reuses a thread-local
-    // `RParser` (tree-sitter parsers are Send but neither Sync nor
-    // cheap to construct, so one per worker is the right granularity).
-    // Error tolerance matches the previous serial loop: an unreadable
-    // file or a parse failure is skipped, never fatal to the index.
-    // When no pool could be built, the same per-file logic runs inline.
+    parse_paths_with(paths, index_pool())
+}
+
+/// Parse `paths` with an explicit pool (or `None` to parse inline), so
+/// the serial fallback is exercisable without thread exhaustion.
+///
+/// Mirrors the CLI's `ry-cli::pipeline::parse_files`: each worker reuses
+/// a thread-local `RParser` (tree-sitter parsers are Send but neither
+/// Sync nor cheap to construct, so one per worker is the right
+/// granularity). When no pool could be built, the same per-file logic
+/// runs inline.
+fn parse_paths_with(
+    paths: &[PathBuf],
+    pool: Option<&rayon::ThreadPool>,
+) -> HashMap<String, Arc<SourceFile>> {
     let parse_one = |path: &PathBuf| {
         let source = ry_workspace::read_r_source(path).ok()?;
         let path_str = path.to_string_lossy().into_owned();
         let file = parse_with_worker_parser(&path_str, &source)?;
         Some((path_str, Arc::new(file)))
     };
-    match index_pool() {
+    match pool {
         Some(pool) => pool.install(|| paths.par_iter().filter_map(parse_one).collect()),
         None => paths.iter().filter_map(parse_one).collect(),
     }
@@ -232,6 +245,32 @@ mod tests {
             !paths.iter().any(|p| p.ends_with("skip.R")),
             "target/ must be skipped"
         );
+    }
+
+    /// The serial fallback used when no index pool can be built must
+    /// still land every parseable file in the map.
+    #[test]
+    fn serial_index_without_pool_parses_every_file() {
+        let fixture = ry_testkit::FixtureProject::empty().unwrap();
+        let dir = fixture.root();
+        let paths: Vec<PathBuf> = (0..5)
+            .map(|i| {
+                let path = dir.join(format!("s{i}.R"));
+                std::fs::write(&path, format!("y_{i} <- {i}\n")).unwrap();
+                path
+            })
+            .collect();
+
+        let files = parse_paths_with(&paths, None);
+
+        assert_eq!(files.len(), paths.len(), "every file must be indexed");
+        for path in &paths {
+            assert!(
+                files.contains_key(&path.to_string_lossy().into_owned()),
+                "{} missing",
+                path.display()
+            );
+        }
     }
 
     /// Parallel parsing on the bounded pool must land every parseable

--- a/editors/code/CHANGELOG.md
+++ b/editors/code/CHANGELOG.md
@@ -9,6 +9,10 @@
 - Reduce extension size with a minified production bundle.
 - Reuse successful version checks when the language server restarts within
   the same editor session. Changed binaries and failed checks are probed again.
+- New diagnostics can appear after upgrading: multi-value `if`/`while`
+  conditions now surface as RY001, and RY001/RY070 message text changed, so
+  accepted-baseline entries that match the old messages can reappear. See the
+  [core changelog](../../CHANGELOG.md) before regenerating baselines.
 
 ## [0.9.1] - 2026-09-07
 


### PR DESCRIPTION
## What this is

Second review pass over the 0.9.2 RC (all changes since v0.9.0, 104
commits). Six reviewers covered checker semantics, serialized data and
config, the LSP and editors, and release coherence. Five areas came back
"ship", two came back "ship with fixes". This PR carries those fixes.

## The fixes

1. **CLI: parser-init panic.** A rayon worker whose `RParser::new()`
   fails expected its way out and took the whole check with it. The
   failure is now a normal parse failure: `ry check` skips and reports
   the file, `dump-facts` aborts, and the worker slot stays empty so the
   next file retries. Mirrors the tolerance the LSP index already has.
2. **LSP: index pool fallback panic.** When the bounded index pool
   cannot be built, the one-worker fallback still used `expect`, so
   thread exhaustion crashed the server it was supposed to protect. The
   pool is now optional and `parse_paths` falls back to the same per-file
   logic inline, serially.
3. **Extension changelog: upgrade note.** Marketplace and Open VSX
   readers now learn that multi-value conditions surface as RY001 in
   0.9.2 and that RY001/RY070 message changes can make accepted baseline
   entries reappear, with a link to the core changelog.

## Not in this PR

Findings that predate this RC or can wait: a TidySelect-arm data-mask
false positive (`pick(a, .data$b)`), forwarded-default invalidation gaps
for `assign()` and wrapped calls, condition-literal propagation, the
serialized-inventory cache bound, `max-serialized-bytes` validation,
probe identity in the extension, `RAYON_NUM_THREADS` in the LSP pool,
and static liblzma linking. Each gets its own issue so the RC is not
held hostage to checker-semantics churn.

## Verification

- `cargo test --workspace` green on the RC base and on this branch
- `cargo test -p ry-lsp`, `cargo test -p ry-cli` green
- `cargo clippy --workspace --all-targets -- -D warnings` clean
- `cargo fmt --all -- --check` clean
- runbook gates run on the RC base: oracle + semantic_lists suites,
  ledger reconciliation via `check-ledger.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented file checks from crashing when parser initialization fails; the affected file now reports an error and subsequent files can retry.
  * Improved language-server indexing reliability by falling back to single-worker or serial processing when parallel setup is unavailable.

* **Documentation**
  * Updated the editor changelog to note new diagnostics for multi-value `if`/`while` conditions and changed RY001/RY070 messages, which may cause previously accepted baseline entries to reappear.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->