### PR TITLE
fix(checker): carry compound type guard facts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to ry are documented in this file.
 
 ### Fixed
 
+- Widen parameter defaults on the paths proved by compound `&&` and `||`
+  type guards. This avoids false atomic `$` errors for caller-supplied lists
+  while preserving errors on paths the guard does not prove (#408).
+
 - Discard forwarded-default facts after writes before wrapped or nested calls,
   including replacement assignments, loop variables, and literal `assign()`
   targets. Match backticked parameter and argument names consistently

--- a/crates/ry-checker/src/infer/mod.rs
+++ b/crates/ry-checker/src/infer/mod.rs
@@ -712,7 +712,7 @@ impl Checker {
     ) {
         let mut narrowed = HashSet::new();
         let mark = scope.begin_snapshot();
-        if let Some(name) = apply_narrowing_branch(scope, narrowing, NarrowingBranch::Then) {
+        for name in apply_narrowing_branch(scope, narrowing, NarrowingBranch::Then) {
             narrowed.insert(name.to_string());
         }
         for statement in then {
@@ -721,7 +721,7 @@ impl Checker {
         let mut then_delta =
             scope.finish_snapshot(mark, std::mem::take(&mut self.journal_delta_cache));
         let mark = scope.begin_snapshot();
-        if let Some(name) = apply_narrowing_branch(scope, narrowing, NarrowingBranch::Else) {
+        for name in apply_narrowing_branch(scope, narrowing, NarrowingBranch::Else) {
             narrowed.insert(name.to_string());
         }
         if let Some(statements) = else_ {

--- a/crates/ry-checker/src/infer/narrow.rs
+++ b/crates/ry-checker/src/infer/narrow.rs
@@ -12,6 +12,12 @@ use super::*;
 /// from it when that complement is representable.
 #[derive(Debug, Clone)]
 pub(crate) enum Narrowing {
+    /// Each list contains facts proved on that path through a compound guard.
+    Compound {
+        base: Box<Narrowing>,
+        on_true: Vec<Narrowing>,
+        on_false: Vec<Narrowing>,
+    },
     /// No refinement could be extracted from the condition.
     None,
     /// `var` is narrowed to `target` in the positive (then) branch.
@@ -412,9 +418,37 @@ fn type_is_exactly_tested_family(existing: &RType, target: &RType) -> bool {
     }
 }
 
+/// Apply all facts proved by the selected branch and return their binding names.
+pub(crate) fn apply_narrowing_branch<'a>(
+    scope: &mut Scope,
+    narrowing: &'a Narrowing,
+    branch: NarrowingBranch,
+) -> Vec<&'a str> {
+    if let Narrowing::Compound {
+        base,
+        on_true,
+        on_false,
+    } = narrowing
+    {
+        let mut names = apply_narrowing_branch(scope, base, branch);
+        let facts = match branch {
+            NarrowingBranch::Then => on_true,
+            NarrowingBranch::Else => on_false,
+        };
+        for fact in facts {
+            names.extend(apply_narrowing_branch(scope, fact, NarrowingBranch::Then));
+        }
+        names
+    } else {
+        apply_single_narrowing_branch(scope, narrowing, branch)
+            .into_iter()
+            .collect()
+    }
+}
+
 /// Apply only the selected path's refinement. Assertions keep this scope;
 /// conditional expressions supply a single isolated clone for their RHS.
-pub(crate) fn apply_narrowing_branch<'a>(
+fn apply_single_narrowing_branch<'a>(
     scope: &mut Scope,
     narrowing: &'a Narrowing,
     branch: NarrowingBranch,
@@ -591,10 +625,95 @@ fn install_positive_narrowing(scope: &mut Scope, var: &str, target: &RType) -> b
 }
 
 impl Checker {
+    /// Restrict compound facts to predicates without intervening writes or calls.
+    fn compound_guard_is_pure(&self, cond: &Expr, scope: &Scope) -> bool {
+        match cond {
+            Expr::BinOp {
+                op: BinOpKind::AndAnd | BinOpKind::OrOr,
+                lhs,
+                rhs,
+                ..
+            } => self.compound_guard_is_pure(lhs, scope) && self.compound_guard_is_pure(rhs, scope),
+            Expr::UnaryOp {
+                op: UnaryOpKind::Not,
+                expr,
+                ..
+            } => self.compound_guard_is_pure(expr, scope),
+            Expr::Call { func, args, .. } => {
+                let Some(name) = ident_name(func) else {
+                    return false;
+                };
+                predicate_target(crate::semantic_lists::bare_name(name)).is_some()
+                    && self.resolves_to_base(name, scope)
+                    && !scope.data_mask_unknown
+                    && !scope.effects_unknown
+                    && args.len() == 1
+                    && matches!(args[0].value, Expr::Ident { .. })
+            }
+            _ => false,
+        }
+    }
+
+    fn compound_guard_facts(cond: &Expr, truth: bool) -> Vec<Narrowing> {
+        match cond {
+            Expr::BinOp { op, lhs, rhs, .. }
+                if (*op == BinOpKind::AndAnd && truth) || (*op == BinOpKind::OrOr && !truth) =>
+            {
+                let mut facts = Self::compound_guard_facts(lhs, truth);
+                facts.extend(Self::compound_guard_facts(rhs, truth));
+                facts
+            }
+            Expr::UnaryOp {
+                op: UnaryOpKind::Not,
+                expr,
+                ..
+            } => Self::compound_guard_facts(expr, !truth),
+            Expr::Call { func, args, .. } => {
+                let Some(target) = ident_name(func)
+                    .and_then(|name| predicate_target(crate::semantic_lists::bare_name(name)))
+                else {
+                    return Vec::new();
+                };
+                let Some(var) = first_arg_ident(args) else {
+                    return Vec::new();
+                };
+                vec![if truth {
+                    Narrowing::Positive { var, target }
+                } else {
+                    Narrowing::Negative { var, target }
+                }]
+            }
+            _ => Vec::new(),
+        }
+    }
+
     /// Signature-declared predicates extend the built-in predicate vocabulary
     /// only when ordinary typeshed resolution establishes their provenance.
     pub(crate) fn extract_type_narrowing(&self, cond: &Expr, scope: &Scope) -> Narrowing {
         let built_in = extract_builtin_type_narrowing(cond);
+        let mut compound = cond;
+        while let Expr::UnaryOp {
+            op: UnaryOpKind::Not,
+            expr,
+            ..
+        } = compound
+        {
+            compound = expr;
+        }
+        if matches!(
+            compound,
+            Expr::BinOp {
+                op: BinOpKind::AndAnd | BinOpKind::OrOr,
+                ..
+            }
+        ) && self.compound_guard_is_pure(cond, scope)
+        {
+            return Narrowing::Compound {
+                base: Box::new(built_in),
+                on_true: Self::compound_guard_facts(cond, true),
+                on_false: Self::compound_guard_facts(cond, false),
+            };
+        }
         if !matches!(built_in, Narrowing::None) {
             return built_in;
         }
@@ -657,7 +776,7 @@ mod selected_branch_tests {
         // alone would match.
         let mut scope = Scope::default();
         scope.insert_parameter_default("x", RType::scalar(Mode::List));
-        apply_narrowing_branch(
+        apply_single_narrowing_branch(
             &mut scope,
             &Narrowing::Positive {
                 var: "x".into(),
@@ -709,7 +828,7 @@ mod selected_branch_tests {
         // The positive guard requires an intersecting member. The false path
         // of the negated predicate has historically installed its target.
         assert_eq!(
-            apply_narrowing_branch(
+            apply_single_narrowing_branch(
                 &mut positive,
                 &Narrowing::Positive {
                     var: "x".into(),
@@ -721,7 +840,7 @@ mod selected_branch_tests {
         );
         assert_eq!(positive.get("x"), Some(&original));
         assert_eq!(
-            apply_narrowing_branch(
+            apply_single_narrowing_branch(
                 &mut negative,
                 &Narrowing::Negative {
                     var: "x".into(),
@@ -746,7 +865,7 @@ mod selected_branch_tests {
         scope.set_function_alias("untouched", "other".into());
         scope.mark_lexical_function("untouched");
         scope.tidy_injection = Some(InjectionMode::Full);
-        apply_narrowing_branch(
+        apply_single_narrowing_branch(
             &mut scope,
             &Narrowing::Positive {
                 var: "x".into(),
@@ -783,11 +902,12 @@ mod selected_branch_tests {
                 target: None,
             };
             assert_eq!(
-                apply_narrowing_branch(&mut scope, &narrowing, NarrowingBranch::Then),
+                apply_single_narrowing_branch(&mut scope, &narrowing, NarrowingBranch::Then),
                 None
             );
             assert!(!scope.unreachable);
-            let changed = apply_narrowing_branch(&mut scope, &narrowing, NarrowingBranch::Else);
+            let changed =
+                apply_single_narrowing_branch(&mut scope, &narrowing, NarrowingBranch::Else);
             assert_eq!(changed, default_parameter.then_some("x"));
             assert_eq!(scope.unreachable, !default_parameter);
             assert_eq!(

--- a/crates/ry-checker/src/tests/narrowing.rs
+++ b/crates/ry-checker/src/tests/narrowing.rs
@@ -1315,3 +1315,81 @@ fn diverging_branch_does_not_reintroduce_prior_nonfunction_type() {
         );
     }
 }
+
+#[test]
+fn compound_guards_reject_default_modes_on_the_proven_path() {
+    for (condition, body) in [
+        ("is.character(x) || is.null(x)", "1L else x$field"),
+        ("!is.character(x) && !is.null(x)", "x$field else 1L"),
+        ("is.null(x) || is.character(x)", "1L else x$field"),
+        (
+            "base::is.character(x) || base::is.null(x)",
+            "1L else x$field",
+        ),
+        ("!(is.character(x) || is.null(x))", "x$field else 1L"),
+        (
+            "is.character(x) || is.null(x) || is.logical(x)",
+            "1L else x$field",
+        ),
+    ] {
+        let source = format!("f <- function(x = 'default') {{ if ({condition}) {body} }}\nf()\n");
+        let diagnostics = check(&source);
+        assert!(
+            diagnostics.iter().all(|d| d.code != "RY061"),
+            "{source}: {diagnostics:?}"
+        );
+    }
+}
+
+#[test]
+fn compound_guards_do_not_widen_unproved_paths_or_local_values() {
+    for source in [
+        "f <- function(x = 'default') { if (is.character(x) || is.null(x)) x$field }; f()",
+        "f <- function(x = 'default') { if (is.character(x) && is.null(x)) 1L else x$field }; f()",
+        "f <- function(x = 'default') { x <- 'rebound'; if (is.list(x) || is.null(x)) 1L else x$field }; f()",
+        "f <- function(x = 'default') { if (is.data.frame(x) || is.null(x)) 1L else x$field }; f()",
+        "f <- function(x = 'default') { is.character <- function(x) FALSE; if (is.character(x) || is.null(x)) 1L else x$field }; f()",
+        "f <- function(x = 'default') { if (is.character(x) || { x <- 'rebound'; FALSE }) 1L else x$field }; f()",
+    ] {
+        let diagnostics = check(source);
+        assert!(
+            diagnostics.iter().any(|d| d.code == "RY061"),
+            "{source}: {diagnostics:?}"
+        );
+    }
+}
+
+#[test]
+fn compound_guard_refinements_cover_each_parameter_and_stay_in_the_branch() {
+    let source = "f <- function(x = 'x', y = 'y') { if (is.character(x) || is.character(y)) 1L else { x$field; y$field }; x$field }; f()";
+    let diagnostics = check(source);
+    let dollars: Vec<_> = diagnostics.iter().filter(|d| d.code == "RY061").collect();
+    assert_eq!(dollars.len(), 1, "{diagnostics:?}");
+    assert_eq!(
+        &source[dollars[0].span.start..dollars[0].span.end],
+        "x$field"
+    );
+    assert_eq!(dollars[0].span.start, source.rfind("x$field").unwrap());
+}
+
+#[test]
+fn compound_guard_alias_mask_keeps_the_atomic_error() {
+    let diagnostics = check(
+        "is.character <- is.null\nf <- function(x = 'default') { if (is.character(x) || is.null(x)) 1L else x$field }; f()",
+    );
+    assert!(
+        diagnostics.iter().any(|d| d.code == "RY061"),
+        "{diagnostics:?}"
+    );
+}
+
+#[test]
+fn compound_guard_oracle_has_no_atomic_access_errors() {
+    let diagnostics = check(include_str!(
+        "../../testdata/oracle/compound_default_guards.R"
+    ));
+    assert!(
+        diagnostics.iter().all(|d| d.code != "RY061"),
+        "{diagnostics:?}"
+    );
+}

--- a/crates/ry-checker/src/tests/narrowing.rs
+++ b/crates/ry-checker/src/tests/narrowing.rs
@@ -1393,3 +1393,17 @@ fn compound_guard_oracle_has_no_atomic_access_errors() {
         "{diagnostics:?}"
     );
 }
+
+#[test]
+fn compound_guards_refine_assertions_and_positive_conjunctions() {
+    for body in [
+        "stopifnot(!is.character(x) && !is.null(x)); x$field",
+        "if (is.list(x) && !is.null(x)) x$field else 1L",
+    ] {
+        let diagnostics = check(&format!("f <- function(x = 'default') {{ {body} }}; f()"));
+        assert!(
+            diagnostics.iter().all(|d| d.code != "RY061"),
+            "{body}: {diagnostics:?}"
+        );
+    }
+}

--- a/crates/ry-checker/testdata/oracle/compound_default_guards.R
+++ b/crates/ry-checker/testdata/oracle/compound_default_guards.R
@@ -1,0 +1,15 @@
+# oracle: must-pass
+first <- function(x = "default") {
+  if (is.character(x) || is.null(x)) 1L else x$field
+}
+second <- function(x = "default") {
+  if (!is.character(x) && !is.null(x)) x$field else 1L
+}
+stopifnot(first() == 1L, second() == 1L)
+stopifnot(first(NULL) == 1L, second(NULL) == 1L)
+stopifnot(first(list(field = 2L)) == 2L, second(list(field = 2L)) == 2L)
+for (f in list(first, second)) {
+  error <- tryCatch(f(1L), error = identity)
+  stopifnot(inherits(error, "error"))
+  stopifnot(identical(conditionMessage(error), "$ operator is invalid for atomic vectors"))
+}

--- a/crates/ry-checker/testdata/oracle/compound_default_guards.R
+++ b/crates/ry-checker/testdata/oracle/compound_default_guards.R
@@ -13,3 +13,10 @@ for (f in list(first, second)) {
   stopifnot(inherits(error, "error"))
   stopifnot(identical(conditionMessage(error), "$ operator is invalid for atomic vectors"))
 }
+asserted <- function(x = "default") {
+  stopifnot(!is.character(x) && !is.null(x))
+  x$field
+}
+stopifnot(asserted(list(field = 3L)) == 3L)
+rejected_default <- tryCatch(asserted(), error = identity)
+stopifnot(inherits(rejected_default, "error"))


### PR DESCRIPTION
A function such as `f <- function(x = "default") if (is.character(x) || is.null(x)) 1L else x$field` reported RY061 for a caller-supplied list. The character default survived into a branch that rejects character values.

Carry every predicate fact proved on the false path of `||` and the true path of `&&`, including nested negation. Keep those facts local to the branch and preserve the existing scalar/NULL guard rules. The added facts require base predicate resolution and a guard without intervening writes or other calls.

Closes #408.

Validation: workspace tests, Clippy with warnings denied, formatting, and the full R oracle pass. Regression controls cover both branch directions, multiple parameters, rebinding, class predicates, masked functions, and aliases. R accepts the list calls and rejects the atomic control. The fixed 472-package corpus retains all 3,106 baseline diagnostics with no additions or removals; this regression is covered by the focused fixtures.
