### PR TITLE
docs: record scalar guard limits and remaining prerequisites

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -49,6 +49,7 @@ RY003 is registered but default-off: it is omitted from output unless a
 severity override or rule selection names it (for example
 `warn = ["RY003"]`).
 
-RY032 also has a parameter-pattern heuristic. See [scalar guards](scalar-guards.md)
-for its package, assertion, and alias/loop limits, and for the distinction
+RY032 also has a parameter-pattern heuristic. See
+[scalar guards](scalar-guards.md) for its package, assertion, and alias/loop
+limits, and for the distinction
 between a possible vector input and a failure on a valid scalar input.

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -48,3 +48,7 @@ explanation for one rule.
 RY003 is registered but default-off: it is omitted from output unless a
 severity override or rule selection names it (for example
 `warn = ["RY003"]`).
+
+RY032 also has a parameter-pattern heuristic. See [scalar guards](scalar-guards.md)
+for its package, assertion, and alias/loop limits, and for the distinction
+between a possible vector input and a failure on a valid scalar input.

--- a/docs/scalar-guards.md
+++ b/docs/scalar-guards.md
@@ -44,6 +44,6 @@ The remaining work in [#372](https://github.com/sims1253/ry/issues/372) needs
 callee provenance, class and dispatch facts, and invalidation after effects.
 The flow work in [#351](https://github.com/sims1253/ry/issues/351) also needs
 length facts that survive assertions, aliases, and loop joins. Both remain
-outside the 0.10.0 implementation scope under the milestone's rule for work
+outside this milestone's implementation scope under the milestone's rule for work
 that requires broader analysis changes. Existing guards should stay in
 place while these cases remain unresolved.

--- a/docs/scalar-guards.md
+++ b/docs/scalar-guards.md
@@ -1,0 +1,49 @@
+# Scalar guards and RY032
+
+RY032 reports known vector operands of `&&` and `||`. It also warns on some
+parameter guard patterns whose operands may have more than one element.
+Those parameter warnings describe a possible input; they do not prove that a
+function fails for its documented scalar inputs.
+
+```r
+f <- function(x) is.null(x) || is.na(x)
+```
+
+This function accepts `NULL` and scalar values. A vector with two elements
+reaches `is.na(x)` and causes a length error. A scalar default does not prove
+that every caller, or a later assignment from an option, supplies a scalar.
+
+## Current boundaries
+
+| Pattern | What ry can miss or overstate |
+| --- | --- |
+| `length(x) == 1L && x == 1L` in a package | A bare `length` may come from the package or an import. ry can warn even when the guard uses base R and the input is an ordinary vector. |
+| `stopifnot(is.null(x) || length(x) == 1L)` before a later use | The later expression can still receive RY032 after the assertion has excluded non-scalar inputs. |
+| `length(x) > 1L || !x %in% modes` returned to `if` | ry can miss the missing-value result for an empty input. |
+| A parameter copied to a local and then reassigned in a loop | ry can lose the possible vector length before a later `&&` comparison. |
+
+Other return expressions are covered. For example, the first function above
+receives RY032 even though the expression is outside an `if` condition.
+
+## Why a length check needs more than a name
+
+`length(x) > 0` proves only that a value is nonempty. It does not prove that
+its length is one. Even an exact equality needs care for classed objects:
+
+```r
+length.disguised <- function(x) 1L
+x <- structure(c(1L, 2L), class = "disguised")
+base::length(x) == 1L && x == 1L
+```
+
+Base R's `length` dispatches to the method, which reports one, while the
+comparison still produces two values. R rejects the right operand of `&&`.
+Qualifying the function name alone does not establish a scalar value.
+
+The remaining work in [#372](https://github.com/sims1253/ry/issues/372) needs
+callee provenance, class and dispatch facts, and invalidation after effects.
+The flow work in [#351](https://github.com/sims1253/ry/issues/351) also needs
+length facts that survive assertions, aliases, and loop joins. Both remain
+outside the 0.10.0 implementation scope under the milestone's rule for work
+that requires broader analysis changes. Existing guards should stay in
+place while these cases remain unresolved.


### PR DESCRIPTION
The next-release screening reproduces #351 and #372 on main `92c822a` with R 4.6.1. Keep both issues open and cut their implementation from this milestone under its explicit rule for work that requires broader analysis changes. Document the current user-visible boundaries and link them from RY032.

The four #372 toggles still differ. Local/formal masks and S3 dispatch show why relaxing package lookup is insufficient; even qualified `base::length` can hide a vector behind an S3 method. #351 still has assertion-continuation and alias/loop gaps. Some non-if expressions are already covered, but the reported return-membership case is not.

| Probe | R result | RY032 |
| --- | --- | --- |
| standalone | success | none |
| package | success | warning |
| qualified | success | none |
| explicit-import | success | none |
| local-mask | error | warning |
| formal-mask | error | warning |
| s3-length | error | warning |
| qualified-s3-length | error | none |
| nonempty | error | warning |
| assertion-before-use | success | warning |
| return-membership | error | none |
| return-null | error | warning |
| alias-loop | error | none |
| option-scalars | success | warning |
| option-vector | error | warning |

The runtime checks include valid NULL/scalar/default cases, vector-error controls, and a guarded assertion that rejects invalid input before use. Installed library discovery was disabled (`RY_NO_INSTALLED_LIBRARIES=1`); there were no typeshed overrides. Each probe used its own package or standalone directory. This is a 15-case semantic audit, not a new corpus reduction claim.

The documented prerequisites are callee/class provenance and effect invalidation (#372), followed by length facts across assertions, aliases, and loop joins (#351). No diagnostics are suppressed and neither issue is closed by this documentation PR.

Validation: every runtime outcome above was asserted by Rscript; the checker JSON was captured against the same sources. Documentation links and diff whitespace checked. Baseline binary SHA-256: `27d28fd7045a1c009b33226279cd88570064d4de57a2ec4fc9b9c88833c9aeae`.
