### PR TITLE
fix(checker): align condition diagnostic severity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to ry are documented in this file.
 
 ### Fixed
 
+- Return RY001 warnings from the checker API, matching the rule table and CLI.
+  Keep RY002 length warnings when the condition also contains RY100 (#415).
+
 - Discard forwarded-default facts after writes before wrapped or nested calls,
   including replacement assignments, loop variables, and literal `assign()`
   targets. Match backticked parameter and argument names consistently

--- a/crates/ry-checker/src/infer/mod.rs
+++ b/crates/ry-checker/src/infer/mod.rs
@@ -631,7 +631,7 @@ impl Checker {
             && !has_ry100
         {
             self.emit(
-                Severity::Error,
+                Severity::Warning,
                 span_of(cond),
                 "RY001",
                 format!(

--- a/crates/ry-checker/src/tests/type_inference.rs
+++ b/crates/ry-checker/src/tests/type_inference.rs
@@ -1956,13 +1956,14 @@ fn quoted_symbol_existence_does_not_invent_distinct_bindings() {
 fn condition_severities_match_the_rule_registry() {
     for source in [
         "if (NULL) 1L",
+        "if (1L) 1L",
         "if (c(TRUE, FALSE)) 1L",
         "while (list(TRUE)) break",
     ] {
         let diagnostics = check(source);
         let condition = diagnostics
             .iter()
-            .find(|d| matches!(d.code, "RY001" | "RY002"))
+            .find(|d| matches!(d.code, "RY001" | "RY002" | "RY003"))
             .unwrap();
         assert_eq!(
             condition.severity,

--- a/crates/ry-checker/src/tests/type_inference.rs
+++ b/crates/ry-checker/src/tests/type_inference.rs
@@ -1951,3 +1951,36 @@ fn quoted_symbol_existence_does_not_invent_distinct_bindings() {
         );
     }
 }
+
+#[test]
+fn condition_severities_match_the_rule_registry() {
+    for source in [
+        "if (NULL) 1L",
+        "if (c(TRUE, FALSE)) 1L",
+        "while (list(TRUE)) break",
+    ] {
+        let diagnostics = check(source);
+        let condition = diagnostics
+            .iter()
+            .find(|d| matches!(d.code, "RY001" | "RY002"))
+            .unwrap();
+        assert_eq!(
+            condition.severity,
+            crate::rules::find(condition.code).unwrap().default_severity,
+            "{source}"
+        );
+    }
+}
+
+#[test]
+fn logical_condition_length_survives_nested_math_warning() {
+    let diagnostics = check("if (abs(c(1, 2) > 0) > 0) 1L");
+    assert!(
+        diagnostics.iter().any(|d| d.code == "RY100"),
+        "{diagnostics:?}"
+    );
+    assert!(
+        diagnostics.iter().any(|d| d.code == "RY002"),
+        "{diagnostics:?}"
+    );
+}

--- a/crates/ry-checker/testdata/oracle/forwarded_rebinding_after_call.R
+++ b/crates/ry-checker/testdata/oracle/forwarded_rebinding_after_call.R
@@ -1,7 +1,9 @@
-# oracle: must-flag
+# oracle: must-warn RY001
 callee <- function(bins = 30L) if (bins == 1L) 1L else 2L
 caller <- function(bins = NULL) {
   identity(callee(bins))
   bins <- 1L
 }
-caller()
+error <- tryCatch(caller(), error = identity)
+stopifnot(inherits(error, "error"))
+stopifnot(identical(conditionMessage(error), "argument is of length zero"))

--- a/crates/ry-checker/testdata/oracle/forwarded_superassignment.R
+++ b/crates/ry-checker/testdata/oracle/forwarded_superassignment.R
@@ -1,4 +1,4 @@
-# oracle: must-flag
+# oracle: must-warn RY001
 bins <- 0L
 callee <- function(bins = 30L) if (bins == 1L) 1L else 2L
 statement <- function(bins = NULL) {
@@ -40,4 +40,3 @@ expect_length_error(rightward())
 expect_length_error(right_condition())
 expect_length_error(right_indexed())
 stopifnot(identical(bins, 1L))
-statement()

--- a/crates/ry-checker/tests/snapshots/corpus__checker_fixture_diagnostics.snap
+++ b/crates/ry-checker/tests/snapshots/corpus__checker_fixture_diagnostics.snap
@@ -1051,7 +1051,7 @@ expression: snapshots
 - diagnostics:
     - code: RY001
       message: "`if` condition is `character<len=1>`, expected length-1 logical (or a value R coerces to logical)"
-      severity: error
+      severity: warning
       span:
         column: 4
         end: 126
@@ -1287,7 +1287,7 @@ expression: snapshots
 - diagnostics:
     - code: RY001
       message: "`if` condition is `NULL<len=0>`, expected length-1 logical (or a value R coerces to logical)"
-      severity: error
+      severity: warning
       span:
         column: 6
         end: 61
@@ -1307,7 +1307,7 @@ expression: snapshots
 - diagnostics:
     - code: RY001
       message: "`if` condition is `character<len=1>`, expected length-1 logical (or a value R coerces to logical)"
-      severity: error
+      severity: warning
       span:
         column: 9
         end: 419
@@ -1315,7 +1315,7 @@ expression: snapshots
         start: 416
     - code: RY001
       message: "`if` condition is `character<len=1>`, expected length-1 logical (or a value R coerces to logical)"
-      severity: error
+      severity: warning
       span:
         column: 9
         end: 445
@@ -1323,7 +1323,7 @@ expression: snapshots
         start: 439
     - code: RY001
       message: "`if` condition is `character<len=1>`, expected length-1 logical (or a value R coerces to logical)"
-      severity: error
+      severity: warning
       span:
         column: 9
         end: 468
@@ -1331,7 +1331,7 @@ expression: snapshots
         start: 465
     - code: RY001
       message: "`if` condition is `character<len=1>`, expected length-1 logical (or a value R coerces to logical)"
-      severity: error
+      severity: warning
       span:
         column: 9
         end: 492
@@ -1339,7 +1339,7 @@ expression: snapshots
         start: 488
     - code: RY001
       message: "`if` condition is `character<len=1>`, expected length-1 logical (or a value R coerces to logical)"
-      severity: error
+      severity: warning
       span:
         column: 9
         end: 514
@@ -1347,7 +1347,7 @@ expression: snapshots
         start: 512
     - code: RY001
       message: "`if` condition is `character<len=2>`, expected length-1 logical (or a value R coerces to logical)"
-      severity: error
+      severity: warning
       span:
         column: 9
         end: 552
@@ -1355,7 +1355,7 @@ expression: snapshots
         start: 534
     - code: RY001
       message: "`if` condition is `character<len=0>`, expected length-1 logical (or a value R coerces to logical)"
-      severity: error
+      severity: warning
       span:
         column: 9
         end: 584
@@ -1363,7 +1363,7 @@ expression: snapshots
         start: 572
     - code: RY001
       message: "`if` condition is `list<len=1>{[[1]]:logical<len=1>}`, expected length-1 logical (or a value R coerces to logical)"
-      severity: error
+      severity: warning
       span:
         column: 9
         end: 614
@@ -1371,7 +1371,7 @@ expression: snapshots
         start: 604
     - code: RY001
       message: "`if` condition is `complex<len=0>`, expected length-1 logical (or a value R coerces to logical)"
-      severity: error
+      severity: warning
       span:
         column: 9
         end: 654
@@ -1379,7 +1379,7 @@ expression: snapshots
         start: 634
     - code: RY001
       message: "`if` condition is `complex<len=2>`, expected length-1 logical (or a value R coerces to logical)"
-      severity: error
+      severity: warning
       span:
         column: 9
         end: 694
@@ -1389,7 +1389,7 @@ expression: snapshots
 - diagnostics:
     - code: RY001
       message: "`if` condition is `NULL<len=0>`, expected length-1 logical (or a value R coerces to logical)"
-      severity: error
+      severity: warning
       span:
         column: 6
         end: 74


### PR DESCRIPTION
The checker API returned RY001 as an error while the rule table and CLI exposed it as a warning. Return a warning at the source so API consumers receive the documented severity.

Pin the existing RY002 behavior when a condition also contains RY100: the length warning remains because the multi-value condition still errors in R. Update the two RY001 oracle fixtures to assert their runtime errors and expect the documented warning. The corpus snapshot changes only the severity of 13 existing RY001 findings.

Closes #415.

Validation: workspace tests, Clippy with warnings denied, formatting, and the full R oracle pass. CLI diagnostic output keeps its existing severity.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * RY001 condition diagnostics are now consistently reported as warnings across the checker API, rule table, and command-line output.
  * RY002 length warnings are retained when the same condition also triggers RY100.
  * Improved handling of forwarded and reassigned values in condition checks, with clearer runtime error reporting in affected scenarios.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->