### PR TITLE
fix(workspace): pin the parser with resource limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to ry are documented in this file.
 
 ### Fixed
 
+- Bound serialized-data parser nesting and materialized collection storage,
+  including metadata loaded in lazy mode. Keep cycle-safe deduplication and
+  the static liblzma build while updating the pinned parser to its 0.2.1 base
+  (#412, #433). Unsupported or limited inventories still produce degraded
+  scope notices.
+
 - Discard forwarded-default facts after writes before wrapped or nested calls,
   including replacement assignments, loop variables, and literal `assign()`
   targets. Match backticked parameter and argument names consistently

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1261,8 +1261,8 @@ dependencies = [
 
 [[package]]
 name = "rds2rust"
-version = "0.2.0"
-source = "git+https://github.com/sims1253/rds2rust?rev=6d4014b316e465024d99fe30c0e8b424ce11cca1#6d4014b316e465024d99fe30c0e8b424ce11cca1"
+version = "0.2.1"
+source = "git+https://github.com/sims1253/rds2rust?rev=77c6b0f65ef76fcb0bb27a63ed09f37cc679b8ea#77c6b0f65ef76fcb0bb27a63ed09f37cc679b8ea"
 dependencies = [
  "byteorder",
  "flate2",
@@ -1691,7 +1691,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.3",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,9 +50,10 @@ proptest = "1.7"
 # parallelism (Project::check pass 3 + CLI parsing)
 rayon = "1"
 # Static inventory of R serialized data files (never evaluates R code).
-# rds2rust 0.2.0 with liblzma and cycle-safe composite deduplication.
-# Replace this fork pin when a registry release includes both fixes.
-rds2rust = { git = "https://github.com/sims1253/rds2rust", rev = "6d4014b316e465024d99fe30c0e8b424ce11cca1" }
+# rds2rust 0.2.1 plus cycle-safe deduplication and parser resource limits.
+# Upstream PRs: andrewwbutler/rds2rust#6 and #7. Keep an exact revision
+# until a registry release contains both fixes (tracking issue #433).
+rds2rust = { git = "https://github.com/sims1253/rds2rust", rev = "77c6b0f65ef76fcb0bb27a63ed09f37cc679b8ea" }
 bzip2 = "0.6"
 flate2 = "1"
 liblzma = { version = "0.4.8", default-features = false, features = ["static"] }


### PR DESCRIPTION
Pin the serialized-data reader to rds2rust 0.2.1 plus cycle-safe deduplication and parser resource limits. This keeps the static liblzma build and adds a default nesting limit of 64, capped at 128, with materialized collection checks in lazy mode. Failed inventory reads continue through ry's existing degraded-scope reporting.

Closes #412. Refs #433: the exact git revision remains necessary until a registry release contains the required fixes. Both upstream patches are open: [cycle-safe deduplication](https://github.com/andrewwbutler/rds2rust/pull/6) and [parser limits](https://github.com/andrewwbutler/rds2rust/pull/7). The registry replacement is therefore tracked, not claimed complete.

Validation: a fresh build passes all workspace tests, Clippy with warnings denied, and formatting. The parser patch separately passes native tests with eight self-contained small-object limit cases, WebAssembly compilation, and a 1,000-run bounded writer-round-trip target. These are per-collection limits, not a total memory budget. Existing fixture-dependent upstream tests can skip when their R data files are absent.

The release preparation will verify this pin in the integrated MSRV, corpus, tracked-only build, and nine-platform artifact gates. Git-host availability remains a source-build dependency; distributed binaries do not fetch the parser at runtime.

The lock refresh also selects getrandom 0.3.4 for tempfile 3.27.0, whose declared range is >=0.3.0,<0.5. Both getrandom versions were already in the graph; no package was added or removed for that edge. `cargo tree --locked -p tempfile` confirms the selection, and MSRV CI passes with it.
