### PR TITLE
feat(discovery): explain skipped files and support build-ignore exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to ry are documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- Explain source discovery with `ry check --explain-files`. Use
+  `include-build-ignored` in `ry.toml` to include selected build-ignored files
+  in both CLI checks and editor indexing (#363).
+
 ### Fixed
 
 - Discard forwarded-default facts after writes before wrapped or nested calls,
@@ -92,10 +98,6 @@ reading serialized package data.
 ## [0.9.0] - 2026-09-07
 
 ### Added
-
-- Explain source discovery with `ry check --explain-files`. Use
-  `include-build-ignored` in `ry.toml` to include selected build-ignored files
-  in both CLI checks and editor indexing (#363).
 
 - Embed verified ggplot2 signatures for 498 functions, 145 exported values, and
   11 lazy datasets. Curated capture metadata now owns aesthetic evaluation;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,10 @@ reading serialized package data.
 
 ### Added
 
+- Explain source discovery with `ry check --explain-files`. Use
+  `include-build-ignored` in `ry.toml` to include selected build-ignored files
+  in both CLI checks and editor indexing (#363).
+
 - Embed verified ggplot2 signatures for 498 functions, 145 exported values, and
   11 lazy datasets. Curated capture metadata now owns aesthetic evaluation;
   ordinary helpers such as `aes_string` no longer suppress unbound arguments.

--- a/crates/ry-cli/src/check.rs
+++ b/crates/ry-cli/src/check.rs
@@ -112,6 +112,7 @@ pub(crate) fn run_check(
         color,
         watch,
         statistics,
+        explain_files,
         write_baseline,
         baseline,
         min_confidence,
@@ -182,7 +183,13 @@ pub(crate) fn run_check(
     } else {
         paths
     };
-    let mut all_paths = rescan(&search_roots, config_root.as_deref(), &cfg, true);
+    let mut all_paths = rescan(
+        &search_roots,
+        config_root.as_deref(),
+        &cfg,
+        true,
+        explain_files,
+    );
 
     if all_paths.is_empty() {
         // An empty discovery result still needs a complete machine-readable report.
@@ -240,7 +247,7 @@ pub(crate) fn run_check(
         // Re-scan for new/deleted files via shared bounded discovery.
         // Truncation was already reported on the initial scan, so the
         // poll keeps stderr quiet.
-        let current_paths = rescan(&search_roots, config_root.as_deref(), &cfg, false);
+        let current_paths = rescan(&search_roots, config_root.as_deref(), &cfg, false, false);
 
         // Check for any file modification or file set change.
         let mut changed = current_paths != all_paths;
@@ -697,11 +704,26 @@ fn rescan(
     config_root: Option<&std::path::Path>,
     cfg: &config::Config,
     report: bool,
+    explain: bool,
 ) -> Vec<PathBuf> {
     let mut paths = Vec::new();
     for root in search_roots {
         let result =
             ry_workspace::discover_r_files(root, config_root, cfg, cfg.check_test_fixtures);
+        if explain {
+            for file in &result.files {
+                eprintln!("ry: include {}", file.display());
+            }
+            for (path, reason) in &result.skipped.entries {
+                eprintln!("ry: skip {} ({reason})", path.display());
+            }
+            if result.skipped.omitted > 0 {
+                eprintln!(
+                    "ry: {} more skipped paths omitted from explanation",
+                    result.skipped.omitted
+                );
+            }
+        }
         paths.extend(result.files);
         if report {
             report_truncation(&result.truncated, root);

--- a/crates/ry-cli/src/main.rs
+++ b/crates/ry-cli/src/main.rs
@@ -131,6 +131,9 @@ struct CheckArgs {
     /// `--statistics`). Useful for corpus research and triage.
     #[arg(long)]
     statistics: bool,
+    /// Explain included files and skipped paths on stderr before checking.
+    #[arg(long)]
+    explain_files: bool,
     /// Write the current diagnostics as a line-number-free JSON baseline.
     #[arg(long, value_name = "PATH", conflicts_with = "baseline")]
     write_baseline: Option<PathBuf>,
@@ -156,6 +159,7 @@ impl Default for CheckArgs {
             color: ColorChoice::default(),
             watch: false,
             statistics: false,
+            explain_files: false,
             write_baseline: None,
             baseline: None,
             min_confidence: ConfidenceChoice::default(),

--- a/crates/ry-cli/tests/config_e2e.rs
+++ b/crates/ry-cli/tests/config_e2e.rs
@@ -1303,3 +1303,38 @@ fn excluded_sources_still_emit_json_document() {
     let value: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
     assert_eq!(value, serde_json::json!([]));
 }
+
+#[test]
+fn explain_files_keeps_json_valid_and_reports_deliberate_reinclusion() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    fs::write(root.join("DESCRIPTION"), "Package: example\n").unwrap();
+    fs::write(root.join(".Rbuildignore"), "^vignettes$\n").unwrap();
+    fs::create_dir(root.join("vignettes")).unwrap();
+    fs::write(root.join("vignettes/broken.R"), "x <- )\n").unwrap();
+    let run = || {
+        Command::new(env!("CARGO_BIN_EXE_ry"))
+            .current_dir(root)
+            .args(["check", ".", "--explain-files", "--output-format", "json"])
+            .output()
+            .unwrap()
+    };
+    let skipped = run();
+    let json: serde_json::Value = serde_json::from_slice(&skipped.stdout).unwrap();
+    assert_eq!(json, serde_json::json!([]));
+    assert!(String::from_utf8_lossy(&skipped.stderr).contains("(.Rbuildignore)"));
+    fs::write(
+        root.join("ry.toml"),
+        "include-build-ignored = ['vignettes/*.R']\n",
+    )
+    .unwrap();
+    let included = run();
+    let json: serde_json::Value = serde_json::from_slice(&included.stdout).unwrap();
+    assert!(
+        json.as_array()
+            .unwrap()
+            .iter()
+            .any(|d| d["code"] == "RY000")
+    );
+    assert!(String::from_utf8_lossy(&included.stderr).contains("include ./vignettes/broken.R"));
+}

--- a/crates/ry-cli/tests/config_e2e.rs
+++ b/crates/ry-cli/tests/config_e2e.rs
@@ -1338,3 +1338,35 @@ fn explain_files_keeps_json_valid_and_reports_deliberate_reinclusion() {
     );
     assert!(String::from_utf8_lossy(&included.stderr).contains("include ./vignettes/broken.R"));
 }
+
+#[test]
+fn explicitly_requested_build_ignored_directory_still_gets_checked() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    fs::write(root.join("DESCRIPTION"), "Package: example\n").unwrap();
+    fs::write(root.join(".Rbuildignore"), "^vignettes$\n").unwrap();
+    fs::create_dir(root.join("vignettes")).unwrap();
+    fs::write(root.join("vignettes/doc.R"), "y <- )\n").unwrap();
+    let output = Command::new(env!("CARGO_BIN_EXE_ry"))
+        .current_dir(root)
+        .args([
+            "check",
+            "vignettes",
+            "--explain-files",
+            "--output-format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    let diagnostics: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert!(
+        diagnostics
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|d| d["code"] == "RY000"),
+        "{diagnostics}"
+    );
+    assert!(String::from_utf8_lossy(&output.stderr).contains("include vignettes/doc.R"));
+}

--- a/crates/ry-config/src/config.rs
+++ b/crates/ry-config/src/config.rs
@@ -120,6 +120,9 @@ pub struct Config {
     pub extend_select: Vec<String>,
     /// Exclude patterns (gitignore-style). Default: empty.
     pub exclude: Vec<String>,
+    /// Source globs to include despite `.Rbuildignore`, relative to `ry.toml`.
+    #[serde(alias = "include-build-ignored")]
+    pub include_build_ignored: Vec<String>,
     /// Check R fixture data nested under a package's `tests/` tree.
     /// Default: false.
     #[serde(alias = "check-test-fixtures")]
@@ -164,6 +167,7 @@ impl Default for Config {
             select: None,
             extend_select: Vec::new(),
             exclude: Vec::new(),
+            include_build_ignored: Vec::new(),
             check_test_fixtures: false,
             output_format: DEFAULT_OUTPUT_FORMAT.to_string(),
             verbose: 0,
@@ -232,6 +236,15 @@ impl Config {
                     }
                 })?;
             }
+        }
+        for pattern in &cfg.include_build_ignored {
+            glob::Pattern::new(&pattern.replace('\\', "/")).map_err(|source| {
+                ConfigError::InvalidIncludePattern {
+                    path: path.to_path_buf(),
+                    pattern: pattern.clone(),
+                    source,
+                }
+            })?;
         }
         for dir in &mut cfg.typeshed {
             if dir.is_relative() {
@@ -383,6 +396,7 @@ impl Config {
             select: self.select,
             extend_select: self.extend_select,
             exclude: self.exclude,
+            include_build_ignored: self.include_build_ignored,
             check_test_fixtures: self.check_test_fixtures,
             output_format,
             // Saturating add so a config value of 255 plus a CLI flag
@@ -473,6 +487,12 @@ pub enum ConfigError {
         "config file {path} has invalid max-serialized-bytes: expected 1..=268435456 (256 MiB)"
     )]
     InvalidSerializedLimit { path: PathBuf },
+    #[error("config file {path} has invalid include-build-ignored pattern `{pattern}`: {source}")]
+    InvalidIncludePattern {
+        path: PathBuf,
+        pattern: String,
+        source: glob::PatternError,
+    },
     #[error("config file {path} has invalid environment path pattern `{pattern}`: {source}")]
     InvalidEnvironmentPattern {
         path: PathBuf,
@@ -486,6 +506,17 @@ mod tests {
     use super::*;
     use std::fs;
     use tempfile::TempDir;
+
+    #[test]
+    fn invalid_build_include_globs_are_configuration_errors() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("ry.toml");
+        fs::write(&path, "include-build-ignored = ['[']\n").unwrap();
+        assert!(matches!(
+            Config::load_file(&path),
+            Err(ConfigError::InvalidIncludePattern { .. })
+        ));
+    }
 
     #[test]
     fn invalid_environment_globs_are_configuration_errors() {

--- a/crates/ry-workspace/src/discovery.rs
+++ b/crates/ry-workspace/src/discovery.rs
@@ -76,6 +76,60 @@ impl TruncationReport {
     }
 }
 
+/// Paths pruned during discovery. A directory entry covers its whole subtree.
+#[derive(Clone, Debug, Default)]
+pub struct SkippedPaths {
+    pub entries: Vec<(PathBuf, &'static str)>,
+    /// Additional entries omitted when the report reached `index.max-files`.
+    pub omitted: usize,
+}
+
+impl SkippedPaths {
+    fn record(&mut self, path: &Path, directory: bool, reason: &'static str, limit: usize) {
+        if !directory && !is_source_path(path) {
+            return;
+        }
+        if self.entries.len() < limit {
+            self.entries.push((path.to_path_buf(), reason));
+        } else {
+            self.omitted += 1;
+        }
+    }
+}
+
+struct BuildIgnoredIncludes {
+    root: PathBuf,
+    patterns: Vec<glob::Pattern>,
+}
+
+impl BuildIgnoredIncludes {
+    fn matches(&self, path: &Path) -> bool {
+        let Ok(path) = std::path::absolute(path) else {
+            return false;
+        };
+        let Ok(relative) = path.strip_prefix(&self.root) else {
+            return false;
+        };
+        let relative = relative.to_string_lossy().replace('\\', "/");
+        self.patterns.iter().any(|pattern| {
+            pattern.matches_with(
+                &relative,
+                glob::MatchOptions {
+                    require_literal_separator: true,
+                    ..Default::default()
+                },
+            )
+        })
+    }
+}
+
+fn is_source_path(path: &Path) -> bool {
+    matches!(
+        path.extension().and_then(|e| e.to_str()),
+        Some("R" | "r" | "S" | "s" | "q")
+    )
+}
+
 /// Result of a bounded directory discovery.
 #[derive(Clone, Debug, Default)]
 pub struct DiscoveryResult {
@@ -83,6 +137,7 @@ pub struct DiscoveryResult {
     pub files: Vec<PathBuf>,
     /// Structured cap report. Empty when no limit was reached.
     pub truncated: TruncationReport,
+    pub skipped: SkippedPaths,
 }
 
 /// Discover all eligible R source files under `walk_root`, applying the
@@ -107,7 +162,7 @@ pub fn discover_r_files(
     if walk_root.is_file() {
         return DiscoveryResult {
             files: vec![walk_root.to_path_buf()],
-            truncated: TruncationReport::default(),
+            ..Default::default()
         };
     }
     let limits = DiscoveryLimits::from_config(config);
@@ -115,6 +170,16 @@ pub fn discover_r_files(
     let has_excludes = !excludes.is_empty();
     let mut files = Vec::new();
     let mut truncated = TruncationReport::default();
+    let mut skipped = SkippedPaths::default();
+    let include_root = exclude_root.unwrap_or(walk_root);
+    let includes = BuildIgnoredIncludes {
+        root: std::path::absolute(include_root).unwrap_or_else(|_| include_root.to_path_buf()),
+        patterns: config
+            .include_build_ignored
+            .iter()
+            .filter_map(|pattern| glob::Pattern::new(&pattern.replace('\\', "/")).ok())
+            .collect(),
+    };
     let package_root = walk_root
         .ancestors()
         .find(|ancestor| ancestor.join("DESCRIPTION").is_file())
@@ -127,6 +192,9 @@ pub fn discover_r_files(
         walk_root,
         &mut files,
         &mut truncated,
+        &mut skipped,
+        &includes,
+        false,
         package_root.as_deref(),
         &buildignore,
         check_test_fixtures,
@@ -138,7 +206,12 @@ pub fn discover_r_files(
     );
     files.sort();
     files.dedup();
-    DiscoveryResult { files, truncated }
+    skipped.entries.sort_by(|a, b| a.0.cmp(&b.0));
+    DiscoveryResult {
+        files,
+        truncated,
+        skipped,
+    }
 }
 
 /// Whether `path` is test data under a package's `tests/` tree rather than
@@ -207,6 +280,9 @@ fn discover_recursive(
     dir: &Path,
     out: &mut Vec<PathBuf>,
     truncated: &mut TruncationReport,
+    skipped: &mut SkippedPaths,
+    includes: &BuildIgnoredIncludes,
+    inherited_buildignore: bool,
     package_root: Option<&Path>,
     buildignore: &[glob::Pattern],
     check_test_fixtures: bool,
@@ -226,19 +302,32 @@ fn discover_recursive(
         let Ok(file_type) = entry.file_type() else {
             continue;
         };
+        let path = entry.path();
+        let directory = file_type.is_dir();
         if file_type.is_symlink() {
+            skipped.record(&path, false, "symlink", limits.max_files);
             continue;
         }
-        let path = entry.path();
         // Apply ry.toml exclude patterns (relative to the config root).
         if has_excludes
             && let Some(anchor) = exclude_root
             && !is_file_eligible_with_excludes(&path, anchor, excludes)
         {
+            skipped.record(&path, directory, "ry.toml exclude", limits.max_files);
             continue;
         }
         // Apply .Rbuildignore patterns (relative to the package root).
-        if package_root.is_some_and(|root| is_rbuildignored(root, &path, buildignore)) {
+        let build_ignored = inherited_buildignore
+            || package_root.is_some_and(|root| {
+                path.ancestors()
+                    .take_while(|p| *p != root)
+                    .any(|ancestor| is_rbuildignored(root, ancestor, buildignore))
+            });
+        if build_ignored
+            && ((directory && includes.patterns.is_empty())
+                || (!directory && !includes.matches(&path)))
+        {
+            skipped.record(&path, directory, ".Rbuildignore", limits.max_files);
             continue;
         }
         if path.is_dir() {
@@ -249,9 +338,16 @@ fn discover_recursive(
                     || (name == "renv" && package_root.is_some())
                     || name.ends_with(".Rcheck"))
             {
+                skipped.record(
+                    &path,
+                    true,
+                    "hidden or generated directory",
+                    limits.max_files,
+                );
                 continue;
             }
             if package_root.is_some_and(|root| is_excluded_package_directory(root, &path)) {
+                skipped.record(&path, true, "package support directory", limits.max_files);
                 continue;
             }
             // depth cap prunes further descent.
@@ -268,6 +364,9 @@ fn discover_recursive(
                 &path,
                 out,
                 truncated,
+                skipped,
+                includes,
+                build_ignored,
                 nested_package_root.as_deref(),
                 &nested_buildignore,
                 check_test_fixtures,
@@ -277,11 +376,11 @@ fn discover_recursive(
                 has_excludes,
                 exclude_root,
             );
-        } else if matches!(
-            path.extension().and_then(|e| e.to_str()),
-            Some("R") | Some("r") | Some("S") | Some("s") | Some("q")
-        ) && (check_test_fixtures || !is_test_fixture(&path))
-        {
+        } else if is_source_path(&path) {
+            if !check_test_fixtures && is_test_fixture(&path) {
+                skipped.record(&path, false, "test fixture", limits.max_files);
+                continue;
+            }
             // max-files cap.
             if out.len() >= limits.max_files {
                 truncated.max_files_hit = true;
@@ -907,6 +1006,96 @@ mod shared_tests {
                 root.join("tests/testthat/test-package.R"),
             ]
         );
+    }
+
+    #[test]
+    fn build_ignored_includes_are_narrow_and_explained() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        std::fs::write(root.join("DESCRIPTION"), "Package: example\n").unwrap();
+        std::fs::write(root.join(".Rbuildignore"), "^vignettes$\n").unwrap();
+        for relative in [
+            "R/main.R",
+            "vignettes/keep.R",
+            "vignettes/drop.R",
+            "vignettes/nested/helper.R",
+            "vignettes/nested/other.R",
+            "vignettes/.hidden/keep.R",
+        ] {
+            let path = root.join(relative);
+            std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+            std::fs::write(path, "x <- 1L\n").unwrap();
+        }
+        let baseline = discover_r_files(root, Some(root), &ry_config::Config::default(), false);
+        assert_eq!(baseline.files, vec![root.join("R/main.R")]);
+        assert!(
+            baseline
+                .skipped
+                .entries
+                .contains(&(root.join("vignettes"), ".Rbuildignore"))
+        );
+        let config = ry_config::Config {
+            include_build_ignored: vec![
+                "vignettes/keep.R".into(),
+                "vignettes/nested/*.R".into(),
+                "vignettes/.hidden/keep.R".into(),
+            ],
+            exclude: vec!["vignettes/nested/other.R".into()],
+            ..Default::default()
+        };
+        let selected = discover_r_files(root, Some(root), &config, false);
+        assert_eq!(
+            selected.files,
+            vec![
+                root.join("R/main.R"),
+                root.join("vignettes/keep.R"),
+                root.join("vignettes/nested/helper.R")
+            ]
+        );
+        assert!(
+            selected
+                .skipped
+                .entries
+                .contains(&(root.join("vignettes/drop.R"), ".Rbuildignore"))
+        );
+        assert!(
+            selected
+                .skipped
+                .entries
+                .contains(&(root.join("vignettes/nested/other.R"), "ry.toml exclude"))
+        );
+    }
+
+    #[test]
+    fn include_does_not_clear_ignored_ancestor_at_a_nested_package() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        std::fs::write(root.join("DESCRIPTION"), "Package: outer\n").unwrap();
+        std::fs::write(root.join(".Rbuildignore"), "^examples$\n").unwrap();
+        let nested = root.join("examples/package");
+        std::fs::create_dir_all(nested.join("R")).unwrap();
+        std::fs::write(nested.join("DESCRIPTION"), "Package: inner\n").unwrap();
+        std::fs::write(nested.join("R/keep.R"), "x <- 1L\n").unwrap();
+        std::fs::write(nested.join("R/drop.R"), "x <- 1L\n").unwrap();
+        let config = ry_config::Config {
+            include_build_ignored: vec!["examples/package/R/keep.R".into()],
+            ..Default::default()
+        };
+        let result = discover_r_files(root, Some(root), &config, false);
+        assert_eq!(result.files, vec![nested.join("R/keep.R")]);
+    }
+
+    #[test]
+    fn skipped_path_report_is_bounded() {
+        let dir = tempfile::tempdir().unwrap();
+        for name in [".a", ".b", ".c"] {
+            std::fs::create_dir(dir.path().join(name)).unwrap();
+        }
+        let mut config = ry_config::Config::default();
+        config.index.max_files = 1;
+        let result = discover_r_files(dir.path(), None, &config, false);
+        assert_eq!(result.skipped.entries.len(), 1);
+        assert_eq!(result.skipped.omitted, 2);
     }
 
     #[test]

--- a/crates/ry-workspace/src/discovery.rs
+++ b/crates/ry-workspace/src/discovery.rs
@@ -190,6 +190,7 @@ pub fn discover_r_files(
         .unwrap_or_default();
     discover_recursive(
         walk_root,
+        walk_root,
         &mut files,
         &mut truncated,
         &mut skipped,
@@ -278,6 +279,7 @@ pub(super) fn is_testthat_code_name(name: &str) -> bool {
 #[allow(clippy::too_many_arguments)]
 fn discover_recursive(
     dir: &Path,
+    walk_root: &Path,
     out: &mut Vec<PathBuf>,
     truncated: &mut TruncationReport,
     skipped: &mut SkippedPaths,
@@ -320,7 +322,7 @@ fn discover_recursive(
         let build_ignored = inherited_buildignore
             || package_root.is_some_and(|root| {
                 path.ancestors()
-                    .take_while(|p| *p != root)
+                    .take_while(|p| *p != root && *p != walk_root)
                     .any(|ancestor| is_rbuildignored(root, ancestor, buildignore))
             });
         if build_ignored
@@ -362,6 +364,7 @@ fn discover_recursive(
             };
             discover_recursive(
                 &path,
+                walk_root,
                 out,
                 truncated,
                 skipped,

--- a/crates/ry-workspace/src/lib.rs
+++ b/crates/ry-workspace/src/lib.rs
@@ -6,8 +6,8 @@
 
 mod discovery;
 pub use discovery::{
-    DiscoveryLimits, DiscoveryResult, TruncationReport, discover_r_files, is_file_eligible,
-    rbuildignore_pattern,
+    DiscoveryLimits, DiscoveryResult, SkippedPaths, TruncationReport, discover_r_files,
+    is_file_eligible, rbuildignore_pattern,
 };
 use discovery::{is_r_source_name, is_testthat_code_name};
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -63,6 +63,9 @@ lets CLI discovery and editor indexing check selected files excluded by
 `.Rbuildignore`. It does not override `exclude`, fixture settings, symlink
 rules, hidden or generated directories, or resource limits.
 
+Use `vignettes/**` to include source files throughout that directory;
+`vignettes` alone matches only the directory, not its files.
+
 Run `ry check . --explain-files` to see included files and skipped paths on
 stderr. A skipped directory represents its whole subtree; ry does not scan it
 to count the files inside. Diagnostic output, including JSON, stays on stdout.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -38,6 +38,9 @@ output-format    = "full"     # full | concise | json | github | gitlab | junit
 # gitignore-style patterns, relative to this ry.toml's directory.
 exclude = ["renv", "tests/snaps/**"]
 
+# Check these source files even when .Rbuildignore excludes them.
+include-build-ignored = ["vignettes/benchmark.R"]
+
 # Include R fixture data nested under package tests/ directories.
 check-test-fixtures = false
 
@@ -54,6 +57,15 @@ max-files      = 20000   # files discovered per root (default: 20,000)
 max-file-bytes = 2097152 # bytes per R file (default: 2 MiB)
 max-depth      = 64      # directory depth (default: 64)
 ```
+
+`include-build-ignored` contains glob patterns relative to `ry.toml`. It
+lets CLI discovery and editor indexing check selected files excluded by
+`.Rbuildignore`. It does not override `exclude`, fixture settings, symlink
+rules, hidden or generated directories, or resource limits.
+
+Run `ry check . --explain-files` to see included files and skipped paths on
+stderr. A skipped directory represents its whole subtree; ry does not scan it
+to count the files inside. Diagnostic output, including JSON, stays on stdout.
 
 Serialized R data files are inventoried by decoding at most
 `max-serialized-bytes` bytes; one further byte is read to detect overflow. The

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -75,6 +75,17 @@ under `tests/` are treated as fixture data unless they are runners at
 `tests/` root or `test*`, `helper*`, `setup*`, or `teardown*` files directly
 under `tests/testthat/`; set `check-test-fixtures = true` to check fixture data.
 
+Vignette `.R` files are included unless a discovery rule excludes them.
+Use `ry check . --explain-files` to see those decisions. To check one ignored
+file, pass its path directly. For a persistent CLI and editor setting, add:
+
+```toml
+include-build-ignored = ["vignettes/benchmark.R"]
+```
+
+This setting overrides only `.Rbuildignore`. See
+[configuration](configuration.md) for the other discovery rules.
+
 Typed purrr maps check the callback's return type. For example, save this as
 `parallel.R` and run `ry check parallel.R`:
 


### PR DESCRIPTION
`ry check . --explain-files` now lists included files and skipped paths on stderr. This explains cases such as dtplyr's ignored vignette while keeping JSON diagnostics valid on stdout.

`include-build-ignored = ["vignettes/benchmark.R"]` adds a persistent exception to `.Rbuildignore` for CLI discovery and editor indexing. It preserves explicit config excludes, fixture settings, hidden/generated directory rules, symlink handling, and discovery caps. A skipped directory represents its subtree; explanations are bounded by `index.max-files`.

Validation: a fresh workspace build, workspace tests, Clippy with warnings denied, and formatting pass. Tests cover ignored ancestors across nested packages, narrow exceptions, config-exclude precedence, report limits, invalid globs, and the CLI's JSON output. The existing LSP protocol and discovery tests pass through the same shared walker.

Closes #363.
