### PR TITLE
fix(workspace): resolve registered native routine bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to ry are documented in this file.
 
 ### Fixed
 
+- Read literal C and C++ routine registration tables so registered symbols
+  also resolve through wrappers such as cleancall. Unknown registration forms
+  keep the existing fallback (#379).
+
 - Discard forwarded-default facts after writes before wrapped or nested calls,
   including replacement assignments, loop variables, and literal `assign()`
   targets. Match backticked parameter and argument names consistently

--- a/crates/ry-cli/tests/config_e2e.rs
+++ b/crates/ry-cli/tests/config_e2e.rs
@@ -1303,3 +1303,55 @@ fn excluded_sources_still_emit_json_document() {
     let value: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
     assert_eq!(value, serde_json::json!([]));
 }
+
+#[test]
+fn c_registration_inventory_resolves_wrapper_arguments_and_keeps_typos() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    fs::write(root.join("DESCRIPTION"), "Package: example\n").unwrap();
+    fs::create_dir(root.join("R")).unwrap();
+    fs::create_dir(root.join("src")).unwrap();
+    fs::write(root.join("src/init.c"), r#"
+#define CALLDEF(name, n) { #name, (DL_FUNC)&name, n }
+static const R_CallMethodDef calls[] = { CALLDEF(entry, 1), {"native_alias_xyz", (DL_FUNC)&implementation, 0}, {NULL, NULL, 0} };
+void R_init_example(DllInfo *dll) { R_registerRoutines(dll, NULL, calls, NULL, NULL); }
+"#).unwrap();
+    fs::write(root.join("R/wrapper.R"), "wrapper <- function(ptr, ...) .Call(cleancall_call, pairlist(ptr, ...))\nrun <- function() { wrapper(C_entry); wrapper(C_native_alias_xyz); wrapper(C_typo); wrapper(other_missing) }\n").unwrap();
+    fs::write(
+        root.join("NAMESPACE"),
+        "useDynLib(example, .registration = TRUE, .fixes = 'C_')\n",
+    )
+    .unwrap();
+    let declared = ry_check(root);
+    let stdout = String::from_utf8_lossy(&declared.stdout);
+    assert!(
+        !stdout.contains("`C_entry`") && !stdout.contains("`C_native_alias_xyz`"),
+        "{stdout}"
+    );
+    // Prefix handling has its own existing fallback; use an unrelated name
+    // as the control that wrapper arguments remain ordinary value reads.
+    assert!(stdout.contains("other_missing"), "{stdout}");
+    fs::write(
+        root.join("NAMESPACE"),
+        "useDynLib(example, .registration = TRUE)\n",
+    )
+    .unwrap();
+    fs::write(root.join("R/wrapper.R"), "wrapper <- function(ptr, ...) .Call(cleancall_call, pairlist(ptr, ...))\nrun <- function() { wrapper(entry); wrapper(native_alias_xyz); wrapper(typo); wrapper(other_missing) }\n").unwrap();
+    let declared = ry_check(root);
+    let stdout = String::from_utf8_lossy(&declared.stdout);
+    assert!(
+        !stdout.contains("`entry`") && !stdout.contains("`native_alias_xyz`"),
+        "{stdout}"
+    );
+    assert!(
+        stdout.contains("`typo`") && stdout.contains("other_missing"),
+        "{stdout}"
+    );
+    fs::write(root.join("NAMESPACE"), "useDynLib(example)\n").unwrap();
+    let undeclared = ry_check(root);
+    let stdout = String::from_utf8_lossy(&undeclared.stdout);
+    assert!(
+        stdout.contains("`entry`") && stdout.contains("`native_alias_xyz`"),
+        "{stdout}"
+    );
+}

--- a/crates/ry-lsp/src/backend.rs
+++ b/crates/ry-lsp/src/backend.rs
@@ -544,6 +544,7 @@ impl Backend {
             serde_json::json!({"globPattern": "**/ry.toml"}),
             serde_json::json!({"globPattern": "**/DESCRIPTION"}),
             serde_json::json!({"globPattern": "**/NAMESPACE"}),
+            serde_json::json!({"globPattern": "**/src/*.{c,cc,cpp,cxx}"}),
             serde_json::json!({"globPattern": "**/*.{rda,RData,rdata,json}"}),
         ];
         for path in &paths {

--- a/crates/ry-lsp/src/backend/handlers.rs
+++ b/crates/ry-lsp/src/backend/handlers.rs
@@ -372,6 +372,14 @@ impl LanguageServer for Backend {
                 let path = change.uri.path();
                 path.ends_with("DESCRIPTION")
                     || path.ends_with("NAMESPACE")
+                    || change.uri.to_file_path().is_ok_and(|path| {
+                        path.parent().and_then(std::path::Path::file_name)
+                            == Some(std::ffi::OsStr::new("src"))
+                            && matches!(
+                                path.extension().and_then(|ext| ext.to_str()),
+                                Some("c" | "cc" | "cpp" | "cxx")
+                            )
+                    })
                     || path.ends_with(".rda")
                     || path.ends_with(".RData")
                     || path.ends_with(".rdata")

--- a/crates/ry-lsp/tests/configuration_refresh.rs
+++ b/crates/ry-lsp/tests/configuration_refresh.rs
@@ -441,7 +441,7 @@ fn custom_configuration_is_watched_and_reloaded_after_path_changes() {
                 .await
                 .unwrap();
             let patterns = &request["params"]["registrations"][0]["registerOptions"]["watchers"];
-            let pattern = &patterns[4]["globPattern"];
+            let pattern = &patterns.as_array().unwrap().last().unwrap()["globPattern"];
             if relative {
                 assert_eq!(
                     pattern["baseUri"],
@@ -513,8 +513,9 @@ fn custom_configuration_is_watched_and_reloaded_after_path_changes() {
                 .respond_to_request("client/registerCapability", json!(null))
                 .await
                 .unwrap();
-            let pattern = &registration["params"]["registrations"][0]["registerOptions"]["watchers"]
-                [4]["globPattern"];
+            let watchers =
+                &registration["params"]["registrations"][0]["registerOptions"]["watchers"];
+            let pattern = &watchers.as_array().unwrap().last().unwrap()["globPattern"];
             if relative {
                 assert_eq!(
                     pattern["baseUri"],

--- a/crates/ry-lsp/tests/native_registration.rs
+++ b/crates/ry-lsp/tests/native_registration.rs
@@ -35,11 +35,22 @@ fn native_registration_edits_refresh_open_document_bindings() {
             let root = file_uri(fixture.root()).unwrap();
             let uri = file_uri(&fixture.path("R/main.R")).unwrap();
             let id = client.request("initialize", json!({
-                "processId": null, "rootUri": root, "capabilities": {},
+                "processId": null, "rootUri": root, "capabilities": {
+                    "workspace": {"didChangeWatchedFiles": {"dynamicRegistration": true}}
+                },
                 "workspaceFolders": [{"uri": root, "name": "example"}]
             })).await.unwrap();
             client.receive_until(|message| message["id"] == id, 20).await.unwrap();
             client.notify("initialized", json!({})).await.unwrap();
+            let watchers = client.receive_until(|message| {
+                message["method"] == "client/registerCapability"
+            }, 20).await.unwrap();
+            client.send(&json!({"jsonrpc": "2.0", "id": watchers["id"], "result": null})).await.unwrap();
+            assert!(watchers["params"]["registrations"].as_array().unwrap().iter().any(|registration| {
+                registration["registerOptions"]["watchers"].as_array().is_some_and(|watchers| {
+                    watchers.iter().any(|watcher| watcher["globPattern"] == "**/src/*.{c,cc,cpp,cxx}")
+                })
+            }), "{watchers}");
             client.notify("textDocument/didOpen", json!({"textDocument": {
                 "uri": uri, "languageId": "r", "version": 1, "text": source
             }})).await.unwrap();

--- a/crates/ry-lsp/tests/native_registration.rs
+++ b/crates/ry-lsp/tests/native_registration.rs
@@ -1,0 +1,70 @@
+use ry_testkit::{AsyncJsonRpcClient, FixtureProject, file_uri};
+use serde_json::{Value, json};
+
+fn unbound(message: &Value, name: &str) -> bool {
+    message["params"]["diagnostics"]
+        .as_array()
+        .is_some_and(|diagnostics| {
+            diagnostics.iter().any(|diagnostic| {
+                diagnostic["code"] == "RY010"
+                    && diagnostic["message"]
+                        .as_str()
+                        .is_some_and(|text| text.contains(name))
+            })
+        })
+}
+
+#[test]
+fn native_registration_edits_refresh_open_document_bindings() {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap()
+        .block_on(async {
+            let fixture = FixtureProject::empty().unwrap();
+            fixture.write_file("DESCRIPTION", "Package: example\nVersion: 1.0\n").unwrap();
+            fixture.write_file("NAMESPACE", "useDynLib(example, .registration=TRUE)\n").unwrap();
+            let source = "native_entry_xyz\nother_missing\n";
+            fixture.write_file("R/main.R", source).unwrap();
+            fixture.write_file("src/init.c", "").unwrap();
+            let (client, server) = tokio::io::duplex(128 * 1024);
+            let (reader, writer) = tokio::io::split(server);
+            let server = tokio::spawn(ry_lsp::run_with(reader, writer));
+            let (reader, writer) = tokio::io::split(client);
+            let mut client = AsyncJsonRpcClient::new(reader, writer);
+            let root = file_uri(fixture.root()).unwrap();
+            let uri = file_uri(&fixture.path("R/main.R")).unwrap();
+            let id = client.request("initialize", json!({
+                "processId": null, "rootUri": root, "capabilities": {},
+                "workspaceFolders": [{"uri": root, "name": "example"}]
+            })).await.unwrap();
+            client.receive_until(|message| message["id"] == id, 20).await.unwrap();
+            client.notify("initialized", json!({})).await.unwrap();
+            client.notify("textDocument/didOpen", json!({"textDocument": {
+                "uri": uri, "languageId": "r", "version": 1, "text": source
+            }})).await.unwrap();
+            tokio::time::timeout(std::time::Duration::from_secs(10),
+                client.receive_until(|message| {
+                    message["method"] == "textDocument/publishDiagnostics"
+                        && unbound(message, "native_entry_xyz") && unbound(message, "other_missing")
+                }, 50)).await.unwrap().unwrap();
+            let registration = r#"
+static const R_CallMethodDef calls[] = { {"native_entry_xyz", (DL_FUNC)&implementation, 0}, {NULL, NULL, 0} };
+void R_init_example(DllInfo *dll) { R_registerRoutines(dll, NULL, calls, NULL, NULL); }
+"#;
+            for (contents, missing) in [(registration, false), ("", true)] {
+                fixture.write_file("src/init.c", contents).unwrap();
+                client.notify("workspace/didChangeWatchedFiles", json!({"changes": [{
+                    "uri": file_uri(&fixture.path("src/init.c")).unwrap(), "type": 2
+                }]})).await.unwrap();
+                tokio::time::timeout(std::time::Duration::from_secs(10),
+                    client.receive_until(|message| {
+                        message["method"] == "textDocument/publishDiagnostics"
+                            && unbound(message, "native_entry_xyz") == missing
+                            && unbound(message, "other_missing")
+                    }, 50)).await.unwrap().unwrap();
+            }
+            drop(client);
+            server.abort();
+        });
+}

--- a/crates/ry-workspace/src/lib.rs
+++ b/crates/ry-workspace/src/lib.rs
@@ -5,6 +5,7 @@
 //! checker bindings.
 
 mod discovery;
+mod native;
 pub use discovery::{
     DiscoveryLimits, DiscoveryResult, TruncationReport, discover_r_files, is_file_eligible,
     rbuildignore_pattern,
@@ -142,6 +143,7 @@ pub fn resolve_workspace_context<'a>(
     let mut export_cache: HashMap<String, HashSet<String>> = HashMap::new();
     let mut dataset_cache: HashMap<PathBuf, DataInventory> = HashMap::new();
     let mut source_binding_cache: HashMap<PathBuf, SourceBindings> = HashMap::new();
+    let mut native_inventory_cache = HashMap::new();
     // A package root is visited once per file in it, so cache the
     // DESCRIPTION read like the sibling namespace/dataset caches.
     let mut description_cache: HashMap<PathBuf, DescriptionPackages> = HashMap::new();
@@ -221,12 +223,24 @@ pub fn resolve_workspace_context<'a>(
             let metadata = namespace_cache
                 .entry(root.clone())
                 .or_insert_with(|| read_namespace(&root.join("NAMESPACE")));
-            // `useDynLib(pkg, .registration = TRUE)` binds every routine in
-            // the package's `R_registerRoutines` table into the namespace.
-            // ry does not read `src/`, so the witness set collected above --
-            // names this package itself passes as an FFI entry point -- is
-            // the evidence that a name is one of them. Without the
-            // declaration the same names are ordinary unbound reads.
+            // Literal registered tables also cover symbols passed through
+            // wrappers. Keep the existing direct-call witnesses for sources
+            // whose build-time registration cannot be enumerated.
+            let native_inventory =
+                native_inventory_cache
+                    .entry(root.clone())
+                    .or_insert_with(|| {
+                        metadata
+                            .registered_native_libraries
+                            .iter()
+                            .flat_map(|(library, prefix)| {
+                                native::registered_symbols(&root, library)
+                                    .into_iter()
+                                    .map(move |name| format!("{prefix}{name}"))
+                            })
+                            .collect::<HashSet<_>>()
+                    });
+            file_bindings.extend(native_inventory.iter().cloned());
             if metadata.native_registration {
                 file_bindings.extend(source_bindings.native_symbols.iter().cloned());
                 file_bindings.extend(metadata.native_routines.iter().cloned());

--- a/crates/ry-workspace/src/native.rs
+++ b/crates/ry-workspace/src/native.rs
@@ -241,6 +241,7 @@ fn source_tokens(source: &str) -> Vec<Token> {
         } else if conditional_depth == 0 {
             code.push_str(line);
         } else {
+            output.push(Token::Barrier);
             code.push_str(" ; ");
         }
         code.push('\n');
@@ -302,6 +303,9 @@ fn table_symbols(tokens: &[Token]) -> HashSet<String> {
                 && !rest.is_empty()
             {
                 found.insert(name.clone());
+            } else {
+                // A null name ends registration. An unknown name may be null.
+                break;
             }
             index = end + 1;
         } else if tokens[index] == Token::RegistrationMacro {
@@ -321,6 +325,8 @@ fn table_symbols(tokens: &[Token]) -> HashSet<String> {
             } else {
                 index += 1;
             }
+        } else if tokens[index] == Token::Barrier {
+            break;
         } else {
             index += 1;
         }
@@ -377,6 +383,21 @@ fn source_symbols(source: &str, library: &str) -> HashSet<String> {
         let Some(body_end) = balanced_end(&tokens, body_start, '{', '}') else {
             continue;
         };
+        let shadowed_tables: HashSet<_> = tokens[body_start + 1..body_end]
+            .windows(2)
+            .filter(|pair| {
+                matches!(
+                    pair[0].word(),
+                    Some(
+                        "R_CallMethodDef"
+                            | "R_CMethodDef"
+                            | "R_FortranMethodDef"
+                            | "R_ExternalMethodDef"
+                    )
+                )
+            })
+            .filter_map(|pair| pair[1].word())
+            .collect();
         let mut position = body_start + 1;
         while position < body_end {
             // Only direct statements in this initializer establish inventory.
@@ -407,7 +428,9 @@ fn source_symbols(source: &str, library: &str) -> HashSet<String> {
                 && call == "R_registerRoutines"
             {
                 for table in [c, call_table, fortran, external] {
-                    if let Some(names) = tables.get(table) {
+                    if !shadowed_tables.contains(table.as_str())
+                        && let Some(names) = tables.get(table)
+                    {
                         found.extend(names.iter().cloned());
                     }
                 }
@@ -467,6 +490,38 @@ void R_init_example(DllInfo *dll) { R_registerRoutines(dll, NULL, calls, NULL, N
             source_symbols(source, "example"),
             HashSet::from(["before".into(), "redefined".into()])
         );
+    }
+
+    #[test]
+    fn terminated_or_uncertain_rows_stop_registration() {
+        for row in [
+            "{NULL, NULL, 0}",
+            "{0, 0, 0}",
+            "{nullptr, nullptr, 0}",
+            "{dynamic_name, (DL_FUNC)&entry, 0}",
+            "\n#if UNKNOWN\n{NULL, NULL, 0},\n#endif\n",
+        ] {
+            let source = source(
+                &format!(
+                    "{{\"before\", (DL_FUNC)&entry, 0}}, {row}, {{\"after\", (DL_FUNC)&entry, 0}}"
+                ),
+                "R_registerRoutines(dll, NULL, calls, NULL, NULL);",
+            );
+            assert_eq!(
+                source_symbols(&source, "example"),
+                HashSet::from(["before".into()]),
+                "{source}"
+            );
+        }
+    }
+
+    #[test]
+    fn local_table_does_not_resolve_through_a_shadowed_global_table() {
+        let source = source(
+            "{\"global_entry\", (DL_FUNC)&entry, 0}",
+            "const R_CallMethodDef calls[] = { {NULL, NULL, 0} }; R_registerRoutines(dll, NULL, calls, NULL, NULL);",
+        );
+        assert!(source_symbols(&source, "example").is_empty());
     }
 
     #[test]
@@ -608,9 +663,9 @@ void R_init_example(DllInfo *dll) { R_registerRoutines(dll, NULL, calls, NULL, N
     }
 
     #[test]
-    fn conditional_rows_do_not_hide_unconditional_registration() {
+    fn conditional_rows_preserve_prior_proven_registration() {
         let source = source(
-            "\n#ifdef ENABLE\n{\"optional\", (DL_FUNC)&optional, 0},\n#endif\n{\"always\", (DL_FUNC)&always, 0}",
+            "{\"always\", (DL_FUNC)&always, 0},\n#ifdef ENABLE\n{\"optional\", (DL_FUNC)&optional, 0},\n#endif\n{\"later\", (DL_FUNC)&later, 0}",
             "R_registerRoutines(dll, NULL, calls, NULL, NULL);",
         );
         assert_eq!(

--- a/crates/ry-workspace/src/native.rs
+++ b/crates/ry-workspace/src/native.rs
@@ -6,6 +6,7 @@ use std::path::Path;
 #[derive(Clone, Debug, PartialEq, Eq)]
 enum Token {
     Word(String),
+    RegistrationMacro,
     String(String),
     Punct(char),
     Barrier,
@@ -191,27 +192,40 @@ fn strip_comments(source: &str) -> Option<String> {
     Some(clean)
 }
 
-fn source_tokens(source: &str) -> (Vec<Token>, HashSet<String>) {
+fn append_code_tokens(code: &mut String, macros: &HashSet<String>, tokens: &mut Vec<Token>) {
+    tokens.extend(lex(code).into_iter().map(|token| {
+        if token.word().is_some_and(|name| macros.contains(name)) {
+            Token::RegistrationMacro
+        } else {
+            token
+        }
+    }));
+    code.clear();
+}
+
+fn source_tokens(source: &str) -> Vec<Token> {
     let joined = source.replace("\\\r\n", "").replace("\\\n", "");
     let Some(joined) = strip_comments(&joined) else {
-        return (Vec::new(), HashSet::new());
+        return Vec::new();
     };
     let mut macros = HashSet::new();
     let mut conditional_depth = 0usize;
     let mut code = String::new();
+    let mut output = Vec::new();
     // Comment stripping preserves strings and directive line boundaries.
     for line in joined.lines() {
         let trimmed = line.trim_start();
         if let Some(directive) = trimmed.strip_prefix('#') {
+            append_code_tokens(&mut code, &macros, &mut output);
             let tokens = lex(directive);
             let kind = tokens.first().and_then(Token::word);
             match kind {
                 Some("if" | "ifdef" | "ifndef") => conditional_depth += 1,
                 Some("endif") => conditional_depth = conditional_depth.saturating_sub(1),
-                Some("define") if conditional_depth == 0 => {
+                Some("define") => {
                     if let Some(name) = tokens.get(1).and_then(Token::word) {
                         macros.remove(name);
-                        if registration_macro(&tokens[2..]) {
+                        if conditional_depth == 0 && registration_macro(&tokens[2..]) {
                             macros.insert(name.to_string());
                         }
                     }
@@ -231,7 +245,8 @@ fn source_tokens(source: &str) -> (Vec<Token>, HashSet<String>) {
         }
         code.push('\n');
     }
-    (lex(&code), macros)
+    append_code_tokens(&mut code, &macros, &mut output);
+    output
 }
 
 /// Accept only the common two-parameter `#name, (DL_FUNC)&name, count` macro.
@@ -269,7 +284,7 @@ fn balanced_end(tokens: &[Token], start: usize, open: char, close: char) -> Opti
     None
 }
 
-fn table_symbols(tokens: &[Token], macros: &HashSet<String>) -> HashSet<String> {
+fn table_symbols(tokens: &[Token]) -> HashSet<String> {
     let mut found = HashSet::new();
     let mut index = 0;
     while index < tokens.len() {
@@ -289,10 +304,7 @@ fn table_symbols(tokens: &[Token], macros: &HashSet<String>) -> HashSet<String> 
                 found.insert(name.clone());
             }
             index = end + 1;
-        } else if tokens[index]
-            .word()
-            .is_some_and(|name| macros.contains(name))
-        {
+        } else if tokens[index] == Token::RegistrationMacro {
             if let Some(
                 [
                     Token::Punct('('),
@@ -317,7 +329,7 @@ fn table_symbols(tokens: &[Token], macros: &HashSet<String>) -> HashSet<String> 
 }
 
 fn source_symbols(source: &str, library: &str) -> HashSet<String> {
-    let (tokens, macros) = source_tokens(source);
+    let tokens = source_tokens(source);
     let mut tables = HashMap::new();
     let mut brace_depth = 0usize;
     for (index, token) in tokens.iter().enumerate() {
@@ -349,10 +361,7 @@ fn source_symbols(source: &str, library: &str) -> HashSet<String> {
         };
         let start = index + 5;
         if let Some(end) = balanced_end(&tokens, start, '{', '}') {
-            tables.insert(
-                name.clone(),
-                table_symbols(&tokens[start + 1..end], &macros),
-            );
+            tables.insert(name.clone(), table_symbols(&tokens[start + 1..end]));
         }
     }
     let init = format!("R_init_{}", library.replace('.', "_"));
@@ -433,6 +442,31 @@ mod tests {
             HashSet::from(["alias".into(), "entry".into()])
         );
         assert!(source_symbols(&source, "other").is_empty());
+    }
+
+    #[test]
+    fn macro_definitions_apply_at_each_table_row() {
+        let source = r#"
+#define CALLDEF(name, n) { #name, (DL_FUNC)&name, n }
+static const R_CallMethodDef calls[] = {
+    CALLDEF(before, 1),
+#undef CALLDEF
+    CALLDEF(after_undef, 1),
+#define CALLDEF(name, n) { #name, (DL_FUNC)&name, n }
+    CALLDEF(redefined, 1),
+#if UNKNOWN
+#define CALLDEF(name, n) custom(name, n)
+#endif
+    CALLDEF(after_conditional, 1),
+    {NULL, NULL, 0}
+};
+void R_init_example(DllInfo *dll) { R_registerRoutines(dll, NULL, calls, NULL, NULL); }
+#undef CALLDEF
+"#;
+        assert_eq!(
+            source_symbols(source, "example"),
+            HashSet::from(["before".into(), "redefined".into()])
+        );
     }
 
     #[test]

--- a/crates/ry-workspace/src/native.rs
+++ b/crates/ry-workspace/src/native.rs
@@ -1,0 +1,587 @@
+//! Literal native registration tables from a package's C and C++ sources.
+
+use std::collections::{HashMap, HashSet};
+use std::path::Path;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum Token {
+    Word(String),
+    String(String),
+    Punct(char),
+    Barrier,
+}
+
+impl Token {
+    fn word(&self) -> Option<&str> {
+        match self {
+            Self::Word(value) => Some(value),
+            _ => None,
+        }
+    }
+}
+
+/// Read ordinary source files only. Headers, generated sources, and custom
+/// build steps may supply more routines; this inventory is never exhaustive.
+pub(crate) fn registered_symbols(root: &Path, library: &str) -> HashSet<String> {
+    let Ok(entries) = std::fs::read_dir(root.join("src")) else {
+        return HashSet::new();
+    };
+    let mut paths: Vec<_> = entries
+        .take(4096)
+        .flatten()
+        .filter(|entry| {
+            entry.file_type().is_ok_and(|kind| kind.is_file())
+                && matches!(
+                    entry.path().extension().and_then(|s| s.to_str()),
+                    Some("c" | "cc" | "cpp" | "cxx")
+                )
+        })
+        .map(|entry| entry.path())
+        .collect();
+    paths.sort();
+    let mut remaining = 8 * 1024 * 1024;
+    let mut found = HashSet::new();
+    for path in paths.into_iter().take(256) {
+        let Ok(size) = path.metadata().map(|m| m.len()) else {
+            continue;
+        };
+        if size > 2 * 1024 * 1024 || size > remaining {
+            continue;
+        }
+        // Bound the read even if the file grows after metadata was read.
+        use std::io::Read;
+        let Ok(file) = std::fs::File::open(&path) else {
+            continue;
+        };
+        let mut bytes = Vec::new();
+        if file.take(size + 1).read_to_end(&mut bytes).is_err() || bytes.len() as u64 != size {
+            continue;
+        }
+        remaining -= size;
+        if let Ok(source) = std::str::from_utf8(&bytes) {
+            found.extend(source_symbols(source, library));
+        }
+    }
+    found
+}
+
+fn lex(source: &str) -> Vec<Token> {
+    let mut chars = source.chars().peekable();
+    let mut tokens = Vec::new();
+    while let Some(ch) = chars.next() {
+        if ch.is_whitespace() {
+            continue;
+        }
+        if ch == '/' && chars.peek() == Some(&'/') {
+            chars.next();
+            for c in chars.by_ref() {
+                if c == '\n' {
+                    break;
+                }
+            }
+        } else if ch == '/' && chars.peek() == Some(&'*') {
+            chars.next();
+            let mut closed = false;
+            while let Some(c) = chars.next() {
+                if c == '*' && chars.peek() == Some(&'/') {
+                    chars.next();
+                    closed = true;
+                    break;
+                }
+            }
+            if !closed {
+                return Vec::new();
+            }
+        } else if ch == '"' || ch == '\'' {
+            let mut value = String::new();
+            let mut valid = ch == '"';
+            let mut closed = false;
+            while let Some(c) = chars.next() {
+                if c == ch {
+                    closed = true;
+                    break;
+                }
+                if c == '\\' {
+                    match chars.next() {
+                        Some(c @ ('\\' | '"')) => value.push(c),
+                        Some(_) => valid = false,
+                        None => break,
+                    }
+                } else {
+                    value.push(c);
+                }
+            }
+            if !closed {
+                return Vec::new();
+            }
+            tokens.push(if valid {
+                Token::String(value)
+            } else {
+                Token::Barrier
+            });
+        } else if ch.is_ascii_alphanumeric() || ch == '_' {
+            let mut value = ch.to_string();
+            while chars
+                .peek()
+                .is_some_and(|c| c.is_ascii_alphanumeric() || *c == '_')
+            {
+                value.push(chars.next().unwrap());
+            }
+            tokens.push(Token::Word(value));
+        } else {
+            tokens.push(Token::Punct(ch));
+        }
+    }
+    tokens
+}
+
+fn strip_comments(source: &str) -> Option<String> {
+    let mut chars = source.chars().peekable();
+    let mut clean = String::new();
+    while let Some(ch) = chars.next() {
+        if ch == '/' && chars.peek() == Some(&'/') {
+            chars.next();
+            clean.push(' ');
+            for c in chars.by_ref() {
+                if c == '\n' {
+                    clean.push(c);
+                    break;
+                }
+            }
+        } else if ch == '/' && chars.peek() == Some(&'*') {
+            chars.next();
+            clean.push(' ');
+            let mut closed = false;
+            while let Some(c) = chars.next() {
+                if c == '\n' {
+                    clean.push(c);
+                }
+                if c == '*' && chars.peek() == Some(&'/') {
+                    chars.next();
+                    closed = true;
+                    break;
+                }
+            }
+            if !closed {
+                return None;
+            }
+        } else if ch == 'R' && chars.peek() == Some(&'"') {
+            // Raw C++ strings need a delimiter parser; leave this file opaque.
+            return None;
+        } else if ch == '"' || ch == '\'' {
+            clean.push(ch);
+            let mut closed = false;
+            while let Some(c) = chars.next() {
+                clean.push(c);
+                if c == ch {
+                    closed = true;
+                    break;
+                }
+                if c == '\\' {
+                    clean.push(chars.next()?);
+                }
+            }
+            if !closed {
+                return None;
+            }
+        } else {
+            clean.push(ch);
+        }
+    }
+    Some(clean)
+}
+
+fn source_tokens(source: &str) -> (Vec<Token>, HashSet<String>) {
+    let joined = source.replace("\\\r\n", "").replace("\\\n", "");
+    let Some(joined) = strip_comments(&joined) else {
+        return (Vec::new(), HashSet::new());
+    };
+    let mut macros = HashSet::new();
+    let mut conditional_depth = 0usize;
+    let mut code = String::new();
+    // Comment stripping preserves strings and directive line boundaries.
+    for line in joined.lines() {
+        let trimmed = line.trim_start();
+        if let Some(directive) = trimmed.strip_prefix('#') {
+            let tokens = lex(directive);
+            let kind = tokens.first().and_then(Token::word);
+            match kind {
+                Some("if" | "ifdef" | "ifndef") => conditional_depth += 1,
+                Some("endif") => conditional_depth = conditional_depth.saturating_sub(1),
+                Some("define") if conditional_depth == 0 => {
+                    if let Some(name) = tokens.get(1).and_then(Token::word) {
+                        macros.remove(name);
+                        if registration_macro(&tokens[2..]) {
+                            macros.insert(name.to_string());
+                        }
+                    }
+                }
+                Some("undef") => {
+                    if let Some(name) = tokens.get(1).and_then(Token::word) {
+                        macros.remove(name);
+                    }
+                }
+                _ => {}
+            }
+            code.push_str(" ; ");
+        } else if conditional_depth == 0 {
+            code.push_str(line);
+        } else {
+            code.push_str(" ; ");
+        }
+        code.push('\n');
+    }
+    (lex(&code), macros)
+}
+
+/// Accept only the common two-parameter `#name, (DL_FUNC)&name, count` macro.
+fn registration_macro(tokens: &[Token]) -> bool {
+    let [
+        Token::Punct('('),
+        Token::Word(name),
+        Token::Punct(','),
+        Token::Word(count),
+        Token::Punct(')'),
+        rest @ ..,
+    ] = tokens
+    else {
+        return false;
+    };
+    rest == lex(&format!("{{ #{name}, (DL_FUNC)&{name}, {count} }}"))
+}
+
+fn balanced_end(tokens: &[Token], start: usize, open: char, close: char) -> Option<usize> {
+    if tokens.get(start) != Some(&Token::Punct(open)) {
+        return None;
+    }
+    let mut depth = 0usize;
+    for (index, token) in tokens.iter().enumerate().skip(start) {
+        if token == &Token::Punct(open) {
+            depth += 1;
+        }
+        if token == &Token::Punct(close) {
+            depth = depth.checked_sub(1)?;
+            if depth == 0 {
+                return Some(index);
+            }
+        }
+    }
+    None
+}
+
+fn table_symbols(tokens: &[Token], macros: &HashSet<String>) -> HashSet<String> {
+    let mut found = HashSet::new();
+    let mut index = 0;
+    while index < tokens.len() {
+        if tokens[index] == Token::Punct('{') {
+            let Some(end) = balanced_end(tokens, index, '{', '}') else {
+                break;
+            };
+            if let [
+                Token::Punct('{'),
+                Token::String(name),
+                Token::Punct(','),
+                rest @ ..,
+            ] = &tokens[index..end]
+                && !name.is_empty()
+                && !rest.is_empty()
+            {
+                found.insert(name.clone());
+            }
+            index = end + 1;
+        } else if tokens[index]
+            .word()
+            .is_some_and(|name| macros.contains(name))
+        {
+            if let Some(
+                [
+                    Token::Punct('('),
+                    Token::Word(name),
+                    Token::Punct(','),
+                    Token::Word(count),
+                    Token::Punct(')'),
+                ],
+            ) = tokens.get(index + 1..index + 6)
+                && count.parse::<u32>().is_ok()
+            {
+                found.insert(name.clone());
+                index += 6;
+            } else {
+                index += 1;
+            }
+        } else {
+            index += 1;
+        }
+    }
+    found
+}
+
+fn source_symbols(source: &str, library: &str) -> HashSet<String> {
+    let (tokens, macros) = source_tokens(source);
+    let mut tables = HashMap::new();
+    let mut brace_depth = 0usize;
+    for (index, token) in tokens.iter().enumerate() {
+        match token {
+            Token::Punct('{') => brace_depth += 1,
+            Token::Punct('}') => brace_depth = brace_depth.saturating_sub(1),
+            _ => {}
+        }
+        if brace_depth != 0 {
+            continue;
+        }
+        if !matches!(
+            token.word(),
+            Some("R_CallMethodDef" | "R_CMethodDef" | "R_FortranMethodDef" | "R_ExternalMethodDef")
+        ) {
+            continue;
+        }
+        let Some(
+            [
+                Token::Word(name),
+                Token::Punct('['),
+                Token::Punct(']'),
+                Token::Punct('='),
+                Token::Punct('{'),
+            ],
+        ) = tokens.get(index + 1..index + 6)
+        else {
+            continue;
+        };
+        let start = index + 5;
+        if let Some(end) = balanced_end(&tokens, start, '{', '}') {
+            tables.insert(
+                name.clone(),
+                table_symbols(&tokens[start + 1..end], &macros),
+            );
+        }
+    }
+    let init = format!("R_init_{}", library.replace('.', "_"));
+    let mut found = HashSet::new();
+    for (index, token) in tokens.iter().enumerate() {
+        if token.word() != Some(&init) {
+            continue;
+        }
+        let Some(params_end) = balanced_end(&tokens, index + 1, '(', ')') else {
+            continue;
+        };
+        let body_start = params_end + 1;
+        let Some(body_end) = balanced_end(&tokens, body_start, '{', '}') else {
+            continue;
+        };
+        let mut position = body_start + 1;
+        while position < body_end {
+            // Only direct statements in this initializer establish inventory.
+            let start = position;
+            while position < body_end && !matches!(tokens[position], Token::Punct(';' | '{')) {
+                position += 1;
+            }
+            if position < body_end && tokens[position] == Token::Punct('{') {
+                position =
+                    balanced_end(&tokens, position, '{', '}').map_or(body_end, |end| end + 1);
+                continue;
+            }
+            let statement = &tokens[start..position];
+            if let [
+                Token::Word(call),
+                Token::Punct('('),
+                Token::Word(_dll),
+                Token::Punct(','),
+                Token::Word(c),
+                Token::Punct(','),
+                Token::Word(call_table),
+                Token::Punct(','),
+                Token::Word(fortran),
+                Token::Punct(','),
+                Token::Word(external),
+                Token::Punct(')'),
+            ] = statement
+                && call == "R_registerRoutines"
+            {
+                for table in [c, call_table, fortran, external] {
+                    if let Some(names) = tables.get(table) {
+                        found.extend(names.iter().cloned());
+                    }
+                }
+            }
+            position += 1;
+        }
+    }
+    found
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn source(table: &str, init: &str) -> String {
+        format!(
+            "static const R_CallMethodDef calls[] = {{ {table}, {{NULL, NULL, 0}} }};\nvoid R_init_example(DllInfo *dll) {{ {init} }}"
+        )
+    }
+
+    #[test]
+    fn registered_literal_and_local_macro_rows_supply_names() {
+        let source = format!(
+            "#define CALLDEF(name, n) \\\n {{ #name, (DL_FUNC)&name, n }}\n{}",
+            source(
+                r#"{"alias", (DL_FUNC)&implementation, 1}, CALLDEF(entry, 2)"#,
+                "R_registerRoutines(dll, NULL, calls, NULL, NULL);",
+            )
+        );
+        assert_eq!(
+            source_symbols(&source, "example"),
+            HashSet::from(["alias".into(), "entry".into()])
+        );
+        assert!(source_symbols(&source, "other").is_empty());
+    }
+
+    #[test]
+    fn file_inventory_reads_registered_tables() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir(dir.path().join("src")).unwrap();
+        let source = format!(
+            "#define CALLDEF(name, n) {{ #name, (DL_FUNC)&name, n }}\n{}",
+            source(
+                "CALLDEF(entry, 1)",
+                "R_registerRoutines(dll, NULL, calls, NULL, NULL);"
+            )
+        );
+        std::fs::write(dir.path().join("src/init.c"), source).unwrap();
+        assert_eq!(
+            registered_symbols(dir.path(), "example"),
+            HashSet::from(["entry".into()])
+        );
+    }
+
+    #[test]
+    fn workspace_context_receives_the_native_inventory() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        std::fs::create_dir(root.join("src")).unwrap();
+        std::fs::create_dir(root.join("R")).unwrap();
+        std::fs::write(root.join("DESCRIPTION"), "Package: example\n").unwrap();
+        std::fs::write(
+            root.join("NAMESPACE"),
+            "useDynLib(example, .registration = TRUE)\n",
+        )
+        .unwrap();
+        std::fs::write(
+            root.join("src/init.c"),
+            source(
+                "{\"entry\", (DL_FUNC)&entry, 0}",
+                "R_registerRoutines(dll, NULL, calls, NULL, NULL);",
+            ),
+        )
+        .unwrap();
+        let path = root.join("R/use.R").to_string_lossy().into_owned();
+        let mut parser = ry_core::RParser::new().unwrap();
+        let file = parser.parse(&path, "f <- function() entry\n").unwrap();
+        let config = ry_config::Config::default();
+        let files = [file];
+        let stubs = std::collections::BTreeMap::new();
+        let context = crate::resolve_workspace_context(
+            root,
+            &config,
+            crate::ResolutionEnvironment {
+                files: files.iter().collect(),
+                user_stubs: &stubs,
+            },
+        )
+        .unwrap();
+        assert!(
+            context.external_bindings[&path].contains("entry"),
+            "{:?}",
+            context.external_bindings
+        );
+    }
+
+    #[test]
+    fn macro_can_be_the_first_table_entry() {
+        let source = r#"
+#define CALLDEF(name, n) { #name, (DL_FUNC)&name, n }
+static const R_CallMethodDef calls[] = { CALLDEF(entry, 1), {"alias", (DL_FUNC)&implementation, 0}, {NULL, NULL, 0} };
+void R_init_example(DllInfo *dll) { R_registerRoutines(dll, NULL, calls, NULL, NULL); }
+"#;
+        assert_eq!(
+            source_symbols(source, "example"),
+            HashSet::from(["entry".into(), "alias".into()])
+        );
+    }
+
+    #[test]
+    fn unregistered_conditional_and_dynamic_rows_do_not_supply_names() {
+        for source in [
+            source(
+                r#"{"entry", (DL_FUNC)&entry, 0}"#,
+                "R_registerRoutines(dll, NULL, other, NULL, NULL);",
+            ),
+            source(
+                "{dynamic_name, (DL_FUNC)&entry, 0}",
+                "R_registerRoutines(dll, NULL, calls, NULL, NULL);",
+            ),
+            source(
+                r#"{"entry", (DL_FUNC)&entry, 0}"#,
+                "if (enabled) R_registerRoutines(dll, NULL, calls, NULL, NULL);",
+            ),
+            source(
+                r#"{"entry", (DL_FUNC)&entry, 0}"#,
+                "if (enabled) { R_registerRoutines(dll, NULL, calls, NULL, NULL); }",
+            ),
+            source(
+                r#"{"entry", (DL_FUNC)&entry, 0}"#,
+                "\n#ifdef ENABLE\nR_registerRoutines(dll, NULL, calls, NULL, NULL);\n#endif\n",
+            ),
+            format!(
+                "/*\n#define CALLDEF(name,n) {{ #name, (DL_FUNC)&name, n }}\n*/\n{}",
+                source(
+                    "CALLDEF(entry, 0)",
+                    "R_registerRoutines(dll, NULL, calls, NULL, NULL);"
+                )
+            ),
+            format!(
+                "#define CALLDEF(name,n) {{ \"different\", (DL_FUNC)&name, n }}\n{}",
+                source(
+                    "CALLDEF(entry, 0)",
+                    "R_registerRoutines(dll, NULL, calls, NULL, NULL);"
+                )
+            ),
+        ] {
+            assert!(source_symbols(&source, "example").is_empty(), "{source}");
+        }
+    }
+
+    #[test]
+    fn comments_and_string_contents_are_not_registration_code() {
+        let declaration = source(
+            r#"{"entry", (DL_FUNC)&entry, 0}"#,
+            "R_registerRoutines(dll, NULL, calls, NULL, NULL);",
+        );
+        assert!(source_symbols(&format!("/* {declaration} */"), "example").is_empty());
+        assert!(source_symbols(&format!("const char *s = {declaration:?};"), "example").is_empty());
+        assert!(
+            source_symbols(
+                &format!("const char *s = R\"tag({declaration})tag\";"),
+                "example"
+            )
+            .is_empty()
+        );
+        let commented =
+            declaration.replace("R_registerRoutines", "/* ignored */ R_registerRoutines");
+        assert_eq!(
+            source_symbols(&commented, "example"),
+            HashSet::from(["entry".into()])
+        );
+    }
+
+    #[test]
+    fn conditional_rows_do_not_hide_unconditional_registration() {
+        let source = source(
+            "\n#ifdef ENABLE\n{\"optional\", (DL_FUNC)&optional, 0},\n#endif\n{\"always\", (DL_FUNC)&always, 0}",
+            "R_registerRoutines(dll, NULL, calls, NULL, NULL);",
+        );
+        assert_eq!(
+            source_symbols(&source, "example"),
+            HashSet::from(["always".into()])
+        );
+    }
+}

--- a/crates/ry-workspace/src/packages.rs
+++ b/crates/ry-workspace/src/packages.rs
@@ -17,8 +17,8 @@ pub const NATIVE_ROUTINE_PREFIX_SENTINEL: &str = "\0useDynLib:";
 
 /// External-binding sentinel recording `useDynLib(..., .registration = TRUE)`.
 /// The registered entry points are declared in `src/`'s `R_registerRoutines`
-/// table, which ry does not read, so the flag instead licenses bare symbols in
-/// native-call argument position.
+/// table. This flag also retains call-position support when source tables
+/// cannot be enumerated.
 pub const NATIVE_REGISTRATION_SENTINEL: &str = "\0useDynLibRegistration";
 
 /// Bindings and whole-package imports declared by an R package NAMESPACE.
@@ -31,6 +31,8 @@ pub struct NamespaceMetadata {
     /// Whether `useDynLib(..., .registration = TRUE)` enables registered
     /// symbols in native-call positions without enumerating C sources.
     pub native_registration: bool,
+    /// Literal DLL names and binding prefixes with registration enabled.
+    pub registered_native_libraries: Vec<(String, String)>,
     /// Names introduced by `importFrom(package, name, ...)`.
     pub imported_bindings: HashSet<String>,
     /// Exact package provenance for `importFrom(package, name, ...)` names.
@@ -67,6 +69,20 @@ pub fn namespace_metadata(file: &SourceFile) -> NamespaceMetadata {
                     arg.name.as_deref() == Some(".registration")
                         && matches!(&arg.value, Expr::Logical(true, _))
                 });
+                if args.iter().any(|arg| {
+                    arg.name.as_deref() == Some(".registration")
+                        && matches!(&arg.value, Expr::Logical(true, _))
+                }) && let Some(library) = args.first().and_then(|arg| static_name(&arg.value))
+                {
+                    let prefix = args
+                        .iter()
+                        .find(|arg| arg.name.as_deref() == Some(".fixes"));
+                    if let Some(prefix) =
+                        prefix.map_or(Some(String::new()), |arg| static_name(&arg.value))
+                    {
+                        metadata.registered_native_libraries.push((library, prefix));
+                    }
+                }
                 metadata.native_routines.extend(
                     args.iter()
                         .skip(1)
@@ -219,6 +235,16 @@ my_library(dplyr)
         assert_eq!(
             metadata.native_routine_prefixes,
             HashSet::from(["pkg_".to_string()])
+        );
+    }
+
+    #[test]
+    fn registered_libraries_keep_their_own_prefixes() {
+        let mut parser = ry_core::RParser::new().unwrap();
+        let file = parser.parse("NAMESPACE", "useDynLib(example, .registration = TRUE)\nuseDynLib(other, .registration = TRUE, .fixes = 'C_')").unwrap();
+        assert_eq!(
+            namespace_metadata(&file).registered_native_libraries,
+            vec![("example".into(), "".into()), ("other".into(), "C_".into())]
         );
     }
 

--- a/crates/ry-workspace/src/packages.rs
+++ b/crates/ry-workspace/src/packages.rs
@@ -65,14 +65,13 @@ pub fn namespace_metadata(file: &SourceFile) -> NamespaceMetadata {
                         .filter_map(|arg| static_name(&arg.value))
                         .filter(|prefix| !prefix.is_empty()),
                 );
-                metadata.native_registration |= args.iter().any(|arg| {
+                let registered = args.iter().any(|arg| {
                     arg.name.as_deref() == Some(".registration")
                         && matches!(&arg.value, Expr::Logical(true, _))
                 });
-                if args.iter().any(|arg| {
-                    arg.name.as_deref() == Some(".registration")
-                        && matches!(&arg.value, Expr::Logical(true, _))
-                }) && let Some(library) = args.first().and_then(|arg| static_name(&arg.value))
+                metadata.native_registration |= registered;
+                if registered
+                    && let Some(library) = args.first().and_then(|arg| static_name(&arg.value))
                 {
                     let prefix = args
                         .iter()


### PR DESCRIPTION
Read literal native registration tables from package C/C++ sources so wrapper calls such as `cleancall::call(ptr, ...)` can resolve the registered `ptr` value. otelsdk's 34 RY010 findings disappear without treating every wrapper argument as a native symbol.

Closes #379.

The inventory follows `useDynLib(..., .registration = TRUE)` and its `.fixes` prefix, then reads tables passed directly to `R_registerRoutines` in the matching `R_init_*` function. It supports literal rows and the common local two-argument `CALLDEF` macro. Names from unused tables, conditional source regions, comments, and unrelated initializers do not establish bindings. Existing direct-call and prefix fallbacks remain in place.

| Boundary | Limit |
| --- | --- |
| Source files | Direct `src/` C/C++ files; no symlink traversal |
| Reads | 2 MiB per file, 8 MiB total, at most 256 files |
| Source interpretation | Literal tables and the supported macro; no C execution or general preprocessor |

The language server watches these source files and rebuilds the inventory when they change. Headers and build-generated registrations can remain unknown.

Table interpretation stops at null, unknown-name, or conditional rows that may terminate registration. Local table declarations prevent a global table with the same name from supplying bindings. Supported macros follow source order, so a later `#undef` does not erase earlier registrations.

Validation: fresh workspace tests, Clippy with warnings denied, and formatting pass. Final follow-up checks at `22dbe1a` cover the workspace inventory, CLI behavior, and LSP add/remove watcher protocol. Tests cover opt-in, prefixes, alias names, wrappers, typos, terminators, conditional rows, macro ordering, and local table shadowing. Small packages compiled and installed with R 4.6.1 confirm the prefixed bindings, wrapper results, and termination at NULL. All PR CI checks pass, and Pullfrog reviewed the final head with no new issues.

The initial fixed 472-package comparison removed exactly 34 RY010 findings, all in otelsdk, with zero additions. The final combined candidate in #452 removes those exact same 34 findings. C/header/Makevars fingerprints stayed fixed alongside the R-source fingerprints. The complete aggregate comparison, ledger checks, and installed editor checks are recorded on #452.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved recognition of registered C and C++ routines, including symbols referenced through wrapper calls.
  - Preserved existing diagnostics for genuinely unbound names, misspellings, and unsupported registration formats.
  - Native routine diagnostics now update when package source files change, including when registrations are added or removed.

- **Documentation**
  - Added an unreleased changelog entry describing improved native routine resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->