### PR TITLE
chore(release): prepare 0.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to ry are documented in this file.
 
 ## [Unreleased]
 
-## [0.9.2] - 2026-09-09
+## [0.9.2] - 2026-09-10
 
 This release reduces false positives in package code and fixes a crash when
 reading serialized package data.

--- a/editors/code/CHANGELOG.md
+++ b/editors/code/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-## [0.9.2] - 2026-09-09
+## [0.9.2] - 2026-09-10
 
 - Bundle ry 0.9.2 with fewer false positives in package code and a fix for
   cyclic serialized-data crashes.


### PR DESCRIPTION
Release prep for the 0.9.2 core tag.

- Date both `[0.9.2]` changelog sections 2026-09-10 (actual release day)
- Versions already bumped: core workspace `Cargo.toml`/`Cargo.lock` and VS Code `package.json` at 0.9.2
- Comparison links already correct (`[0.9.2]: v0.9.0...v0.9.2`, `[Unreleased]: v0.9.2...HEAD`)

Follows the release runbook; the tagged commit will be the dry-run-verified tip of this branch merged to main.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected the 0.9.2 release date in the changelog to September 10, 2026.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->