### PR TITLE
fix(checker): track literal character conditions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to ry are documented in this file.
 
 ### Fixed
 
+- Report invalid character conditions through literal assignments and aliases.
+  Discard literal facts across calls, writes, loops, and branch merges (#425).
+
 - Return RY001 warnings from the checker API, matching the rule table and CLI.
   Keep RY002 length warnings when the condition also contains RY100 (#415).
 

--- a/crates/ry-checker/src/infer/binop.rs
+++ b/crates/ry-checker/src/infer/binop.rs
@@ -18,6 +18,8 @@ impl Checker {
         operand_proof: OperandEvidence,
         scope: &mut Scope,
     ) -> RType {
+        scope.invalidate_literal_values_for_dispatch(&lt);
+        scope.invalidate_literal_values_for_dispatch(&rt);
         let OperandEvidence {
             known_null: known_null_is_actionable,
             plain_vectors,

--- a/crates/ry-checker/src/infer/binop.rs
+++ b/crates/ry-checker/src/infer/binop.rs
@@ -660,6 +660,9 @@ fn data_frame_binop_result(op: BinOpKind, lhs: &RType, rhs: &RType) -> Option<RT
 /// to model guard narrowing, so copy just those assignment targets back (not
 /// the guard refinement itself) after evaluating the RHS.
 fn merge_condition_assignments(scope: &mut Scope, evaluated: &Scope, expr: &Expr) {
+    if evaluated.literal_values_unknown {
+        scope.invalidate_literal_values();
+    }
     scope.effects_unknown |= evaluated.effects_unknown;
     let mut names = HashSet::new();
     collect_condition_assignment_names(expr, &mut names);

--- a/crates/ry-checker/src/infer/call.rs
+++ b/crates/ry-checker/src/infer/call.rs
@@ -19,6 +19,7 @@ impl Checker {
         let environment_known_before_call = !scope.ops_environment_unknown;
         let pure = ops_chooser::pure_literal_constructor(self, func, args, scope);
         if !pure {
+            scope.invalidate_literal_values();
             scope.invalidate_ops_environment();
         }
         let result = self.infer_call_inner(func, args, scope, span, environment_known_before_call);

--- a/crates/ry-checker/src/infer/cloned_scope_reference.rs
+++ b/crates/ry-checker/src/infer/cloned_scope_reference.rs
@@ -59,9 +59,12 @@ impl Checker {
         // Types can compare equal after replacing a literal function. Do not
         // carry its identity or constant result across a branch merge.
         scope.clear_ops_facts();
+        scope.clear_known_strings();
         scope.ops_environment_unknown |=
             then_scope.ops_environment_unknown || else_scope.ops_environment_unknown;
         scope.effects_unknown |= then_scope.effects_unknown || else_scope.effects_unknown;
+        scope.literal_values_unknown |=
+            then_scope.literal_values_unknown || else_scope.literal_values_unknown;
         scope.has_escaped_slot_names |=
             then_scope.has_escaped_slot_names || else_scope.has_escaped_slot_names;
         // A diverging branch contributes no state to the continuation. Treat

--- a/crates/ry-checker/src/infer/loops.rs
+++ b/crates/ry-checker/src/infer/loops.rs
@@ -29,6 +29,7 @@ fn join_path(paths: &mut Option<Box<Scope>>, incoming: &Scope) {
         .retain(|name| incoming.has_list_origin(name));
     joined.ops_environment_unknown |= incoming.ops_environment_unknown;
     joined.effects_unknown |= incoming.effects_unknown;
+    joined.literal_values_unknown |= incoming.literal_values_unknown;
     joined.has_escaped_slot_names |= incoming.has_escaped_slot_names;
 }
 
@@ -77,6 +78,7 @@ impl Checker {
     }
 
     pub(crate) fn begin_loop(&mut self, inner: &mut Scope) {
+        inner.clear_known_strings();
         inner.loop_frame = Some(self.loop_frames.len());
         self.loop_frames.push(LoopExitFrame::default());
     }
@@ -108,6 +110,7 @@ impl Checker {
         always_true: bool,
         entered: bool,
     ) {
+        scope.clear_known_strings();
         let frame = self.loop_frames.pop().expect("active loop frame");
         let has_transfer = frame.breaks.is_some() || frame.nexts.is_some();
         let body_unreachable = inner.unreachable;
@@ -115,6 +118,7 @@ impl Checker {
         // leaving the loop. A previously recorded safe break cannot erase it.
         scope.ops_environment_unknown |= inner.ops_environment_unknown;
         scope.effects_unknown |= inner.effects_unknown;
+        scope.literal_values_unknown |= inner.literal_values_unknown;
         scope.has_escaped_slot_names |= inner.has_escaped_slot_names;
         let mut exits = frame.breaks;
         if has_transfer && inner.effects_unknown {
@@ -146,6 +150,7 @@ impl Checker {
         if let Some(exit) = exits {
             scope.ops_environment_unknown |= exit.ops_environment_unknown;
             scope.effects_unknown |= exit.effects_unknown;
+            scope.literal_values_unknown |= exit.literal_values_unknown;
             scope.has_escaped_slot_names |= exit.has_escaped_slot_names;
             for (binding, ty) in exit.bindings {
                 let list_origin = exit.list_origin_bindings.contains(&binding);

--- a/crates/ry-checker/src/infer/mod.rs
+++ b/crates/ry-checker/src/infer/mod.rs
@@ -270,11 +270,14 @@ impl Checker {
                 // declarations, since a user-defined list-returning
                 // function marks its binding too.
                 let value_has_list_origin = scope_marked_origin || every_mode_is_list(&vt);
-                let known_string = (ops_chooser::ordinary_assignment(self, target, value)
-                    && !ops_chooser::operator_rebound(self, "<-", scope)
-                    && !ops_chooser::operator_rebound(self, "=", scope))
-                .then(|| condition_string_literal(value, scope).map(Arc::<str>::from))
-                .flatten();
+                let known_string = condition_string_literal(value, scope)
+                    .filter(|_| !scope.literal_values_unknown && !scope.effects_unknown)
+                    .filter(|_| {
+                        ops_chooser::ordinary_assignment(self, target, value)
+                            && !ops_chooser::operator_rebound(self, "<-", scope)
+                            && !ops_chooser::operator_rebound(self, "=", scope)
+                    })
+                    .map(Arc::<str>::from);
                 let function_alias = self.function_alias_target(value, scope);
                 let literal_function = ops_chooser::literal_function(self, value, scope);
                 let plain_vector = ops_chooser::plain_vector(self, value, scope);
@@ -1978,11 +1981,14 @@ impl Checker {
                     }
                     let class_write = self.prepare_class_attribute(lhs, rhs, scope);
                     let rt = self.infer(rhs, scope);
-                    let known_string = (*op == BinOpKind::Assign
-                        && !ops_chooser::operator_rebound(self, "<-", scope)
-                        && !ops_chooser::operator_rebound(self, "=", scope))
-                    .then(|| condition_string_literal(rhs, scope).map(Arc::<str>::from))
-                    .flatten();
+                    let known_string = condition_string_literal(rhs, scope)
+                        .filter(|_| !scope.literal_values_unknown && !scope.effects_unknown)
+                        .filter(|_| {
+                            *op == BinOpKind::Assign
+                                && !ops_chooser::operator_rebound(self, "<-", scope)
+                                && !ops_chooser::operator_rebound(self, "=", scope)
+                        })
+                        .map(Arc::<str>::from);
                     if self.try_assign_value(lhs, rt.clone(), class_write, scope)
                         && let Some(name) = binding_name(lhs)
                         && let Some(value) = known_string

--- a/crates/ry-checker/src/infer/mod.rs
+++ b/crates/ry-checker/src/infer/mod.rs
@@ -1262,7 +1262,8 @@ impl Checker {
         scope: &mut Scope,
     ) -> bool {
         if binding_name(target).is_none() {
-            // Replacement functions may mutate a method or its environment.
+            // Replacement functions may install bindings in the caller.
+            scope.invalidate_literal_values();
             scope.invalidate_ops_environment();
         }
 
@@ -1930,6 +1931,12 @@ impl Checker {
             Expr::Na(t, _) => t.clone(),
             Expr::Ident { name, span } => self.infer_identifier(name, span, scope),
             Expr::BinOp { op, lhs, rhs, span } => {
+                if !scope.literal_values_unknown {
+                    let symbol = op_symbol(*op);
+                    if self.has_explicit_operator_mask(symbol, &format!("`{symbol}`"), scope) {
+                        scope.invalidate_literal_values();
+                    }
+                }
                 if let Some(result) = self.infer_custom_operator(*op, scope) {
                     return result;
                 }
@@ -2067,6 +2074,7 @@ impl Checker {
                     return RType::unknown();
                 }
                 let t = self.infer(expr, scope);
+                scope.invalidate_literal_values_for_dispatch(&t);
                 // Base R's `Math.data.frame`/`Ops.data.frame` apply unary
                 // operators column-wise. Preserve the frame rather than
                 // treating its list storage mode as primitive evidence.
@@ -2166,6 +2174,7 @@ impl Checker {
                 );
                 scope.invalidate_ops_environment();
                 let bt = self.infer(base, scope);
+                scope.invalidate_literal_values_for_dispatch(&bt);
                 self.infer_index(bt, *kind, args, *span, default_null_receiver, scope)
             }
             Expr::Function { params, body, .. } => {

--- a/crates/ry-checker/src/infer/mod.rs
+++ b/crates/ry-checker/src/infer/mod.rs
@@ -1714,8 +1714,9 @@ impl Checker {
         let mut found_lexical = false;
         let mut unresolved = false;
         if scope.is_parameter(name) || scope.get(name).is_none() {
-            // Forcing a promise can mutate the method environment.
+            // Forcing a promise can mutate methods or install active bindings.
             scope.invalidate_ops_environment();
+            scope.invalidate_literal_values();
         }
         let result = (|| match scope.get(name) {
             Some(t) => {

--- a/crates/ry-checker/src/infer/mod.rs
+++ b/crates/ry-checker/src/infer/mod.rs
@@ -82,15 +82,12 @@ fn is_coercible_scalar_condition_mode(t: &RType) -> bool {
         && matches!(t.length, Length::One | Length::Unknown)
 }
 
-/// The decoded text of a direct string-literal condition, or `None` for
-/// any other shape. The parser decodes escapes and raw strings when it
-/// builds `Expr::String`, so `"\x54RUE"`, `"\124RUE"`, and `r"(TRUE)"`
-/// all compare as `"TRUE"` — matching R, which decodes the literal
-/// before coercion. The parser drops redundant parentheses, so
-/// `(("TRUE"))` still reaches this helper as a direct literal.
-fn condition_string_literal(cond: &Expr) -> Option<&str> {
+/// Decoded character text from a literal or a binding with a known value.
+/// The parser decodes escapes and removes redundant parentheses.
+fn condition_string_literal<'a>(cond: &'a Expr, scope: &'a Scope) -> Option<&'a str> {
     match cond {
         Expr::String(value, _) => Some(value),
+        Expr::Ident { name, .. } => scope.known_string(name),
         _ => None,
     }
 }
@@ -273,12 +270,20 @@ impl Checker {
                 // declarations, since a user-defined list-returning
                 // function marks its binding too.
                 let value_has_list_origin = scope_marked_origin || every_mode_is_list(&vt);
+                let known_string = (ops_chooser::ordinary_assignment(self, target, value)
+                    && !ops_chooser::operator_rebound(self, "<-", scope)
+                    && !ops_chooser::operator_rebound(self, "=", scope))
+                .then(|| condition_string_literal(value, scope).map(Arc::<str>::from))
+                .flatten();
                 let function_alias = self.function_alias_target(value, scope);
                 let literal_function = ops_chooser::literal_function(self, value, scope);
                 let plain_vector = ops_chooser::plain_vector(self, value, scope);
                 if self.try_assign_value(target, vt, class_write, scope)
                     && let Some(name) = binding_name(target)
                 {
+                    if let Some(value) = known_string {
+                        scope.set_known_string(name, value);
+                    }
                     if self.capture_references {
                         self.install_reference_definition(
                             scope,
@@ -608,7 +613,7 @@ impl Checker {
         // non-coercible literal re-establishes the diagnostic here.
         let invalid_string_literal = matches!(ct.mode, Mode::Character)
             && matches!(ct.length, Length::One)
-            && condition_string_literal(cond)
+            && condition_string_literal(cond, scope)
                 .is_some_and(|value| !r_condition_string_is_accepted(value));
         // Preserve the established if-only logical-vector RY002 rule.
         // Other proven multi-value conditions use RY001, never RY003.
@@ -756,9 +761,12 @@ impl Checker {
             })
             .collect();
         scope.clear_ops_facts();
+        scope.clear_known_strings();
         scope.ops_environment_unknown |=
             then_delta.ops_environment_unknown || else_delta.ops_environment_unknown;
         scope.effects_unknown |= then_delta.effects_unknown || else_delta.effects_unknown;
+        scope.literal_values_unknown |=
+            then_delta.literal_values_unknown || else_delta.literal_values_unknown;
         scope.has_escaped_slot_names |=
             then_delta.has_escaped_slot_names || else_delta.has_escaped_slot_names;
         // Compute definite assignments only when both arms change a type,
@@ -1970,7 +1978,17 @@ impl Checker {
                     }
                     let class_write = self.prepare_class_attribute(lhs, rhs, scope);
                     let rt = self.infer(rhs, scope);
-                    self.try_assign_value(lhs, rt.clone(), class_write, scope);
+                    let known_string = (*op == BinOpKind::Assign
+                        && !ops_chooser::operator_rebound(self, "<-", scope)
+                        && !ops_chooser::operator_rebound(self, "=", scope))
+                    .then(|| condition_string_literal(rhs, scope).map(Arc::<str>::from))
+                    .flatten();
+                    if self.try_assign_value(lhs, rt.clone(), class_write, scope)
+                        && let Some(name) = binding_name(lhs)
+                        && let Some(value) = known_string
+                    {
+                        scope.set_known_string(name, value);
+                    }
                     return rt;
                 }
                 // `:` sequence operator: when both operands are

--- a/crates/ry-checker/src/infer/pipe.rs
+++ b/crates/ry-checker/src/infer/pipe.rs
@@ -286,17 +286,26 @@ impl Checker {
                 child.ops_environment_unknown,
                 child.effects_unknown,
                 child.unreachable,
+                child.literal_values_unknown,
             )
         };
-        let (then_t, then_ops, then_effects, then_unreachable) =
+        let (then_t, then_ops, then_effects, then_unreachable, then_literals) =
             infer_arm(then, NarrowingBranch::Then);
-        let (else_t, else_ops, else_effects, else_unreachable) = match else_ {
+        let (else_t, else_ops, else_effects, else_unreachable, else_literals) = match else_ {
             Some(e) => infer_arm(e, NarrowingBranch::Else),
-            None => (RType::new(Mode::Null, Length::Zero), false, false, false),
+            None => (
+                RType::new(Mode::Null, Length::Zero),
+                false,
+                false,
+                false,
+                false,
+            ),
         };
         scope.clear_ops_facts();
+        scope.clear_known_strings();
         scope.ops_environment_unknown |= then_ops || else_ops;
         scope.effects_unknown |= then_effects || else_effects;
+        scope.literal_values_unknown |= then_literals || else_literals;
         scope.unreachable |= then_unreachable && else_unreachable;
         match (then_unreachable, else_unreachable) {
             (true, false) => else_t,

--- a/crates/ry-checker/src/lib.rs
+++ b/crates/ry-checker/src/lib.rs
@@ -18,6 +18,7 @@ mod fixpoint;
 pub mod format;
 mod higher_order;
 mod infer;
+mod literal_values;
 mod nse;
 pub mod project;
 mod reference_facts;
@@ -309,6 +310,8 @@ pub struct Scope {
     pub(crate) effects_unknown: bool,
     /// Closed class-only vector construction, lost on writes and control-flow merges.
     pub(crate) plain_ops_vectors: FxSet<String>,
+    pub(crate) literal_values_unknown: bool,
+    pub(crate) known_strings: FxMap<String, Arc<str>>,
     pub(crate) literal_functions: FxMap<String, Arc<infer::ops_chooser::LiteralFunction>>,
     pub(crate) reference_provenance: Option<Box<reference_facts::ScopeProvenance>>,
     pub bindings: FxMap<String, RType>,
@@ -349,6 +352,8 @@ impl Clone for Scope {
             effects_unknown: self.effects_unknown,
             ops_environment_unknown: self.ops_environment_unknown,
             literal_functions: self.literal_functions.clone(),
+            known_strings: self.known_strings.clone(),
+            literal_values_unknown: self.literal_values_unknown,
             plain_ops_vectors: self.plain_ops_vectors.clone(),
             reference_provenance: self.reference_provenance.clone(),
             bindings: self.bindings.clone(),
@@ -374,6 +379,7 @@ impl Scope {
     pub(crate) fn independent_execution_scope(&self) -> Self {
         let mut scope = self.clone();
         scope.loop_frame = None;
+        scope.known_strings.clear();
         scope.unreachable = false;
         scope
     }
@@ -381,6 +387,7 @@ impl Scope {
     /// Unknown code may mutate values or install active bindings. Keep names,
     /// but make value uncertainty persist across writes.
     pub(crate) fn invalidate_unknown_effects(&mut self) {
+        self.clear_known_strings();
         if self.snapshot_depth > 0 {
             let names: HashSet<_> = self
                 .bindings
@@ -417,6 +424,7 @@ impl Scope {
     }
 
     pub(crate) fn invalidate_ops_environment(&mut self) {
+        self.clear_known_strings();
         self.clear_ops_facts();
         self.ops_environment_unknown = true;
     }
@@ -427,6 +435,7 @@ impl Scope {
 
     pub fn insert(&mut self, name: impl Into<String>, t: RType) {
         let name = name.into();
+        self.clear_known_string(&name);
         if !self.has_escaped_slot_names {
             self.has_escaped_slot_names = infer::custom_operator::escaped_name_may_mask_slot(&name);
         }

--- a/crates/ry-checker/src/literal_values.rs
+++ b/crates/ry-checker/src/literal_values.rs
@@ -1,0 +1,49 @@
+//! Character values known within the current execution path.
+use super::*;
+use crate::scope_journal::Undo;
+
+impl Scope {
+    pub(crate) fn invalidate_literal_values(&mut self) {
+        self.clear_known_strings();
+        self.literal_values_unknown = true;
+    }
+
+    pub(crate) fn known_string(&self, name: &str) -> Option<&str> {
+        self.known_strings
+            .get(semantic_argument_name(name))
+            .map(AsRef::as_ref)
+    }
+
+    pub(crate) fn set_known_string(&mut self, name: &str, value: Arc<str>) {
+        if self.effects_unknown || self.literal_values_unknown {
+            return;
+        }
+        let name = semantic_argument_name(name).to_string();
+        let previous = self.known_strings.insert(name.clone(), value);
+        if self.snapshot_depth > 0 {
+            self.undo.push(Undo::KnownString(name, previous));
+        }
+    }
+
+    pub(crate) fn clear_known_string(&mut self, name: &str) {
+        if self.known_strings.is_empty() {
+            return;
+        }
+        let name = semantic_argument_name(name);
+        if let Some(value) = self.known_strings.remove(name)
+            && self.snapshot_depth > 0
+        {
+            self.undo
+                .push(Undo::KnownString(name.to_string(), Some(value)));
+        }
+    }
+
+    pub(crate) fn clear_known_strings(&mut self) {
+        if self.snapshot_depth > 0 && !self.known_strings.is_empty() {
+            self.undo
+                .push(Undo::KnownStrings(std::mem::take(&mut self.known_strings)));
+        } else {
+            self.known_strings.clear();
+        }
+    }
+}

--- a/crates/ry-checker/src/literal_values.rs
+++ b/crates/ry-checker/src/literal_values.rs
@@ -8,6 +8,15 @@ impl Scope {
         self.literal_values_unknown = true;
     }
 
+    pub(crate) fn invalidate_literal_values_for_dispatch(&mut self, value: &RType) {
+        if value.class.is_unknown()
+            || value.class.has_known_class()
+            || matches!(value.mode, Mode::Opaque | Mode::Union)
+        {
+            self.invalidate_literal_values();
+        }
+    }
+
     pub(crate) fn known_string(&self, name: &str) -> Option<&str> {
         self.known_strings
             .get(semantic_argument_name(name))

--- a/crates/ry-checker/src/scope_journal.rs
+++ b/crates/ry-checker/src/scope_journal.rs
@@ -134,6 +134,8 @@ pub(crate) enum MarkerKind {
 
 #[derive(Debug)]
 pub(crate) enum Undo {
+    KnownString(String, Option<Arc<str>>),
+    KnownStrings(FxMap<String, Arc<str>>),
     Assignment(String, AssignmentUndo),
     Binding(String, BindingState),
     Marker(MarkerKind, String, bool),
@@ -152,6 +154,7 @@ pub(crate) enum Undo {
 }
 
 pub(crate) struct Mark {
+    literal_values_unknown: bool,
     len: usize,
     data_mask_unknown: bool,
     tidy_injection: Option<InjectionMode>,
@@ -168,6 +171,7 @@ pub(crate) type BranchChanges =
     hashbrown::HashMap<String, BindingState, std::collections::hash_map::RandomState>;
 
 pub(crate) struct BranchDelta {
+    pub literal_values_unknown: bool,
     pub changed: BranchChanges,
     pub unreachable: bool,
     pub effects_unknown: bool,
@@ -380,6 +384,7 @@ impl Scope {
     pub(crate) fn begin_snapshot(&mut self) -> Mark {
         self.snapshot_depth += 1;
         Mark {
+            literal_values_unknown: self.literal_values_unknown,
             len: self.undo.len(),
             loop_frame: self.loop_frame,
             effects_unknown: self.effects_unknown,
@@ -436,10 +441,15 @@ impl Scope {
                         .entry_ref(name.as_str())
                         .or_insert_with(|| BindingState::capture(self, name));
                 }
-                Undo::Provenance(_) | Undo::OpsBinding(..) | Undo::OpsTables(..) => {}
+                Undo::Provenance(_)
+                | Undo::OpsBinding(..)
+                | Undo::OpsTables(..)
+                | Undo::KnownString(..)
+                | Undo::KnownStrings(..) => {}
             }
         }
         let delta = BranchDelta {
+            literal_values_unknown: self.literal_values_unknown,
             effects_unknown: self.effects_unknown,
             ops_environment_unknown: self.ops_environment_unknown,
             has_escaped_slot_names: self.has_escaped_slot_names,
@@ -448,6 +458,14 @@ impl Scope {
         };
         while self.undo.len() > mark.len {
             match self.undo.pop().unwrap() {
+                Undo::KnownString(name, previous) => {
+                    if let Some(value) = previous {
+                        self.known_strings.insert(name, value);
+                    } else {
+                        self.known_strings.remove(&name);
+                    }
+                }
+                Undo::KnownStrings(previous) => self.known_strings = previous,
                 Undo::Assignment(name, state) => state.restore(self, name),
                 Undo::Binding(name, state) => state.restore(self, name),
                 Undo::Marker(kind, name, present) => {
@@ -503,6 +521,7 @@ impl Scope {
         self.effects_unknown = mark.effects_unknown;
         self.ops_environment_unknown = mark.ops_environment_unknown;
         self.has_escaped_slot_names = mark.has_escaped_slot_names;
+        self.literal_values_unknown = mark.literal_values_unknown;
         self.data_mask_unknown = mark.data_mask_unknown;
         self.tidy_injection = mark.tidy_injection;
         self.search_path_unknown = mark.search_path_unknown;
@@ -685,6 +704,8 @@ mod tests {
         assert_eq!(left.lexical_functions, right.lexical_functions);
         assert_eq!(left.function_aliases, right.function_aliases);
         assert_eq!(left.plain_ops_vectors, right.plain_ops_vectors);
+        assert_eq!(left.known_strings, right.known_strings);
+        assert_eq!(left.literal_values_unknown, right.literal_values_unknown);
         assert_eq!(left.literal_functions.len(), right.literal_functions.len());
         for (name, function) in &left.literal_functions {
             assert_eq!(

--- a/crates/ry-checker/src/tests/literal_conditions.rs
+++ b/crates/ry-checker/src/tests/literal_conditions.rs
@@ -1,0 +1,79 @@
+use super::*;
+
+#[test]
+fn assigned_character_literals_are_checked_in_conditions() {
+    for source in [
+        "d <- 'hello'; if (d) 1L",
+        "d <- 'NA'; alias <- d; if (alias) 1L",
+        "a <- d <- 'hello'; if (d) 1L",
+        "`flag value` <- 'hello'; if (`flag value`) 1L",
+        "d <- 'hello'; while (d) break",
+        "f <- function() { d <- 'hello'; if (d) 1L }; f()",
+        "d <- 'TRUE'; d <- 'hello'; if (d) 1L",
+    ] {
+        let diagnostics = check(source);
+        assert!(
+            diagnostics.iter().any(|d| d.code == "RY001"),
+            "{source}: {diagnostics:?}"
+        );
+    }
+}
+
+#[test]
+fn accepted_literals_and_invalidated_values_stay_silent() {
+    for source in [
+        "d <- 'TRUE'; if (d) 1L",
+        "d <- 'hello'; d <- 'False'; if (d) 1L",
+        "d <- 'hello'; d[1L] <- 'TRUE'; if (d) 1L",
+        "d <- 'hello'; if (flag) d <- 'TRUE'; if (d) 1L",
+        "d <- 'TRUE'; if (flag) d <- 'hello'; if (d) 1L",
+        "d <- 'hello'; f <- function() { if (d) 1L }; d <- 'TRUE'; f()",
+        "f <- function(d = 'hello') { if (d) 1L }; f('TRUE')",
+        "d <- 'hello'; mutate(); if (d) 1L",
+        "FALSE || { mutate(); TRUE }; d <- 'hello'; if (d) 1L",
+        "if (flag) mutate(); d <- 'hello'; if (d) 1L",
+        "result <- if (flag) mutate() else 1L; d <- 'hello'; if (d) 1L",
+        "d <- 'hello'; for (i in 1:2) d <- 'TRUE'; if (d) 1L",
+    ] {
+        let diagnostics = check(source);
+        assert!(
+            diagnostics.iter().all(|d| d.code != "RY001"),
+            "{source}: {diagnostics:?}"
+        );
+    }
+}
+
+#[test]
+fn branch_literal_values_do_not_leak_into_sibling_branches() {
+    let source = "d <- 'TRUE'; if (flag) { d <- 'hello'; if (d) 1L } else { if (d) 1L }";
+    let diagnostics = check(source);
+    let invalid: Vec<_> = diagnostics.iter().filter(|d| d.code == "RY001").collect();
+    assert_eq!(invalid.len(), 1, "{diagnostics:?}");
+    assert_eq!(invalid[0].span.start, source.find("if (d)").unwrap() + 4);
+}
+
+#[test]
+fn active_bindings_and_custom_assignment_do_not_supply_literal_values() {
+    for source in [
+        "makeActiveBinding('d', function(value) 'TRUE', globalenv()); d <- 'hello'; if (d) 1L",
+        "`<-` <- function(x, value) NULL; d <- 'hello'; if (d) 1L",
+        "d <- 'TRUE'; f <- function() { d <- 'TRUE'; d <<- 'hello'; if (d) 1L }; f()",
+    ] {
+        let diagnostics = check(source);
+        assert!(
+            diagnostics.iter().all(|d| d.code != "RY001"),
+            "{source}: {diagnostics:?}"
+        );
+    }
+}
+
+#[test]
+fn assigned_character_condition_oracle_retains_the_warning() {
+    let diagnostics = check(include_str!(
+        "../../testdata/oracle/assigned_character_conditions.R"
+    ));
+    assert!(
+        diagnostics.iter().any(|d| d.code == "RY001"),
+        "{diagnostics:?}"
+    );
+}

--- a/crates/ry-checker/src/tests/literal_conditions.rs
+++ b/crates/ry-checker/src/tests/literal_conditions.rs
@@ -45,7 +45,8 @@ fn accepted_literals_and_invalidated_values_stay_silent() {
 
 #[test]
 fn branch_literal_values_do_not_leak_into_sibling_branches() {
-    let source = "d <- 'TRUE'; if (flag) { d <- 'hello'; if (d) 1L } else { if (d) 1L }";
+    let source =
+        "flag <- TRUE; d <- 'TRUE'; if (flag) { d <- 'hello'; if (d) 1L } else { if (d) 1L }";
     let diagnostics = check(source);
     let invalid: Vec<_> = diagnostics.iter().filter(|d| d.code == "RY001").collect();
     assert_eq!(invalid.len(), 1, "{diagnostics:?}");
@@ -96,4 +97,19 @@ fn method_and_replacement_effects_block_later_literal_claims() {
         diagnostics.iter().any(|d| d.code == "RY001"),
         "{diagnostics:?}"
     );
+}
+
+#[test]
+fn forced_promises_block_later_literal_claims() {
+    for source in [
+        "f <- function(x) { x; e <- 'hello'; if (e) 1L }",
+        "unknown_value; e <- 'hello'; if (e) 1L",
+        include_str!("../../testdata/oracle/literal_conditions_after_promises.R"),
+    ] {
+        let diagnostics = check(source);
+        assert!(
+            diagnostics.iter().all(|d| d.code != "RY001"),
+            "{source}: {diagnostics:?}"
+        );
+    }
 }

--- a/crates/ry-checker/src/tests/literal_conditions.rs
+++ b/crates/ry-checker/src/tests/literal_conditions.rs
@@ -77,3 +77,23 @@ fn assigned_character_condition_oracle_retains_the_warning() {
         "{diagnostics:?}"
     );
 }
+
+#[test]
+fn method_and_replacement_effects_block_later_literal_claims() {
+    for source in [
+        "`+.flag` <- function(a, b) { makeActiveBinding('e', function(value) 'TRUE', globalenv()); a }; d <- 1L; class(d) <- 'flag'; x <- d + 1L; e <- 'hello'; if (e) 1L",
+        "`activate<-` <- function(x, value) { makeActiveBinding('e', function(value) 'TRUE', globalenv()); x }; d <- 1L; activate(d) <- 1L; e <- 'hello'; if (e) 1L",
+        "`+.flag` <- function(a, b) { makeActiveBinding('e', function(value) 'TRUE', globalenv()); a }; d <- base::structure(1L, class = 'flag'); x <- d + 1L; e <- 'hello'; if (e) 1L",
+    ] {
+        let diagnostics = check(source);
+        assert!(
+            diagnostics.iter().all(|d| d.code != "RY001"),
+            "{source}: {diagnostics:?}"
+        );
+    }
+    let diagnostics = check("d <- 1L; x <- d + 1L; e <- 'hello'; if (e) 1L");
+    assert!(
+        diagnostics.iter().any(|d| d.code == "RY001"),
+        "{diagnostics:?}"
+    );
+}

--- a/crates/ry-checker/src/tests/mod.rs
+++ b/crates/ry-checker/src/tests/mod.rs
@@ -71,3 +71,5 @@ mod deferred_calls;
 mod missing_args;
 mod printf_provenance;
 mod switch_selection;
+
+mod literal_conditions;

--- a/crates/ry-checker/testdata/oracle/assigned_character_conditions.R
+++ b/crates/ry-checker/testdata/oracle/assigned_character_conditions.R
@@ -1,0 +1,19 @@
+# oracle: must-warn RY001
+bad <- function() {
+  value <- "hello"
+  alias <- value
+  if (alias) 1L else 2L
+}
+good <- function() {
+  value <- "TRUE"
+  if (value) 1L else 2L
+}
+rebound <- function() {
+  value <- "hello"
+  value <- "False"
+  if (value) 1L else 2L
+}
+stopifnot(good() == 1L, rebound() == 2L)
+error <- tryCatch(bad(), error = identity)
+stopifnot(inherits(error, "error"))
+stopifnot(identical(conditionMessage(error), "argument is not interpretable as logical"))

--- a/crates/ry-checker/testdata/oracle/literal_conditions_after_methods.R
+++ b/crates/ry-checker/testdata/oracle/literal_conditions_after_methods.R
@@ -1,0 +1,9 @@
+# oracle: must-pass
+`+.flag` <- function(a, b) {
+  makeActiveBinding("e", function(value) "TRUE", globalenv())
+  a
+}
+d <- base::structure(1L, class = "flag")
+x <- d + 1L
+e <- "hello"
+stopifnot(if (e) TRUE else FALSE)

--- a/crates/ry-checker/testdata/oracle/literal_conditions_after_promises.R
+++ b/crates/ry-checker/testdata/oracle/literal_conditions_after_promises.R
@@ -1,0 +1,12 @@
+# oracle: must-pass
+# Default promises run in the callee's frame and can change later bindings.
+f <- function(x = {
+  makeActiveBinding("e", function(value) "TRUE", environment())
+  1L
+}) {
+  x
+  e <- "hello"
+  if (e) 1L
+}
+answer <- f()
+stopifnot(identical(answer, 1L))


### PR DESCRIPTION
`value <- "hello"; if (value) 1L` was silent even though R rejects the condition. Track decoded character literals through ordinary assignments and identifier aliases, then apply the existing condition check to their values.

Keep these facts in the scope journal so branch rollback restores the right value. Writes, loops, branch merges, and deferred execution discard them. Calls with unknown effects also prevent later assignments from claiming a literal value, because a call can install an active binding. Tests cover accepted strings, aliases, backticks, chained assignment, sibling branches, closures, superassignment, and custom binding behavior.

Closes #425. Depends on #442 for the condition family's documented warning severity. Known NA constants remain tracked in #354, as described in #425.

Validation: workspace tests, Clippy with warnings denied, formatting, and the full R oracle pass. The oracle confirms accepted and rebound strings and the exact error for the rejected alias. The fixed 472-package corpus retains all 3,106 baseline diagnostics with no additions or removals; the regression is covered by focused fixtures.

The method-effect follow-up also passes a fresh workspace build, full R oracle, and all eight release performance tests. Its fixed 472-package comparison retains all 3,106 baseline diagnostics, with zero additions and zero removals.
