### PR TITLE
fix(typeshed): resolve set6 and dictionar6 imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to ry are documented in this file.
 
 ### Fixed
 
+- Bundle set6 and dictionar6 export inventories so wholesale imports resolve
+  their R6 objects and functions without installed copies of those packages
+  (#366). Keep unrelated unknown names reportable.
 - Discard forwarded-default facts after writes before wrapped or nested calls,
   including replacement assignments, loop variables, and literal `assign()`
   targets. Match backticked parameter and argument names consistently

--- a/crates/ry-cli/tests/config_e2e.rs
+++ b/crates/ry-cli/tests/config_e2e.rs
@@ -962,6 +962,64 @@ fn package_namespace_whole_import_binds_installed_exports() {
 }
 
 #[test]
+fn bundled_set6_imports_bind_exports_without_hiding_misspellings() {
+    for (namespace, unbound) in [
+        ("import(set6)\nimport(dictionar6)\n", vec!["Reaals"]),
+        (
+            "importFrom(set6, Set)\nimportFrom(dictionar6, Dictionary)\n",
+            vec!["Reals", "Interval", "as.Set", "dct", "Reaals"],
+        ),
+        (
+            "",
+            vec![
+                "Set",
+                "Reals",
+                "Interval",
+                "Dictionary",
+                "as.Set",
+                "dct",
+                "Reaals",
+            ],
+        ),
+    ] {
+        let tmp = tempfile::tempdir().unwrap();
+        fs::create_dir(tmp.path().join("R")).unwrap();
+        fs::write(
+            tmp.path().join("DESCRIPTION"),
+            "Package: inventoryfixture\nVersion: 0.0.1\nImports: set6, dictionar6\n",
+        )
+        .unwrap();
+        fs::write(tmp.path().join("NAMESPACE"), namespace).unwrap();
+        fs::write(
+            tmp.path().join("R/use.R"),
+            "values <- list(Set, Reals, Interval, Dictionary, as.Set, dct, Reaals)\n",
+        )
+        .unwrap();
+
+        let output = Command::new(env!("CARGO_BIN_EXE_ry"))
+            .args(["check", "--output-format", "json"])
+            .arg(tmp.path())
+            .env("RY_NO_INSTALLED_LIBRARIES", "1")
+            .output()
+            .unwrap();
+        assert!(output.status.success(), "{output:?}");
+        let diagnostics: Vec<serde_json::Value> = serde_json::from_slice(&output.stdout).unwrap();
+        let messages: Vec<_> = diagnostics
+            .iter()
+            .map(|diagnostic| {
+                assert_eq!(diagnostic["code"], "RY010", "{diagnostic}");
+                diagnostic["message"].as_str().unwrap()
+            })
+            .collect();
+        let expected: Vec<_> = unbound
+            .iter()
+            .map(|name| format!("variable `{name}` is not bound in this scope"))
+            .collect();
+        assert_eq!(messages, expected, "NAMESPACE: {namespace:?}");
+    }
+}
+
+#[test]
 fn ry_toml_packages_enables_dplyr_nse() {
     // A `packages = ["dplyr"]` in ry.toml makes a bare
     // `filter(df, mpg > 0)` resolve as dplyr's NSE verb, so the column

--- a/crates/ry-typeshed/packages.txt
+++ b/crates/ry-typeshed/packages.txt
@@ -33,3 +33,5 @@ cli
 vctrs
 grid
 ggplot2
+set6
+dictionar6

--- a/crates/ry-typeshed/vendor/SOURCE
+++ b/crates/ry-typeshed/vendor/SOURCE
@@ -1,4 +1,4 @@
 repository: https://github.com/sims1253/r-typeshed
-commit: a682775dd353ffcd4410bd7da69dec4a23e1457f
+commit: cadfe7a035ea06dec3898d3a15c8d8fefb5df0cc
 tree-state: clean
-stubs-sha256: 924b739591ae86499f132bedabb79143c5f9bdc226e174d01d1e0d85a9129cd5
+stubs-sha256: 0a59363ccebaf872e410ee56085ed92ceeac0a98918d4226881dc2326c00a402

--- a/crates/ry-typeshed/vendor/dictionar6/dictionar6.json
+++ b/crates/ry-typeshed/vendor/dictionar6/dictionar6.json
@@ -1,0 +1,26 @@
+{
+  "schema_version": "2",
+  "package": "dictionar6",
+  "version": "0.0.1",
+  "functions": {
+    "dct": {
+      "params": [
+        "...",
+        "x",
+        "types"
+      ],
+      "return": {
+        "mode": "opaque",
+        "length": "unknown",
+        "na": true
+      }
+    }
+  },
+  "datasets": {
+    "Dictionary": {
+      "mode": "opaque",
+      "length": "unknown",
+      "na": true
+    }
+  }
+}

--- a/crates/ry-typeshed/vendor/set6/set6.json
+++ b/crates/ry-typeshed/vendor/set6/set6.json
@@ -1,0 +1,997 @@
+{
+  "schema_version": "2",
+  "package": "set6",
+  "version": "0.0.1",
+  "functions": {
+    "%-%": {
+      "params": [
+        "x",
+        "y"
+      ],
+      "return": {
+        "mode": "opaque",
+        "length": "unknown",
+        "na": true
+      }
+    },
+    "%inset%": {
+      "params": [
+        "x",
+        "y"
+      ],
+      "return": {
+        "mode": "opaque",
+        "length": "unknown",
+        "na": true
+      }
+    },
+    "as.FuzzyMultiset": {
+      "params": [
+        "object"
+      ],
+      "return": {
+        "mode": "opaque",
+        "length": "unknown",
+        "na": true
+      }
+    },
+    "as.FuzzySet": {
+      "params": [
+        "object"
+      ],
+      "return": {
+        "mode": "opaque",
+        "length": "unknown",
+        "na": true
+      }
+    },
+    "as.FuzzyTuple": {
+      "params": [
+        "object"
+      ],
+      "return": {
+        "mode": "opaque",
+        "length": "unknown",
+        "na": true
+      }
+    },
+    "as.Interval": {
+      "params": [
+        "object"
+      ],
+      "return": {
+        "mode": "opaque",
+        "length": "unknown",
+        "na": true
+      }
+    },
+    "as.Multiset": {
+      "params": [
+        "object"
+      ],
+      "return": {
+        "mode": "opaque",
+        "length": "unknown",
+        "na": true
+      }
+    },
+    "as.Set": {
+      "params": [
+        "object"
+      ],
+      "return": {
+        "mode": "opaque",
+        "length": "unknown",
+        "na": true
+      }
+    },
+    "as.Tuple": {
+      "params": [
+        "object"
+      ],
+      "return": {
+        "mode": "opaque",
+        "length": "unknown",
+        "na": true
+      }
+    },
+    "assertClosed": {
+      "params": [
+        "object",
+        "errormsg"
+      ],
+      "return": {
+        "mode": "opaque",
+        "length": "unknown",
+        "na": true
+      }
+    },
+    "assertClosedAbove": {
+      "params": [
+        "object",
+        "errormsg"
+      ],
+      "return": {
+        "mode": "opaque",
+        "length": "unknown",
+        "na": true
+      }
+    },
+    "assertClosedBelow": {
+      "params": [
+        "object",
+        "errormsg"
+      ],
+      "return": {
+        "mode": "opaque",
+        "length": "unknown",
+        "na": true
+      }
+    },
+    "assertConditionalSet": {
+      "params": [
+        "object",
+        "errormsg"
+      ],
+      "return": {
+        "mode": "opaque",
+        "length": "unknown",
+        "na": true
+      }
+    },
+    "assertContains": {
+      "params": [
+        "object",
+        "elements",
+        "errormsg"
+      ],
+      "return": {
+        "mode": "opaque",
+        "length": "unknown",
+        "na": true
+      }
+    },
+    "assertCountablyFinite": {
+      "params": [
+        "object",
+        "errormsg"
+      ],
+      "return": {
+        "mode": "opaque",
+        "length": "unknown",
+        "na": true
+      }
+    },
+    "assertCrisp": {
+      "params": [
+        "object",
+        "errormsg"
+      ],
+      "return": {
+        "mode": "opaque",
+        "length": "unknown",
+        "na": true
+      }
+    },
+    "assertEmpty": {
+      "params": [
+        "object",
+        "errormsg"
+      ],
+      "return": {
+        "mode": "opaque",
+        "length": "unknown",
+        "na": true
+      }
+    },
+    "assertFinite": {
+      "params": [
+        "object",
+        "errormsg"
+      ],
+      "return": {
+        "mode": "opaque",
+        "length": "unknown",
+        "na": true
+      }
+    },
+    "assertFuzzy": {
+      "params": [
+        "object",
+        "errormsg"
+      ],
+      "return": {
+        "mode": "opaque",
+        "length": "unknown",
+        "na": true
+      }
+    },
+    "assertFuzzyMultiset": {
+      "params": [
+        "object",
+        "errormsg"
+      ],
+      "return": {
+        "mode": "opaque",
+        "length": "unknown",
+        "na": true
+      }
+    },
+    "assertFuzzySet": {
+      "params": [
+        "object",
+        "errormsg"
+      ],
+      "return": {
+        "mode": "opaque",
+        "length": "unknown",
+        "na": true
+      }
+    },
+    "assertFuzzyTuple": {
+      "params": [
+        "object",
+        "errormsg"
+      ],
+      "return": {
+        "mode": "opaque",
+        "length": "unknown",
+        "na": true
+      }
+    },
+    "assertInterval": {
+      "params": [
+        "object",
+        "errormsg"
+      ],
+      "return": {
+        "mode": "opaque",
+        "length": "unknown",
+        "na": true
+      }
+    },
+    "assertMultiset": {
+      "params": [
+        "object",
+        "errormsg"
+      ],
+      "return": {
+        "mode": "opaque",
+        "length": "unknown",
+        "na": true
+      }
+    },
+    "assertSet": {
+      "params": [
+        "object",
+        "errormsg"
+      ],
+      "return": {
+        "mode": "opaque",
+        "length": "unknown",
+        "na": true
+      }
+    },
+    "assertSetList": {
+      "params": [
+        "object",
+        "errormsg"
+      ],
+      "return": {
+        "mode": "opaque",
+        "length": "unknown",
+        "na": true
+      }
+    },
+    "assertSubset": {
+      "params": [
+        "object",
+        "sets",
+        "proper",
+        "errormsg"
+      ],
+      "return": {
+        "mode": "opaque",
+        "length": "unknown",
+        "na": true
+      }
+    },
+    "assertTuple": {
+      "params": [
+        "object",
+        "errormsg"
+      ],
+      "return": {
+        "mode": "opaque",
+        "length": "unknown",
+        "na": true
+      }
+    },
+    "checkClosed": {
+      "params": [
+        "object",
+        "errormsg"
+      ],
+      "return": {
+        "mode": "opaque",
+        "length": "unknown",
+        "na": true
+      }
+    },
+    "checkClosedAbove": {
+      "params": [
+        "object",
+        "errormsg"
+      ],
+      "return": {
+        "mode": "opaque",
+        "length": "unknown",
+        "na": true
+      }
+    },
+    "checkClosedBelow": {
+      "params": [
+        "object",
+        "errormsg"
+      ],
+      "return": {
+        "mode": "opaque",
+        "length": "unknown",
+        "na": true
+      }
+    },
+    "checkConditionalSet": {
+      "params": [
+        "object",
+        "errormsg"
+      ],
+      "return": {
+        "mode": "opaque",
+        "length": "unknown",
+        "na": true
+      }
+    },
+    "checkContains": {
+      "params": [
+        "object",
+        "elements",
+        "errormsg"
+      ],
+      "return": {
+        "mode": "opaque",
+        "length": "unknown",
+        "na": true
+      }
+    },
+    "checkCountablyFinite": {
+      "params": [
+        "object",
+        "errormsg"
+      ],
+      "return": {
+        "mode": "opaque",
+        "length": "unknown",
+        "na": true
+      }
+    },
+    "checkCrisp": {
+      "params": [
+        "object",
+        "errormsg"
+      ],
+      "return": {
+        "mode": "opaque",
+        "length": "unknown",
+        "na": true
+      }
+    },
+    "checkEmpty": {
+      "params": [
+        "object",
+        "errormsg"
+      ],
+      "return": {
+        "mode": "opaque",
+        "length": "unknown",
+        "na": true
+      }
+    },
+    "checkFinite": {
+      "params": [
+        "object",
+        "errormsg"
+      ],
+      "return": {
+        "mode": "opaque",
+        "length": "unknown",
+        "na": true
+      }
+    },
+    "checkFuzzy": {
+      "params": [
+        "object",
+        "errormsg"
+      ],
+      "return": {
+        "mode": "opaque",
+        "length": "unknown",
+        "na": true
+      }
+    },
+    "checkFuzzyMultiset": {
+      "params": [
+        "object",
+        "errormsg"
+      ],
+      "return": {
+        "mode": "opaque",
+        "length": "unknown",
+        "na": true
+      }
+    },
+    "checkFuzzySet": {
+      "params": [
+        "object",
+        "errormsg"
+      ],
+      "return": {
+        "mode": "opaque",
+        "length": "unknown",
+        "na": true
+      }
+    },
+    "checkFuzzyTuple": {
+      "params": [
+        "object",
+        "errormsg"
+      ],
+      "return": {
+        "mode": "opaque",
+        "length": "unknown",
+        "na": true
+      }
+    },
+    "checkInterval": {
+      "params": [
+        "object",
+        "errormsg"
+      ],
+      "return": {
+        "mode": "opaque",
+        "length": "unknown",
+        "na": true
+      }
+    },
+    "checkMultiset": {
+      "params": [
+        "object",
+        "errormsg"
+      ],
+      "return": {
+        "mode": "opaque",
+        "length": "unknown",
+        "na": true
+      }
+    },
+    "checkSet": {
+      "params": [
+        "object",
+        "errormsg"
+      ],
+      "return": {
+        "mode": "opaque",
+        "length": "unknown",
+        "na": true
+      }
+    },
+    "checkSetList": {
+      "params": [
+        "object",
+        "errormsg"
+      ],
+      "return": {
+        "mode": "opaque",
+        "length": "unknown",
+        "na": true
+      }
+    },
+    "checkSubset": {
+      "params": [
+        "object",
+        "sets",
+        "proper",
+        "errormsg"
+      ],
+      "return": {
+        "mode": "opaque",
+        "length": "unknown",
+        "na": true
+      }
+    },
+    "checkTuple": {
+      "params": [
+        "object",
+        "errormsg"
+      ],
+      "return": {
+        "mode": "opaque",
+        "length": "unknown",
+        "na": true
+      }
+    },
+    "listSpecialSets": {
+      "params": [
+        "simplify"
+      ],
+      "return": {
+        "mode": "opaque",
+        "length": "unknown",
+        "na": true
+      }
+    },
+    "powerset": {
+      "params": [
+        "x",
+        "simplify"
+      ],
+      "return": {
+        "mode": "opaque",
+        "length": "unknown",
+        "na": true
+      }
+    },
+    "set6News": {
+      "params": [],
+      "return": {
+        "mode": "opaque",
+        "length": "unknown",
+        "na": true
+      }
+    },
+    "setcomplement": {
+      "params": [
+        "x",
+        "y",
+        "simplify"
+      ],
+      "return": {
+        "mode": "opaque",
+        "length": "unknown",
+        "na": true
+      }
+    },
+    "setintersect": {
+      "params": [
+        "x",
+        "y"
+      ],
+      "return": {
+        "mode": "opaque",
+        "length": "unknown",
+        "na": true
+      }
+    },
+    "setpower": {
+      "params": [
+        "x",
+        "power",
+        "simplify",
+        "nest"
+      ],
+      "return": {
+        "mode": "opaque",
+        "length": "unknown",
+        "na": true
+      }
+    },
+    "setproduct": {
+      "params": [
+        "...",
+        "simplify",
+        "nest"
+      ],
+      "return": {
+        "mode": "opaque",
+        "length": "unknown",
+        "na": true
+      }
+    },
+    "setsymdiff": {
+      "params": [
+        "x",
+        "y",
+        "simplify"
+      ],
+      "return": {
+        "mode": "opaque",
+        "length": "unknown",
+        "na": true
+      }
+    },
+    "setunion": {
+      "params": [
+        "...",
+        "simplify"
+      ],
+      "return": {
+        "mode": "opaque",
+        "length": "unknown",
+        "na": true
+      }
+    },
+    "testClosed": {
+      "params": [
+        "object",
+        "errormsg"
+      ],
+      "return": {
+        "mode": "opaque",
+        "length": "unknown",
+        "na": true
+      }
+    },
+    "testClosedAbove": {
+      "params": [
+        "object",
+        "errormsg"
+      ],
+      "return": {
+        "mode": "opaque",
+        "length": "unknown",
+        "na": true
+      }
+    },
+    "testClosedBelow": {
+      "params": [
+        "object",
+        "errormsg"
+      ],
+      "return": {
+        "mode": "opaque",
+        "length": "unknown",
+        "na": true
+      }
+    },
+    "testConditionalSet": {
+      "params": [
+        "object",
+        "errormsg"
+      ],
+      "return": {
+        "mode": "opaque",
+        "length": "unknown",
+        "na": true
+      }
+    },
+    "testContains": {
+      "params": [
+        "object",
+        "elements",
+        "errormsg"
+      ],
+      "return": {
+        "mode": "opaque",
+        "length": "unknown",
+        "na": true
+      }
+    },
+    "testCountablyFinite": {
+      "params": [
+        "object",
+        "errormsg"
+      ],
+      "return": {
+        "mode": "opaque",
+        "length": "unknown",
+        "na": true
+      }
+    },
+    "testCrisp": {
+      "params": [
+        "object",
+        "errormsg"
+      ],
+      "return": {
+        "mode": "opaque",
+        "length": "unknown",
+        "na": true
+      }
+    },
+    "testEmpty": {
+      "params": [
+        "object",
+        "errormsg"
+      ],
+      "return": {
+        "mode": "opaque",
+        "length": "unknown",
+        "na": true
+      }
+    },
+    "testFinite": {
+      "params": [
+        "object",
+        "errormsg"
+      ],
+      "return": {
+        "mode": "opaque",
+        "length": "unknown",
+        "na": true
+      }
+    },
+    "testFuzzy": {
+      "params": [
+        "object",
+        "errormsg"
+      ],
+      "return": {
+        "mode": "opaque",
+        "length": "unknown",
+        "na": true
+      }
+    },
+    "testFuzzyMultiset": {
+      "params": [
+        "object",
+        "errormsg"
+      ],
+      "return": {
+        "mode": "opaque",
+        "length": "unknown",
+        "na": true
+      }
+    },
+    "testFuzzySet": {
+      "params": [
+        "object",
+        "errormsg"
+      ],
+      "return": {
+        "mode": "opaque",
+        "length": "unknown",
+        "na": true
+      }
+    },
+    "testFuzzyTuple": {
+      "params": [
+        "object",
+        "errormsg"
+      ],
+      "return": {
+        "mode": "opaque",
+        "length": "unknown",
+        "na": true
+      }
+    },
+    "testInterval": {
+      "params": [
+        "object",
+        "errormsg"
+      ],
+      "return": {
+        "mode": "opaque",
+        "length": "unknown",
+        "na": true
+      }
+    },
+    "testMultiset": {
+      "params": [
+        "object",
+        "errormsg"
+      ],
+      "return": {
+        "mode": "opaque",
+        "length": "unknown",
+        "na": true
+      }
+    },
+    "testSet": {
+      "params": [
+        "object",
+        "errormsg"
+      ],
+      "return": {
+        "mode": "opaque",
+        "length": "unknown",
+        "na": true
+      }
+    },
+    "testSetList": {
+      "params": [
+        "object",
+        "errormsg"
+      ],
+      "return": {
+        "mode": "opaque",
+        "length": "unknown",
+        "na": true
+      }
+    },
+    "testSubset": {
+      "params": [
+        "object",
+        "sets",
+        "proper",
+        "errormsg"
+      ],
+      "return": {
+        "mode": "opaque",
+        "length": "unknown",
+        "na": true
+      }
+    },
+    "testTuple": {
+      "params": [
+        "object",
+        "errormsg"
+      ],
+      "return": {
+        "mode": "opaque",
+        "length": "unknown",
+        "na": true
+      }
+    },
+    "useUnicode": {
+      "params": [
+        "use"
+      ],
+      "return": {
+        "mode": "opaque",
+        "length": "unknown",
+        "na": true
+      }
+    }
+  },
+  "datasets": {
+    "ComplementSet": {
+      "mode": "opaque",
+      "length": "unknown",
+      "na": true
+    },
+    "Complex": {
+      "mode": "opaque",
+      "length": "unknown",
+      "na": true
+    },
+    "ConditionalSet": {
+      "mode": "opaque",
+      "length": "unknown",
+      "na": true
+    },
+    "ExponentSet": {
+      "mode": "opaque",
+      "length": "unknown",
+      "na": true
+    },
+    "ExtendedReals": {
+      "mode": "opaque",
+      "length": "unknown",
+      "na": true
+    },
+    "FuzzyMultiset": {
+      "mode": "opaque",
+      "length": "unknown",
+      "na": true
+    },
+    "FuzzySet": {
+      "mode": "opaque",
+      "length": "unknown",
+      "na": true
+    },
+    "FuzzyTuple": {
+      "mode": "opaque",
+      "length": "unknown",
+      "na": true
+    },
+    "Integers": {
+      "mode": "opaque",
+      "length": "unknown",
+      "na": true
+    },
+    "Interval": {
+      "mode": "opaque",
+      "length": "unknown",
+      "na": true
+    },
+    "Logicals": {
+      "mode": "opaque",
+      "length": "unknown",
+      "na": true
+    },
+    "LogicalSet": {
+      "mode": "opaque",
+      "length": "unknown",
+      "na": true
+    },
+    "Multiset": {
+      "mode": "opaque",
+      "length": "unknown",
+      "na": true
+    },
+    "Naturals": {
+      "mode": "opaque",
+      "length": "unknown",
+      "na": true
+    },
+    "NegIntegers": {
+      "mode": "opaque",
+      "length": "unknown",
+      "na": true
+    },
+    "NegRationals": {
+      "mode": "opaque",
+      "length": "unknown",
+      "na": true
+    },
+    "NegReals": {
+      "mode": "opaque",
+      "length": "unknown",
+      "na": true
+    },
+    "PosIntegers": {
+      "mode": "opaque",
+      "length": "unknown",
+      "na": true
+    },
+    "PosNaturals": {
+      "mode": "opaque",
+      "length": "unknown",
+      "na": true
+    },
+    "PosRationals": {
+      "mode": "opaque",
+      "length": "unknown",
+      "na": true
+    },
+    "PosReals": {
+      "mode": "opaque",
+      "length": "unknown",
+      "na": true
+    },
+    "PowersetSet": {
+      "mode": "opaque",
+      "length": "unknown",
+      "na": true
+    },
+    "ProductSet": {
+      "mode": "opaque",
+      "length": "unknown",
+      "na": true
+    },
+    "Rationals": {
+      "mode": "opaque",
+      "length": "unknown",
+      "na": true
+    },
+    "Reals": {
+      "mode": "opaque",
+      "length": "unknown",
+      "na": true
+    },
+    "Set": {
+      "mode": "opaque",
+      "length": "unknown",
+      "na": true
+    },
+    "Tuple": {
+      "mode": "opaque",
+      "length": "unknown",
+      "na": true
+    },
+    "UnionSet": {
+      "mode": "opaque",
+      "length": "unknown",
+      "na": true
+    },
+    "Universal": {
+      "mode": "opaque",
+      "length": "unknown",
+      "na": true
+    },
+    "UniversalSet": {
+      "mode": "opaque",
+      "length": "unknown",
+      "na": true
+    }
+  }
+}

--- a/docs/corpus/set6-inventory.md
+++ b/docs/corpus/set6-inventory.md
@@ -1,0 +1,61 @@
+# set6 and dictionar6 import inventories
+
+Issue [#366](https://github.com/sims1253/ry/issues/366) reports unbound names
+from wholesale imports in param6 and distr6. ry parses those imports, but needs
+the dependency's export inventory to resolve each name. The bundled stubs now
+supply all exports from set6 0.2.4 and dictionar6 0.1.3.
+
+```text
+NAMESPACE import(set6)
+  → bundled exports: Set, Reals, Interval, ...
+  → imported names resolve without an installed set6
+  → Reaals still produces RY010
+```
+
+R6 generators such as `Set` and `Dictionary` are opaque values. Function
+formals remain inference-only. The stubs make no return-type, length, or
+missingness claims. The r-typeshed runtime test compares all exports and
+formals with the archived R packages and checks R6 construction.
+
+## Reported packages
+
+The comparison used one binary built from tracked ry commit `92c822a` and
+stubs from r-typeshed commit `cadfe7a035ea06dec3898d3a15c8d8fefb5df0cc`.
+Installed-library lookup was disabled with `RY_NO_INSTALLED_LIBRARIES=1`.
+Neither package had project configuration or globals overrides. Both runs
+used the same package-root discovery and compared all diagnostic JSON fields.
+All files in the checked source directories matched their CRAN archives.
+
+| Package source | Baseline diagnostics | With inventories | Removed RY010 |
+| --- | ---: | ---: | ---: |
+| param6 0.2.4 | 133 | 0 | 133 |
+| distr6 1.6.9 | 191 | 10 | 181 |
+
+All 314 removed findings name verified exports from the two new inventories.
+No diagnostic was added. The remaining distr6 findings are eight RY010s and
+two RY100s; every diagnostic is unchanged from the baseline. These counts
+describe the pinned sources, not other versions of the packages.
+
+The source archive SHA-256 checksums are:
+
+```text
+param6_0.2.4.tar.gz   4d06afac7b9c228a0706c8af098853f001e68b3b754dc5005e7a7f700c159940
+distr6_1.6.9.tar.gz   10b7545813be12cdefcf5ea9465845d6ca90dd75365fd35b4f263c90c1eb88ee
+set6_0.2.4.tar.gz     099cdadbca907cc72777b642c1c59c9089ac6121256cbdf3a9478d7381f95c1b
+dictionar6_0.1.3.tar.gz 2e55026e43adf8dc6929bd9c09a5e67bc57d148560a0d1e2840f5fe22f2ae9e5
+```
+
+To replay with the baseline binary and a checkout of the stub commit:
+
+```sh
+RY_NO_INSTALLED_LIBRARIES=1 ry check "$package_path" --output-format json
+RY_NO_INSTALLED_LIBRARIES=1 ry check "$package_path" --output-format json \
+  --typeshed "$typeshed_checkout/stubs/set6" \
+  --typeshed "$typeshed_checkout/stubs/dictionar6"
+```
+
+The CLI regression test runs without installed-library lookup. It checks
+wholesale imports, selective `importFrom` declarations, and an absent import,
+with `Reaals` as a misspelling that must remain reportable. This change supplies
+two missing inventories; other unavailable dependencies still need installed
+metadata, local stubs, or reviewed project globals.


### PR DESCRIPTION
Packages with `import(set6)` or `import(dictionar6)` report valid exports as unbound when those dependencies are not installed. Vendor the complete export inventories from [r-typeshed #41](https://github.com/sims1253/r-typeshed/pull/41), register both packages, and test the CLI with installed-library lookup disabled.

```text
import(set6) → bundled exports → Set, Reals, Interval resolve
importFrom(set6, Set)          → only Set resolves
                              → Reaals still reports RY010
```

The stubs keep R6 generators opaque and function formals inference-only. The upstream runtime tests compare all exports and formals against set6 0.2.4 and dictionar6 0.1.3. This PR records the clean upstream commit in `vendor/SOURCE`; merge the typeshed PR first.

On the pinned sources from #366, param6 0.2.4 goes from 133 diagnostics to zero and distr6 1.6.9 from 191 to 10. All 314 removed findings are RY010s for verified exports. No diagnostic is added, and all remaining findings match the baseline. Source hashes, reproduction commands, and limits are in `docs/corpus/set6-inventory.md`. Other missing dependency inventories remain outside this change.

A wider comparison used the same baseline binary with only the two new stub directories as overrides across 472 local package checkouts. Diagnostics fell from 3,106 to 2,784: 322 RY010s removed, none added. Only param6 and distr6 changed; that panel uses distr6 1.8.4, which accounts for the larger reduction. Every removed name is a verified export. The bundled binary produces identical results for both reported packages and for the changed corpus packages.

Validation:

- The new CLI regression fails on `92c822a` and passes with the vendored stubs. It covers wholesale imports, selective imports, absent imports, and a misspelling.
- `cargo test --locked --workspace`, Clippy with warnings denied, formatting, and the full R oracle (`--include-ignored`) pass.
- Typeshed validation passes for all 38 stub files. The sync harness and release-checksum unit tests pass.
- The tracked tidyverse corpus matches its committed reports. All GitHub CI jobs pass, including the Posit corpus and ledger regression checks. The extra local full-tier Posit run was stopped after CI passed; it is not counted as a completed check.
- Pullfrog reviewed this commit and the upstream typeshed PR and found no new issues.
