### PR TITLE
fix(workspace): bound serialized caches and report degraded scopes

### DIFF
--- a/crates/ry-config/src/config.rs
+++ b/crates/ry-config/src/config.rs
@@ -35,6 +35,7 @@ pub const CONFIG_FILENAME: &str = "ry.toml";
 /// note instead of unbounded decoding. Explicit `max-serialized-bytes` values,
 /// including small ones, always win.
 const DEFAULT_MAX_SERIALIZED_BYTES: u64 = 16 * 1024 * 1024;
+const MAX_SERIALIZED_BYTES: u64 = 256 * 1024 * 1024;
 
 /// Defaults for bounded directory discovery.
 const DEFAULT_INDEX_MAX_FILES: u64 = 20_000;
@@ -242,18 +243,26 @@ impl Config {
         {
             *baseline = root.join(&*baseline);
         }
-        cfg.validate().map_err(|field| ConfigError::InvalidIndex {
-            path: path.to_path_buf(),
-            field,
+        cfg.validate().map_err(|field| {
+            if field == "max-serialized-bytes" {
+                ConfigError::InvalidSerializedLimit {
+                    path: path.to_path_buf(),
+                }
+            } else {
+                ConfigError::InvalidIndex {
+                    path: path.to_path_buf(),
+                    field,
+                }
+            }
         })?;
         Ok(cfg)
     }
 
-    /// Validate that bounded discovery limits are positive integers.
-    /// Zero is a configuration error rather than an undocumented
-    /// "unlimited" sentinel. Returns the offending
-    /// field name on failure.
+    /// Return the first invalid resource limit.
     pub fn validate(&self) -> Result<(), &'static str> {
+        if !(1..=MAX_SERIALIZED_BYTES).contains(&self.max_serialized_bytes) {
+            return Err("max-serialized-bytes");
+        }
         if self.index.max_files == 0 {
             return Err("index.max-files");
         }
@@ -460,6 +469,10 @@ pub enum ConfigError {
         "config file {path} has invalid value for {field}: bounded discovery limits must be positive integers, zero is not permitted"
     )]
     InvalidIndex { path: PathBuf, field: &'static str },
+    #[error(
+        "config file {path} has invalid max-serialized-bytes: expected 1..=268435456 (256 MiB)"
+    )]
+    InvalidSerializedLimit { path: PathBuf },
     #[error("config file {path} has invalid environment path pattern `{pattern}`: {source}")]
     InvalidEnvironmentPattern {
         path: PathBuf,
@@ -890,39 +903,36 @@ paths = ["inst/shiny/**"]
     }
 
     #[test]
-    fn index_zero_max_files_is_config_error() {
+    fn resource_limits_are_validated_when_loading_config() {
         let tmp = TempDir::new().unwrap();
-        fs::write(tmp.path().join(CONFIG_FILENAME), "[index]\nmax-files = 0\n").unwrap();
-        let err = Config::load_from_dir(tmp.path()).unwrap_err();
-        assert!(
-            matches!(err, ConfigError::InvalidIndex { field, .. } if field == "index.max-files"),
-            "expected InvalidIndex for max-files=0, got {err:?}"
-        );
-    }
-
-    #[test]
-    fn index_zero_max_file_bytes_is_config_error() {
-        let tmp = TempDir::new().unwrap();
-        fs::write(
-            tmp.path().join(CONFIG_FILENAME),
-            "[index]\nmax-file-bytes = 0\n",
-        )
-        .unwrap();
-        let err = Config::load_from_dir(tmp.path()).unwrap_err();
-        assert!(
-            matches!(err, ConfigError::InvalidIndex { field, .. } if field == "index.max-file-bytes"),
-            "expected InvalidIndex for max-file-bytes=0, got {err:?}"
-        );
-    }
-
-    #[test]
-    fn index_zero_max_depth_is_config_error() {
-        let tmp = TempDir::new().unwrap();
-        fs::write(tmp.path().join(CONFIG_FILENAME), "[index]\nmax-depth = 0\n").unwrap();
-        let err = Config::load_from_dir(tmp.path()).unwrap_err();
-        assert!(
-            matches!(err, ConfigError::InvalidIndex { field, .. } if field == "index.max-depth"),
-            "expected InvalidIndex for max-depth=0, got {err:?}"
-        );
+        let path = tmp.path().join(CONFIG_FILENAME);
+        for field in ["max-files", "max-file-bytes", "max-depth"] {
+            fs::write(&path, format!("[index]\n{field} = 0\n")).unwrap();
+            let error = Config::load_file(&path).unwrap_err();
+            assert!(
+                matches!(error, ConfigError::InvalidIndex { .. }),
+                "{error:?}"
+            );
+            assert!(error.to_string().contains(field));
+        }
+        for value in [
+            0,
+            1,
+            DEFAULT_MAX_SERIALIZED_BYTES,
+            MAX_SERIALIZED_BYTES,
+            MAX_SERIALIZED_BYTES + 1,
+            i64::MAX as u64,
+        ] {
+            fs::write(&path, format!("max-serialized-bytes = {value}\n")).unwrap();
+            let result = Config::load_file(&path);
+            if (1..=MAX_SERIALIZED_BYTES).contains(&value) {
+                assert_eq!(result.unwrap().max_serialized_bytes, value);
+            } else {
+                assert!(
+                    matches!(result, Err(ConfigError::InvalidSerializedLimit { .. })),
+                    "{result:?}"
+                );
+            }
+        }
     }
 }

--- a/crates/ry-lsp/src/backend.rs
+++ b/crates/ry-lsp/src/backend.rs
@@ -1171,6 +1171,15 @@ impl Backend {
                     }
                 }
                 state.initial_index_pending = false;
+                drop(state);
+                for (_, context) in &contexts {
+                    for (path, reason) in &context.degraded_scopes {
+                        self.client.log_message(
+                            tower_lsp::lsp_types::MessageType::WARNING,
+                            format!("ry: {}: {reason}; using a file-stem binding. Raise max-serialized-bytes in ry.toml to enumerate it.", path.display()),
+                        ).await;
+                    }
+                }
                 if cap_hit {
                     let _ = self
                         .client

--- a/crates/ry-lsp/src/index.rs
+++ b/crates/ry-lsp/src/index.rs
@@ -43,46 +43,23 @@ pub(crate) fn index_workspace(root: &Path, config: &Config) -> IndexOutcome {
 /// Upper bound on index parse parallelism (see [`index_pool`]).
 const MAX_INDEX_THREADS: usize = 8;
 
-/// Bounded rayon pool dedicated to workspace indexing, created lazily on
-/// the first index and reused for every re-index (watched-files and
-/// configuration changes trigger rescans) so worker threads and their
-/// cached parsers survive between scans. Returns `None` when no pool can
-/// be built at all (thread exhaustion), in which case callers index
-/// serially: indexing must never take the server down.
-///
-/// The CLI parses on rayon's global pool — its whole process exists to
-/// check one workspace and then exit, so using every core is right. The
-/// LSP is different: it is a long-lived background process sharing the
-/// machine with the editor, and it indexes while the user types.
-/// Saturating every core would starve the editor and any other language
-/// server, so index parallelism is capped at `min(8,
-/// available_parallelism)`: enough to hide parse latency on large
-/// workspaces while leaving headroom on big machines. Idle pool threads
-/// park (no CPU cost) and each holds one parser, so the pool's steady
-/// footprint is at most 8 cached tree-sitter parsers.
+/// Reuse at most eight workers so indexing leaves room for the editor.
+/// If thread creation fails, parse inline instead.
 fn index_pool() -> Option<&'static rayon::ThreadPool> {
     static POOL: OnceLock<Option<rayon::ThreadPool>> = OnceLock::new();
     POOL.get_or_init(|| {
-        let threads = std::thread::available_parallelism()
-            .map(|n| n.get())
-            .unwrap_or(1)
-            .clamp(1, MAX_INDEX_THREADS);
+        let threads = std::env::var("RAYON_NUM_THREADS")
+            .ok()
+            .and_then(|value| value.parse::<usize>().ok())
+            .filter(|&threads| threads > 0)
+            .unwrap_or_else(|| std::thread::available_parallelism().map_or(1, |n| n.get()))
+            .min(MAX_INDEX_THREADS);
         rayon::ThreadPoolBuilder::new()
             .num_threads(threads)
             .thread_name(|i| format!("ry-index-{i}"))
             .build()
-            .or_else(|error| {
-                tracing::warn!(%error, threads, "failed to build index pool; indexing single-threaded");
-                // Indexing must never take the server down: degrade to
-                // one worker rather than propagate the panic.
-                rayon::ThreadPoolBuilder::new()
-                    .num_threads(1)
-                    .thread_name(|i| format!("ry-index-{i}"))
-                    .build()
-            })
-            .map_err(|error| {
-                tracing::warn!(%error, "single-threaded index pool also failed; indexing serially");
-                error
+            .inspect_err(|error| {
+                tracing::warn!(%error, threads, "failed to build index pool; indexing serially");
             })
             .ok()
     })

--- a/crates/ry-lsp/tests/serialized_notice.rs
+++ b/crates/ry-lsp/tests/serialized_notice.rs
@@ -1,0 +1,68 @@
+use ry_testkit::{AsyncJsonRpcClient, FixtureProject, file_uri};
+use serde_json::json;
+
+#[test]
+fn indexing_reports_degraded_serialized_scope_to_the_client() {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap()
+        .block_on(async {
+            let fixture = FixtureProject::empty().unwrap();
+            fixture
+                .write_file("DESCRIPTION", "Package: example\nVersion: 1.0\n")
+                .unwrap();
+            fixture
+                .write_file("ry.toml", "max-serialized-bytes = 1\n")
+                .unwrap();
+            fixture.write_file("R/main.R", "sysdata\n").unwrap();
+            fixture
+                .write_file("R/sysdata.rda", b"over the configured cap")
+                .unwrap();
+            let (client, server) = tokio::io::duplex(128 * 1024);
+            let (reader, writer) = tokio::io::split(server);
+            let server = tokio::spawn(ry_lsp::run_with(reader, writer));
+            let (reader, writer) = tokio::io::split(client);
+            let mut client = AsyncJsonRpcClient::new(reader, writer);
+            let root = file_uri(fixture.root()).unwrap();
+            let id = client
+                .request(
+                    "initialize",
+                    json!({
+                        "processId": null, "rootUri": root, "capabilities": {},
+                        "workspaceFolders": [{"uri": root, "name": "example"}]
+                    }),
+                )
+                .await
+                .unwrap();
+            client
+                .receive_until(|message| message["id"] == id, 20)
+                .await
+                .unwrap();
+            client.notify("initialized", json!({})).await.unwrap();
+            let notice = tokio::time::timeout(
+                std::time::Duration::from_secs(10),
+                client.receive_until(
+                    |message| {
+                        message["method"] == "window/logMessage"
+                            && message["params"]["message"]
+                                .as_str()
+                                .is_some_and(|text| text.contains("max-serialized-bytes"))
+                    },
+                    20,
+                ),
+            )
+            .await
+            .unwrap()
+            .unwrap();
+            assert_eq!(notice["params"]["type"], 2);
+            assert!(
+                notice["params"]["message"]
+                    .as_str()
+                    .unwrap()
+                    .contains("R/sysdata.rda")
+            );
+            drop(client);
+            server.abort();
+        });
+}

--- a/crates/ry-workspace/src/serialized.rs
+++ b/crates/ry-workspace/src/serialized.rs
@@ -1,9 +1,11 @@
 //! Enumerate serialized R bindings without evaluating R code.
 
 use super::file_stem_binding;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use std::io::Read;
-use std::path::{Path, PathBuf};
+#[cfg(unix)]
+use std::os::unix::fs::MetadataExt;
+use std::path::Path;
 
 /// Inventory of a serialized R data file (`.rda`/`.rdata`). `bindings`
 /// are the enumerated object names, or a single file-stem fallback when
@@ -26,50 +28,64 @@ pub(super) struct SerializedInventory {
 /// binding set is reduced to a single file-stem fallback ([`file_stem_binding`])
 /// so unbound-variable analysis (RY010) stays live.
 pub(super) fn serialized_inventory(path: &Path, cap: u64) -> SerializedInventory {
-    /// What the cached inventory was derived from. A mismatch on any field
-    /// means the entry is stale. `cap` is part of it because raising
-    /// `max-serialized-bytes` must re-enumerate a file that was previously
-    /// reduced to its stem.
-    type Stamp = (u64, u128, u64);
-    static CACHE: std::sync::OnceLock<
-        std::sync::Mutex<HashMap<PathBuf, (Stamp, SerializedInventory)>>,
-    > = std::sync::OnceLock::new();
-    let Ok(metadata) = std::fs::metadata(path) else {
-        return SerializedInventory {
-            bindings: HashSet::new(),
-            degraded: false,
-        };
-    };
-    let modified = metadata
-        .modified()
-        .ok()
-        .and_then(|time| time.duration_since(std::time::UNIX_EPOCH).ok())
-        .map(|duration| duration.as_nanos())
-        .unwrap_or_default();
-    let stamp: Stamp = (metadata.len(), modified, cap);
-    let cache = CACHE.get_or_init(|| std::sync::Mutex::new(HashMap::new()));
-    // A panic in another thread poisons this mutex. The cache guards no
-    // invariant, so recover the map instead of cascading the panic into
-    // the LSP.
-    if let Some(inventory) = cache
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner())
-        .get(path)
-        .filter(|(cached, _)| *cached == stamp)
-        .map(|(_, inventory)| inventory.clone())
-    {
-        return inventory;
+    let mut inventory =
+        cached_inventory(path, cap).unwrap_or_else(|| serialized_inventory_uncached(path, cap));
+    if inventory.degraded {
+        inventory.bindings = file_stem_binding(path);
     }
-    let inventory = serialized_inventory_uncached(path, cap);
-    // Keyed on the path, not on (path, stamp): a long-lived LSP session
-    // re-checks the same data files after every edit, and keying on the
-    // stamp would retain one binding set per historical version forever.
-    // Replacing the entry bounds the cache by the number of distinct files.
-    cache
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner())
-        .insert(path.to_path_buf(), (stamp, inventory.clone()));
     inventory
+}
+
+fn cached_inventory(path: &Path, cap: u64) -> Option<SerializedInventory> {
+    // Without a change-time stamp, re-read rather than trust a preserved mtime.
+    #[cfg(not(unix))]
+    {
+        let _ = (path, cap);
+        None
+    }
+    #[cfg(unix)]
+    {
+        type Stamp = (u64, i64, i64, u64, u64, u64);
+        use std::{collections::VecDeque, path::PathBuf};
+        type Entry = (PathBuf, Stamp, SerializedInventory);
+        static CACHE: std::sync::OnceLock<std::sync::Mutex<VecDeque<Entry>>> =
+            std::sync::OnceLock::new();
+        let key = path.canonicalize().ok()?;
+        let metadata = std::fs::metadata(&key).ok()?;
+        let stamp = (
+            metadata.len(),
+            metadata.ctime(),
+            metadata.ctime_nsec(),
+            metadata.dev(),
+            metadata.ino(),
+            cap,
+        );
+        let cache = CACHE.get_or_init(Default::default);
+        let lock = || {
+            cache
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+        };
+        {
+            let mut entries = lock();
+            if let Some(index) = entries.iter().position(|(path, _, _)| path == &key) {
+                let entry = entries.remove(index)?;
+                if entry.1 == stamp {
+                    let inventory = entry.2.clone();
+                    entries.push_back(entry);
+                    return Some(inventory);
+                }
+            }
+        }
+        let inventory = serialized_inventory_uncached(&key, cap);
+        let mut entries = lock();
+        entries.retain(|(path, _, _)| path != &key);
+        if entries.len() == 1024 {
+            entries.pop_front();
+        }
+        entries.push_back((key, stamp, inventory.clone()));
+        Some(inventory)
+    }
 }
 
 fn serialized_inventory_uncached(path: &Path, cap: u64) -> SerializedInventory {
@@ -164,6 +180,7 @@ fn decode_capped(decoder: impl std::io::Read, cap: u64) -> Decoded {
 mod tests {
     use super::*;
     use std::io::Write;
+    use std::path::PathBuf;
 
     struct TinyReads<'a> {
         bytes: &'a [u8],
@@ -352,6 +369,57 @@ mod tests {
         let inventory = serialized_inventory(&path, 1 << 20);
         assert!(!inventory.degraded);
         assert!(inventory.bindings.is_empty());
+    }
+
+    #[test]
+    fn inventory_cache_tracks_caps_aliases_and_replacements() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("data.rda");
+        let first = rda_v2_workspace(&[("first", ProbeValue::Doubles(1))]);
+        let second = rda_v2_workspace(&[("other", ProbeValue::Doubles(1))]);
+        assert_eq!(first.len(), second.len());
+        std::fs::write(&path, &first).unwrap();
+        let time = std::time::UNIX_EPOCH + std::time::Duration::from_secs(1_700_000_000);
+        std::fs::File::options()
+            .write(true)
+            .open(&path)
+            .unwrap()
+            .set_modified(time)
+            .unwrap();
+        assert!(serialized_inventory(&path, 1).degraded);
+        assert!(serialized_inventory(&path, 4096).bindings.contains("first"));
+        let replacement = dir.path().join("new.rda");
+        std::fs::write(&replacement, second).unwrap();
+        std::fs::File::options()
+            .write(true)
+            .open(&replacement)
+            .unwrap()
+            .set_modified(time)
+            .unwrap();
+        std::fs::rename(replacement, &path).unwrap();
+        assert_eq!(std::fs::metadata(&path).unwrap().modified().unwrap(), time);
+        assert_eq!(
+            serialized_inventory(&path, 4096).bindings,
+            HashSet::from(["other".into()])
+        );
+        #[cfg(unix)]
+        {
+            let alias = dir.path().join("alias.rda");
+            std::os::unix::fs::symlink(&path, &alias).unwrap();
+            assert!(
+                serialized_inventory(&alias, 4096)
+                    .bindings
+                    .contains("other")
+            );
+            assert_eq!(
+                serialized_inventory(&alias, 1).bindings,
+                HashSet::from(["alias".into()])
+            );
+            assert_eq!(
+                serialized_inventory(&path, 1).bindings,
+                HashSet::from(["data".into()])
+            );
+        }
     }
 
     #[test]

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -58,8 +58,9 @@ max-depth      = 64      # directory depth (default: 64)
 Serialized R data files are inventoried by decoding at most
 `max-serialized-bytes` bytes; one further byte is read to detect overflow. The
 16 MiB default covers real package sysdata such as gt's ~8 MB table bundle. A
-file above the cap falls back to a file-stem binding and `ry check` reports it
-as a degraded scope; raise the value to enumerate such files precisely.
+file above the cap falls back to a file-stem binding. The CLI and LSP report
+these files as degraded scopes. Set the cap from 1 byte through 268435456 bytes
+(256 MiB); zero does not mean unlimited.
 
 Use an environment profile for bindings supplied only to selected files:
 


### PR DESCRIPTION
## Changes

- Accept `max-serialized-bytes` from 1 byte through 256 MiB; reject invalid values when loading config.
- Keep at most 1,024 serialized inventories in an LRU cache. Canonicalize paths and check Unix device, inode, and change time. Re-read on other platforms rather than trust mtime alone.
- Report degraded serialized scopes through `window/logMessage`.
- Honor positive `RAYON_NUM_THREADS` values, capped at eight. Parse inline if pool creation fails; remove the redundant one-worker pool attempt.

Closes #413. Closes #427. Closes #414. Closes #430.

## Checks

Fresh-target workspace tests, Clippy with warnings denied, and formatting pass. The cache test covers cap changes, same-size/same-mtime replacements, and symlink aliases. One protocol test verifies the client receives the degraded-scope warning. Config loading tests now cover all limit boundaries in one table.

CI passes, including both ecosystem jobs. This bounds the inventory cache and decoded-byte setting; it does not fix parser recursion or allocation limits in #412.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `MAX_SERIALIZED_BYTES` limit and `InvalidSerializedLimit` error to `Config` validation
> - Adds `MAX_SERIALIZED_BYTES` constant and validates `max-serialized-bytes` to the inclusive 1-byte through 256 MiB range, checked before existing index-limit validation in `Config::validate`.
> - Maps invalid serialized-byte limits to a new `ConfigError::InvalidSerializedLimit` variant, so `Config::load_file` distinguishes them from invalid index-limit errors.
> - Updates tests to exercise invalid limits through `Config::load_file` and verify the specialized error classification.
> - Behavioral Change: `Config::load_file` now reports `InvalidSerializedLimit` instead of `InvalidIndex` for out-of-range `max-serialized-bytes`; validation order checks serialized limit before index limits.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 98de0d6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
